### PR TITLE
Use FnSpec type for closure

### DIFF
--- a/src/liveness-example/liveness_property.rs
+++ b/src/liveness-example/liveness_property.rs
@@ -40,13 +40,13 @@ proof fn prove_a_leads_to_b()
         if lift_state(a_state_pred()).satisfied_by(any_ex) {
             // We need a witness to coax Verus that there exists a a_b() action that is enabled when x_is_a()
             let witness_action = Action {
-                state: any_ex(0),
+                state: any_ex.head(),
                 state_prime: SimpleState {
                     x: ABC::B,
-                    happy: any_ex(0).happy,
+                    happy: any_ex.head().happy,
                 }
             };
-            assert(a_b_action_pred().satisfied_by(witness_action) && witness_action.state === any_ex(0));
+            assert(a_b_action_pred().satisfied_by(witness_action) && witness_action.state === any_ex.head());
         }
     };
     wf1::<SimpleState>(next_action_pred(), a_b_action_pred(), a_state_pred(), b_state_pred());
@@ -124,13 +124,13 @@ proof fn prove_b_leads_to_c()
         if lift_state(b_state_pred()).satisfied_by(any_ex) {
             // We need a witness to coax Verus that there exists a b_c() action that is enabled when x_is_b()
             let witness_action = Action {
-                state: any_ex(0),
+                state: any_ex.head(),
                 state_prime: SimpleState {
                     x: ABC::C,
-                    happy: any_ex(0).happy,
+                    happy: any_ex.head().happy,
                 }
             };
-            assert(b_c_action_pred().satisfied_by(witness_action) && witness_action.state === any_ex(0));
+            assert(b_c_action_pred().satisfied_by(witness_action) && witness_action.state === any_ex.head());
         }
     };
     wf1::<SimpleState>(next_action_pred(), b_c_action_pred(), b_state_pred(), c_state_pred());

--- a/src/liveness-example/state.rs
+++ b/src/liveness-example/state.rs
@@ -12,7 +12,25 @@ pub struct Action<T> {
     pub state_prime: T,
 }
 
-pub type Execution<T> = FnSpec(nat) -> T;
+pub struct Execution<T> {
+    pub nat_to_state: FnSpec(nat) -> T,
+}
+
+impl<T> Execution<T> {
+    pub open spec fn head(self) -> T {
+        (self.nat_to_state)(0)
+    }
+
+    pub open spec fn head_next(self) -> T {
+        (self.nat_to_state)(1)
+    }
+
+    pub open spec fn suffix(self, pos: nat) -> Self {
+        Execution {
+            nat_to_state: |i: nat| (self.nat_to_state)(i + pos),
+        }
+    }
+}
 
 pub struct StatePred<#[verifier(maybe_negative)] T> {
     // It is better to keep pred private,

--- a/src/liveness-example/temporal_logic.rs
+++ b/src/liveness-example/temporal_logic.rs
@@ -32,7 +32,7 @@ verus! {
 /// lift_xxx allows us to implement temporal predicates on top of state/action predicates.
 
 pub open spec fn lift_state<T>(state_pred: StatePred<T>) -> TempPred<T> {
-    TempPred::new(|ex: Execution<T>| state_pred.satisfied_by(ex(0)))
+    TempPred::new(|ex: Execution<T>| state_pred.satisfied_by(ex.head()))
 }
 
 /// Similar to lift_state except that it applies the state predicate to the second state.
@@ -40,7 +40,7 @@ pub open spec fn lift_state<T>(state_pred: StatePred<T>) -> TempPred<T> {
 /// See P', Q' in Fig 5.
 
 pub open spec fn lift_state_prime<T>(state_pred: StatePred<T>) -> TempPred<T> {
-    TempPred::new(|ex: Execution<T>| state_pred.satisfied_by(ex(1)))
+    TempPred::new(|ex: Execution<T>| state_pred.satisfied_by(ex.head_next()))
 }
 
 /// Transforms an action predicate to a temporal predicate
@@ -50,21 +50,8 @@ pub open spec fn lift_state_prime<T>(state_pred: StatePred<T>) -> TempPred<T> {
 
 pub open spec fn lift_action<T>(action_pred: ActionPred<T>) -> TempPred<T> {
     TempPred::new(|ex: Execution<T>|
-        exists |a: Action<T>|
-            #[trigger] action_pred.satisfied_by(a) && a.state === ex(0) && a.state_prime === ex(1)
+        exists |a: Action<T>| #[trigger] action_pred.satisfied_by(a) && a.state === ex.head() && a.state_prime === ex.head_next()
     )
-}
-
-/// Takes an execution `ex` and returns its suffix starting from `pos`.
-
-pub open spec fn suffix<T>(ex: Execution<T>, pos: nat) -> Execution<T> {
-    |i: nat| ex(i + pos)
-}
-
-/// Returns the suffix by removing the first state in `ex`.
-
-pub open spec fn later<T>(ex: Execution<T>) -> Execution<T> {
-    suffix(ex, 1)
 }
 
 /// `~` for temporal predicates in TLA+ (i.e., `!` in Verus).
@@ -112,7 +99,7 @@ pub open spec fn implies<T>(temp_pred_a: TempPred<T>, temp_pred_b: TempPred<T>) 
 /// Defined in 3.1.
 
 pub open spec fn always<T>(temp_pred: TempPred<T>) -> TempPred<T> {
-    TempPred::new(|ex:Execution<T>| forall |i:nat| #[trigger] temp_pred.satisfied_by(suffix(ex, i)))
+    TempPred::new(|ex: Execution<T>| forall |i: nat| #[trigger] temp_pred.satisfied_by(ex.suffix(i)))
 }
 
 /// `<>` for temporal predicates in TLA+.


### PR DESCRIPTION
Adopt the new Verus feature `FnSpec` type, instead of `Fn` trait, for the closures. Turn `Execution` to a struct that wraps `FnSpec`.

Signed-off-by: Xudong Sun <xudongs1@vmware.com>