### PR TITLE
Cosmetic changes before complicating simple controller spec

### DIFF
--- a/src/simple_controller/proof/liveness.rs
+++ b/src/simple_controller/proof/liveness.rs
@@ -20,53 +20,27 @@ use builtin_macros::*;
 
 verus! {
 
-spec fn liveness_stability(cr: ResourceObj) -> TempPred<State>
+spec fn match_cr(cr: ResourceObj) -> TempPred<State>
     recommends
         cr.key.kind.is_CustomResourceKind(),
 {
-    lift_state(|s: State| s.resource_obj_exists(cr))
-        .leads_to(always(lift_state(|s: State| s.resource_key_exists(simple_reconciler::subresource_configmap(cr.key).key))))
+    lift_state(|s: State| s.resource_key_exists(simple_reconciler::subresource_configmap(cr.key).key))
+}
+
+spec fn liveness(cr: ResourceObj) -> TempPred<State>
+    recommends
+        cr.key.kind.is_CustomResourceKind(),
+{
+    lift_state(|s: State| s.resource_obj_exists(cr)).leads_to(always(match_cr(cr)))
 }
 
 proof fn liveness_proof_forall_cr()
     ensures
-        forall |cr: ResourceObj| cr.key.kind.is_CustomResourceKind() ==> #[trigger] sm_spec(simple_reconciler()).entails(liveness_stability(cr)),
+        forall |cr: ResourceObj| cr.key.kind.is_CustomResourceKind() ==> #[trigger] sm_spec(simple_reconciler()).entails(liveness(cr)),
 {
-    assert forall |cr: ResourceObj| cr.key.kind.is_CustomResourceKind() implies #[trigger] sm_spec(simple_reconciler()).entails(liveness_stability(cr)) by {
-        liveness_stability_proof(cr);
+    assert forall |cr: ResourceObj| cr.key.kind.is_CustomResourceKind() implies #[trigger] sm_spec(simple_reconciler()).entails(liveness(cr)) by {
+        liveness_proof(cr);
     };
-}
-
-proof fn liveness_stability_proof(cr: ResourceObj)
-    requires
-        cr.key.kind.is_CustomResourceKind(),
-    ensures
-        sm_spec(simple_reconciler()).entails(
-            lift_state(|s: State| s.resource_obj_exists(cr))
-                .leads_to(always(lift_state(|s: State| s.resource_key_exists(simple_reconciler::subresource_configmap(cr.key).key))))
-        ),
-{
-    let cr_exists = |s: State| s.resource_obj_exists(cr);
-    let cm_exists = |s: State| s.resource_key_exists(simple_reconciler::subresource_configmap(cr.key).key);
-    let delete_cm_req_msg_not_sent = |s: State| !exists |m: Message| {
-        &&& #[trigger] s.message_sent(m)
-        &&& m.dst === HostId::KubernetesAPI
-        &&& m.is_delete_request()
-        &&& m.get_delete_request().key === simple_reconciler::subresource_configmap(cr.key).key
-    };
-
-    liveness_proof(cr);
-
-    safety::lemma_delete_cm_req_msg_never_sent(cr.key);
-    let next_and_invariant = |s: State, s_prime: State| {
-        &&& next(simple_reconciler())(s, s_prime)
-        &&& delete_cm_req_msg_not_sent(s)
-    };
-
-    entails_and_temp::<State>(sm_spec(simple_reconciler()), always(lift_action(next(simple_reconciler()))), always(lift_state(delete_cm_req_msg_not_sent)));
-    always_and_equality::<State>(lift_action(next(simple_reconciler())), lift_state(delete_cm_req_msg_not_sent));
-    temp_pred_equality::<State>(lift_action(next(simple_reconciler())).and(lift_state(delete_cm_req_msg_not_sent)), lift_action(next_and_invariant));
-    leads_to_stable::<State>(sm_spec(simple_reconciler()), next_and_invariant, cr_exists, cm_exists);
 }
 
 proof fn liveness_proof(cr: ResourceObj)
@@ -75,21 +49,21 @@ proof fn liveness_proof(cr: ResourceObj)
     ensures
         sm_spec(simple_reconciler()).entails(
             lift_state(|s: State| s.resource_obj_exists(cr))
-                .leads_to(lift_state(|s: State| s.resource_key_exists(simple_reconciler::subresource_configmap(cr.key).key)))
+                .leads_to(always(lift_state(|s: State| s.resource_key_exists(simple_reconciler::subresource_configmap(cr.key).key))))
         ),
 {
     leads_to_weaken_auto::<State>(sm_spec(simple_reconciler()));
     kubernetes_api_safety::lemma_always_res_exists_implies_added_event_sent(simple_reconciler(), cr);
-    lemma_cr_added_event_msg_sent_leads_to_cm_exists(cr);
+    lemma_cr_added_event_msg_sent_leads_to_cm_always_exists(cr);
 }
 
-proof fn lemma_cr_added_event_msg_sent_leads_to_cm_exists(cr: ResourceObj)
+proof fn lemma_cr_added_event_msg_sent_leads_to_cm_always_exists(cr: ResourceObj)
     requires
         cr.key.kind.is_CustomResourceKind(),
     ensures
         sm_spec(simple_reconciler()).entails(
             lift_state(|s: State| s.message_sent(form_msg(HostId::KubernetesAPI, HostId::CustomController, added_event_msg(cr))))
-                .leads_to(lift_state(|s: State| s.resource_key_exists(simple_reconciler::subresource_configmap(cr.key).key)))
+                .leads_to(always(lift_state(|s: State| s.resource_key_exists(simple_reconciler::subresource_configmap(cr.key).key))))
         ),
 {
     let cr_added_event_msg_sent = |s: State| s.message_sent(form_msg(HostId::KubernetesAPI, HostId::CustomController, added_event_msg(cr)));
@@ -99,9 +73,9 @@ proof fn lemma_cr_added_event_msg_sent_leads_to_cm_exists(cr: ResourceObj)
     leads_to_weaken_auto::<State>(sm_spec(simple_reconciler()));
 
     lemma_cr_added_event_msg_sent_leads_to_controller_in_reconcile(cr);
-    lemma_controller_in_reconcile_leads_to_cm_exists(cr);
+    lemma_controller_in_reconcile_leads_to_cm_always_exists(cr);
 
-    leads_to_trans::<State>(sm_spec(simple_reconciler()), cr_added_event_msg_sent, controller_in_reconcile, cm_exists);
+    leads_to_trans_temp::<State>(sm_spec(simple_reconciler()), lift_state(cr_added_event_msg_sent), lift_state(controller_in_reconcile), always(lift_state(cm_exists)));
 
 }
 
@@ -141,13 +115,13 @@ proof fn lemma_cr_added_event_msg_sent_leads_to_controller_in_reconcile(cr: Reso
     or_leads_to_combine::<State>(sm_spec(simple_reconciler()), cr_added_event_msg_sent_and_controller_not_in_reconcile, cr_added_event_msg_sent_and_controller_in_reconcile, controller_in_reconcile);
 }
 
-proof fn lemma_controller_in_reconcile_leads_to_cm_exists(cr: ResourceObj)
+proof fn lemma_controller_in_reconcile_leads_to_cm_always_exists(cr: ResourceObj)
     requires
         cr.key.kind.is_CustomResourceKind(),
     ensures
         sm_spec(simple_reconciler()).entails(
             lift_state(|s: State| s.reconcile_state_contains(cr.key))
-                .leads_to(lift_state(|s: State| s.resource_key_exists(simple_reconciler::subresource_configmap(cr.key).key)))
+                .leads_to(always(lift_state(|s: State| s.resource_key_exists(simple_reconciler::subresource_configmap(cr.key).key))))
         ),
 {
     let cm = simple_reconciler::subresource_configmap(cr.key);
@@ -174,29 +148,29 @@ proof fn lemma_controller_in_reconcile_leads_to_cm_exists(cr: ResourceObj)
 
     // This proof is also straightforward once we have proved the four following lemmas
     // The four lemmas cover all the possible values of reconcile_pc
-    lemma_init_pc_leads_to_cm_exists(cr); // reconcile_at_init_pc ~> cm_exists
-    lemma_after_get_cr_pc_leads_to_cm_exists(cr); // reconciler_at_after_get_cr_pc ~> cm_exists
-    lemma_after_create_cm_pc_leads_to_cm_exists(cr); // reconciler_at_after_create_cm_pc ~> cm_exists
-    lemma_reconcile_done_leads_to_cm_exists(cr); // reconciler_reconcile_done ~> cm_exists
+    lemma_init_pc_leads_to_cm_always_exists(cr); // reconcile_at_init_pc ~> []cm_exists
+    lemma_after_get_cr_pc_leads_to_cm_always_exists(cr); // reconciler_at_after_get_cr_pc ~> []cm_exists
+    lemma_after_create_cm_pc_leads_to_cm_always_exists(cr); // reconciler_at_after_create_cm_pc ~> []cm_exists
+    lemma_reconcile_done_leads_to_cm_always_exists(cr); // reconciler_reconcile_done ~> []cm_exists
 
     // Now we combine the four cases together
-    // and we will get s.reconcile_state_contains(cr.key) ~> cm_exists
-    or_leads_to_combine::<State>(sm_spec(simple_reconciler()), reconcile_at_init_pc, reconciler_at_after_get_cr_pc, cm_exists);
-    or_leads_to_combine::<State>(sm_spec(simple_reconciler()), reconciler_at_after_create_cm_pc, reconciler_reconcile_done, cm_exists);
-    or_leads_to_combine::<State>(sm_spec(simple_reconciler()),
-        |s: State| {
+    // and we will get s.reconcile_state_contains(cr.key) ~> []cm_exists
+    or_leads_to_combine_temp::<State>(sm_spec(simple_reconciler()), lift_state(reconcile_at_init_pc), lift_state(reconciler_at_after_get_cr_pc), always(lift_state(cm_exists)));
+    or_leads_to_combine_temp::<State>(sm_spec(simple_reconciler()), lift_state(reconciler_at_after_create_cm_pc), lift_state(reconciler_reconcile_done), always(lift_state(cm_exists)));
+    or_leads_to_combine_temp::<State>(sm_spec(simple_reconciler()),
+        lift_state(|s: State| {
             ||| reconcile_at_init_pc(s)
             ||| reconciler_at_after_get_cr_pc(s)
-        },
-        |s: State| {
+        }),
+        lift_state(|s: State| {
             ||| reconciler_at_after_create_cm_pc(s)
             ||| reconciler_reconcile_done(s)
-        },
-        cm_exists
+        }),
+        always(lift_state(cm_exists))
     );
 }
 
-proof fn lemma_init_pc_leads_to_cm_exists(cr: ResourceObj)
+proof fn lemma_init_pc_leads_to_cm_always_exists(cr: ResourceObj)
     requires
         cr.key.kind.is_CustomResourceKind(),
     ensures
@@ -204,7 +178,7 @@ proof fn lemma_init_pc_leads_to_cm_exists(cr: ResourceObj)
             lift_state(|s: State| {
                 &&& s.reconcile_state_contains(cr.key)
                 &&& s.reconcile_state_of(cr.key).local_state.reconcile_pc === simple_reconciler::init_pc()
-            }).leads_to(lift_state(|s: State| s.resource_key_exists(simple_reconciler::subresource_configmap(cr.key).key)))
+            }).leads_to(always(lift_state(|s: State| s.resource_key_exists(simple_reconciler::subresource_configmap(cr.key).key))))
         ),
 {
     let cm = simple_reconciler::subresource_configmap(cr.key);
@@ -239,12 +213,12 @@ proof fn lemma_init_pc_leads_to_cm_exists(cr: ResourceObj)
     // Get the leads-to formula from lemma_init_pc_leads_to_after_get_cr_pc and connect it with the above asserted one
     lemma_init_pc_leads_to_after_get_cr_pc(cr.key);
     leads_to_trans::<State>(sm_spec(simple_reconciler()), reconcile_at_init_pc, reconcile_at_init_pc_and_no_pending_req, reconciler_at_after_get_cr_pc);
-    // Since we have prove that spec |= reconciler_at_after_get_cr_pc ~> cm_exists, we will just take a shortcut here
-    lemma_after_get_cr_pc_leads_to_cm_exists(cr);
-    leads_to_trans::<State>(sm_spec(simple_reconciler()), reconcile_at_init_pc, reconciler_at_after_get_cr_pc, cm_exists);
+    // Since we have prove that spec |= reconciler_at_after_get_cr_pc ~> []cm_exists, we will just take a shortcut here
+    lemma_after_get_cr_pc_leads_to_cm_always_exists(cr);
+    leads_to_trans_temp::<State>(sm_spec(simple_reconciler()), lift_state(reconcile_at_init_pc), lift_state(reconciler_at_after_get_cr_pc), always(lift_state(cm_exists)));
 }
 
-proof fn lemma_after_get_cr_pc_leads_to_cm_exists(cr: ResourceObj)
+proof fn lemma_after_get_cr_pc_leads_to_cm_always_exists(cr: ResourceObj)
     requires
         cr.key.kind.is_CustomResourceKind(),
     ensures
@@ -252,7 +226,7 @@ proof fn lemma_after_get_cr_pc_leads_to_cm_exists(cr: ResourceObj)
             lift_state(|s: State| {
                 &&& s.reconcile_state_contains(cr.key)
                 &&& s.reconcile_state_of(cr.key).local_state.reconcile_pc === simple_reconciler::after_get_cr_pc()
-            }).leads_to(lift_state(|s: State| s.resource_key_exists(simple_reconciler::subresource_configmap(cr.key).key)))
+            }).leads_to(always(lift_state(|s: State| s.resource_key_exists(simple_reconciler::subresource_configmap(cr.key).key))))
         ),
 {
     let get_cr_req_msg = controller_req_msg(APIRequest::GetRequest(GetRequest{key: cr.key}));
@@ -328,12 +302,12 @@ proof fn lemma_after_get_cr_pc_leads_to_cm_exists(cr: ResourceObj)
         },
         reconciler_at_after_create_cm_pc
     );
-    // Since we have prove that spec |= reconciler_at_after_create_cm_pc ~> cm_exists, we will just take a shortcut here
-    lemma_after_create_cm_pc_leads_to_cm_exists(cr);
-    leads_to_trans::<State>(sm_spec(simple_reconciler()), reconciler_at_after_get_cr_pc, reconciler_at_after_create_cm_pc, cm_exists);
+    // Since we have prove that spec |= reconciler_at_after_create_cm_pc ~> []cm_exists, we will just take a shortcut here
+    lemma_after_create_cm_pc_leads_to_cm_always_exists(cr);
+    leads_to_trans_temp::<State>(sm_spec(simple_reconciler()), lift_state(reconciler_at_after_get_cr_pc), lift_state(reconciler_at_after_create_cm_pc), always(lift_state(cm_exists)));
 }
 
-proof fn lemma_after_create_cm_pc_leads_to_cm_exists(cr: ResourceObj)
+proof fn lemma_after_create_cm_pc_leads_to_cm_always_exists(cr: ResourceObj)
     requires
         cr.key.kind.is_CustomResourceKind(),
     ensures
@@ -341,9 +315,7 @@ proof fn lemma_after_create_cm_pc_leads_to_cm_exists(cr: ResourceObj)
             lift_state(|s: State| {
                 &&& s.reconcile_state_contains(cr.key)
                 &&& s.reconcile_state_of(cr.key).local_state.reconcile_pc === simple_reconciler::after_create_cm_pc()
-            }).leads_to(lift_state(|s: State| {
-                s.resource_key_exists(simple_reconciler::subresource_configmap(cr.key).key)
-            }))
+            }).leads_to(always(lift_state(|s: State| s.resource_key_exists(simple_reconciler::subresource_configmap(cr.key).key))))
         ),
 {
     let create_cm_req_msg = controller_req_msg(simple_reconciler::create_cm_req(cr.key));
@@ -376,12 +348,15 @@ proof fn lemma_after_create_cm_pc_leads_to_cm_exists(cr: ResourceObj)
             }))
     ));
     // lemma_create_req_leads_to_res_exists gives us spec |= create_cm_req_msg_sent ~> cm_exists
-    // and then apply leads_to_trans we are done
+    // and then apply leads_to_trans to get spec |= reconciler_at_after_create_cm_pc ~> cm_exists
     kubernetes_api_liveness::lemma_create_req_leads_to_res_exists(simple_reconciler(), create_cm_req_msg, cm);
     leads_to_trans::<State>(sm_spec(simple_reconciler()), reconciler_at_after_create_cm_pc, create_cm_req_msg_sent, cm_exists);
+
+    // finally prove stability: spec |= reconciler_at_after_create_cm_pc ~> []cm_exists
+    lemma_p_leads_to_cm_always_exists(cr, lift_state(reconciler_at_after_create_cm_pc));
 }
 
-proof fn lemma_reconcile_done_leads_to_cm_exists(cr: ResourceObj)
+proof fn lemma_reconcile_done_leads_to_cm_always_exists(cr: ResourceObj)
     requires
         cr.key.kind.is_CustomResourceKind(),
     ensures
@@ -389,7 +364,7 @@ proof fn lemma_reconcile_done_leads_to_cm_exists(cr: ResourceObj)
             lift_state(|s: State| {
                 &&& s.reconcile_state_contains(cr.key)
                 &&& (simple_reconciler().reconcile_done)(s.reconcile_state_of(cr.key).local_state)
-            }).leads_to(lift_state(|s: State| s.resource_key_exists(simple_reconciler::subresource_configmap(cr.key).key)))
+            }).leads_to(always(lift_state(|s: State| s.resource_key_exists(simple_reconciler::subresource_configmap(cr.key).key))))
         ),
 {
     let cm = simple_reconciler::subresource_configmap(cr.key);
@@ -412,8 +387,40 @@ proof fn lemma_reconcile_done_leads_to_cm_exists(cr: ResourceObj)
     // and the rescheduled reconcile leads to the init reconcile state,
     // which we have proved leads to cm_exists
     controller_runtime_liveness::lemma_reconcile_done_leads_to_reconcile_triggered(simple_reconciler(), cr.key);
-    lemma_init_pc_leads_to_cm_exists(cr);
-    leads_to_trans::<State>(sm_spec(simple_reconciler()), reconciler_reconcile_done, reconcile_at_init_pc, cm_exists);
+    lemma_init_pc_leads_to_cm_always_exists(cr);
+    leads_to_trans_temp::<State>(sm_spec(simple_reconciler()), lift_state(reconciler_reconcile_done), lift_state(reconcile_at_init_pc), always(lift_state(cm_exists)));
+}
+
+proof fn lemma_p_leads_to_cm_always_exists(cr: ResourceObj, p: TempPred<State>)
+    requires
+        cr.key.kind.is_CustomResourceKind(),
+        sm_spec(simple_reconciler()).entails(
+            p.leads_to(lift_state(|s: State| s.resource_key_exists(simple_reconciler::subresource_configmap(cr.key).key)))
+        ),
+    ensures
+        sm_spec(simple_reconciler()).entails(
+            p.leads_to(always(lift_state(|s: State| s.resource_key_exists(simple_reconciler::subresource_configmap(cr.key).key))))
+        ),
+{
+    let cm = simple_reconciler::subresource_configmap(cr.key);
+
+    let cm_exists = |s: State| s.resource_key_exists(cm.key);
+    let delete_cm_req_msg_not_sent = |s: State| !exists |m: Message| {
+        &&& #[trigger] s.message_sent(m)
+        &&& m.dst === HostId::KubernetesAPI
+        &&& m.is_delete_request()
+        &&& m.get_delete_request().key === simple_reconciler::subresource_configmap(cr.key).key
+    };
+    safety::lemma_delete_cm_req_msg_never_sent(cr.key);
+    let next_and_invariant = |s: State, s_prime: State| {
+        &&& next(simple_reconciler())(s, s_prime)
+        &&& delete_cm_req_msg_not_sent(s)
+    };
+
+    entails_and_temp::<State>(sm_spec(simple_reconciler()), always(lift_action(next(simple_reconciler()))), always(lift_state(delete_cm_req_msg_not_sent)));
+    always_and_equality::<State>(lift_action(next(simple_reconciler())), lift_state(delete_cm_req_msg_not_sent));
+    temp_pred_equality::<State>(lift_action(next(simple_reconciler())).and(lift_state(delete_cm_req_msg_not_sent)), lift_action(next_and_invariant));
+    leads_to_stable_temp::<State>(sm_spec(simple_reconciler()), lift_action(next_and_invariant), p, lift_state(cm_exists));
 }
 
 proof fn lemma_relevant_event_sent_leads_to_init_pc(msg: Message, cr_key: ResourceKey)
@@ -525,15 +532,17 @@ proof fn lemma_msg_sent_and_after_get_cr_pc_leads_to_after_create_cm_pc(msg: Mes
     temp_pred_equality::<State>(lift_state(pre), m_to_pre1(msg).and(pre2));
 }
 
-proof fn lemma_tla_exists_msg_sent_and_after_get_cr_pc_leads_to_after_create_cm_pc(cr_key: ResourceKey)
+proof fn lemma_exists_msg_sent_and_after_get_cr_pc_leads_to_after_create_cm_pc(cr_key: ResourceKey)
     requires
         cr_key.kind.is_CustomResourceKind(),
     ensures
         sm_spec(simple_reconciler()).entails(
-            tla_exists(|m: Message| lift_state(|s: State| {
-                &&& s.message_sent(m)
-                &&& resp_msg_matches_req_msg(m, controller_req_msg(APIRequest::GetRequest(GetRequest{key: cr_key})))
-            })).and(lift_state(|s: State| {
+            lift_state(|s: State| {
+                exists |m: Message| {
+                    &&& #[trigger] s.message_sent(m)
+                    &&& resp_msg_matches_req_msg(m, controller_req_msg(APIRequest::GetRequest(GetRequest{key: cr_key})))
+                }
+            }).and(lift_state(|s: State| {
                 &&& s.reconcile_state_contains(cr_key)
                 &&& s.reconcile_state_of(cr_key).local_state.reconcile_pc === simple_reconciler::after_get_cr_pc()
                 &&& s.reconcile_state_of(cr_key).pending_req_msg === Option::Some(controller_req_msg(APIRequest::GetRequest(GetRequest{key: cr_key})))
@@ -565,33 +574,23 @@ proof fn lemma_tla_exists_msg_sent_and_after_get_cr_pc_leads_to_after_create_cm_
     };
     leads_to_exists_intro::<State, Message>(sm_spec(simple_reconciler()), |m| m_to_pre1(m).and(pre2), post);
     tla_exists_and_equality::<State, Message>(m_to_pre1, pre2);
-}
 
-/// How to prove this? This is obvious according to lemma_tla_exists_msg_sent_and_after_get_cr_pc_leads_to_after_create_cm_pc
-/// but I find it difficult to prove tla_exists(|m| lift_state(|s| ...)) === lift_state(|s| exists |m| ...)
-#[verifier(external_body)]
-proof fn lemma_exists_msg_sent_and_after_get_cr_pc_leads_to_after_create_cm_pc(cr_key: ResourceKey)
-    requires
-        cr_key.kind.is_CustomResourceKind(),
-    ensures
-        sm_spec(simple_reconciler()).entails(
-            lift_state(|s: State| {
-                exists |m: Message| {
-                    &&& #[trigger] s.message_sent(m)
-                    &&& resp_msg_matches_req_msg(m, controller_req_msg(APIRequest::GetRequest(GetRequest{key: cr_key})))
-                }
-            }).and(lift_state(|s: State| {
-                &&& s.reconcile_state_contains(cr_key)
-                &&& s.reconcile_state_of(cr_key).local_state.reconcile_pc === simple_reconciler::after_get_cr_pc()
-                &&& s.reconcile_state_of(cr_key).pending_req_msg === Option::Some(controller_req_msg(APIRequest::GetRequest(GetRequest{key: cr_key})))
-            }))
-                .leads_to(lift_state(|s: State| {
-                    &&& s.reconcile_state_contains(cr_key)
-                    &&& s.reconcile_state_of(cr_key).local_state.reconcile_pc === simple_reconciler::after_create_cm_pc()
-                    &&& s.reconcile_state_of(cr_key).pending_req_msg === Option::Some(controller_req_msg(simple_reconciler::create_cm_req(cr_key)))
-                    &&& s.message_sent(controller_req_msg(simple_reconciler::create_cm_req(cr_key)))
-                }))
-        ),
-{}
+    // This is very tedious proof to show exists_m_to_pre1 === tla_exists(m_to_pre1)
+    // I hope we can encapsulate this as a lemma
+    let exists_m_to_pre1 = lift_state(|s: State| {
+        exists |m: Message| {
+            &&& #[trigger] s.message_sent(m)
+            &&& resp_msg_matches_req_msg(m, controller_req_msg(APIRequest::GetRequest(GetRequest{key: cr_key})))
+        }
+    });
+    assert forall |ex| #[trigger] exists_m_to_pre1.satisfied_by(ex) implies tla_exists(m_to_pre1).satisfied_by(ex) by {
+        let m = choose |m: Message| {
+            &&& #[trigger] ex.head().message_sent(m)
+            &&& resp_msg_matches_req_msg(m, controller_req_msg(APIRequest::GetRequest(GetRequest{key: cr_key})))
+        };
+        assert(m_to_pre1(m).satisfied_by(ex));
+    };
+    temp_pred_equality::<State>(exists_m_to_pre1, tla_exists(m_to_pre1));
+}
 
 }

--- a/src/simple_controller/spec/simple_reconciler.rs
+++ b/src/simple_controller/spec/simple_reconciler.rs
@@ -106,19 +106,19 @@ pub open spec fn create_cm_req(cr_key: ResourceKey) -> APIRequest
     })
 }
 
-pub open spec fn create_sts_req(cr_key: ResourceKey) -> APIRequest
-    recommends
-        cr_key.kind.is_CustomResourceKind(),
-{
-    APIRequest::CreateRequest(CreateRequest{
-        obj: ResourceObj {
-            key: ResourceKey {
-                name: cr_key.name + sts_suffix(),
-                namespace: cr_key.namespace,
-                kind: ResourceKind::StatefulSetKind
-            },
-        },
-    })
-}
+// pub open spec fn create_sts_req(cr_key: ResourceKey) -> APIRequest
+//     recommends
+//         cr_key.kind.is_CustomResourceKind(),
+// {
+//     APIRequest::CreateRequest(CreateRequest{
+//         obj: ResourceObj {
+//             key: ResourceKey {
+//                 name: cr_key.name + sts_suffix(),
+//                 namespace: cr_key.namespace,
+//                 kind: ResourceKind::StatefulSetKind
+//             },
+//         },
+//     })
+// }
 
 }

--- a/src/temporal_logic/rules.rs
+++ b/src/temporal_logic/rules.rs
@@ -653,6 +653,17 @@ pub proof fn tla_forall_always_equality<T, A>(a_to_p: FnSpec(A) -> TempPred<T>)
     temp_pred_equality::<T>(tla_forall(|a: A| always(a_to_p(a))), always(tla_forall(a_to_p)));
 }
 
+pub proof fn tla_forall_always_equality_variant<T, A>(a_to_always: FnSpec(A) -> TempPred<T>, a_to_p: FnSpec(A) -> TempPred<T>)
+    requires
+        forall |a: A| #![trigger a_to_always(a)] valid(a_to_always(a).equals((|a: A| always(a_to_p(a)))(a))),
+    ensures
+        tla_forall(a_to_always) === always(tla_forall(a_to_p)),
+{
+    a_to_temp_pred_equality::<T, A>(a_to_always, |a: A| always(a_to_p(a)));
+    temp_pred_equality::<T>(tla_forall(a_to_always), tla_forall(|a: A| always(a_to_p(a))));
+    tla_forall_always_equality::<T, A>(a_to_p);
+}
+
 pub proof fn tla_forall_not_equality<T, A>(a_to_p: FnSpec(A) -> TempPred<T>)
     ensures
         tla_forall(|a: A| not(a_to_p(a))) === not(tla_exists(a_to_p)),
@@ -766,11 +777,7 @@ pub proof fn tla_forall_leads_to_equality1<T, A>(a_to_p: FnSpec(A) -> TempPred<T
     ensures
         tla_forall(|a: A| a_to_p(a).leads_to(q)) === tla_exists(a_to_p).leads_to(q),
 {
-    let a_to_p_implies_eventually_q = |a: A| a_to_p(a).implies(eventually(q));
-    a_to_temp_pred_equality::<T, A>(|a: A| a_to_p(a).leads_to(q), |a: A| always(a_to_p_implies_eventually_q(a)));
-    temp_pred_equality::<T>(tla_forall(|a: A| a_to_p(a).leads_to(q)), tla_forall(|a: A| always(a_to_p_implies_eventually_q(a))));
-    tla_forall_always_equality::<T, A>(|a: A| a_to_p(a).implies(eventually(q)));
-
+    tla_forall_always_equality_variant::<T, A>(|a: A| a_to_p(a).leads_to(q), |a: A| a_to_p(a).implies(eventually(q)));
     tla_forall_implies_equality1::<T, A>(a_to_p, eventually(q));
 }
 
@@ -778,11 +785,7 @@ pub proof fn tla_forall_always_implies_equality2<T, A>(p: TempPred<T>, a_to_q: F
     ensures
         tla_forall(|a: A| always(p.implies(a_to_q(a)))) === always(p.implies(tla_forall(a_to_q))),
 {
-    let a_to_p_implies_q = |a: A| p.implies(a_to_q(a));
-    a_to_temp_pred_equality::<T, A>(|a: A| always(p.implies(a_to_q(a))), |a: A| always(a_to_p_implies_q(a)));
-    temp_pred_equality::<T>(tla_forall(|a: A| always(p.implies(a_to_q(a)))), tla_forall(|a: A| always(a_to_p_implies_q(a))));
-    tla_forall_always_equality::<T, A>(a_to_p_implies_q);
-
+    tla_forall_always_equality_variant::<T, A>(|a: A| always(p.implies(a_to_q(a))), |a: A| p.implies(a_to_q(a)));
     tla_forall_implies_equality2::<T, A>(p, a_to_q);
 }
 


### PR DESCRIPTION
This PR does the following:
- Prove all the lemmas used by simple controller liveness proof
- Simplify some lemmas using a new lemma tla_forall_always_equality_variant
- Simplify some lemmas using a new lemma execution_equality, which replaces the old execution_merge/split lemmas