### PR TITLE
Simple controller: prove stability

### DIFF
--- a/src/kubernetes_cluster/spec/client.rs
+++ b/src/kubernetes_cluster/spec/client.rs
@@ -1,9 +1,9 @@
 // Copyright 2022 VMware, Inc.
 // SPDX-License-Identifier: MIT
 #![allow(unused_imports)]
-use crate::state_machine::action::*;
 use crate::kubernetes_cluster::spec::common::*;
 use crate::pervasive::{option::*, seq::*, set::*};
+use crate::state_machine::action::*;
 use crate::state_machine::state_machine::*;
 use crate::temporal_logic::defs::*;
 use builtin::*;
@@ -29,8 +29,8 @@ pub type ClientAction = Action<ClientState, ClientActionInput, Set<Message>>;
 
 pub type ClientActionResult = ActionResult<ClientState, Set<Message>>;
 
-pub open spec fn msg_to_kubernetes_api(msg_content: MessageContent) -> Message {
-    form_msg(HostId::Client, HostId::KubernetesAPI, msg_content)
+pub open spec fn client_req_msg(req: APIRequest) -> Message {
+    form_msg(HostId::Client, HostId::KubernetesAPI, MessageContent::APIRequest(req))
 }
 
 pub open spec fn send_create_cr() -> ClientAction {
@@ -40,7 +40,7 @@ pub open spec fn send_create_cr() -> ClientAction {
             &&& input.recv.is_None()
         },
         transition: |input: ClientActionInput, s| {
-            (s, set![msg_to_kubernetes_api(create_req_msg(ResourceObj{key: input.cr.key}))])
+            (s, set![client_req_msg(create_req(ResourceObj{key: input.cr.key}))])
         },
     }
 }
@@ -52,7 +52,7 @@ pub open spec fn send_delete_cr() -> ClientAction {
             &&& input.recv.is_None()
         },
         transition: |input: ClientActionInput, s| {
-            (s, set![msg_to_kubernetes_api(delete_req_msg(input.cr.key))])
+            (s, set![client_req_msg(delete_req(input.cr.key))])
         },
     }
 }

--- a/src/kubernetes_cluster/spec/common.rs
+++ b/src/kubernetes_cluster/spec/common.rs
@@ -381,16 +381,24 @@ pub open spec fn list_req_msg(kind: ResourceKind) -> MessageContent {
     }))
 }
 
-pub open spec fn create_req_msg(obj: ResourceObj) -> MessageContent {
-    MessageContent::APIRequest(APIRequest::CreateRequest(CreateRequest{
+pub open spec fn create_req(obj: ResourceObj) -> APIRequest {
+    APIRequest::CreateRequest(CreateRequest{
         obj: obj,
-    }))
+    })
+}
+
+pub open spec fn create_req_msg(obj: ResourceObj) -> MessageContent {
+    MessageContent::APIRequest(create_req(obj))
+}
+
+pub open spec fn delete_req(key: ResourceKey) -> APIRequest {
+    APIRequest::DeleteRequest(DeleteRequest{
+        key: key,
+    })
 }
 
 pub open spec fn delete_req_msg(key: ResourceKey) -> MessageContent {
-    MessageContent::APIRequest(APIRequest::DeleteRequest(DeleteRequest{
-        key: key,
-    }))
+    MessageContent::APIRequest(delete_req(key))
 }
 
 pub open spec fn get_resp_msg(res: Result<ResourceObj, APIError>, req: GetRequest) -> MessageContent {

--- a/src/kubernetes_cluster/spec/controller/common.rs
+++ b/src/kubernetes_cluster/spec/controller/common.rs
@@ -1,9 +1,9 @@
 // Copyright 2022 VMware, Inc.
 // SPDX-License-Identifier: MIT
 #![allow(unused_imports)]
-use crate::state_machine::action::*;
 use crate::kubernetes_cluster::spec::{common::*, reconciler::*};
 use crate::pervasive::{map::*, option::*, seq::*, set::*};
+use crate::state_machine::action::*;
 use crate::state_machine::state_machine::*;
 use builtin::*;
 use builtin_macros::*;
@@ -39,8 +39,8 @@ pub type ControllerAction = Action<ControllerState, ControllerActionInput, Set<M
 
 pub type ControllerActionResult = ActionResult<ControllerState, Set<Message>>;
 
-pub open spec fn msg_to_kubernetes_api(msg_content: MessageContent) -> Message {
-    form_msg(HostId::CustomController, HostId::KubernetesAPI, msg_content)
+pub open spec fn controller_req_msg(req: APIRequest) -> Message {
+    form_msg(HostId::CustomController, HostId::KubernetesAPI, MessageContent::APIRequest(req))
 }
 
 }

--- a/src/kubernetes_cluster/spec/controller/controller_runtime.rs
+++ b/src/kubernetes_cluster/spec/controller/controller_runtime.rs
@@ -1,9 +1,9 @@
 // Copyright 2022 VMware, Inc.
 // SPDX-License-Identifier: MIT
 #![allow(unused_imports)]
-use crate::state_machine::action::*;
 use crate::kubernetes_cluster::spec::{common::*, controller::common::*, reconciler::*};
 use crate::pervasive::{map::*, option::*, seq::*, set::*};
+use crate::state_machine::action::*;
 use crate::state_machine::state_machine::*;
 use crate::temporal_logic::defs::*;
 use builtin::*;
@@ -105,7 +105,7 @@ pub open spec fn continue_reconcile(reconciler: Reconciler) -> ControllerAction 
             let (local_state_prime, req_o) = (reconciler.reconcile_core)(cr_key, resp_o, reconcile_state.local_state);
 
             let pending_req_msg = if req_o.is_Some() {
-                Option::Some(form_msg(HostId::CustomController, HostId::KubernetesAPI, MessageContent::APIRequest(req_o.get_Some_0())))
+                Option::Some(controller_req_msg(req_o.get_Some_0()))
             } else {
                 Option::None
             };

--- a/src/simple_controller/proof/liveness.rs
+++ b/src/simple_controller/proof/liveness.rs
@@ -5,7 +5,7 @@ use crate::kubernetes_cluster::{
     proof::{controller_runtime_liveness, kubernetes_api_liveness, kubernetes_api_safety},
     spec::{
         common::*,
-        controller::common::ControllerActionInput,
+        controller::common::{controller_req_msg, ControllerActionInput},
         controller::controller_runtime::{continue_reconcile, end_reconcile, trigger_reconcile},
         controller::state_machine::controller,
         distributed_system::*,
@@ -225,8 +225,8 @@ proof fn lemma_after_get_cr_pc_leads_to_cm_exists(cr: ResourceObj)
             }).leads_to(lift_state(|s: State| s.resource_key_exists(simple_reconciler::subresource_configmap(cr.key).key)))
         ),
 {
-    let get_cr_req_msg = form_msg(HostId::CustomController, HostId::KubernetesAPI, MessageContent::APIRequest(APIRequest::GetRequest(GetRequest{key: cr.key})));
-    let create_cm_req_msg = form_msg(HostId::CustomController, HostId::KubernetesAPI, MessageContent::APIRequest(simple_reconciler::create_cm_req(cr.key)));
+    let get_cr_req_msg = controller_req_msg(APIRequest::GetRequest(GetRequest{key: cr.key}));
+    let create_cm_req_msg = controller_req_msg(simple_reconciler::create_cm_req(cr.key));
     let cm = simple_reconciler::subresource_configmap(cr.key);
 
     // Just layout all the state predicates we are going to repeatedly use later since they are so long
@@ -316,7 +316,7 @@ proof fn lemma_after_create_cm_pc_leads_to_cm_exists(cr: ResourceObj)
             }))
         ),
 {
-    let create_cm_req_msg = form_msg(HostId::CustomController, HostId::KubernetesAPI, MessageContent::APIRequest(simple_reconciler::create_cm_req(cr.key)));
+    let create_cm_req_msg = controller_req_msg(simple_reconciler::create_cm_req(cr.key));
     let cm = simple_reconciler::subresource_configmap(cr.key);
 
     // Just layout all the state predicates we are going to repeatedly use later since they are so long
@@ -421,8 +421,8 @@ proof fn lemma_init_pc_leads_to_after_get_cr_pc(cr_key: ResourceKey)
             }).leads_to(lift_state(|s: State| {
                     &&& s.reconcile_state_contains(cr_key)
                     &&& s.reconcile_state_of(cr_key).local_state.reconcile_pc === simple_reconciler::after_get_cr_pc()
-                    &&& s.reconcile_state_of(cr_key).pending_req_msg === Option::Some(form_msg(HostId::CustomController, HostId::KubernetesAPI, MessageContent::APIRequest(APIRequest::GetRequest(GetRequest{key: cr_key}))))
-                    &&& s.message_sent(form_msg(HostId::CustomController, HostId::KubernetesAPI, MessageContent::APIRequest(APIRequest::GetRequest(GetRequest{key: cr_key}))))
+                    &&& s.reconcile_state_of(cr_key).pending_req_msg === Option::Some(controller_req_msg(APIRequest::GetRequest(GetRequest{key: cr_key})))
+                    &&& s.message_sent(controller_req_msg(APIRequest::GetRequest(GetRequest{key: cr_key})))
                 }))
         ),
 {
@@ -434,8 +434,8 @@ proof fn lemma_init_pc_leads_to_after_get_cr_pc(cr_key: ResourceKey)
     let post = |s: State| {
         &&& s.reconcile_state_contains(cr_key)
         &&& s.reconcile_state_of(cr_key).local_state.reconcile_pc === simple_reconciler::after_get_cr_pc()
-        &&& s.reconcile_state_of(cr_key).pending_req_msg === Option::Some(form_msg(HostId::CustomController, HostId::KubernetesAPI, MessageContent::APIRequest(APIRequest::GetRequest(GetRequest{key: cr_key}))))
-        &&& s.message_sent(form_msg(HostId::CustomController, HostId::KubernetesAPI, MessageContent::APIRequest(APIRequest::GetRequest(GetRequest{key: cr_key}))))
+        &&& s.reconcile_state_of(cr_key).pending_req_msg === Option::Some(controller_req_msg(APIRequest::GetRequest(GetRequest{key: cr_key})))
+        &&& s.message_sent(controller_req_msg(APIRequest::GetRequest(GetRequest{key: cr_key})))
     };
     let input = ControllerActionInput {
         recv: Option::None,
@@ -451,31 +451,31 @@ proof fn lemma_msg_sent_and_after_get_cr_pc_leads_to_after_create_cm_pc(msg: Mes
         sm_spec(simple_reconciler()).entails(
             (|m: Message| lift_state(|s: State| {
                 &&& s.message_sent(m)
-                &&& resp_msg_matches_req_msg(m, form_msg(HostId::CustomController, HostId::KubernetesAPI, MessageContent::APIRequest(APIRequest::GetRequest(GetRequest{key: cr_key}))))
+                &&& resp_msg_matches_req_msg(m, controller_req_msg(APIRequest::GetRequest(GetRequest{key: cr_key})))
             }))(msg).and(lift_state(|s: State| {
                 &&& s.reconcile_state_contains(cr_key)
                 &&& s.reconcile_state_of(cr_key).local_state.reconcile_pc === simple_reconciler::after_get_cr_pc()
-                &&& s.reconcile_state_of(cr_key).pending_req_msg === Option::Some(form_msg(HostId::CustomController, HostId::KubernetesAPI, MessageContent::APIRequest(APIRequest::GetRequest(GetRequest{key: cr_key}))))
+                &&& s.reconcile_state_of(cr_key).pending_req_msg === Option::Some(controller_req_msg(APIRequest::GetRequest(GetRequest{key: cr_key})))
             })).leads_to(lift_state(|s: State| {
                     &&& s.reconcile_state_contains(cr_key)
                     &&& s.reconcile_state_of(cr_key).local_state.reconcile_pc === simple_reconciler::after_create_cm_pc()
-                    &&& s.reconcile_state_of(cr_key).pending_req_msg === Option::Some(form_msg(HostId::CustomController, HostId::KubernetesAPI, MessageContent::APIRequest(simple_reconciler::create_cm_req(cr_key))))
-                    &&& s.message_sent(form_msg(HostId::CustomController, HostId::KubernetesAPI, MessageContent::APIRequest(simple_reconciler::create_cm_req(cr_key))))
+                    &&& s.reconcile_state_of(cr_key).pending_req_msg === Option::Some(controller_req_msg(simple_reconciler::create_cm_req(cr_key)))
+                    &&& s.message_sent(controller_req_msg(simple_reconciler::create_cm_req(cr_key)))
                 }))
         ),
 {
     let pre = |s: State| {
         &&& s.message_sent(msg)
-        &&& resp_msg_matches_req_msg(msg, form_msg(HostId::CustomController, HostId::KubernetesAPI, MessageContent::APIRequest(APIRequest::GetRequest(GetRequest{key: cr_key}))))
+        &&& resp_msg_matches_req_msg(msg, controller_req_msg(APIRequest::GetRequest(GetRequest{key: cr_key})))
         &&& s.reconcile_state_contains(cr_key)
         &&& s.reconcile_state_of(cr_key).local_state.reconcile_pc === simple_reconciler::after_get_cr_pc()
-        &&& s.reconcile_state_of(cr_key).pending_req_msg === Option::Some(form_msg(HostId::CustomController, HostId::KubernetesAPI, MessageContent::APIRequest(APIRequest::GetRequest(GetRequest{key: cr_key}))))
+        &&& s.reconcile_state_of(cr_key).pending_req_msg === Option::Some(controller_req_msg(APIRequest::GetRequest(GetRequest{key: cr_key})))
     };
     let post = |s: State| {
         &&& s.reconcile_state_contains(cr_key)
         &&& s.reconcile_state_of(cr_key).local_state.reconcile_pc === simple_reconciler::after_create_cm_pc()
-        &&& s.reconcile_state_of(cr_key).pending_req_msg === Option::Some(form_msg(HostId::CustomController, HostId::KubernetesAPI, MessageContent::APIRequest(simple_reconciler::create_cm_req(cr_key))))
-        &&& s.message_sent(form_msg(HostId::CustomController, HostId::KubernetesAPI, MessageContent::APIRequest(simple_reconciler::create_cm_req(cr_key))))
+        &&& s.reconcile_state_of(cr_key).pending_req_msg === Option::Some(controller_req_msg(simple_reconciler::create_cm_req(cr_key)))
+        &&& s.message_sent(controller_req_msg(simple_reconciler::create_cm_req(cr_key)))
     };
     let input = ControllerActionInput {
         recv: Option::Some(msg),
@@ -485,12 +485,12 @@ proof fn lemma_msg_sent_and_after_get_cr_pc_leads_to_after_create_cm_pc(msg: Mes
 
     let m_to_pre1 = |m: Message| lift_state(|s: State| {
         &&& s.message_sent(m)
-        &&& resp_msg_matches_req_msg(m, form_msg(HostId::CustomController, HostId::KubernetesAPI, MessageContent::APIRequest(APIRequest::GetRequest(GetRequest{key: cr_key}))))
+        &&& resp_msg_matches_req_msg(m, controller_req_msg(APIRequest::GetRequest(GetRequest{key: cr_key})))
     });
     let pre2 = lift_state(|s: State| {
         &&& s.reconcile_state_contains(cr_key)
         &&& s.reconcile_state_of(cr_key).local_state.reconcile_pc === simple_reconciler::after_get_cr_pc()
-        &&& s.reconcile_state_of(cr_key).pending_req_msg === Option::Some(form_msg(HostId::CustomController, HostId::KubernetesAPI, MessageContent::APIRequest(APIRequest::GetRequest(GetRequest{key: cr_key}))))
+        &&& s.reconcile_state_of(cr_key).pending_req_msg === Option::Some(controller_req_msg(APIRequest::GetRequest(GetRequest{key: cr_key})))
     });
     temp_pred_equality::<State>(lift_state(pre), m_to_pre1(msg).and(pre2));
 }
@@ -502,33 +502,33 @@ proof fn lemma_tla_exists_msg_sent_and_after_get_cr_pc_leads_to_after_create_cm_
         sm_spec(simple_reconciler()).entails(
             tla_exists(|m: Message| lift_state(|s: State| {
                 &&& s.message_sent(m)
-                &&& resp_msg_matches_req_msg(m, form_msg(HostId::CustomController, HostId::KubernetesAPI, MessageContent::APIRequest(APIRequest::GetRequest(GetRequest{key: cr_key}))))
+                &&& resp_msg_matches_req_msg(m, controller_req_msg(APIRequest::GetRequest(GetRequest{key: cr_key})))
             })).and(lift_state(|s: State| {
                 &&& s.reconcile_state_contains(cr_key)
                 &&& s.reconcile_state_of(cr_key).local_state.reconcile_pc === simple_reconciler::after_get_cr_pc()
-                &&& s.reconcile_state_of(cr_key).pending_req_msg === Option::Some(form_msg(HostId::CustomController, HostId::KubernetesAPI, MessageContent::APIRequest(APIRequest::GetRequest(GetRequest{key: cr_key}))))
+                &&& s.reconcile_state_of(cr_key).pending_req_msg === Option::Some(controller_req_msg(APIRequest::GetRequest(GetRequest{key: cr_key})))
             })).leads_to(lift_state(|s: State| {
                     &&& s.reconcile_state_contains(cr_key)
                     &&& s.reconcile_state_of(cr_key).local_state.reconcile_pc === simple_reconciler::after_create_cm_pc()
-                    &&& s.reconcile_state_of(cr_key).pending_req_msg === Option::Some(form_msg(HostId::CustomController, HostId::KubernetesAPI, MessageContent::APIRequest(simple_reconciler::create_cm_req(cr_key))))
-                    &&& s.message_sent(form_msg(HostId::CustomController, HostId::KubernetesAPI, MessageContent::APIRequest(simple_reconciler::create_cm_req(cr_key))))
+                    &&& s.reconcile_state_of(cr_key).pending_req_msg === Option::Some(controller_req_msg(simple_reconciler::create_cm_req(cr_key)))
+                    &&& s.message_sent(controller_req_msg(simple_reconciler::create_cm_req(cr_key)))
                 }))
         ),
 {
     let m_to_pre1 = |m: Message| lift_state(|s: State| {
         &&& s.message_sent(m)
-        &&& resp_msg_matches_req_msg(m, form_msg(HostId::CustomController, HostId::KubernetesAPI, MessageContent::APIRequest(APIRequest::GetRequest(GetRequest{key: cr_key}))))
+        &&& resp_msg_matches_req_msg(m, controller_req_msg(APIRequest::GetRequest(GetRequest{key: cr_key})))
     });
     let pre2 = lift_state(|s: State| {
         &&& s.reconcile_state_contains(cr_key)
         &&& s.reconcile_state_of(cr_key).local_state.reconcile_pc === simple_reconciler::after_get_cr_pc()
-        &&& s.reconcile_state_of(cr_key).pending_req_msg === Option::Some(form_msg(HostId::CustomController, HostId::KubernetesAPI, MessageContent::APIRequest(APIRequest::GetRequest(GetRequest{key: cr_key}))))
+        &&& s.reconcile_state_of(cr_key).pending_req_msg === Option::Some(controller_req_msg(APIRequest::GetRequest(GetRequest{key: cr_key})))
     });
     let post = lift_state(|s: State| {
         &&& s.reconcile_state_contains(cr_key)
         &&& s.reconcile_state_of(cr_key).local_state.reconcile_pc === simple_reconciler::after_create_cm_pc()
-        &&& s.reconcile_state_of(cr_key).pending_req_msg === Option::Some(form_msg(HostId::CustomController, HostId::KubernetesAPI, MessageContent::APIRequest(simple_reconciler::create_cm_req(cr_key))))
-        &&& s.message_sent(form_msg(HostId::CustomController, HostId::KubernetesAPI, MessageContent::APIRequest(simple_reconciler::create_cm_req(cr_key))))
+        &&& s.reconcile_state_of(cr_key).pending_req_msg === Option::Some(controller_req_msg(simple_reconciler::create_cm_req(cr_key)))
+        &&& s.message_sent(controller_req_msg(simple_reconciler::create_cm_req(cr_key)))
     });
     assert forall |m: Message| #[trigger] sm_spec(simple_reconciler()).entails(m_to_pre1(m).and(pre2).leads_to(post)) by {
         lemma_msg_sent_and_after_get_cr_pc_leads_to_after_create_cm_pc(m, cr_key);
@@ -548,18 +548,18 @@ proof fn lemma_exists_msg_sent_and_after_get_cr_pc_leads_to_after_create_cm_pc(c
             lift_state(|s: State| {
                 exists |m: Message| {
                     &&& #[trigger] s.message_sent(m)
-                    &&& resp_msg_matches_req_msg(m, form_msg(HostId::CustomController, HostId::KubernetesAPI, MessageContent::APIRequest(APIRequest::GetRequest(GetRequest{key: cr_key}))))
+                    &&& resp_msg_matches_req_msg(m, controller_req_msg(APIRequest::GetRequest(GetRequest{key: cr_key})))
                 }
             }).and(lift_state(|s: State| {
                 &&& s.reconcile_state_contains(cr_key)
                 &&& s.reconcile_state_of(cr_key).local_state.reconcile_pc === simple_reconciler::after_get_cr_pc()
-                &&& s.reconcile_state_of(cr_key).pending_req_msg === Option::Some(form_msg(HostId::CustomController, HostId::KubernetesAPI, MessageContent::APIRequest(APIRequest::GetRequest(GetRequest{key: cr_key}))))
+                &&& s.reconcile_state_of(cr_key).pending_req_msg === Option::Some(controller_req_msg(APIRequest::GetRequest(GetRequest{key: cr_key})))
             }))
                 .leads_to(lift_state(|s: State| {
                     &&& s.reconcile_state_contains(cr_key)
                     &&& s.reconcile_state_of(cr_key).local_state.reconcile_pc === simple_reconciler::after_create_cm_pc()
-                    &&& s.reconcile_state_of(cr_key).pending_req_msg === Option::Some(form_msg(HostId::CustomController, HostId::KubernetesAPI, MessageContent::APIRequest(simple_reconciler::create_cm_req(cr_key))))
-                    &&& s.message_sent(form_msg(HostId::CustomController, HostId::KubernetesAPI, MessageContent::APIRequest(simple_reconciler::create_cm_req(cr_key))))
+                    &&& s.reconcile_state_of(cr_key).pending_req_msg === Option::Some(controller_req_msg(simple_reconciler::create_cm_req(cr_key)))
+                    &&& s.message_sent(controller_req_msg(simple_reconciler::create_cm_req(cr_key)))
                 }))
         ),
 {}

--- a/src/simple_controller/proof/safety.rs
+++ b/src/simple_controller/proof/safety.rs
@@ -128,4 +128,16 @@ pub proof fn lemma_always_reconcile_create_cm_done_implies_pending_create_cm_req
     temp_pred_equality::<State>(lift_state(invariant), invariant_temp_pred);
 }
 
+pub proof fn lemma_delete_cm_req_msg_never_sent(cr_key: ResourceKey)
+    requires
+        cr_key.kind.is_CustomResourceKind(),
+    ensures
+        sm_spec(simple_reconciler()).entails(always(
+            lift_state(|s: State| !s.message_sent(form_msg(HostId::CustomController, HostId::KubernetesAPI, MessageContent::APIRequest(APIRequest::DeleteRequest(DeleteRequest{key: cr_key})))))
+        )),
+{
+    let invariant = |s: State| !s.message_sent(form_msg(HostId::CustomController, HostId::KubernetesAPI, MessageContent::APIRequest(APIRequest::DeleteRequest(DeleteRequest{key: cr_key}))));
+    init_invariant::<State>(sm_spec(simple_reconciler()), init(simple_reconciler()), next(simple_reconciler()), invariant);
+}
+
 }

--- a/src/simple_controller/proof/safety.rs
+++ b/src/simple_controller/proof/safety.rs
@@ -3,7 +3,7 @@
 #![allow(unused_imports)]
 use crate::kubernetes_cluster::spec::{
     common::*,
-    controller::common::{ControllerAction, ControllerActionInput},
+    controller::common::{controller_req_msg, ControllerAction, ControllerActionInput},
     distributed_system::*,
 };
 use crate::pervasive::{option::*, result::*};
@@ -62,8 +62,8 @@ pub proof fn lemma_always_reconcile_get_cr_done_implies_pending_get_cr_req(cr_ke
                 .implies(lift_state(|s: State| {
                     &&& s.reconcile_state_contains(cr_key)
                     &&& s.reconcile_state_of(cr_key).local_state.reconcile_pc === simple_reconciler::after_get_cr_pc()
-                    &&& s.reconcile_state_of(cr_key).pending_req_msg === Option::Some(form_msg(HostId::CustomController, HostId::KubernetesAPI, MessageContent::APIRequest(APIRequest::GetRequest(GetRequest{key: cr_key}))))
-                    &&& s.message_sent(form_msg(HostId::CustomController, HostId::KubernetesAPI, MessageContent::APIRequest(APIRequest::GetRequest(GetRequest{key: cr_key}))))
+                    &&& s.reconcile_state_of(cr_key).pending_req_msg === Option::Some(controller_req_msg(APIRequest::GetRequest(GetRequest{key: cr_key})))
+                    &&& s.message_sent(controller_req_msg(APIRequest::GetRequest(GetRequest{key: cr_key})))
                 }))
         )),
 {
@@ -72,8 +72,8 @@ pub proof fn lemma_always_reconcile_get_cr_done_implies_pending_get_cr_req(cr_ke
         && s.reconcile_state_of(cr_key).local_state.reconcile_pc === simple_reconciler::after_get_cr_pc()
         ==> s.reconcile_state_contains(cr_key)
             && s.reconcile_state_of(cr_key).local_state.reconcile_pc === simple_reconciler::after_get_cr_pc()
-            && s.reconcile_state_of(cr_key).pending_req_msg === Option::Some(form_msg(HostId::CustomController, HostId::KubernetesAPI, MessageContent::APIRequest(APIRequest::GetRequest(GetRequest{key: cr_key}))))
-            && s.message_sent(form_msg(HostId::CustomController, HostId::KubernetesAPI, MessageContent::APIRequest(APIRequest::GetRequest(GetRequest{key: cr_key}))))
+            && s.reconcile_state_of(cr_key).pending_req_msg === Option::Some(controller_req_msg(APIRequest::GetRequest(GetRequest{key: cr_key})))
+            && s.message_sent(controller_req_msg(APIRequest::GetRequest(GetRequest{key: cr_key})))
     };
     init_invariant::<State>(sm_spec(simple_reconciler()), init(simple_reconciler()), next(simple_reconciler()), invariant);
 
@@ -83,8 +83,8 @@ pub proof fn lemma_always_reconcile_get_cr_done_implies_pending_get_cr_req(cr_ke
     }).implies(lift_state(|s: State| {
         &&& s.reconcile_state_contains(cr_key)
         &&& s.reconcile_state_of(cr_key).local_state.reconcile_pc === simple_reconciler::after_get_cr_pc()
-        &&& s.reconcile_state_of(cr_key).pending_req_msg === Option::Some(form_msg(HostId::CustomController, HostId::KubernetesAPI, MessageContent::APIRequest(APIRequest::GetRequest(GetRequest{key: cr_key}))))
-        &&& s.message_sent(form_msg(HostId::CustomController, HostId::KubernetesAPI, MessageContent::APIRequest(APIRequest::GetRequest(GetRequest{key: cr_key}))))
+        &&& s.reconcile_state_of(cr_key).pending_req_msg === Option::Some(controller_req_msg(APIRequest::GetRequest(GetRequest{key: cr_key})))
+        &&& s.message_sent(controller_req_msg(APIRequest::GetRequest(GetRequest{key: cr_key})))
     }));
     temp_pred_equality::<State>(lift_state(invariant), invariant_temp_pred);
 }
@@ -101,8 +101,8 @@ pub proof fn lemma_always_reconcile_create_cm_done_implies_pending_create_cm_req
                 .implies(lift_state(|s: State| {
                     &&& s.reconcile_state_contains(cr_key)
                     &&& s.reconcile_state_of(cr_key).local_state.reconcile_pc === simple_reconciler::after_create_cm_pc()
-                    &&& s.reconcile_state_of(cr_key).pending_req_msg === Option::Some(form_msg(HostId::CustomController, HostId::KubernetesAPI, MessageContent::APIRequest(simple_reconciler::create_cm_req(cr_key))))
-                    &&& s.message_sent(form_msg(HostId::CustomController, HostId::KubernetesAPI, MessageContent::APIRequest(simple_reconciler::create_cm_req(cr_key))))
+                    &&& s.reconcile_state_of(cr_key).pending_req_msg === Option::Some(controller_req_msg(simple_reconciler::create_cm_req(cr_key)))
+                    &&& s.message_sent(controller_req_msg(simple_reconciler::create_cm_req(cr_key)))
                 }))
         )),
 {
@@ -111,8 +111,8 @@ pub proof fn lemma_always_reconcile_create_cm_done_implies_pending_create_cm_req
         && s.reconcile_state_of(cr_key).local_state.reconcile_pc === simple_reconciler::after_create_cm_pc()
         ==> s.reconcile_state_contains(cr_key)
             && s.reconcile_state_of(cr_key).local_state.reconcile_pc === simple_reconciler::after_create_cm_pc()
-            && s.reconcile_state_of(cr_key).pending_req_msg === Option::Some(form_msg(HostId::CustomController, HostId::KubernetesAPI, MessageContent::APIRequest(simple_reconciler::create_cm_req(cr_key))))
-            && s.message_sent(form_msg(HostId::CustomController, HostId::KubernetesAPI, MessageContent::APIRequest(simple_reconciler::create_cm_req(cr_key))))
+            && s.reconcile_state_of(cr_key).pending_req_msg === Option::Some(controller_req_msg(simple_reconciler::create_cm_req(cr_key)))
+            && s.message_sent(controller_req_msg(simple_reconciler::create_cm_req(cr_key)))
     };
     init_invariant::<State>(sm_spec(simple_reconciler()), init(simple_reconciler()), next(simple_reconciler()), invariant);
 
@@ -122,8 +122,8 @@ pub proof fn lemma_always_reconcile_create_cm_done_implies_pending_create_cm_req
     }).implies(lift_state(|s: State| {
         &&& s.reconcile_state_contains(cr_key)
         &&& s.reconcile_state_of(cr_key).local_state.reconcile_pc === simple_reconciler::after_create_cm_pc()
-        &&& s.reconcile_state_of(cr_key).pending_req_msg === Option::Some(form_msg(HostId::CustomController, HostId::KubernetesAPI, MessageContent::APIRequest(simple_reconciler::create_cm_req(cr_key))))
-        &&& s.message_sent(form_msg(HostId::CustomController, HostId::KubernetesAPI, MessageContent::APIRequest(simple_reconciler::create_cm_req(cr_key))))
+        &&& s.reconcile_state_of(cr_key).pending_req_msg === Option::Some(controller_req_msg(simple_reconciler::create_cm_req(cr_key)))
+        &&& s.message_sent(controller_req_msg(simple_reconciler::create_cm_req(cr_key)))
     }));
     temp_pred_equality::<State>(lift_state(invariant), invariant_temp_pred);
 }
@@ -133,10 +133,10 @@ pub proof fn lemma_delete_cm_req_msg_never_sent(cr_key: ResourceKey)
         cr_key.kind.is_CustomResourceKind(),
     ensures
         sm_spec(simple_reconciler()).entails(always(
-            lift_state(|s: State| !s.message_sent(form_msg(HostId::CustomController, HostId::KubernetesAPI, MessageContent::APIRequest(APIRequest::DeleteRequest(DeleteRequest{key: cr_key})))))
+            lift_state(|s: State| !s.message_sent(controller_req_msg(APIRequest::DeleteRequest(DeleteRequest{key: cr_key}))))
         )),
 {
-    let invariant = |s: State| !s.message_sent(form_msg(HostId::CustomController, HostId::KubernetesAPI, MessageContent::APIRequest(APIRequest::DeleteRequest(DeleteRequest{key: cr_key}))));
+    let invariant = |s: State| !s.message_sent(controller_req_msg(APIRequest::DeleteRequest(DeleteRequest{key: cr_key})));
     init_invariant::<State>(sm_spec(simple_reconciler()), init(simple_reconciler()), next(simple_reconciler()), invariant);
 }
 

--- a/src/temporal_logic/rules.rs
+++ b/src/temporal_logic/rules.rs
@@ -542,6 +542,21 @@ pub proof fn temp_pred_equality<T>(p: TempPred<T>, q: TempPred<T>)
     fun_ext::<Execution<T>, bool>(p.pred, q.pred);
 }
 
+pub proof fn always_and_equality<T>(p: TempPred<T>, q: TempPred<T>)
+    ensures
+        always(p.and(q)) === always(p).and(always(q)),
+{}
+
+pub proof fn p_and_always_p_equals_always_p<T>(p: TempPred<T>)
+    ensures
+        p.and(always(p)) === always(p),
+{
+    assert forall |ex| #[trigger] always(p).satisfied_by(ex) implies p.and(always(p)).satisfied_by(ex) by {
+        always_to_current::<T>(ex, p);
+    };
+    temp_pred_equality::<T>(p.and(always(p)), always(p));
+}
+
 pub proof fn a_to_temp_pred_equality<T, A>(p: FnSpec(A) -> TempPred<T>, q: FnSpec(A) -> TempPred<T>)
     requires
         forall |a: A| #[trigger] valid(p(a).equals(q(a))),
@@ -571,16 +586,6 @@ pub proof fn tla_exists_equality<T, A>(f: FnSpec(A, T) -> bool)
     };
 
     temp_pred_equality::<T>(p, q);
-}
-
-pub proof fn p_and_always_p_equals_always_p<T>(p: TempPred<T>)
-    ensures
-        p.and(always(p)) === always(p),
-{
-    assert forall |ex| #[trigger] always(p).satisfied_by(ex) implies p.and(always(p)).satisfied_by(ex) by {
-        always_to_current::<T>(ex, p);
-    };
-    temp_pred_equality::<T>(p.and(always(p)), always(p));
 }
 
 pub proof fn tla_forall_always_equality<T, A>(a_to_p: FnSpec(A) -> TempPred<T>)
@@ -2053,5 +2058,13 @@ pub proof fn leads_to_contraposition<T>(spec: TempPred<T>, p: StatePred<T>, q: S
 {
     leads_to_contraposition_temp::<T>(spec, lift_state(p), lift_state(q));
 }
+
+pub proof fn entails_and_temp<T>(spec: TempPred<T>, p: TempPred<T>, q: TempPred<T>)
+    requires
+        spec.entails(p),
+        spec.entails(q),
+    ensures
+        spec.entails(p.and(q)),
+{}
 
 }


### PR DESCRIPTION
Enhance the liveness property of the simple controller by adding stability. That is, existence of the CR leads to existence of the configmap, and the configmap always exists from then.