### PR TITLE
Use preconditions in temporal logic lemmas to make debugging easier

### DIFF
--- a/src/temporal_logic_examples/controller_example/liveness.rs
+++ b/src/temporal_logic_examples/controller_example/liveness.rs
@@ -136,7 +136,7 @@ proof fn lemma_init_leads_to_obj1()
     create1_enabled();
     wf1::<CState>(next_action_pred(), create1_action_pred(), create1_pre_state_pred(), obj1_state_pred());
 
-    leads_to_trans::<CState>(send1_pre_state_pred(), create1_pre_state_pred(), obj1_state_pred());
+    leads_to_trans::<CState>(sm_spec(), send1_pre_state_pred().lift(), create1_pre_state_pred().lift(), obj1_state_pred().lift());
 }
 
 proof fn lemma_obj1_and_not_sent2_leads_to_obj2()
@@ -162,7 +162,7 @@ proof fn lemma_obj1_and_not_sent2_leads_to_obj2()
     create2_enabled();
     wf1::<CState>(next_action_pred(), create2_action_pred(), create2_pre_state_pred(), obj2_state_pred());
 
-    leads_to_trans::<CState>(send2_pre_state_pred(), create2_pre_state_pred(), obj2_state_pred());
+    leads_to_trans::<CState>(sm_spec(), send2_pre_state_pred().lift(), create2_pre_state_pred().lift(), obj2_state_pred().lift());
 
     /*
      * Now we have `(s.obj_1_exists /\ ~s.obj_2_exists /\ ~s.sent_2_create) ~> s.obj_2_exists`.
@@ -334,7 +334,7 @@ proof fn lemma_eventually_obj1()
 
     lemma_init_leads_to_obj1();
 
-    leads_to_apply::<CState>(init_state_pred(), obj1_state_pred());
+    leads_to_apply::<CState>(sm_spec(), init_state_pred().lift(), obj1_state_pred().lift());
 }
 
 proof fn lemma_eventually_obj2()
@@ -354,9 +354,9 @@ proof fn lemma_eventually_obj2()
 
     lemma_obj1_leads_to_obj2();
 
-    leads_to_trans::<CState>(init_state_pred(), obj1_state_pred(), obj2_state_pred());
+    leads_to_trans::<CState>(sm_spec(), init_state_pred().lift(), obj1_state_pred().lift(), obj2_state_pred().lift());
 
-    leads_to_apply::<CState>(init_state_pred(), obj2_state_pred());
+    leads_to_apply::<CState>(sm_spec(), init_state_pred().lift(), obj2_state_pred().lift());
 }
 
 proof fn liveness()

--- a/src/temporal_logic_examples/simple_example/liveness.rs
+++ b/src/temporal_logic_examples/simple_example/liveness.rs
@@ -90,13 +90,13 @@ proof fn prove_eventually_c()
     // assert(valid(implies(sm_spec(), leads_to(b_temp_pred(), c_temp_pred()))));
 
     // leads_to_trans connects the two leads_to together
-    leads_to_trans::<SimpleState>(a_state_pred(), b_state_pred(), c_state_pred());
+    leads_to_trans::<SimpleState>(sm_spec(), a_state_pred().lift(), b_state_pred().lift(), c_state_pred().lift());
     // Now we have:
     // assert(valid(implies(sm_spec(), leads_to(a_temp_pred(), c_temp_pred()))));
 
     // leads_to_apply gives us eventually from leads_to
     // Note that init_state_pred(), as part of sm_spec(), implies a_temp_pred()
-    leads_to_apply::<SimpleState>(a_state_pred(), c_state_pred());
+    leads_to_apply::<SimpleState>(sm_spec(), a_state_pred().lift(), c_state_pred().lift());
     // Now we have:
     // assert(valid(implies(sm_spec(), eventually(c_temp_pred()))));
 }

--- a/src/temporal_logic_examples/temporal_logic.rs
+++ b/src/temporal_logic_examples/temporal_logic.rs
@@ -306,23 +306,23 @@ pub proof fn eventually_weaken<T>(p: TempPred<T>, q: TempPred<T>)
 /// Proves eventually q if we have p and p leads_to q.
 /// `|= p /\ (p ~> q) -> <>q`
 #[verifier(external_body)]
-pub proof fn leads_to_apply<T>(p: StatePred<T>, q: StatePred<T>)
+pub proof fn leads_to_apply<T>(spec: TempPred<T>, p: TempPred<T>, q: TempPred<T>)
+    requires
+        valid(spec.implies(p)),
+        valid(spec.implies(p.leads_to(q))),
     ensures
-        valid(
-            p.lift().and(
-                p.lift().leads_to(q.lift()))
-            .implies(eventually(q.lift()))),
+        valid(spec.implies(eventually(q))),
 {}
 
 /// Connects two leads_to with the transitivity of leads_to.
 /// `|= ((p ~> q) /\ (q ~> r)) => (p ~> r)`
 #[verifier(external_body)]
-pub proof fn leads_to_trans<T>(p: StatePred<T>, q: StatePred<T>, r: StatePred<T>)
+pub proof fn leads_to_trans<T>(spec: TempPred<T>, p: TempPred<T>, q: TempPred<T>, r: TempPred<T>)
+    requires
+        valid(spec.implies(p.leads_to(q))),
+        valid(spec.implies(q.leads_to(r))),
     ensures
-        valid(
-            p.lift().leads_to(q.lift()).and(
-                q.lift().leads_to(r.lift()))
-            .implies(p.lift().leads_to(r.lift()))),
+        valid(spec.implies(p.leads_to(r))),
 {}
 
 /// Gets (p1 leads_to q1) implies (p2 leads_to q2) if:


### PR DESCRIPTION
Tweak the liveness proof by using preconditions in lemmas and apply leads_to_assume_not earlier to make the proof easier to follow.

This does not fundamentally make the proof process easier, but I think the majority of the proof can be mechanically done except for the safety reasoning part:
* Applying wf1 to get initial leads_to is straightforward
* Applying leads_to_assume_not is also straightforward since the pattern is obvious `p /\ ~q ~> q`
* It is also obvious that one needs to prove `(s.obj_1_exists /\ s.sent_2_create) ~> s.obj_2_exists`

But how to prove `(s.obj_1_exists && s.sent_2_create) ~> s.obj_2_exists` is not that obvious, which requires safety reasoning.
