### PR TITLE
Make ReconcileState a generic type RS

### DIFF
--- a/src/kubernetes_cluster/proof/controller_runtime_liveness.rs
+++ b/src/kubernetes_cluster/proof/controller_runtime_liveness.rs
@@ -22,67 +22,67 @@ use builtin_macros::*;
 
 verus! {
 
-pub proof fn lemma_pre_leads_to_post_by_controller(reconciler: Reconciler, input: ControllerActionInput, action: ControllerAction, pre: StatePred<State>, post: StatePred<State>)
+pub proof fn lemma_pre_leads_to_post_by_controller<RS>(reconciler: Reconciler<RS>, input: ControllerActionInput, action: ControllerAction<RS>, pre: StatePred<State<RS>>, post: StatePred<State<RS>>)
     requires
         controller(reconciler).actions.contains(action),
-        forall |s, s_prime: State| pre(s) && #[trigger] next(reconciler)(s, s_prime) ==> pre(s_prime) || post(s_prime),
-        forall |s, s_prime: State| pre(s) && #[trigger] next(reconciler)(s, s_prime) && controller_next(reconciler).forward(input)(s, s_prime) ==> post(s_prime),
-        forall |s: State| #[trigger] pre(s) ==> controller_action_pre(reconciler, action, input)(s),
+        forall |s, s_prime: State<RS>| pre(s) && #[trigger] next(reconciler)(s, s_prime) ==> pre(s_prime) || post(s_prime),
+        forall |s, s_prime: State<RS>| pre(s) && #[trigger] next(reconciler)(s, s_prime) && controller_next(reconciler).forward(input)(s, s_prime) ==> post(s_prime),
+        forall |s: State<RS>| #[trigger] pre(s) ==> controller_action_pre(reconciler, action, input)(s),
     ensures
         sm_spec(reconciler).entails(lift_state(pre).leads_to(lift_state(post))),
 {
-    use_tla_forall::<State, ControllerActionInput>(sm_spec(reconciler), |i| controller_next(reconciler).weak_fairness(i), input);
+    use_tla_forall::<State<RS>, ControllerActionInput>(sm_spec(reconciler), |i| controller_next(reconciler).weak_fairness(i), input);
 
-    controller_action_pre_implies_next_pre(reconciler, action, input);
-    valid_implies_trans::<State>(lift_state(pre), lift_state(controller_action_pre(reconciler, action, input)), lift_state(controller_next(reconciler).pre(input)));
+    controller_action_pre_implies_next_pre::<RS>(reconciler, action, input);
+    valid_implies_trans::<State<RS>>(lift_state(pre), lift_state(controller_action_pre(reconciler, action, input)), lift_state(controller_next(reconciler).pre(input)));
 
     controller_next(reconciler).wf1(input, sm_spec(reconciler), next(reconciler), pre, post);
 }
 
-pub proof fn lemma_pre_leads_to_post_with_assumption_by_controller(reconciler: Reconciler, input: ControllerActionInput, action: ControllerAction, assumption: StatePred<State>, pre: StatePred<State>, post: StatePred<State>)
+pub proof fn lemma_pre_leads_to_post_with_assumption_by_controller<RS>(reconciler: Reconciler<RS>, input: ControllerActionInput, action: ControllerAction<RS>, assumption: StatePred<State<RS>>, pre: StatePred<State<RS>>, post: StatePred<State<RS>>)
     requires
         controller(reconciler).actions.contains(action),
-        forall |s, s_prime: State| pre(s) && #[trigger] next(reconciler)(s, s_prime) && assumption(s) ==> pre(s_prime) || post(s_prime),
-        forall |s, s_prime: State| pre(s) && #[trigger] next(reconciler)(s, s_prime) && controller_next(reconciler).forward(input)(s, s_prime) ==> post(s_prime),
-        forall |s: State| #[trigger] pre(s) ==> controller_action_pre(reconciler, action, input)(s),
+        forall |s, s_prime: State<RS>| pre(s) && #[trigger] next(reconciler)(s, s_prime) && assumption(s) ==> pre(s_prime) || post(s_prime),
+        forall |s, s_prime: State<RS>| pre(s) && #[trigger] next(reconciler)(s, s_prime) && controller_next(reconciler).forward(input)(s, s_prime) ==> post(s_prime),
+        forall |s: State<RS>| #[trigger] pre(s) ==> controller_action_pre(reconciler, action, input)(s),
     ensures
         sm_spec(reconciler).entails(lift_state(pre).and(always(lift_state(assumption))).leads_to(lift_state(post))),
 {
-    use_tla_forall::<State, ControllerActionInput>(sm_spec(reconciler), |i| controller_next(reconciler).weak_fairness(i), input);
+    use_tla_forall::<State<RS>, ControllerActionInput>(sm_spec(reconciler), |i| controller_next(reconciler).weak_fairness(i), input);
 
-    controller_action_pre_implies_next_pre(reconciler, action, input);
-    valid_implies_trans::<State>(lift_state(pre), lift_state(controller_action_pre(reconciler, action, input)), lift_state(controller_next(reconciler).pre(input)));
+    controller_action_pre_implies_next_pre::<RS>(reconciler, action, input);
+    valid_implies_trans::<State<RS>>(lift_state(pre), lift_state(controller_action_pre(reconciler, action, input)), lift_state(controller_next(reconciler).pre(input)));
 
     controller_next(reconciler).wf1_assume(input, sm_spec(reconciler), next(reconciler), assumption, pre, post);
 }
 
-pub proof fn lemma_relevant_event_sent_leads_to_reconcile_triggered(reconciler: Reconciler, msg: Message, cr_key: ResourceKey)
+pub proof fn lemma_relevant_event_sent_leads_to_reconcile_triggered<RS>(reconciler: Reconciler<RS>, msg: Message, cr_key: ResourceKey)
     requires
         cr_key.kind.is_CustomResourceKind(),
     ensures
         sm_spec(reconciler).entails(
-            lift_state(|s: State| {
+            lift_state(|s: State<RS>| {
                 &&& s.message_sent(msg)
                 &&& msg.dst === HostId::CustomController
                 &&& msg.content.is_WatchEvent()
                 &&& (reconciler.reconcile_trigger)(msg) === Option::Some(cr_key)
                 &&& !s.reconcile_state_contains(cr_key)
             })
-                .leads_to(lift_state(|s: State| {
+                .leads_to(lift_state(|s: State<RS>| {
                     &&& s.reconcile_state_contains(cr_key)
                     &&& s.reconcile_state_of(cr_key).local_state === (reconciler.reconcile_init_state)()
                     &&& s.reconcile_state_of(cr_key).pending_req_msg.is_None()
                 }))
         ),
 {
-    let pre = |s: State| {
+    let pre = |s: State<RS>| {
         &&& s.message_sent(msg)
         &&& msg.dst === HostId::CustomController
         &&& msg.content.is_WatchEvent()
         &&& (reconciler.reconcile_trigger)(msg) === Option::Some(cr_key)
         &&& !s.reconcile_state_contains(cr_key)
     };
-    let post = |s: State| {
+    let post = |s: State<RS>| {
         &&& s.reconcile_state_contains(cr_key)
         &&& s.reconcile_state_of(cr_key).local_state === (reconciler.reconcile_init_state)()
         &&& s.reconcile_state_of(cr_key).pending_req_msg.is_None()
@@ -91,29 +91,29 @@ pub proof fn lemma_relevant_event_sent_leads_to_reconcile_triggered(reconciler: 
         recv: Option::Some(msg),
         scheduled_cr_key: Option::None,
     };
-    lemma_pre_leads_to_post_by_controller(reconciler, input, trigger_reconcile(reconciler), pre, post);
+    lemma_pre_leads_to_post_by_controller::<RS>(reconciler, input, trigger_reconcile(reconciler), pre, post);
 }
 
-pub proof fn lemma_reconcile_done_leads_to_reconcile_scheduled(reconciler: Reconciler, cr_key: ResourceKey)
+pub proof fn lemma_reconcile_done_leads_to_reconcile_scheduled<RS>(reconciler: Reconciler<RS>, cr_key: ResourceKey)
     requires
         cr_key.kind.is_CustomResourceKind(),
     ensures
         sm_spec(reconciler).entails(
-            lift_state(|s: State| {
+            lift_state(|s: State<RS>| {
                 &&& s.reconcile_state_contains(cr_key)
                 &&& (reconciler.reconcile_done)(s.reconcile_state_of(cr_key).local_state)
             })
-                .leads_to(lift_state(|s: State| {
+                .leads_to(lift_state(|s: State<RS>| {
                     &&& !s.reconcile_state_contains(cr_key)
                     &&& s.reconcile_scheduled_for(cr_key)
                 }))
         ),
 {
-    let pre = |s: State| {
+    let pre = |s: State<RS>| {
         &&& s.reconcile_state_contains(cr_key)
         &&& (reconciler.reconcile_done)(s.reconcile_state_of(cr_key).local_state)
     };
-    let post = |s: State| {
+    let post = |s: State<RS>| {
         &&& !s.reconcile_state_contains(cr_key)
         &&& s.reconcile_scheduled_for(cr_key)
     };
@@ -121,30 +121,30 @@ pub proof fn lemma_reconcile_done_leads_to_reconcile_scheduled(reconciler: Recon
         recv: Option::None,
         scheduled_cr_key: Option::Some(cr_key),
     };
-    lemma_pre_leads_to_post_by_controller(reconciler, input, end_reconcile(reconciler), pre, post);
+    lemma_pre_leads_to_post_by_controller::<RS>(reconciler, input, end_reconcile(reconciler), pre, post);
 }
 
-pub proof fn lemma_scheduled_reconcile_leads_to_init(reconciler: Reconciler, cr_key: ResourceKey)
+pub proof fn lemma_scheduled_reconcile_leads_to_init<RS>(reconciler: Reconciler<RS>, cr_key: ResourceKey)
     requires
         cr_key.kind.is_CustomResourceKind(),
     ensures
         sm_spec(reconciler).entails(
-            lift_state(|s: State| {
+            lift_state(|s: State<RS>| {
                 &&& !s.reconcile_state_contains(cr_key)
                 &&& s.reconcile_scheduled_for(cr_key)
             })
-                .leads_to(lift_state(|s: State| {
+                .leads_to(lift_state(|s: State<RS>| {
                     &&& s.reconcile_state_contains(cr_key)
                     &&& s.reconcile_state_of(cr_key).local_state === (reconciler.reconcile_init_state)()
                     &&& s.reconcile_state_of(cr_key).pending_req_msg.is_None()
                 }))
         ),
 {
-    let pre = |s: State| {
+    let pre = |s: State<RS>| {
         &&& !s.reconcile_state_contains(cr_key)
         &&& s.reconcile_scheduled_for(cr_key)
     };
-    let post = |s: State| {
+    let post = |s: State<RS>| {
         &&& s.reconcile_state_contains(cr_key)
         &&& s.reconcile_state_of(cr_key).local_state === (reconciler.reconcile_init_state)()
         &&& s.reconcile_state_of(cr_key).pending_req_msg.is_None()
@@ -153,41 +153,41 @@ pub proof fn lemma_scheduled_reconcile_leads_to_init(reconciler: Reconciler, cr_
         recv: Option::None,
         scheduled_cr_key: Option::Some(cr_key),
     };
-    lemma_pre_leads_to_post_by_controller(reconciler, input, run_scheduled_reconcile(reconciler), pre, post);
+    lemma_pre_leads_to_post_by_controller::<RS>(reconciler, input, run_scheduled_reconcile(reconciler), pre, post);
 }
 
-pub proof fn lemma_reconcile_done_leads_to_reconcile_triggered(reconciler: Reconciler, cr_key: ResourceKey)
+pub proof fn lemma_reconcile_done_leads_to_reconcile_triggered<RS>(reconciler: Reconciler<RS>, cr_key: ResourceKey)
     requires
         cr_key.kind.is_CustomResourceKind(),
     ensures
         sm_spec(reconciler).entails(
-            lift_state(|s: State| {
+            lift_state(|s: State<RS>| {
                 &&& s.reconcile_state_contains(cr_key)
                 &&& (reconciler.reconcile_done)(s.reconcile_state_of(cr_key).local_state)
             })
-                .leads_to(lift_state(|s: State| {
+                .leads_to(lift_state(|s: State<RS>| {
                     &&& s.reconcile_state_contains(cr_key)
                     &&& s.reconcile_state_of(cr_key).local_state === (reconciler.reconcile_init_state)()
                     &&& s.reconcile_state_of(cr_key).pending_req_msg.is_None()
                 }))
         ),
 {
-    lemma_reconcile_done_leads_to_reconcile_scheduled(reconciler, cr_key);
-    lemma_scheduled_reconcile_leads_to_init(reconciler, cr_key);
-    let reconcile_ended = |s: State| {
+    lemma_reconcile_done_leads_to_reconcile_scheduled::<RS>(reconciler, cr_key);
+    lemma_scheduled_reconcile_leads_to_init::<RS>(reconciler, cr_key);
+    let reconcile_ended = |s: State<RS>| {
         &&& s.reconcile_state_contains(cr_key)
         &&& (reconciler.reconcile_done)(s.reconcile_state_of(cr_key).local_state)
     };
-    let reconcile_rescheduled = |s: State| {
+    let reconcile_rescheduled = |s: State<RS>| {
         &&& !s.reconcile_state_contains(cr_key)
         &&& s.reconcile_scheduled_for(cr_key)
     };
-    let reconcile_at_init = |s: State| {
+    let reconcile_at_init = |s: State<RS>| {
         &&& s.reconcile_state_contains(cr_key)
         &&& s.reconcile_state_of(cr_key).local_state === (reconciler.reconcile_init_state)()
         &&& s.reconcile_state_of(cr_key).pending_req_msg.is_None()
     };
-    leads_to_trans::<State>(sm_spec(reconciler), reconcile_ended, reconcile_rescheduled, reconcile_at_init);
+    leads_to_trans::<State<RS>>(sm_spec(reconciler), reconcile_ended, reconcile_rescheduled, reconcile_at_init);
 }
 
 }

--- a/src/kubernetes_cluster/proof/kubernetes_api_liveness.rs
+++ b/src/kubernetes_cluster/proof/kubernetes_api_liveness.rs
@@ -19,91 +19,91 @@ use builtin_macros::*;
 
 verus! {
 
-pub proof fn lemma_pre_leads_to_post_by_kubernetes_api<RS>(reconciler: Reconciler<RS>, input: KubernetesAPIActionInput, action: KubernetesAPIAction, pre: StatePred<State<RS>>, post: StatePred<State<RS>>)
+pub proof fn lemma_pre_leads_to_post_by_kubernetes_api<T>(reconciler: Reconciler<T>, input: KubernetesAPIActionInput, action: KubernetesAPIAction, pre: StatePred<State<T>>, post: StatePred<State<T>>)
     requires
         kubernetes_api().actions.contains(action),
-        forall |s, s_prime: State<RS>| pre(s) && #[trigger] next(reconciler)(s, s_prime) ==> pre(s_prime) || post(s_prime),
-        forall |s, s_prime: State<RS>| pre(s) && #[trigger] next(reconciler)(s, s_prime) && kubernetes_api_next().forward(input)(s, s_prime) ==> post(s_prime),
-        forall |s: State<RS>| #[trigger] pre(s) ==> kubernetes_api_action_pre(action, input)(s),
+        forall |s, s_prime: State<T>| pre(s) && #[trigger] next(reconciler)(s, s_prime) ==> pre(s_prime) || post(s_prime),
+        forall |s, s_prime: State<T>| pre(s) && #[trigger] next(reconciler)(s, s_prime) && kubernetes_api_next().forward(input)(s, s_prime) ==> post(s_prime),
+        forall |s: State<T>| #[trigger] pre(s) ==> kubernetes_api_action_pre(action, input)(s),
     ensures
         sm_spec(reconciler).entails(lift_state(pre).leads_to(lift_state(post))),
 {
-    use_tla_forall::<State<RS>, KubernetesAPIActionInput>(sm_spec(reconciler), |i| kubernetes_api_next().weak_fairness(i), input);
+    use_tla_forall::<State<T>, KubernetesAPIActionInput>(sm_spec(reconciler), |i| kubernetes_api_next().weak_fairness(i), input);
 
-    kubernetes_api_action_pre_implies_next_pre::<RS>(action, input);
-    valid_implies_trans::<State<RS>>(lift_state(pre), lift_state(kubernetes_api_action_pre(action, input)), lift_state(kubernetes_api_next().pre(input)));
+    kubernetes_api_action_pre_implies_next_pre::<T>(action, input);
+    valid_implies_trans::<State<T>>(lift_state(pre), lift_state(kubernetes_api_action_pre(action, input)), lift_state(kubernetes_api_next().pre(input)));
 
     kubernetes_api_next().wf1(input, sm_spec(reconciler), next(reconciler), pre, post);
 }
 
-pub proof fn lemma_pre_leads_to_post_with_assumption_by_kubernetes_api<RS>(reconciler: Reconciler<RS>, input: KubernetesAPIActionInput, action: KubernetesAPIAction, assumption: StatePred<State<RS>>, pre: StatePred<State<RS>>, post: StatePred<State<RS>>)
+pub proof fn lemma_pre_leads_to_post_with_assumption_by_kubernetes_api<T>(reconciler: Reconciler<T>, input: KubernetesAPIActionInput, action: KubernetesAPIAction, assumption: StatePred<State<T>>, pre: StatePred<State<T>>, post: StatePred<State<T>>)
     requires
         kubernetes_api().actions.contains(action),
-        forall |s, s_prime: State<RS>| pre(s) && #[trigger] next(reconciler)(s, s_prime) && assumption(s) ==> pre(s_prime) || post(s_prime),
-        forall |s, s_prime: State<RS>| pre(s) && #[trigger] next(reconciler)(s, s_prime) && kubernetes_api_next().forward(input)(s, s_prime) ==> post(s_prime),
-        forall |s: State<RS>| #[trigger] pre(s) ==> kubernetes_api_action_pre(action, input)(s),
+        forall |s, s_prime: State<T>| pre(s) && #[trigger] next(reconciler)(s, s_prime) && assumption(s) ==> pre(s_prime) || post(s_prime),
+        forall |s, s_prime: State<T>| pre(s) && #[trigger] next(reconciler)(s, s_prime) && kubernetes_api_next().forward(input)(s, s_prime) ==> post(s_prime),
+        forall |s: State<T>| #[trigger] pre(s) ==> kubernetes_api_action_pre(action, input)(s),
     ensures
         sm_spec(reconciler).entails(lift_state(pre).and(always(lift_state(assumption))).leads_to(lift_state(post))),
 {
-    use_tla_forall::<State<RS>, KubernetesAPIActionInput>(sm_spec(reconciler), |i| kubernetes_api_next().weak_fairness(i), input);
+    use_tla_forall::<State<T>, KubernetesAPIActionInput>(sm_spec(reconciler), |i| kubernetes_api_next().weak_fairness(i), input);
 
-    kubernetes_api_action_pre_implies_next_pre::<RS>(action, input);
-    valid_implies_trans::<State<RS>>(lift_state(pre), lift_state(kubernetes_api_action_pre(action, input)), lift_state(kubernetes_api_next().pre(input)));
+    kubernetes_api_action_pre_implies_next_pre::<T>(action, input);
+    valid_implies_trans::<State<T>>(lift_state(pre), lift_state(kubernetes_api_action_pre(action, input)), lift_state(kubernetes_api_next().pre(input)));
 
     kubernetes_api_next().wf1_assume(input, sm_spec(reconciler), next(reconciler), assumption, pre, post);
 }
 
-pub proof fn lemma_create_req_leads_to_ok_resp<RS>(reconciler: Reconciler<RS>, msg: Message)
+pub proof fn lemma_create_req_leads_to_ok_resp<T>(reconciler: Reconciler<T>, msg: Message)
     ensures
         sm_spec(reconciler).entails(
-            lift_state(|s: State<RS>| {
+            lift_state(|s: State<T>| {
                 &&& s.message_sent(msg)
                 &&& msg.dst === HostId::KubernetesAPI
                 &&& msg.is_create_request()
                 &&& !s.resource_key_exists(msg.get_create_request().obj.key)
             })
-            .and(always(lift_state(|s: State<RS>| {
+            .and(always(lift_state(|s: State<T>| {
                 forall |other: Message|
                     #[trigger] s.message_sent(other) && other.content === msg.content && other.dst === msg.dst
                         ==> other === msg
             })))
                 .leads_to(
-                    lift_state(|s: State<RS>| {
+                    lift_state(|s: State<T>| {
                         &&& s.message_sent(form_msg(msg.dst, msg.src, create_resp_msg(Result::Ok(msg.get_create_request().obj), msg.get_create_request())))
                         &&& s.resource_key_exists(msg.get_create_request().obj.key)
                     })
                 )
         ),
 {
-    let assumption = |s: State<RS>| {
+    let assumption = |s: State<T>| {
         forall |other: Message|
             #[trigger] s.message_sent(other) && other.content === msg.content && other.dst === msg.dst
                 ==> other === msg
     };
-    let pre = |s: State<RS>| {
+    let pre = |s: State<T>| {
         &&& s.message_sent(msg)
         &&& msg.dst === HostId::KubernetesAPI
         &&& msg.is_create_request()
         &&& !s.resource_key_exists(msg.get_create_request().obj.key)
     };
-    let post = |s: State<RS>| {
+    let post = |s: State<T>| {
         &&& s.message_sent(form_msg(msg.dst, msg.src, create_resp_msg(Result::Ok(msg.get_create_request().obj), msg.get_create_request())))
         &&& s.resource_key_exists(msg.get_create_request().obj.key)
     };
-    lemma_pre_leads_to_post_with_assumption_by_kubernetes_api::<RS>(reconciler, Option::Some(msg), handle_request(), assumption, pre, post);
+    lemma_pre_leads_to_post_with_assumption_by_kubernetes_api::<T>(reconciler, Option::Some(msg), handle_request(), assumption, pre, post);
 }
 
-pub proof fn lemma_get_req_leads_to_some_resp<RS>(reconciler: Reconciler<RS>, msg: Message, key: ResourceKey)
+pub proof fn lemma_get_req_leads_to_some_resp<T>(reconciler: Reconciler<T>, msg: Message, key: ResourceKey)
     ensures
         sm_spec(reconciler).entails(
-            lift_state(|s: State<RS>| {
+            lift_state(|s: State<T>| {
                     &&& s.message_sent(msg)
                     &&& msg.dst === HostId::KubernetesAPI
                     &&& msg.is_get_request()
                     &&& msg.get_get_request().key === key
                 })
                 .leads_to(
-                    lift_state(|s: State<RS>|
+                    lift_state(|s: State<T>|
                         exists |resp_msg: Message| {
                             &&& #[trigger] s.message_sent(resp_msg)
                             &&& resp_msg_matches_req_msg(resp_msg, msg)
@@ -113,17 +113,17 @@ pub proof fn lemma_get_req_leads_to_some_resp<RS>(reconciler: Reconciler<RS>, ms
         ),
 {
     let input = Option::Some(msg);
-    let pre = |s: State<RS>| {
+    let pre = |s: State<T>| {
         &&& s.message_sent(msg)
         &&& msg.dst === HostId::KubernetesAPI
         &&& msg.is_get_request()
         &&& msg.get_get_request().key === key
     };
-    let post = |s: State<RS>| exists |resp_msg: Message| {
+    let post = |s: State<T>| exists |resp_msg: Message| {
         &&& #[trigger] s.message_sent(resp_msg)
         &&& resp_msg_matches_req_msg(resp_msg, msg)
     };
-    assert forall |s, s_prime: State<RS>| pre(s) && #[trigger] next(reconciler)(s, s_prime) && kubernetes_api_next().forward(input)(s, s_prime)
+    assert forall |s, s_prime: State<T>| pre(s) && #[trigger] next(reconciler)(s, s_prime) && kubernetes_api_next().forward(input)(s, s_prime)
     implies post(s_prime) by {
         if s.resource_key_exists(key) {
             let ok_resp_msg = form_get_resp_msg(msg, Result::Ok(s.resource_obj_of(key)));
@@ -135,53 +135,53 @@ pub proof fn lemma_get_req_leads_to_some_resp<RS>(reconciler: Reconciler<RS>, ms
             assert(resp_msg_matches_req_msg(err_resp_msg, msg));
         }
     };
-    lemma_pre_leads_to_post_by_kubernetes_api::<RS>(reconciler, input, handle_request(), pre, post);
+    lemma_pre_leads_to_post_by_kubernetes_api::<T>(reconciler, input, handle_request(), pre, post);
 }
 
-pub proof fn lemma_get_req_leads_to_ok_or_err_resp<RS>(reconciler: Reconciler<RS>, msg: Message, key: ResourceKey)
+pub proof fn lemma_get_req_leads_to_ok_or_err_resp<T>(reconciler: Reconciler<T>, msg: Message, key: ResourceKey)
     ensures
         sm_spec(reconciler).entails(
-            lift_state(|s: State<RS>| {
+            lift_state(|s: State<T>| {
                 &&& s.message_sent(msg)
                 &&& msg.dst === HostId::KubernetesAPI
                 &&& msg.is_get_request()
                 &&& msg.get_get_request().key === key
             })
                 .leads_to(
-                    lift_state(|s: State<RS>| s.message_sent(form_get_resp_msg(msg, Result::Ok(s.resource_obj_of(key)))))
-                    .or(lift_state(|s: State<RS>| s.message_sent(form_get_resp_msg(msg, Result::Err(APIError::ObjectNotFound)))))
+                    lift_state(|s: State<T>| s.message_sent(form_get_resp_msg(msg, Result::Ok(s.resource_obj_of(key)))))
+                    .or(lift_state(|s: State<T>| s.message_sent(form_get_resp_msg(msg, Result::Err(APIError::ObjectNotFound)))))
                 )
         ),
 {
-    let pre = |s: State<RS>| {
+    let pre = |s: State<T>| {
         &&& s.message_sent(msg)
         &&& msg.dst === HostId::KubernetesAPI
         &&& msg.is_get_request()
         &&& msg.get_get_request().key === key
     };
-    let post = |s: State<RS>| {
+    let post = |s: State<T>| {
         ||| s.message_sent(form_get_resp_msg(msg, Result::Ok(s.resource_obj_of(key))))
         ||| s.message_sent(form_get_resp_msg(msg, Result::Err(APIError::ObjectNotFound)))
     };
-    lemma_pre_leads_to_post_by_kubernetes_api::<RS>(reconciler, Option::Some(msg), handle_request(), pre, post);
-    temp_pred_equality::<State<RS>>(
+    lemma_pre_leads_to_post_by_kubernetes_api::<T>(reconciler, Option::Some(msg), handle_request(), pre, post);
+    temp_pred_equality::<State<T>>(
         lift_state(post),
-        lift_state(|s: State<RS>| s.message_sent(form_get_resp_msg(msg, Result::Ok(s.resource_obj_of(key)))))
-        .or(lift_state(|s: State<RS>| s.message_sent(form_get_resp_msg(msg, Result::Err(APIError::ObjectNotFound)))))
+        lift_state(|s: State<T>| s.message_sent(form_get_resp_msg(msg, Result::Ok(s.resource_obj_of(key)))))
+        .or(lift_state(|s: State<T>| s.message_sent(form_get_resp_msg(msg, Result::Err(APIError::ObjectNotFound)))))
     );
 }
 
-pub proof fn lemma_get_req_leads_to_ok_resp_if_never_delete<RS>(reconciler: Reconciler<RS>, msg: Message, res: ResourceObj)
+pub proof fn lemma_get_req_leads_to_ok_resp_if_never_delete<T>(reconciler: Reconciler<T>, msg: Message, res: ResourceObj)
     ensures
         sm_spec(reconciler).entails(
-            lift_state(|s: State<RS>| {
+            lift_state(|s: State<T>| {
                 &&& s.message_sent(msg)
                 &&& msg.dst === HostId::KubernetesAPI
                 &&& msg.is_get_request()
                 &&& msg.get_get_request().key === res.key
                 &&& s.resource_obj_exists(res)
             })
-            .and(always(lift_state(|s: State<RS>| {
+            .and(always(lift_state(|s: State<T>| {
                 forall |other: Message|
                 !{
                     &&& #[trigger] s.message_sent(other)
@@ -190,17 +190,17 @@ pub proof fn lemma_get_req_leads_to_ok_resp_if_never_delete<RS>(reconciler: Reco
                     &&& other.get_delete_request().key === res.key
                 }
             })))
-                .leads_to(lift_state(|s: State<RS>| s.message_sent(form_get_resp_msg(msg, Result::Ok(res)))))
+                .leads_to(lift_state(|s: State<T>| s.message_sent(form_get_resp_msg(msg, Result::Ok(res)))))
         ),
 {
-    let pre = |s: State<RS>| {
+    let pre = |s: State<T>| {
         &&& s.message_sent(msg)
         &&& msg.dst === HostId::KubernetesAPI
         &&& msg.is_get_request()
         &&& msg.get_get_request().key === res.key
         &&& s.resource_obj_exists(res)
     };
-    let assumption = |s: State<RS>| {
+    let assumption = |s: State<T>| {
         forall |other: Message|
             !{
                 &&& #[trigger] s.message_sent(other)
@@ -209,7 +209,7 @@ pub proof fn lemma_get_req_leads_to_ok_resp_if_never_delete<RS>(reconciler: Reco
                 &&& other.get_delete_request().key === res.key
             }
     };
-    let post = |s: State<RS>| s.message_sent(form_msg(
+    let post = |s: State<T>| s.message_sent(form_msg(
         msg.dst,
         msg.src,
         get_resp_msg(
@@ -217,39 +217,39 @@ pub proof fn lemma_get_req_leads_to_ok_resp_if_never_delete<RS>(reconciler: Reco
             msg.get_get_request()
         )
     ));
-    lemma_pre_leads_to_post_with_assumption_by_kubernetes_api::<RS>(reconciler, Option::Some(msg), handle_request(), assumption, pre, post);
+    lemma_pre_leads_to_post_with_assumption_by_kubernetes_api::<T>(reconciler, Option::Some(msg), handle_request(), assumption, pre, post);
 }
 
-pub proof fn lemma_get_req_leads_to_ok_resp_if_res_always_exists<RS>(reconciler: Reconciler<RS>, msg: Message, res: ResourceObj)
+pub proof fn lemma_get_req_leads_to_ok_resp_if_res_always_exists<T>(reconciler: Reconciler<T>, msg: Message, res: ResourceObj)
     ensures
         sm_spec(reconciler).entails(
-            lift_state(|s: State<RS>| {
+            lift_state(|s: State<T>| {
                 &&& s.message_sent(msg)
                 &&& msg.dst === HostId::KubernetesAPI
                 &&& msg.is_get_request()
                 &&& msg.get_get_request().key === res.key
             })
-            .and(always(lift_state(|s: State<RS>| s.resource_obj_exists(res))))
-                .leads_to(lift_state(|s: State<RS>| s.message_sent(form_get_resp_msg(msg, Result::Ok(res)))))
+            .and(always(lift_state(|s: State<T>| s.resource_obj_exists(res))))
+                .leads_to(lift_state(|s: State<T>| s.message_sent(form_get_resp_msg(msg, Result::Ok(res)))))
         ),
 {
-    leads_to_weaken_auto::<State<RS>>(sm_spec(reconciler));
+    leads_to_weaken_auto::<State<T>>(sm_spec(reconciler));
 
-    let get_req_msg_sent = |s: State<RS>| {
+    let get_req_msg_sent = |s: State<T>| {
         &&& s.message_sent(msg)
         &&& msg.dst === HostId::KubernetesAPI
         &&& msg.is_get_request()
         &&& msg.get_get_request().key === res.key
     };
-    let res_exists = |s: State<RS>| s.resource_obj_exists(res);
-    let get_req_msg_sent_and_res_exists = |s: State<RS>| {
+    let res_exists = |s: State<T>| s.resource_obj_exists(res);
+    let get_req_msg_sent_and_res_exists = |s: State<T>| {
         &&& s.message_sent(msg)
         &&& msg.dst === HostId::KubernetesAPI
         &&& msg.is_get_request()
         &&& msg.get_get_request().key === res.key
         &&& s.resource_obj_exists(res)
     };
-    let delete_req_never_sent = |s: State<RS>| {
+    let delete_req_never_sent = |s: State<T>| {
         forall |other: Message|
         !{
             &&& #[trigger] s.message_sent(other)
@@ -258,18 +258,18 @@ pub proof fn lemma_get_req_leads_to_ok_resp_if_res_always_exists<RS>(reconciler:
             &&& other.get_delete_request().key === res.key
         }
     };
-    let ok_resp_msg_sent = |s: State<RS>| s.message_sent(form_get_resp_msg(msg, Result::Ok(res)));
+    let ok_resp_msg_sent = |s: State<T>| s.message_sent(form_get_resp_msg(msg, Result::Ok(res)));
 
-    lemma_always_res_always_exists_implies_forall_delete_never_sent::<RS>(reconciler, res);
+    lemma_always_res_always_exists_implies_forall_delete_never_sent::<T>(reconciler, res);
     // Now we have spec.entails(always(always(lift_state(res_exists)).implies(always(lift_state(delete_req_never_sent)))))
     // We want to add get_req_msg_sent_and_res_exists to both ends by using sandwich_always_implies_temp
-    sandwich_always_implies_temp::<State<RS>>(sm_spec(reconciler),
+    sandwich_always_implies_temp::<State<T>>(sm_spec(reconciler),
         lift_state(get_req_msg_sent_and_res_exists),
         always(lift_state(res_exists)),
         always(lift_state(delete_req_never_sent))
     );
 
-    lemma_get_req_leads_to_ok_resp_if_never_delete::<RS>(reconciler, msg, res);
+    lemma_get_req_leads_to_ok_resp_if_never_delete::<T>(reconciler, msg, res);
     // Use the assert to trigger leads_to_weaken_auto
     // The always-implies formula required by leads_to_weaken_auto is given by the above sandwich_always_implies_temp
     assert(sm_spec(reconciler).entails(
@@ -277,7 +277,7 @@ pub proof fn lemma_get_req_leads_to_ok_resp_if_res_always_exists<RS>(reconciler:
             .leads_to(lift_state(ok_resp_msg_sent))
     ));
 
-    temp_pred_equality::<State<RS>>(
+    temp_pred_equality::<State<T>>(
         lift_state(get_req_msg_sent_and_res_exists).and(always(lift_state(res_exists))),
         lift_state(get_req_msg_sent).and(lift_state(res_exists).and(always(lift_state(res_exists))))
     );
@@ -287,62 +287,62 @@ pub proof fn lemma_get_req_leads_to_ok_resp_if_res_always_exists<RS>(reconciler:
             .leads_to(lift_state(ok_resp_msg_sent))
     ));
     // Last step: use p_and_always_p_equals_always_p to remove the .and(lift_state(res_exists)) from the premise
-    p_and_always_p_equals_always_p::<State<RS>>(lift_state(res_exists));
+    p_and_always_p_equals_always_p::<State<T>>(lift_state(res_exists));
 }
 
-pub proof fn lemma_create_req_leads_to_res_exists<RS>(reconciler: Reconciler<RS>, msg: Message, res: ResourceObj)
+pub proof fn lemma_create_req_leads_to_res_exists<T>(reconciler: Reconciler<T>, msg: Message, res: ResourceObj)
     ensures
         sm_spec(reconciler).entails(
-            lift_state(|s: State<RS>| {
+            lift_state(|s: State<T>| {
                 &&& s.message_sent(msg)
                 &&& msg.dst === HostId::KubernetesAPI
                 &&& msg.is_create_request()
                 &&& msg.get_create_request().obj === res
             })
-                .leads_to(lift_state(|s: State<RS>| s.resource_key_exists(res.key)))
+                .leads_to(lift_state(|s: State<T>| s.resource_key_exists(res.key)))
         ),
 {
-    let pre = |s: State<RS>| {
+    let pre = |s: State<T>| {
         &&& s.message_sent(msg)
         &&& msg.dst === HostId::KubernetesAPI
         &&& msg.is_create_request()
         &&& msg.get_create_request().obj === res
     };
-    let post = |s: State<RS>| {
+    let post = |s: State<T>| {
         s.resource_key_exists(res.key)
     };
-    lemma_pre_leads_to_post_by_kubernetes_api::<RS>(reconciler, Option::Some(msg), handle_request(), pre, post);
+    lemma_pre_leads_to_post_by_kubernetes_api::<T>(reconciler, Option::Some(msg), handle_request(), pre, post);
 }
 
-pub proof fn lemma_delete_req_leads_to_res_not_exists<RS>(reconciler: Reconciler<RS>, msg: Message, res: ResourceObj)
+pub proof fn lemma_delete_req_leads_to_res_not_exists<T>(reconciler: Reconciler<T>, msg: Message, res: ResourceObj)
     ensures
         sm_spec(reconciler).entails(
-            lift_state(|s: State<RS>| {
+            lift_state(|s: State<T>| {
                 &&& s.message_sent(msg)
                 &&& msg.dst === HostId::KubernetesAPI
                 &&& msg.is_delete_request()
                 &&& msg.get_delete_request().key === res.key
             })
-                .leads_to(lift_state(|s: State<RS>| !s.resource_obj_exists(res)))
+                .leads_to(lift_state(|s: State<T>| !s.resource_obj_exists(res)))
         ),
 {
-    let pre = |s: State<RS>| {
+    let pre = |s: State<T>| {
         &&& s.message_sent(msg)
         &&& msg.dst === HostId::KubernetesAPI
         &&& msg.is_delete_request()
         &&& msg.get_delete_request().key === res.key
     };
-    let post = |s: State<RS>| {
+    let post = |s: State<T>| {
         !s.resource_obj_exists(res)
     };
-    lemma_pre_leads_to_post_by_kubernetes_api::<RS>(reconciler, Option::Some(msg), handle_request(), pre, post);
+    lemma_pre_leads_to_post_by_kubernetes_api::<T>(reconciler, Option::Some(msg), handle_request(), pre, post);
 }
 
-pub proof fn lemma_always_res_always_exists_implies_delete_never_sent<RS>(reconciler: Reconciler<RS>, msg: Message, res: ResourceObj)
+pub proof fn lemma_always_res_always_exists_implies_delete_never_sent<T>(reconciler: Reconciler<T>, msg: Message, res: ResourceObj)
     ensures
         sm_spec(reconciler).entails(always(
-            always(lift_state(|s: State<RS>| s.resource_obj_exists(res)))
-                .implies(always(lift_state(|s: State<RS>| {
+            always(lift_state(|s: State<T>| s.resource_obj_exists(res)))
+                .implies(always(lift_state(|s: State<T>| {
                     !{
                         &&& s.message_sent(msg)
                         &&& msg.dst === HostId::KubernetesAPI
@@ -352,28 +352,28 @@ pub proof fn lemma_always_res_always_exists_implies_delete_never_sent<RS>(reconc
                 })))
         )),
 {
-    lemma_delete_req_leads_to_res_not_exists::<RS>(reconciler, msg, res);
-    leads_to_contraposition::<State<RS>>(sm_spec(reconciler),
-        |s: State<RS>| {
+    lemma_delete_req_leads_to_res_not_exists::<T>(reconciler, msg, res);
+    leads_to_contraposition::<State<T>>(sm_spec(reconciler),
+        |s: State<T>| {
             &&& s.message_sent(msg)
             &&& msg.dst === HostId::KubernetesAPI
             &&& msg.is_delete_request()
             &&& msg.get_delete_request().key === res.key
         },
-        |s: State<RS>| !s.resource_obj_exists(res)
+        |s: State<T>| !s.resource_obj_exists(res)
     );
-    temp_pred_equality::<State<RS>>(
-        not(lift_state(|s: State<RS>| !s.resource_obj_exists(res))),
-        lift_state(|s: State<RS>| s.resource_obj_exists(res))
+    temp_pred_equality::<State<T>>(
+        not(lift_state(|s: State<T>| !s.resource_obj_exists(res))),
+        lift_state(|s: State<T>| s.resource_obj_exists(res))
     );
-    temp_pred_equality::<State<RS>>(
-        not(lift_state(|s: State<RS>| {
+    temp_pred_equality::<State<T>>(
+        not(lift_state(|s: State<T>| {
             &&& s.message_sent(msg)
             &&& msg.dst === HostId::KubernetesAPI
             &&& msg.is_delete_request()
             &&& msg.get_delete_request().key === res.key
         })),
-        lift_state(|s: State<RS>| {
+        lift_state(|s: State<T>| {
             !{
                 &&& s.message_sent(msg)
                 &&& msg.dst === HostId::KubernetesAPI
@@ -385,11 +385,11 @@ pub proof fn lemma_always_res_always_exists_implies_delete_never_sent<RS>(reconc
 }
 
 /// How to prove this? It is obvious according to lemma_always_res_always_exists_implies_delete_never_sent
-pub proof fn lemma_always_res_always_exists_implies_forall_delete_never_sent<RS>(reconciler: Reconciler<RS>, res: ResourceObj)
+pub proof fn lemma_always_res_always_exists_implies_forall_delete_never_sent<T>(reconciler: Reconciler<T>, res: ResourceObj)
     ensures
         sm_spec(reconciler).entails(always(
-            always(lift_state(|s: State<RS>| s.resource_obj_exists(res)))
-                .implies(always(lift_state(|s: State<RS>| {
+            always(lift_state(|s: State<T>| s.resource_obj_exists(res)))
+                .implies(always(lift_state(|s: State<T>| {
                     forall |msg: Message|
                     !{
                         &&& #[trigger] s.message_sent(msg)
@@ -400,8 +400,8 @@ pub proof fn lemma_always_res_always_exists_implies_forall_delete_never_sent<RS>
                 })))
         )),
 {
-    let pre = always(lift_state(|s: State<RS>| s.resource_obj_exists(res)));
-    let m_to_always_m_not_sent = |msg: Message| always(lift_state(|s: State<RS>| {
+    let pre = always(lift_state(|s: State<T>| s.resource_obj_exists(res)));
+    let m_to_always_m_not_sent = |msg: Message| always(lift_state(|s: State<T>| {
         !{
             &&& s.message_sent(msg)
             &&& msg.dst === HostId::KubernetesAPI
@@ -412,9 +412,9 @@ pub proof fn lemma_always_res_always_exists_implies_forall_delete_never_sent<RS>
     assert forall |msg: Message| sm_spec(reconciler).entails(#[trigger] always(pre.implies(m_to_always_m_not_sent(msg)))) by {
         lemma_always_res_always_exists_implies_delete_never_sent(reconciler, msg, res);
     };
-    always_implies_forall_intro::<State<RS>, Message>(sm_spec(reconciler), pre, m_to_always_m_not_sent);
+    always_implies_forall_intro::<State<T>, Message>(sm_spec(reconciler), pre, m_to_always_m_not_sent);
 
-    let m_to_m_not_sent = |msg: Message| lift_state(|s: State<RS>| {
+    let m_to_m_not_sent = |msg: Message| lift_state(|s: State<T>| {
         !{
             &&& s.message_sent(msg)
             &&& msg.dst === HostId::KubernetesAPI
@@ -422,9 +422,9 @@ pub proof fn lemma_always_res_always_exists_implies_forall_delete_never_sent<RS>
             &&& msg.get_delete_request().key === res.key
         }
     });
-    tla_forall_always_equality_variant::<State<RS>, Message>(m_to_always_m_not_sent, m_to_m_not_sent);
+    tla_forall_always_equality_variant::<State<T>, Message>(m_to_always_m_not_sent, m_to_m_not_sent);
 
-    let forall_m_to_m_not_sent = lift_state(|s: State<RS>| {
+    let forall_m_to_m_not_sent = lift_state(|s: State<T>| {
         forall |msg: Message|
         !{
             &&& #[trigger] s.message_sent(msg)
@@ -445,7 +445,7 @@ pub proof fn lemma_always_res_always_exists_implies_forall_delete_never_sent<RS>
             assert(m_to_m_not_sent(msg).satisfied_by(ex));
         };
     };
-    temp_pred_equality::<State<RS>>(tla_forall(m_to_m_not_sent), forall_m_to_m_not_sent);
+    temp_pred_equality::<State<T>>(tla_forall(m_to_m_not_sent), forall_m_to_m_not_sent);
 }
 
 }

--- a/src/kubernetes_cluster/proof/kubernetes_api_liveness.rs
+++ b/src/kubernetes_cluster/proof/kubernetes_api_liveness.rs
@@ -19,91 +19,91 @@ use builtin_macros::*;
 
 verus! {
 
-pub proof fn lemma_pre_leads_to_post_by_kubernetes_api(reconciler: Reconciler, input: KubernetesAPIActionInput, action: KubernetesAPIAction, pre: StatePred<State>, post: StatePred<State>)
+pub proof fn lemma_pre_leads_to_post_by_kubernetes_api<RS>(reconciler: Reconciler<RS>, input: KubernetesAPIActionInput, action: KubernetesAPIAction, pre: StatePred<State<RS>>, post: StatePred<State<RS>>)
     requires
         kubernetes_api().actions.contains(action),
-        forall |s, s_prime: State| pre(s) && #[trigger] next(reconciler)(s, s_prime) ==> pre(s_prime) || post(s_prime),
-        forall |s, s_prime: State| pre(s) && #[trigger] next(reconciler)(s, s_prime) && kubernetes_api_next().forward(input)(s, s_prime) ==> post(s_prime),
-        forall |s: State| #[trigger] pre(s) ==> kubernetes_api_action_pre(action, input)(s),
+        forall |s, s_prime: State<RS>| pre(s) && #[trigger] next(reconciler)(s, s_prime) ==> pre(s_prime) || post(s_prime),
+        forall |s, s_prime: State<RS>| pre(s) && #[trigger] next(reconciler)(s, s_prime) && kubernetes_api_next().forward(input)(s, s_prime) ==> post(s_prime),
+        forall |s: State<RS>| #[trigger] pre(s) ==> kubernetes_api_action_pre(action, input)(s),
     ensures
         sm_spec(reconciler).entails(lift_state(pre).leads_to(lift_state(post))),
 {
-    use_tla_forall::<State, KubernetesAPIActionInput>(sm_spec(reconciler), |i| kubernetes_api_next().weak_fairness(i), input);
+    use_tla_forall::<State<RS>, KubernetesAPIActionInput>(sm_spec(reconciler), |i| kubernetes_api_next().weak_fairness(i), input);
 
-    kubernetes_api_action_pre_implies_next_pre(action, input);
-    valid_implies_trans::<State>(lift_state(pre), lift_state(kubernetes_api_action_pre(action, input)), lift_state(kubernetes_api_next().pre(input)));
+    kubernetes_api_action_pre_implies_next_pre::<RS>(action, input);
+    valid_implies_trans::<State<RS>>(lift_state(pre), lift_state(kubernetes_api_action_pre(action, input)), lift_state(kubernetes_api_next().pre(input)));
 
     kubernetes_api_next().wf1(input, sm_spec(reconciler), next(reconciler), pre, post);
 }
 
-pub proof fn lemma_pre_leads_to_post_with_assumption_by_kubernetes_api(reconciler: Reconciler, input: KubernetesAPIActionInput, action: KubernetesAPIAction, assumption: StatePred<State>, pre: StatePred<State>, post: StatePred<State>)
+pub proof fn lemma_pre_leads_to_post_with_assumption_by_kubernetes_api<RS>(reconciler: Reconciler<RS>, input: KubernetesAPIActionInput, action: KubernetesAPIAction, assumption: StatePred<State<RS>>, pre: StatePred<State<RS>>, post: StatePred<State<RS>>)
     requires
         kubernetes_api().actions.contains(action),
-        forall |s, s_prime: State| pre(s) && #[trigger] next(reconciler)(s, s_prime) && assumption(s) ==> pre(s_prime) || post(s_prime),
-        forall |s, s_prime: State| pre(s) && #[trigger] next(reconciler)(s, s_prime) && kubernetes_api_next().forward(input)(s, s_prime) ==> post(s_prime),
-        forall |s: State| #[trigger] pre(s) ==> kubernetes_api_action_pre(action, input)(s),
+        forall |s, s_prime: State<RS>| pre(s) && #[trigger] next(reconciler)(s, s_prime) && assumption(s) ==> pre(s_prime) || post(s_prime),
+        forall |s, s_prime: State<RS>| pre(s) && #[trigger] next(reconciler)(s, s_prime) && kubernetes_api_next().forward(input)(s, s_prime) ==> post(s_prime),
+        forall |s: State<RS>| #[trigger] pre(s) ==> kubernetes_api_action_pre(action, input)(s),
     ensures
         sm_spec(reconciler).entails(lift_state(pre).and(always(lift_state(assumption))).leads_to(lift_state(post))),
 {
-    use_tla_forall::<State, KubernetesAPIActionInput>(sm_spec(reconciler), |i| kubernetes_api_next().weak_fairness(i), input);
+    use_tla_forall::<State<RS>, KubernetesAPIActionInput>(sm_spec(reconciler), |i| kubernetes_api_next().weak_fairness(i), input);
 
-    kubernetes_api_action_pre_implies_next_pre(action, input);
-    valid_implies_trans::<State>(lift_state(pre), lift_state(kubernetes_api_action_pre(action, input)), lift_state(kubernetes_api_next().pre(input)));
+    kubernetes_api_action_pre_implies_next_pre::<RS>(action, input);
+    valid_implies_trans::<State<RS>>(lift_state(pre), lift_state(kubernetes_api_action_pre(action, input)), lift_state(kubernetes_api_next().pre(input)));
 
     kubernetes_api_next().wf1_assume(input, sm_spec(reconciler), next(reconciler), assumption, pre, post);
 }
 
-pub proof fn lemma_create_req_leads_to_ok_resp(reconciler: Reconciler, msg: Message)
+pub proof fn lemma_create_req_leads_to_ok_resp<RS>(reconciler: Reconciler<RS>, msg: Message)
     ensures
         sm_spec(reconciler).entails(
-            lift_state(|s: State| {
+            lift_state(|s: State<RS>| {
                 &&& s.message_sent(msg)
                 &&& msg.dst === HostId::KubernetesAPI
                 &&& msg.is_create_request()
                 &&& !s.resource_key_exists(msg.get_create_request().obj.key)
             })
-            .and(always(lift_state(|s: State| {
+            .and(always(lift_state(|s: State<RS>| {
                 forall |other: Message|
                     #[trigger] s.message_sent(other) && other.content === msg.content && other.dst === msg.dst
                         ==> other === msg
             })))
                 .leads_to(
-                    lift_state(|s: State| {
+                    lift_state(|s: State<RS>| {
                         &&& s.message_sent(form_msg(msg.dst, msg.src, create_resp_msg(Result::Ok(msg.get_create_request().obj), msg.get_create_request())))
                         &&& s.resource_key_exists(msg.get_create_request().obj.key)
                     })
                 )
         ),
 {
-    let assumption = |s: State| {
+    let assumption = |s: State<RS>| {
         forall |other: Message|
             #[trigger] s.message_sent(other) && other.content === msg.content && other.dst === msg.dst
                 ==> other === msg
     };
-    let pre = |s: State| {
+    let pre = |s: State<RS>| {
         &&& s.message_sent(msg)
         &&& msg.dst === HostId::KubernetesAPI
         &&& msg.is_create_request()
         &&& !s.resource_key_exists(msg.get_create_request().obj.key)
     };
-    let post = |s: State| {
+    let post = |s: State<RS>| {
         &&& s.message_sent(form_msg(msg.dst, msg.src, create_resp_msg(Result::Ok(msg.get_create_request().obj), msg.get_create_request())))
         &&& s.resource_key_exists(msg.get_create_request().obj.key)
     };
-    lemma_pre_leads_to_post_with_assumption_by_kubernetes_api(reconciler, Option::Some(msg), handle_request(), assumption, pre, post);
+    lemma_pre_leads_to_post_with_assumption_by_kubernetes_api::<RS>(reconciler, Option::Some(msg), handle_request(), assumption, pre, post);
 }
 
-pub proof fn lemma_get_req_leads_to_some_resp(reconciler: Reconciler, msg: Message, key: ResourceKey)
+pub proof fn lemma_get_req_leads_to_some_resp<RS>(reconciler: Reconciler<RS>, msg: Message, key: ResourceKey)
     ensures
         sm_spec(reconciler).entails(
-            lift_state(|s: State| {
+            lift_state(|s: State<RS>| {
                     &&& s.message_sent(msg)
                     &&& msg.dst === HostId::KubernetesAPI
                     &&& msg.is_get_request()
                     &&& msg.get_get_request().key === key
                 })
                 .leads_to(
-                    lift_state(|s: State|
+                    lift_state(|s: State<RS>|
                         exists |resp_msg: Message| {
                             &&& #[trigger] s.message_sent(resp_msg)
                             &&& resp_msg_matches_req_msg(resp_msg, msg)
@@ -113,17 +113,17 @@ pub proof fn lemma_get_req_leads_to_some_resp(reconciler: Reconciler, msg: Messa
         ),
 {
     let input = Option::Some(msg);
-    let pre = |s: State| {
+    let pre = |s: State<RS>| {
         &&& s.message_sent(msg)
         &&& msg.dst === HostId::KubernetesAPI
         &&& msg.is_get_request()
         &&& msg.get_get_request().key === key
     };
-    let post = |s: State| exists |resp_msg: Message| {
+    let post = |s: State<RS>| exists |resp_msg: Message| {
         &&& #[trigger] s.message_sent(resp_msg)
         &&& resp_msg_matches_req_msg(resp_msg, msg)
     };
-    assert forall |s, s_prime: State| pre(s) && #[trigger] next(reconciler)(s, s_prime) && kubernetes_api_next().forward(input)(s, s_prime)
+    assert forall |s, s_prime: State<RS>| pre(s) && #[trigger] next(reconciler)(s, s_prime) && kubernetes_api_next().forward(input)(s, s_prime)
     implies post(s_prime) by {
         if s.resource_key_exists(key) {
             let ok_resp_msg = form_get_resp_msg(msg, Result::Ok(s.resource_obj_of(key)));
@@ -135,53 +135,53 @@ pub proof fn lemma_get_req_leads_to_some_resp(reconciler: Reconciler, msg: Messa
             assert(resp_msg_matches_req_msg(err_resp_msg, msg));
         }
     };
-    lemma_pre_leads_to_post_by_kubernetes_api(reconciler, input, handle_request(), pre, post);
+    lemma_pre_leads_to_post_by_kubernetes_api::<RS>(reconciler, input, handle_request(), pre, post);
 }
 
-pub proof fn lemma_get_req_leads_to_ok_or_err_resp(reconciler: Reconciler, msg: Message, key: ResourceKey)
+pub proof fn lemma_get_req_leads_to_ok_or_err_resp<RS>(reconciler: Reconciler<RS>, msg: Message, key: ResourceKey)
     ensures
         sm_spec(reconciler).entails(
-            lift_state(|s: State| {
+            lift_state(|s: State<RS>| {
                 &&& s.message_sent(msg)
                 &&& msg.dst === HostId::KubernetesAPI
                 &&& msg.is_get_request()
                 &&& msg.get_get_request().key === key
             })
                 .leads_to(
-                    lift_state(|s: State| s.message_sent(form_get_resp_msg(msg, Result::Ok(s.resource_obj_of(key)))))
-                    .or(lift_state(|s: State| s.message_sent(form_get_resp_msg(msg, Result::Err(APIError::ObjectNotFound)))))
+                    lift_state(|s: State<RS>| s.message_sent(form_get_resp_msg(msg, Result::Ok(s.resource_obj_of(key)))))
+                    .or(lift_state(|s: State<RS>| s.message_sent(form_get_resp_msg(msg, Result::Err(APIError::ObjectNotFound)))))
                 )
         ),
 {
-    let pre = |s: State| {
+    let pre = |s: State<RS>| {
         &&& s.message_sent(msg)
         &&& msg.dst === HostId::KubernetesAPI
         &&& msg.is_get_request()
         &&& msg.get_get_request().key === key
     };
-    let post = |s: State| {
+    let post = |s: State<RS>| {
         ||| s.message_sent(form_get_resp_msg(msg, Result::Ok(s.resource_obj_of(key))))
         ||| s.message_sent(form_get_resp_msg(msg, Result::Err(APIError::ObjectNotFound)))
     };
-    lemma_pre_leads_to_post_by_kubernetes_api(reconciler, Option::Some(msg), handle_request(), pre, post);
-    temp_pred_equality::<State>(
+    lemma_pre_leads_to_post_by_kubernetes_api::<RS>(reconciler, Option::Some(msg), handle_request(), pre, post);
+    temp_pred_equality::<State<RS>>(
         lift_state(post),
-        lift_state(|s: State| s.message_sent(form_get_resp_msg(msg, Result::Ok(s.resource_obj_of(key)))))
-        .or(lift_state(|s: State| s.message_sent(form_get_resp_msg(msg, Result::Err(APIError::ObjectNotFound)))))
+        lift_state(|s: State<RS>| s.message_sent(form_get_resp_msg(msg, Result::Ok(s.resource_obj_of(key)))))
+        .or(lift_state(|s: State<RS>| s.message_sent(form_get_resp_msg(msg, Result::Err(APIError::ObjectNotFound)))))
     );
 }
 
-pub proof fn lemma_get_req_leads_to_ok_resp_if_never_delete(reconciler: Reconciler, msg: Message, res: ResourceObj)
+pub proof fn lemma_get_req_leads_to_ok_resp_if_never_delete<RS>(reconciler: Reconciler<RS>, msg: Message, res: ResourceObj)
     ensures
         sm_spec(reconciler).entails(
-            lift_state(|s: State| {
+            lift_state(|s: State<RS>| {
                 &&& s.message_sent(msg)
                 &&& msg.dst === HostId::KubernetesAPI
                 &&& msg.is_get_request()
                 &&& msg.get_get_request().key === res.key
                 &&& s.resource_obj_exists(res)
             })
-            .and(always(lift_state(|s: State| {
+            .and(always(lift_state(|s: State<RS>| {
                 forall |other: Message|
                 !{
                     &&& #[trigger] s.message_sent(other)
@@ -190,17 +190,17 @@ pub proof fn lemma_get_req_leads_to_ok_resp_if_never_delete(reconciler: Reconcil
                     &&& other.get_delete_request().key === res.key
                 }
             })))
-                .leads_to(lift_state(|s: State| s.message_sent(form_get_resp_msg(msg, Result::Ok(res)))))
+                .leads_to(lift_state(|s: State<RS>| s.message_sent(form_get_resp_msg(msg, Result::Ok(res)))))
         ),
 {
-    let pre = |s: State| {
+    let pre = |s: State<RS>| {
         &&& s.message_sent(msg)
         &&& msg.dst === HostId::KubernetesAPI
         &&& msg.is_get_request()
         &&& msg.get_get_request().key === res.key
         &&& s.resource_obj_exists(res)
     };
-    let assumption = |s: State| {
+    let assumption = |s: State<RS>| {
         forall |other: Message|
             !{
                 &&& #[trigger] s.message_sent(other)
@@ -209,7 +209,7 @@ pub proof fn lemma_get_req_leads_to_ok_resp_if_never_delete(reconciler: Reconcil
                 &&& other.get_delete_request().key === res.key
             }
     };
-    let post = |s: State| s.message_sent(form_msg(
+    let post = |s: State<RS>| s.message_sent(form_msg(
         msg.dst,
         msg.src,
         get_resp_msg(
@@ -217,39 +217,39 @@ pub proof fn lemma_get_req_leads_to_ok_resp_if_never_delete(reconciler: Reconcil
             msg.get_get_request()
         )
     ));
-    lemma_pre_leads_to_post_with_assumption_by_kubernetes_api(reconciler, Option::Some(msg), handle_request(), assumption, pre, post);
+    lemma_pre_leads_to_post_with_assumption_by_kubernetes_api::<RS>(reconciler, Option::Some(msg), handle_request(), assumption, pre, post);
 }
 
-pub proof fn lemma_get_req_leads_to_ok_resp_if_res_always_exists(reconciler: Reconciler, msg: Message, res: ResourceObj)
+pub proof fn lemma_get_req_leads_to_ok_resp_if_res_always_exists<RS>(reconciler: Reconciler<RS>, msg: Message, res: ResourceObj)
     ensures
         sm_spec(reconciler).entails(
-            lift_state(|s: State| {
+            lift_state(|s: State<RS>| {
                 &&& s.message_sent(msg)
                 &&& msg.dst === HostId::KubernetesAPI
                 &&& msg.is_get_request()
                 &&& msg.get_get_request().key === res.key
             })
-            .and(always(lift_state(|s: State| s.resource_obj_exists(res))))
-                .leads_to(lift_state(|s: State| s.message_sent(form_get_resp_msg(msg, Result::Ok(res)))))
+            .and(always(lift_state(|s: State<RS>| s.resource_obj_exists(res))))
+                .leads_to(lift_state(|s: State<RS>| s.message_sent(form_get_resp_msg(msg, Result::Ok(res)))))
         ),
 {
-    leads_to_weaken_auto::<State>(sm_spec(reconciler));
+    leads_to_weaken_auto::<State<RS>>(sm_spec(reconciler));
 
-    let get_req_msg_sent = |s: State| {
+    let get_req_msg_sent = |s: State<RS>| {
         &&& s.message_sent(msg)
         &&& msg.dst === HostId::KubernetesAPI
         &&& msg.is_get_request()
         &&& msg.get_get_request().key === res.key
     };
-    let res_exists = |s: State| s.resource_obj_exists(res);
-    let get_req_msg_sent_and_res_exists = |s: State| {
+    let res_exists = |s: State<RS>| s.resource_obj_exists(res);
+    let get_req_msg_sent_and_res_exists = |s: State<RS>| {
         &&& s.message_sent(msg)
         &&& msg.dst === HostId::KubernetesAPI
         &&& msg.is_get_request()
         &&& msg.get_get_request().key === res.key
         &&& s.resource_obj_exists(res)
     };
-    let delete_req_never_sent = |s: State| {
+    let delete_req_never_sent = |s: State<RS>| {
         forall |other: Message|
         !{
             &&& #[trigger] s.message_sent(other)
@@ -258,18 +258,18 @@ pub proof fn lemma_get_req_leads_to_ok_resp_if_res_always_exists(reconciler: Rec
             &&& other.get_delete_request().key === res.key
         }
     };
-    let ok_resp_msg_sent = |s: State| s.message_sent(form_get_resp_msg(msg, Result::Ok(res)));
+    let ok_resp_msg_sent = |s: State<RS>| s.message_sent(form_get_resp_msg(msg, Result::Ok(res)));
 
-    lemma_always_res_always_exists_implies_forall_delete_never_sent(reconciler, res);
+    lemma_always_res_always_exists_implies_forall_delete_never_sent::<RS>(reconciler, res);
     // Now we have spec.entails(always(always(lift_state(res_exists)).implies(always(lift_state(delete_req_never_sent)))))
     // We want to add get_req_msg_sent_and_res_exists to both ends by using sandwich_always_implies_temp
-    sandwich_always_implies_temp::<State>(sm_spec(reconciler),
+    sandwich_always_implies_temp::<State<RS>>(sm_spec(reconciler),
         lift_state(get_req_msg_sent_and_res_exists),
         always(lift_state(res_exists)),
         always(lift_state(delete_req_never_sent))
     );
 
-    lemma_get_req_leads_to_ok_resp_if_never_delete(reconciler, msg, res);
+    lemma_get_req_leads_to_ok_resp_if_never_delete::<RS>(reconciler, msg, res);
     // Use the assert to trigger leads_to_weaken_auto
     // The always-implies formula required by leads_to_weaken_auto is given by the above sandwich_always_implies_temp
     assert(sm_spec(reconciler).entails(
@@ -277,7 +277,7 @@ pub proof fn lemma_get_req_leads_to_ok_resp_if_res_always_exists(reconciler: Rec
             .leads_to(lift_state(ok_resp_msg_sent))
     ));
 
-    temp_pred_equality::<State>(
+    temp_pred_equality::<State<RS>>(
         lift_state(get_req_msg_sent_and_res_exists).and(always(lift_state(res_exists))),
         lift_state(get_req_msg_sent).and(lift_state(res_exists).and(always(lift_state(res_exists))))
     );
@@ -287,62 +287,62 @@ pub proof fn lemma_get_req_leads_to_ok_resp_if_res_always_exists(reconciler: Rec
             .leads_to(lift_state(ok_resp_msg_sent))
     ));
     // Last step: use p_and_always_p_equals_always_p to remove the .and(lift_state(res_exists)) from the premise
-    p_and_always_p_equals_always_p::<State>(lift_state(res_exists));
+    p_and_always_p_equals_always_p::<State<RS>>(lift_state(res_exists));
 }
 
-pub proof fn lemma_create_req_leads_to_res_exists(reconciler: Reconciler, msg: Message, res: ResourceObj)
+pub proof fn lemma_create_req_leads_to_res_exists<RS>(reconciler: Reconciler<RS>, msg: Message, res: ResourceObj)
     ensures
         sm_spec(reconciler).entails(
-            lift_state(|s: State| {
+            lift_state(|s: State<RS>| {
                 &&& s.message_sent(msg)
                 &&& msg.dst === HostId::KubernetesAPI
                 &&& msg.is_create_request()
                 &&& msg.get_create_request().obj === res
             })
-                .leads_to(lift_state(|s: State| s.resource_key_exists(res.key)))
+                .leads_to(lift_state(|s: State<RS>| s.resource_key_exists(res.key)))
         ),
 {
-    let pre = |s: State| {
+    let pre = |s: State<RS>| {
         &&& s.message_sent(msg)
         &&& msg.dst === HostId::KubernetesAPI
         &&& msg.is_create_request()
         &&& msg.get_create_request().obj === res
     };
-    let post = |s: State| {
+    let post = |s: State<RS>| {
         s.resource_key_exists(res.key)
     };
-    lemma_pre_leads_to_post_by_kubernetes_api(reconciler, Option::Some(msg), handle_request(), pre, post);
+    lemma_pre_leads_to_post_by_kubernetes_api::<RS>(reconciler, Option::Some(msg), handle_request(), pre, post);
 }
 
-pub proof fn lemma_delete_req_leads_to_res_not_exists(reconciler: Reconciler, msg: Message, res: ResourceObj)
+pub proof fn lemma_delete_req_leads_to_res_not_exists<RS>(reconciler: Reconciler<RS>, msg: Message, res: ResourceObj)
     ensures
         sm_spec(reconciler).entails(
-            lift_state(|s: State| {
+            lift_state(|s: State<RS>| {
                 &&& s.message_sent(msg)
                 &&& msg.dst === HostId::KubernetesAPI
                 &&& msg.is_delete_request()
                 &&& msg.get_delete_request().key === res.key
             })
-                .leads_to(lift_state(|s: State| !s.resource_obj_exists(res)))
+                .leads_to(lift_state(|s: State<RS>| !s.resource_obj_exists(res)))
         ),
 {
-    let pre = |s: State| {
+    let pre = |s: State<RS>| {
         &&& s.message_sent(msg)
         &&& msg.dst === HostId::KubernetesAPI
         &&& msg.is_delete_request()
         &&& msg.get_delete_request().key === res.key
     };
-    let post = |s: State| {
+    let post = |s: State<RS>| {
         !s.resource_obj_exists(res)
     };
-    lemma_pre_leads_to_post_by_kubernetes_api(reconciler, Option::Some(msg), handle_request(), pre, post);
+    lemma_pre_leads_to_post_by_kubernetes_api::<RS>(reconciler, Option::Some(msg), handle_request(), pre, post);
 }
 
-pub proof fn lemma_always_res_always_exists_implies_delete_never_sent(reconciler: Reconciler, msg: Message, res: ResourceObj)
+pub proof fn lemma_always_res_always_exists_implies_delete_never_sent<RS>(reconciler: Reconciler<RS>, msg: Message, res: ResourceObj)
     ensures
         sm_spec(reconciler).entails(always(
-            always(lift_state(|s: State| s.resource_obj_exists(res)))
-                .implies(always(lift_state(|s: State| {
+            always(lift_state(|s: State<RS>| s.resource_obj_exists(res)))
+                .implies(always(lift_state(|s: State<RS>| {
                     !{
                         &&& s.message_sent(msg)
                         &&& msg.dst === HostId::KubernetesAPI
@@ -352,28 +352,28 @@ pub proof fn lemma_always_res_always_exists_implies_delete_never_sent(reconciler
                 })))
         )),
 {
-    lemma_delete_req_leads_to_res_not_exists(reconciler, msg, res);
-    leads_to_contraposition::<State>(sm_spec(reconciler),
-        |s: State| {
+    lemma_delete_req_leads_to_res_not_exists::<RS>(reconciler, msg, res);
+    leads_to_contraposition::<State<RS>>(sm_spec(reconciler),
+        |s: State<RS>| {
             &&& s.message_sent(msg)
             &&& msg.dst === HostId::KubernetesAPI
             &&& msg.is_delete_request()
             &&& msg.get_delete_request().key === res.key
         },
-        |s: State| !s.resource_obj_exists(res)
+        |s: State<RS>| !s.resource_obj_exists(res)
     );
-    temp_pred_equality::<State>(
-        not(lift_state(|s: State| !s.resource_obj_exists(res))),
-        lift_state(|s: State| s.resource_obj_exists(res))
+    temp_pred_equality::<State<RS>>(
+        not(lift_state(|s: State<RS>| !s.resource_obj_exists(res))),
+        lift_state(|s: State<RS>| s.resource_obj_exists(res))
     );
-    temp_pred_equality::<State>(
-        not(lift_state(|s: State| {
+    temp_pred_equality::<State<RS>>(
+        not(lift_state(|s: State<RS>| {
             &&& s.message_sent(msg)
             &&& msg.dst === HostId::KubernetesAPI
             &&& msg.is_delete_request()
             &&& msg.get_delete_request().key === res.key
         })),
-        lift_state(|s: State| {
+        lift_state(|s: State<RS>| {
             !{
                 &&& s.message_sent(msg)
                 &&& msg.dst === HostId::KubernetesAPI
@@ -385,11 +385,11 @@ pub proof fn lemma_always_res_always_exists_implies_delete_never_sent(reconciler
 }
 
 /// How to prove this? It is obvious according to lemma_always_res_always_exists_implies_delete_never_sent
-pub proof fn lemma_always_res_always_exists_implies_forall_delete_never_sent(reconciler: Reconciler, res: ResourceObj)
+pub proof fn lemma_always_res_always_exists_implies_forall_delete_never_sent<RS>(reconciler: Reconciler<RS>, res: ResourceObj)
     ensures
         sm_spec(reconciler).entails(always(
-            always(lift_state(|s: State| s.resource_obj_exists(res)))
-                .implies(always(lift_state(|s: State| {
+            always(lift_state(|s: State<RS>| s.resource_obj_exists(res)))
+                .implies(always(lift_state(|s: State<RS>| {
                     forall |msg: Message|
                     !{
                         &&& #[trigger] s.message_sent(msg)
@@ -400,8 +400,8 @@ pub proof fn lemma_always_res_always_exists_implies_forall_delete_never_sent(rec
                 })))
         )),
 {
-    let pre = always(lift_state(|s: State| s.resource_obj_exists(res)));
-    let m_to_always_m_not_sent = |msg: Message| always(lift_state(|s: State| {
+    let pre = always(lift_state(|s: State<RS>| s.resource_obj_exists(res)));
+    let m_to_always_m_not_sent = |msg: Message| always(lift_state(|s: State<RS>| {
         !{
             &&& s.message_sent(msg)
             &&& msg.dst === HostId::KubernetesAPI
@@ -412,9 +412,9 @@ pub proof fn lemma_always_res_always_exists_implies_forall_delete_never_sent(rec
     assert forall |msg: Message| sm_spec(reconciler).entails(#[trigger] always(pre.implies(m_to_always_m_not_sent(msg)))) by {
         lemma_always_res_always_exists_implies_delete_never_sent(reconciler, msg, res);
     };
-    always_implies_forall_intro::<State, Message>(sm_spec(reconciler), pre, m_to_always_m_not_sent);
+    always_implies_forall_intro::<State<RS>, Message>(sm_spec(reconciler), pre, m_to_always_m_not_sent);
 
-    let m_to_m_not_sent = |msg: Message| lift_state(|s: State| {
+    let m_to_m_not_sent = |msg: Message| lift_state(|s: State<RS>| {
         !{
             &&& s.message_sent(msg)
             &&& msg.dst === HostId::KubernetesAPI
@@ -422,9 +422,9 @@ pub proof fn lemma_always_res_always_exists_implies_forall_delete_never_sent(rec
             &&& msg.get_delete_request().key === res.key
         }
     });
-    tla_forall_always_equality_variant::<State, Message>(m_to_always_m_not_sent, m_to_m_not_sent);
+    tla_forall_always_equality_variant::<State<RS>, Message>(m_to_always_m_not_sent, m_to_m_not_sent);
 
-    let forall_m_to_m_not_sent = lift_state(|s: State| {
+    let forall_m_to_m_not_sent = lift_state(|s: State<RS>| {
         forall |msg: Message|
         !{
             &&& #[trigger] s.message_sent(msg)
@@ -445,7 +445,7 @@ pub proof fn lemma_always_res_always_exists_implies_forall_delete_never_sent(rec
             assert(m_to_m_not_sent(msg).satisfied_by(ex));
         };
     };
-    temp_pred_equality::<State>(tla_forall(m_to_m_not_sent), forall_m_to_m_not_sent);
+    temp_pred_equality::<State<RS>>(tla_forall(m_to_m_not_sent), forall_m_to_m_not_sent);
 }
 
 }

--- a/src/kubernetes_cluster/proof/kubernetes_api_safety.rs
+++ b/src/kubernetes_cluster/proof/kubernetes_api_safety.rs
@@ -10,27 +10,27 @@ use builtin_macros::*;
 
 verus! {
 
-pub proof fn lemma_always_res_exists_implies_added_event_sent<RS>(reconciler: Reconciler<RS>, res: ResourceObj)
+pub proof fn lemma_always_res_exists_implies_added_event_sent<T>(reconciler: Reconciler<T>, res: ResourceObj)
     ensures
         sm_spec(reconciler).entails(
             always(
-                lift_state(|s: State<RS>| s.resource_obj_exists(res))
-                    .implies(lift_state(|s: State<RS>| s.message_sent(form_msg(HostId::KubernetesAPI, HostId::CustomController, added_event_msg(res)))))
+                lift_state(|s: State<T>| s.resource_obj_exists(res))
+                    .implies(lift_state(|s: State<T>| s.message_sent(form_msg(HostId::KubernetesAPI, HostId::CustomController, added_event_msg(res)))))
             )
         ),
 {
-    init_invariant::<State<RS>>(sm_spec(reconciler),
+    init_invariant::<State<T>>(sm_spec(reconciler),
         init(reconciler),
         next(reconciler),
-        |s: State<RS>| s.resource_obj_exists(res) ==> s.message_sent(form_msg(HostId::KubernetesAPI, HostId::CustomController, added_event_msg(res)))
+        |s: State<T>| s.resource_obj_exists(res) ==> s.message_sent(form_msg(HostId::KubernetesAPI, HostId::CustomController, added_event_msg(res)))
     );
-    temp_pred_equality::<State<RS>>(
-        lift_state(|s: State<RS>| s.resource_obj_exists(res) ==> s.message_sent(form_msg(HostId::KubernetesAPI, HostId::CustomController, added_event_msg(res)))),
-        lift_state(|s: State<RS>| s.resource_obj_exists(res)).implies(lift_state(|s: State<RS>| s.message_sent(form_msg(HostId::KubernetesAPI, HostId::CustomController, added_event_msg(res)))))
+    temp_pred_equality::<State<T>>(
+        lift_state(|s: State<T>| s.resource_obj_exists(res) ==> s.message_sent(form_msg(HostId::KubernetesAPI, HostId::CustomController, added_event_msg(res)))),
+        lift_state(|s: State<T>| s.resource_obj_exists(res)).implies(lift_state(|s: State<T>| s.message_sent(form_msg(HostId::KubernetesAPI, HostId::CustomController, added_event_msg(res)))))
     );
 }
 
-pub proof fn lemma_always_req_not_sent_implies_resp_not_sent<RS>(reconciler: Reconciler<RS>, req_msg: Message, resp_msg: Message)
+pub proof fn lemma_always_req_not_sent_implies_resp_not_sent<T>(reconciler: Reconciler<T>, req_msg: Message, resp_msg: Message)
     requires
         req_msg.dst === HostId::KubernetesAPI,
         req_msg.content.is_APIRequest(),
@@ -38,18 +38,18 @@ pub proof fn lemma_always_req_not_sent_implies_resp_not_sent<RS>(reconciler: Rec
         resp_msg_matches_req_msg(resp_msg, req_msg),
     ensures
         sm_spec(reconciler).entails(always(
-            lift_state(|s: State<RS>| !s.message_sent(req_msg))
-                .implies(lift_state(|s: State<RS>| !s.message_sent(resp_msg)))
+            lift_state(|s: State<T>| !s.message_sent(req_msg))
+                .implies(lift_state(|s: State<T>| !s.message_sent(resp_msg)))
         )),
 {
-    init_invariant::<State<RS>>(sm_spec(reconciler),
+    init_invariant::<State<T>>(sm_spec(reconciler),
         init(reconciler),
         next(reconciler),
-        |s: State<RS>| !s.message_sent(req_msg) ==> !s.message_sent(resp_msg)
+        |s: State<T>| !s.message_sent(req_msg) ==> !s.message_sent(resp_msg)
     );
-    temp_pred_equality::<State<RS>>(
-        lift_state(|s: State<RS>| !s.message_sent(req_msg) ==> !s.message_sent(resp_msg)),
-        lift_state(|s: State<RS>| !s.message_sent(req_msg)).implies(lift_state(|s: State<RS>| !s.message_sent(resp_msg)))
+    temp_pred_equality::<State<T>>(
+        lift_state(|s: State<T>| !s.message_sent(req_msg) ==> !s.message_sent(resp_msg)),
+        lift_state(|s: State<T>| !s.message_sent(req_msg)).implies(lift_state(|s: State<T>| !s.message_sent(resp_msg)))
     );
 }
 

--- a/src/kubernetes_cluster/proof/kubernetes_api_safety.rs
+++ b/src/kubernetes_cluster/proof/kubernetes_api_safety.rs
@@ -1,9 +1,7 @@
 // Copyright 2022 VMware, Inc.
 // SPDX-License-Identifier: MIT
 #![allow(unused_imports)]
-use crate::kubernetes_cluster::spec::{
-    common::*, distributed_system::*, reconciler::Reconciler,
-};
+use crate::kubernetes_cluster::spec::{common::*, distributed_system::*, reconciler::Reconciler};
 use crate::pervasive::seq::*;
 use crate::temporal_logic::defs::*;
 use crate::temporal_logic::rules::*;
@@ -12,27 +10,27 @@ use builtin_macros::*;
 
 verus! {
 
-pub proof fn lemma_always_res_exists_implies_added_event_sent(reconciler: Reconciler, res: ResourceObj)
+pub proof fn lemma_always_res_exists_implies_added_event_sent<RS>(reconciler: Reconciler<RS>, res: ResourceObj)
     ensures
         sm_spec(reconciler).entails(
             always(
-                lift_state(|s: State| s.resource_obj_exists(res))
-                    .implies(lift_state(|s: State| s.message_sent(form_msg(HostId::KubernetesAPI, HostId::CustomController, added_event_msg(res)))))
+                lift_state(|s: State<RS>| s.resource_obj_exists(res))
+                    .implies(lift_state(|s: State<RS>| s.message_sent(form_msg(HostId::KubernetesAPI, HostId::CustomController, added_event_msg(res)))))
             )
         ),
 {
-    init_invariant::<State>(sm_spec(reconciler),
+    init_invariant::<State<RS>>(sm_spec(reconciler),
         init(reconciler),
         next(reconciler),
-        |s: State| s.resource_obj_exists(res) ==> s.message_sent(form_msg(HostId::KubernetesAPI, HostId::CustomController, added_event_msg(res)))
+        |s: State<RS>| s.resource_obj_exists(res) ==> s.message_sent(form_msg(HostId::KubernetesAPI, HostId::CustomController, added_event_msg(res)))
     );
-    temp_pred_equality::<State>(
-        lift_state(|s: State| s.resource_obj_exists(res) ==> s.message_sent(form_msg(HostId::KubernetesAPI, HostId::CustomController, added_event_msg(res)))),
-        lift_state(|s: State| s.resource_obj_exists(res)).implies(lift_state(|s: State| s.message_sent(form_msg(HostId::KubernetesAPI, HostId::CustomController, added_event_msg(res)))))
+    temp_pred_equality::<State<RS>>(
+        lift_state(|s: State<RS>| s.resource_obj_exists(res) ==> s.message_sent(form_msg(HostId::KubernetesAPI, HostId::CustomController, added_event_msg(res)))),
+        lift_state(|s: State<RS>| s.resource_obj_exists(res)).implies(lift_state(|s: State<RS>| s.message_sent(form_msg(HostId::KubernetesAPI, HostId::CustomController, added_event_msg(res)))))
     );
 }
 
-pub proof fn lemma_always_req_not_sent_implies_resp_not_sent(reconciler: Reconciler, req_msg: Message, resp_msg: Message)
+pub proof fn lemma_always_req_not_sent_implies_resp_not_sent<RS>(reconciler: Reconciler<RS>, req_msg: Message, resp_msg: Message)
     requires
         req_msg.dst === HostId::KubernetesAPI,
         req_msg.content.is_APIRequest(),
@@ -40,18 +38,18 @@ pub proof fn lemma_always_req_not_sent_implies_resp_not_sent(reconciler: Reconci
         resp_msg_matches_req_msg(resp_msg, req_msg),
     ensures
         sm_spec(reconciler).entails(always(
-            lift_state(|s: State| !s.message_sent(req_msg))
-                .implies(lift_state(|s: State| !s.message_sent(resp_msg)))
+            lift_state(|s: State<RS>| !s.message_sent(req_msg))
+                .implies(lift_state(|s: State<RS>| !s.message_sent(resp_msg)))
         )),
 {
-    init_invariant::<State>(sm_spec(reconciler),
+    init_invariant::<State<RS>>(sm_spec(reconciler),
         init(reconciler),
         next(reconciler),
-        |s: State| !s.message_sent(req_msg) ==> !s.message_sent(resp_msg)
+        |s: State<RS>| !s.message_sent(req_msg) ==> !s.message_sent(resp_msg)
     );
-    temp_pred_equality::<State>(
-        lift_state(|s: State| !s.message_sent(req_msg) ==> !s.message_sent(resp_msg)),
-        lift_state(|s: State| !s.message_sent(req_msg)).implies(lift_state(|s: State| !s.message_sent(resp_msg)))
+    temp_pred_equality::<State<RS>>(
+        lift_state(|s: State<RS>| !s.message_sent(req_msg) ==> !s.message_sent(resp_msg)),
+        lift_state(|s: State<RS>| !s.message_sent(req_msg)).implies(lift_state(|s: State<RS>| !s.message_sent(resp_msg)))
     );
 }
 

--- a/src/kubernetes_cluster/proof/wf1_assistant.rs
+++ b/src/kubernetes_cluster/proof/wf1_assistant.rs
@@ -1,7 +1,6 @@
 // Copyright 2022 VMware, Inc.
 // SPDX-License-Identifier: MIT
 #![allow(unused_imports)]
-use crate::state_machine::action::*;
 use crate::kubernetes_cluster::spec::{
     common::*,
     controller,
@@ -20,6 +19,7 @@ use crate::kubernetes_cluster::spec::{
     reconciler::Reconciler,
 };
 use crate::pervasive::{option::*, seq::*, set::*};
+use crate::state_machine::action::*;
 use crate::state_machine::state_machine::*;
 use crate::temporal_logic::defs::*;
 use builtin::*;
@@ -27,18 +27,18 @@ use builtin_macros::*;
 
 verus! {
 
-pub proof fn kubernetes_api_action_pre_implies_next_pre(action: KubernetesAPIAction, input: KubernetesAPIActionInput)
+pub proof fn kubernetes_api_action_pre_implies_next_pre<RS>(action: KubernetesAPIAction, input: KubernetesAPIActionInput)
     requires
         kubernetes_api().actions.contains(action),
     ensures
-        valid(lift_state(kubernetes_api_action_pre(action, input)).implies(lift_state(kubernetes_api_next().pre(input)))),
+        valid(lift_state(kubernetes_api_action_pre::<RS>(action, input)).implies(lift_state(kubernetes_api_next().pre(input)))),
 {
-    assert forall |s| #[trigger] kubernetes_api_action_pre(action, input)(s) implies kubernetes_api_next().pre(input)(s) by {
+    assert forall |s: State<RS>| #[trigger] kubernetes_api_action_pre(action, input)(s) implies kubernetes_api_next().pre(input)(s) by {
         exists_next_kubernetes_api_step(action, input, s.kubernetes_api_state);
     };
 }
 
-pub proof fn controller_action_pre_implies_next_pre(reconciler: Reconciler, action: ControllerAction, input: ControllerActionInput)
+pub proof fn controller_action_pre_implies_next_pre<RS>(reconciler: Reconciler<RS>, action: ControllerAction<RS>, input: ControllerActionInput)
     requires
         controller(reconciler).actions.contains(action),
     ensures
@@ -59,7 +59,7 @@ pub proof fn exists_next_kubernetes_api_step(action: KubernetesAPIAction, input:
     assert(((kubernetes_api().step_to_action)(KubernetesAPIStep::HandleRequest).precondition)(input, s));
 }
 
-pub proof fn exists_next_controller_step(reconciler: Reconciler, action: ControllerAction, input: ControllerActionInput, s: ControllerState)
+pub proof fn exists_next_controller_step<RS>(reconciler: Reconciler<RS>, action: ControllerAction<RS>, input: ControllerActionInput, s: ControllerState<RS>)
     requires
         controller(reconciler).actions.contains(action),
         (action.precondition)(input, s),

--- a/src/kubernetes_cluster/proof/wf1_assistant.rs
+++ b/src/kubernetes_cluster/proof/wf1_assistant.rs
@@ -27,18 +27,18 @@ use builtin_macros::*;
 
 verus! {
 
-pub proof fn kubernetes_api_action_pre_implies_next_pre<RS>(action: KubernetesAPIAction, input: KubernetesAPIActionInput)
+pub proof fn kubernetes_api_action_pre_implies_next_pre<T>(action: KubernetesAPIAction, input: KubernetesAPIActionInput)
     requires
         kubernetes_api().actions.contains(action),
     ensures
-        valid(lift_state(kubernetes_api_action_pre::<RS>(action, input)).implies(lift_state(kubernetes_api_next().pre(input)))),
+        valid(lift_state(kubernetes_api_action_pre::<T>(action, input)).implies(lift_state(kubernetes_api_next().pre(input)))),
 {
-    assert forall |s: State<RS>| #[trigger] kubernetes_api_action_pre(action, input)(s) implies kubernetes_api_next().pre(input)(s) by {
+    assert forall |s: State<T>| #[trigger] kubernetes_api_action_pre(action, input)(s) implies kubernetes_api_next().pre(input)(s) by {
         exists_next_kubernetes_api_step(action, input, s.kubernetes_api_state);
     };
 }
 
-pub proof fn controller_action_pre_implies_next_pre<RS>(reconciler: Reconciler<RS>, action: ControllerAction<RS>, input: ControllerActionInput)
+pub proof fn controller_action_pre_implies_next_pre<T>(reconciler: Reconciler<T>, action: ControllerAction<T>, input: ControllerActionInput)
     requires
         controller(reconciler).actions.contains(action),
     ensures
@@ -59,7 +59,7 @@ pub proof fn exists_next_kubernetes_api_step(action: KubernetesAPIAction, input:
     assert(((kubernetes_api().step_to_action)(KubernetesAPIStep::HandleRequest).precondition)(input, s));
 }
 
-pub proof fn exists_next_controller_step<RS>(reconciler: Reconciler<RS>, action: ControllerAction<RS>, input: ControllerActionInput, s: ControllerState<RS>)
+pub proof fn exists_next_controller_step<T>(reconciler: Reconciler<T>, action: ControllerAction<T>, input: ControllerActionInput, s: ControllerState<T>)
     requires
         controller(reconciler).actions.contains(action),
         (action.precondition)(input, s),

--- a/src/kubernetes_cluster/spec/controller/common.rs
+++ b/src/kubernetes_cluster/spec/controller/common.rs
@@ -10,13 +10,13 @@ use builtin_macros::*;
 
 verus! {
 
-pub struct OngoingReconcile<RS> {
+pub struct OngoingReconcile<T> {
     pub pending_req_msg: Option<Message>,
-    pub local_state: RS,
+    pub local_state: T,
 }
 
-pub struct ControllerState<RS> {
-    pub ongoing_reconciles: Map<ResourceKey, OngoingReconcile<RS>>,
+pub struct ControllerState<T> {
+    pub ongoing_reconciles: Map<ResourceKey, OngoingReconcile<T>>,
     pub scheduled_reconciles: Set<ResourceKey>,
 }
 
@@ -33,11 +33,11 @@ pub enum ControllerStep {
     EndReconcile,
 }
 
-pub type ControllerStateMachine<RS> = StateMachine<ControllerState<RS>, ControllerActionInput, ControllerActionInput, Set<Message>, ControllerStep>;
+pub type ControllerStateMachine<T> = StateMachine<ControllerState<T>, ControllerActionInput, ControllerActionInput, Set<Message>, ControllerStep>;
 
-pub type ControllerAction<RS> = Action<ControllerState<RS>, ControllerActionInput, Set<Message>>;
+pub type ControllerAction<T> = Action<ControllerState<T>, ControllerActionInput, Set<Message>>;
 
-pub type ControllerActionResult<RS> = ActionResult<ControllerState<RS>, Set<Message>>;
+pub type ControllerActionResult<T> = ActionResult<ControllerState<T>, Set<Message>>;
 
 pub open spec fn controller_req_msg(req: APIRequest) -> Message {
     form_msg(HostId::CustomController, HostId::KubernetesAPI, MessageContent::APIRequest(req))

--- a/src/kubernetes_cluster/spec/controller/common.rs
+++ b/src/kubernetes_cluster/spec/controller/common.rs
@@ -10,13 +10,13 @@ use builtin_macros::*;
 
 verus! {
 
-pub struct OngoingReconcile {
+pub struct OngoingReconcile<RS> {
     pub pending_req_msg: Option<Message>,
-    pub local_state: ReconcileState,
+    pub local_state: RS,
 }
 
-pub struct ControllerState {
-    pub ongoing_reconciles: Map<ResourceKey, OngoingReconcile>,
+pub struct ControllerState<RS> {
+    pub ongoing_reconciles: Map<ResourceKey, OngoingReconcile<RS>>,
     pub scheduled_reconciles: Set<ResourceKey>,
 }
 
@@ -33,11 +33,11 @@ pub enum ControllerStep {
     EndReconcile,
 }
 
-pub type ControllerStateMachine = StateMachine<ControllerState, ControllerActionInput, ControllerActionInput, Set<Message>, ControllerStep>;
+pub type ControllerStateMachine<RS> = StateMachine<ControllerState<RS>, ControllerActionInput, ControllerActionInput, Set<Message>, ControllerStep>;
 
-pub type ControllerAction = Action<ControllerState, ControllerActionInput, Set<Message>>;
+pub type ControllerAction<RS> = Action<ControllerState<RS>, ControllerActionInput, Set<Message>>;
 
-pub type ControllerActionResult = ActionResult<ControllerState, Set<Message>>;
+pub type ControllerActionResult<RS> = ActionResult<ControllerState<RS>, Set<Message>>;
 
 pub open spec fn controller_req_msg(req: APIRequest) -> Message {
     form_msg(HostId::CustomController, HostId::KubernetesAPI, MessageContent::APIRequest(req))

--- a/src/kubernetes_cluster/spec/controller/controller_runtime.rs
+++ b/src/kubernetes_cluster/spec/controller/controller_runtime.rs
@@ -21,9 +21,9 @@ verus! {
 /// (3) The watcher deduplicates triggering events for the same object: if an event for object X
 /// comes but there is already another pending event for the same object, the incoming event is
 /// discarded.
-pub open spec fn trigger_reconcile(reconciler: Reconciler) -> ControllerAction {
+pub open spec fn trigger_reconcile<RS>(reconciler: Reconciler<RS>) -> ControllerAction<RS> {
     Action {
-        precondition: |input: ControllerActionInput, s: ControllerState| {
+        precondition: |input: ControllerActionInput, s: ControllerState<RS>| {
             // TODO: We should have multiple queues for storing triggering events.
             // Each queue stores the event relates to the same cr key.
             &&& input.scheduled_cr_key.is_None()
@@ -33,7 +33,7 @@ pub open spec fn trigger_reconcile(reconciler: Reconciler) -> ControllerAction {
             &&& (reconciler.reconcile_trigger)(input.recv.get_Some_0()).is_Some()
             &&& !s.ongoing_reconciles.dom().contains((reconciler.reconcile_trigger)(input.recv.get_Some_0()).get_Some_0())
         },
-        transition: |input: ControllerActionInput, s: ControllerState| {
+        transition: |input: ControllerActionInput, s: ControllerState<RS>| {
             let cr_key = (reconciler.reconcile_trigger)(input.recv.get_Some_0()).get_Some_0();
             let initialized_ongoing_reconcile = OngoingReconcile {
                 pending_req_msg: Option::None,
@@ -49,15 +49,15 @@ pub open spec fn trigger_reconcile(reconciler: Reconciler) -> ControllerAction {
     }
 }
 
-pub open spec fn run_scheduled_reconcile(reconciler: Reconciler) -> ControllerAction {
+pub open spec fn run_scheduled_reconcile<RS>(reconciler: Reconciler<RS>) -> ControllerAction<RS> {
     Action {
-        precondition: |input: ControllerActionInput, s: ControllerState| {
+        precondition: |input: ControllerActionInput, s: ControllerState<RS>| {
             &&& input.scheduled_cr_key.is_Some()
             &&& s.scheduled_reconciles.contains(input.scheduled_cr_key.get_Some_0())
             &&& input.recv.is_None()
             &&& !s.ongoing_reconciles.dom().contains(input.scheduled_cr_key.get_Some_0())
         },
-        transition: |input: ControllerActionInput, s: ControllerState| {
+        transition: |input: ControllerActionInput, s: ControllerState<RS>| {
             let cr_key = input.scheduled_cr_key.get_Some_0();
             let initialized_ongoing_reconcile = OngoingReconcile {
                 pending_req_msg: Option::None,
@@ -74,9 +74,9 @@ pub open spec fn run_scheduled_reconcile(reconciler: Reconciler) -> ControllerAc
     }
 }
 
-pub open spec fn continue_reconcile(reconciler: Reconciler) -> ControllerAction {
+pub open spec fn continue_reconcile<RS>(reconciler: Reconciler<RS>) -> ControllerAction<RS> {
     Action {
-        precondition: |input: ControllerActionInput, s: ControllerState| {
+        precondition: |input: ControllerActionInput, s: ControllerState<RS>| {
             if input.scheduled_cr_key.is_Some() {
                 let cr_key = input.scheduled_cr_key.get_Some_0();
 
@@ -93,7 +93,7 @@ pub open spec fn continue_reconcile(reconciler: Reconciler) -> ControllerAction 
                 false
             }
         },
-        transition: |input: ControllerActionInput, s: ControllerState| {
+        transition: |input: ControllerActionInput, s: ControllerState<RS>| {
             let resp_o = if input.recv.is_Some() {
                 Option::Some(input.recv.get_Some_0().content.get_APIResponse_0())
             } else {
@@ -128,9 +128,9 @@ pub open spec fn continue_reconcile(reconciler: Reconciler) -> ControllerAction 
     }
 }
 
-pub open spec fn end_reconcile(reconciler: Reconciler) -> ControllerAction {
+pub open spec fn end_reconcile<RS>(reconciler: Reconciler<RS>) -> ControllerAction<RS> {
     Action {
-        precondition: |input: ControllerActionInput, s: ControllerState| {
+        precondition: |input: ControllerActionInput, s: ControllerState<RS>| {
             if input.scheduled_cr_key.is_Some() {
                 let cr_key = input.scheduled_cr_key.get_Some_0();
 
@@ -141,7 +141,7 @@ pub open spec fn end_reconcile(reconciler: Reconciler) -> ControllerAction {
                 false
             }
         },
-        transition: |input: ControllerActionInput, s: ControllerState| {
+        transition: |input: ControllerActionInput, s: ControllerState<RS>| {
             let cr_key = input.scheduled_cr_key.get_Some_0();
             let s_prime = ControllerState {
                 ongoing_reconciles: s.ongoing_reconciles.remove(cr_key),

--- a/src/kubernetes_cluster/spec/controller/state_machine.rs
+++ b/src/kubernetes_cluster/spec/controller/state_machine.rs
@@ -13,9 +13,9 @@ use builtin_macros::*;
 
 verus! {
 
-pub open spec fn controller<RS>(reconciler: Reconciler<RS>) -> ControllerStateMachine<RS> {
+pub open spec fn controller<T>(reconciler: Reconciler<T>) -> ControllerStateMachine<T> {
     StateMachine {
-        init: |s: ControllerState<RS>| {
+        init: |s: ControllerState<T>| {
             s === ControllerState {
                 ongoing_reconciles: Map::empty(),
                 scheduled_reconciles: Set::empty(),

--- a/src/kubernetes_cluster/spec/controller/state_machine.rs
+++ b/src/kubernetes_cluster/spec/controller/state_machine.rs
@@ -1,11 +1,11 @@
 // Copyright 2022 VMware, Inc.
 // SPDX-License-Identifier: MIT
 #![allow(unused_imports)]
-use crate::state_machine::action::*;
 use crate::kubernetes_cluster::spec::{
     common::*, controller::common::*, controller::controller_runtime::*, reconciler::*,
 };
 use crate::pervasive::{map::*, option::*, seq::*, set::*, string::*};
+use crate::state_machine::action::*;
 use crate::state_machine::state_machine::*;
 use crate::temporal_logic::defs::*;
 use builtin::*;
@@ -13,9 +13,9 @@ use builtin_macros::*;
 
 verus! {
 
-pub open spec fn controller(reconciler: Reconciler) -> ControllerStateMachine {
+pub open spec fn controller<RS>(reconciler: Reconciler<RS>) -> ControllerStateMachine<RS> {
     StateMachine {
-        init: |s: ControllerState| {
+        init: |s: ControllerState<RS>| {
             s === ControllerState {
                 ongoing_reconciles: Map::empty(),
                 scheduled_reconciles: Set::empty(),

--- a/src/kubernetes_cluster/spec/distributed_system.rs
+++ b/src/kubernetes_cluster/spec/distributed_system.rs
@@ -1,7 +1,6 @@
 // Copyright 2022 VMware, Inc.
 // SPDX-License-Identifier: MIT
 #![allow(unused_imports)]
-use crate::state_machine::action::*;
 use crate::kubernetes_cluster::spec::{
     client,
     client::{client, ClientActionInput, ClientState},
@@ -17,6 +16,7 @@ use crate::kubernetes_cluster::spec::{
     reconciler::Reconciler,
 };
 use crate::pervasive::{map::*, option::*, seq::*, set::*};
+use crate::state_machine::action::*;
 use crate::state_machine::state_machine::*;
 use crate::temporal_logic::defs::*;
 use builtin::*;
@@ -24,14 +24,14 @@ use builtin_macros::*;
 
 verus! {
 
-pub struct State {
+pub struct State<RS> {
     pub kubernetes_api_state: KubernetesAPIState,
-    pub controller_state: ControllerState,
+    pub controller_state: ControllerState<RS>,
     pub client_state: ClientState,
     pub network_state: NetworkState,
 }
 
-impl State {
+impl<RS> State<RS> {
     #[verifier(inline)]
     pub open spec fn message_sent(self, msg: Message) -> bool {
         self.network_state.sent_messages.contains(msg)
@@ -56,7 +56,7 @@ impl State {
         self.controller_state.ongoing_reconciles.dom().contains(key)
     }
 
-    pub open spec fn reconcile_state_of(self, key: ResourceKey) -> OngoingReconcile
+    pub open spec fn reconcile_state_of(self, key: ResourceKey) -> OngoingReconcile<RS>
         recommends self.reconcile_state_contains(key)
     {
         self.controller_state.ongoing_reconciles[key]
@@ -67,8 +67,8 @@ impl State {
     }
 }
 
-pub open spec fn init(reconciler: Reconciler) -> StatePred<State> {
-    |s: State| {
+pub open spec fn init<RS>(reconciler: Reconciler<RS>) -> StatePred<State<RS>> {
+    |s: State<RS>| {
         &&& (kubernetes_api().init)(s.kubernetes_api_state)
         &&& (controller(reconciler).init)(s.controller_state)
         &&& (client().init)(s.client_state)
@@ -84,8 +84,8 @@ pub open spec fn received_msg_destined_for(recv: Option<Message>, host_id: HostI
     }
 }
 
-pub open spec fn kubernetes_api_next() -> Action<State, KubernetesAPIActionInput, ()> {
-    let result = |input: KubernetesAPIActionInput, s: State| {
+pub open spec fn kubernetes_api_next<RS>() -> Action<State<RS>, KubernetesAPIActionInput, ()> {
+    let result = |input: KubernetesAPIActionInput, s: State<RS>| {
         let host_result = kubernetes_api().next_result(input, s.kubernetes_api_state);
         let msg_ops = MessageOps {
             recv: input,
@@ -96,12 +96,12 @@ pub open spec fn kubernetes_api_next() -> Action<State, KubernetesAPIActionInput
         (host_result, network_result)
     };
     Action {
-        precondition: |input: KubernetesAPIActionInput, s: State| {
+        precondition: |input: KubernetesAPIActionInput, s: State<RS>| {
             &&& received_msg_destined_for(input, HostId::KubernetesAPI)
             &&& result(input, s).0.is_Enabled()
             &&& result(input, s).1.is_Enabled()
         },
-        transition: |input: KubernetesAPIActionInput, s: State| {
+        transition: |input: KubernetesAPIActionInput, s: State<RS>| {
             (State {
                 kubernetes_api_state: result(input, s).0.get_Enabled_0(),
                 network_state: result(input, s).1.get_Enabled_0(),
@@ -111,8 +111,8 @@ pub open spec fn kubernetes_api_next() -> Action<State, KubernetesAPIActionInput
     }
 }
 
-pub open spec fn controller_next(reconciler: Reconciler) -> Action<State, ControllerActionInput, ()> {
-    let result = |input: ControllerActionInput, s: State| {
+pub open spec fn controller_next<RS>(reconciler: Reconciler<RS>) -> Action<State<RS>, ControllerActionInput, ()> {
+    let result = |input: ControllerActionInput, s: State<RS>| {
         let host_result = controller(reconciler).next_result(input, s.controller_state);
         let msg_ops = MessageOps {
             recv: input.recv,
@@ -123,12 +123,12 @@ pub open spec fn controller_next(reconciler: Reconciler) -> Action<State, Contro
         (host_result, network_result)
     };
     Action {
-        precondition: |input: ControllerActionInput, s: State| {
+        precondition: |input: ControllerActionInput, s: State<RS>| {
             &&& received_msg_destined_for(input.recv, HostId::CustomController)
             &&& result(input, s).0.is_Enabled()
             &&& result(input, s).1.is_Enabled()
         },
-        transition: |input: ControllerActionInput, s: State| {
+        transition: |input: ControllerActionInput, s: State<RS>| {
             (State {
                 controller_state: result(input, s).0.get_Enabled_0(),
                 network_state: result(input, s).1.get_Enabled_0(),
@@ -138,8 +138,8 @@ pub open spec fn controller_next(reconciler: Reconciler) -> Action<State, Contro
     }
 }
 
-pub open spec fn client_next() -> Action<State, ClientActionInput, ()> {
-    let result = |input: ClientActionInput, s: State| {
+pub open spec fn client_next<RS>() -> Action<State<RS>, ClientActionInput, ()> {
+    let result = |input: ClientActionInput, s: State<RS>| {
         let host_result = client().next_result(input, s.client_state);
         let msg_ops = MessageOps {
             recv: input.recv,
@@ -150,12 +150,12 @@ pub open spec fn client_next() -> Action<State, ClientActionInput, ()> {
         (host_result, network_result)
     };
     Action {
-        precondition: |input: ClientActionInput, s: State| {
+        precondition: |input: ClientActionInput, s: State<RS>| {
             &&& received_msg_destined_for(input.recv, HostId::Client)
             &&& result(input, s).0.is_Enabled()
             &&& result(input, s).1.is_Enabled()
         },
-        transition: |input: ClientActionInput, s: State| {
+        transition: |input: ClientActionInput, s: State<RS>| {
             (State {
                 client_state: result(input, s).0.get_Enabled_0(),
                 network_state: result(input, s).1.get_Enabled_0(),
@@ -165,12 +165,12 @@ pub open spec fn client_next() -> Action<State, ClientActionInput, ()> {
     }
 }
 
-pub open spec fn stutter() -> Action<State, Option<Message>, ()> {
+pub open spec fn stutter<RS>() -> Action<State<RS>, Option<Message>, ()> {
     Action {
-        precondition: |input: Option<Message>, s: State| {
+        precondition: |input: Option<Message>, s: State<RS>| {
             input.is_None()
         },
-        transition: |input: Option<Message>, s: State| {
+        transition: |input: Option<Message>, s: State<RS>| {
             (s, ())
         },
     }
@@ -183,7 +183,7 @@ pub enum Step {
     StutterStep(Option<Message>),
 }
 
-pub open spec fn next_step(reconciler: Reconciler, s: State, s_prime: State, step: Step) -> bool {
+pub open spec fn next_step<RS>(reconciler: Reconciler<RS>, s: State<RS>, s_prime: State<RS>, step: Step) -> bool {
     match step {
         Step::KubernetesAPIStep(input) => kubernetes_api_next().forward(input)(s, s_prime),
         Step::ControllerStep(input) => controller_next(reconciler).forward(input)(s, s_prime),
@@ -195,22 +195,22 @@ pub open spec fn next_step(reconciler: Reconciler, s: State, s_prime: State, ste
 /// `next` chooses:
 /// * which host to take the next action (`Step`)
 /// * whether to deliver a message and which message to deliver (`Option<Message>` in `Step`)
-pub open spec fn next(reconciler: Reconciler) -> ActionPred<State> {
-    |s: State, s_prime: State| exists |step: Step| next_step(reconciler, s, s_prime, step)
+pub open spec fn next<RS>(reconciler: Reconciler<RS>) -> ActionPred<State<RS>> {
+    |s: State<RS>, s_prime: State<RS>| exists |step: Step| next_step(reconciler, s, s_prime, step)
 }
 
 /// We install the reconciler to the Kubernetes cluster state machine spec
 /// TODO: develop a struct for the compound state machine and make reconciler its member
 /// so that we don't have to pass reconciler to init and next in the proof.
-pub open spec fn sm_spec(reconciler: Reconciler) -> TempPred<State> {
+pub open spec fn sm_spec<RS>(reconciler: Reconciler<RS>) -> TempPred<State<RS>> {
     lift_state(init(reconciler))
     .and(always(lift_action(next(reconciler))))
     .and(tla_forall(|input| kubernetes_api_next().weak_fairness(input)))
     .and(tla_forall(|input| controller_next(reconciler).weak_fairness(input)))
 }
 
-pub open spec fn kubernetes_api_action_pre(action: KubernetesAPIAction, input: KubernetesAPIActionInput) -> StatePred<State> {
-    |s: State| {
+pub open spec fn kubernetes_api_action_pre<RS>(action: KubernetesAPIAction, input: KubernetesAPIActionInput) -> StatePred<State<RS>> {
+    |s: State<RS>| {
         let host_result = kubernetes_api().next_action_result(action, input, s.kubernetes_api_state);
         let msg_ops = MessageOps {
             recv: input,
@@ -224,8 +224,8 @@ pub open spec fn kubernetes_api_action_pre(action: KubernetesAPIAction, input: K
     }
 }
 
-pub open spec fn controller_action_pre(reconciler: Reconciler, action: ControllerAction, input: ControllerActionInput) -> StatePred<State> {
-    |s: State| {
+pub open spec fn controller_action_pre<RS>(reconciler: Reconciler<RS>, action: ControllerAction<RS>, input: ControllerActionInput) -> StatePred<State<RS>> {
+    |s: State<RS>| {
         let host_result = controller(reconciler).next_action_result(action, input, s.controller_state);
         let msg_ops = MessageOps {
             recv: input.recv,

--- a/src/kubernetes_cluster/spec/reconciler.rs
+++ b/src/kubernetes_cluster/spec/reconciler.rs
@@ -10,13 +10,13 @@ verus! {
 
 /// Reconciler is the key data structure we use to pack up all the custom controller-specific logic
 /// and install it to the Kubernetes cluster state machine
-pub struct Reconciler {
+pub struct Reconciler<#[verifier(maybe_negative)] RS> {
     // reconcile_init_state returns the initial local state that the reconciler starts
     // its reconcile function with.
     // Currently the local state is hardcoded to a ReconcileState.
     // We would like to make ReconcileState more general and reconcile_init_state
     // can also be more flexible.
-    pub reconcile_init_state: ReconcileInitState,
+    pub reconcile_init_state: ReconcileInitState<RS>,
 
     // reconcile_trigger decides whether the reconcile function should be triggered by an incoming event
     // The trigger condition can be as simple as "trigger only when the CR gets changed".
@@ -27,30 +27,19 @@ pub struct Reconciler {
     // reconcile_core describes the logic of reconcile function and is the key logic we want to verify.
     // Each reconcile_core should take the local state and a response of the previous request (if any) as input
     // and outputs the next local state and the request to send to Kubernetes API (if any).
-    pub reconcile_core: ReconcileCore,
+    pub reconcile_core: ReconcileCore<RS>,
 
     // reconcile_done is used to tell the controller_runtime whether the reconcile function finishes.
     // If it is true, controller_runtime will cleans up its local state and probably requeue the reconcile.
-    pub reconcile_done: ReconcileDone,
+    pub reconcile_done: ReconcileDone<RS>,
 }
 
-/// ReconcileState describes the local state with which the reconcile functions makes decisions.
-/// Unfortunately it is not very general now.
-/// TODO: Make it a trait to allow different reconcilers define different local state
-pub struct ReconcileState {
-    // reconcile_pc, like a program counter, is used to track the progress of reconcile_core
-    // since reconcile_core is frequently "trapped" into the controller_runtime spec.
-    // nat is not the idea way of representing pc, but we cannot use enum here
-    // because the enum type will be specific to the reconciler.
-    pub reconcile_pc: nat,
-}
-
-pub type ReconcileInitState = FnSpec() -> ReconcileState;
-
-pub type ReconcileCore = FnSpec(ResourceKey, Option<APIResponse>, ReconcileState) -> (ReconcileState, Option<APIRequest>);
+pub type ReconcileInitState<RS> = FnSpec() -> RS;
 
 pub type ReconcileTrigger = FnSpec(Message) -> Option<ResourceKey>;
 
-pub type ReconcileDone = FnSpec(ReconcileState) -> bool;
+pub type ReconcileCore<RS> = FnSpec(ResourceKey, Option<APIResponse>, RS) -> (RS, Option<APIRequest>);
+
+pub type ReconcileDone<RS> = FnSpec(RS) -> bool;
 
 }

--- a/src/kubernetes_cluster/spec/reconciler.rs
+++ b/src/kubernetes_cluster/spec/reconciler.rs
@@ -10,13 +10,13 @@ verus! {
 
 /// Reconciler is the key data structure we use to pack up all the custom controller-specific logic
 /// and install it to the Kubernetes cluster state machine
-pub struct Reconciler<#[verifier(maybe_negative)] RS> {
+pub struct Reconciler<#[verifier(maybe_negative)] T> {
     // reconcile_init_state returns the initial local state that the reconciler starts
     // its reconcile function with.
     // Currently the local state is hardcoded to a ReconcileState.
     // We would like to make ReconcileState more general and reconcile_init_state
     // can also be more flexible.
-    pub reconcile_init_state: ReconcileInitState<RS>,
+    pub reconcile_init_state: ReconcileInitState<T>,
 
     // reconcile_trigger decides whether the reconcile function should be triggered by an incoming event
     // The trigger condition can be as simple as "trigger only when the CR gets changed".
@@ -27,19 +27,19 @@ pub struct Reconciler<#[verifier(maybe_negative)] RS> {
     // reconcile_core describes the logic of reconcile function and is the key logic we want to verify.
     // Each reconcile_core should take the local state and a response of the previous request (if any) as input
     // and outputs the next local state and the request to send to Kubernetes API (if any).
-    pub reconcile_core: ReconcileCore<RS>,
+    pub reconcile_core: ReconcileCore<T>,
 
     // reconcile_done is used to tell the controller_runtime whether the reconcile function finishes.
     // If it is true, controller_runtime will cleans up its local state and probably requeue the reconcile.
-    pub reconcile_done: ReconcileDone<RS>,
+    pub reconcile_done: ReconcileDone<T>,
 }
 
-pub type ReconcileInitState<RS> = FnSpec() -> RS;
+pub type ReconcileInitState<T> = FnSpec() -> T;
 
 pub type ReconcileTrigger = FnSpec(Message) -> Option<ResourceKey>;
 
-pub type ReconcileCore<RS> = FnSpec(ResourceKey, Option<APIResponse>, RS) -> (RS, Option<APIRequest>);
+pub type ReconcileCore<T> = FnSpec(ResourceKey, Option<APIResponse>, T) -> (T, Option<APIRequest>);
 
-pub type ReconcileDone<RS> = FnSpec(RS) -> bool;
+pub type ReconcileDone<T> = FnSpec(T) -> bool;
 
 }

--- a/src/simple_controller/proof/liveness.rs
+++ b/src/simple_controller/proof/liveness.rs
@@ -13,25 +13,28 @@ use crate::kubernetes_cluster::{
 };
 use crate::pervasive::{option::*, result::*};
 use crate::simple_controller::proof::safety;
-use crate::simple_controller::spec::{simple_reconciler, simple_reconciler::simple_reconciler};
+use crate::simple_controller::spec::{
+    simple_reconciler,
+    simple_reconciler::{simple_reconciler, SimpleReconcileState},
+};
 use crate::temporal_logic::{defs::*, rules::*};
 use builtin::*;
 use builtin_macros::*;
 
 verus! {
 
-spec fn match_cr(cr: ResourceObj) -> TempPred<State>
+spec fn match_cr(cr: ResourceObj) -> TempPred<State<SimpleReconcileState>>
     recommends
         cr.key.kind.is_CustomResourceKind(),
 {
-    lift_state(|s: State| s.resource_key_exists(simple_reconciler::subresource_configmap(cr.key).key))
+    lift_state(|s: State<SimpleReconcileState>| s.resource_key_exists(simple_reconciler::subresource_configmap(cr.key).key))
 }
 
-spec fn liveness(cr: ResourceObj) -> TempPred<State>
+spec fn liveness(cr: ResourceObj) -> TempPred<State<SimpleReconcileState>>
     recommends
         cr.key.kind.is_CustomResourceKind(),
 {
-    lift_state(|s: State| s.resource_obj_exists(cr)).leads_to(always(match_cr(cr)))
+    lift_state(|s: State<SimpleReconcileState>| s.resource_obj_exists(cr)).leads_to(always(match_cr(cr)))
 }
 
 proof fn liveness_proof_forall_cr()
@@ -48,12 +51,12 @@ proof fn liveness_proof(cr: ResourceObj)
         cr.key.kind.is_CustomResourceKind(),
     ensures
         sm_spec(simple_reconciler()).entails(
-            lift_state(|s: State| s.resource_obj_exists(cr))
-                .leads_to(always(lift_state(|s: State| s.resource_key_exists(simple_reconciler::subresource_configmap(cr.key).key))))
+            lift_state(|s: State<SimpleReconcileState>| s.resource_obj_exists(cr))
+                .leads_to(always(lift_state(|s: State<SimpleReconcileState>| s.resource_key_exists(simple_reconciler::subresource_configmap(cr.key).key))))
         ),
 {
-    leads_to_weaken_auto::<State>(sm_spec(simple_reconciler()));
-    kubernetes_api_safety::lemma_always_res_exists_implies_added_event_sent(simple_reconciler(), cr);
+    leads_to_weaken_auto::<State<SimpleReconcileState>>(sm_spec(simple_reconciler()));
+    kubernetes_api_safety::lemma_always_res_exists_implies_added_event_sent::<SimpleReconcileState>(simple_reconciler(), cr);
     lemma_cr_added_event_msg_sent_leads_to_cm_always_exists(cr);
 }
 
@@ -62,20 +65,20 @@ proof fn lemma_cr_added_event_msg_sent_leads_to_cm_always_exists(cr: ResourceObj
         cr.key.kind.is_CustomResourceKind(),
     ensures
         sm_spec(simple_reconciler()).entails(
-            lift_state(|s: State| s.message_sent(form_msg(HostId::KubernetesAPI, HostId::CustomController, added_event_msg(cr))))
-                .leads_to(always(lift_state(|s: State| s.resource_key_exists(simple_reconciler::subresource_configmap(cr.key).key))))
+            lift_state(|s: State<SimpleReconcileState>| s.message_sent(form_msg(HostId::KubernetesAPI, HostId::CustomController, added_event_msg(cr))))
+                .leads_to(always(lift_state(|s: State<SimpleReconcileState>| s.resource_key_exists(simple_reconciler::subresource_configmap(cr.key).key))))
         ),
 {
-    let cr_added_event_msg_sent = |s: State| s.message_sent(form_msg(HostId::KubernetesAPI, HostId::CustomController, added_event_msg(cr)));
-    let controller_in_reconcile = |s: State| s.reconcile_state_contains(cr.key);
-    let cm_exists = |s: State| s.resource_key_exists(simple_reconciler::subresource_configmap(cr.key).key);
+    let cr_added_event_msg_sent = |s: State<SimpleReconcileState>| s.message_sent(form_msg(HostId::KubernetesAPI, HostId::CustomController, added_event_msg(cr)));
+    let controller_in_reconcile = |s: State<SimpleReconcileState>| s.reconcile_state_contains(cr.key);
+    let cm_exists = |s: State<SimpleReconcileState>| s.resource_key_exists(simple_reconciler::subresource_configmap(cr.key).key);
 
-    leads_to_weaken_auto::<State>(sm_spec(simple_reconciler()));
+    leads_to_weaken_auto::<State<SimpleReconcileState>>(sm_spec(simple_reconciler()));
 
     lemma_cr_added_event_msg_sent_leads_to_controller_in_reconcile(cr);
     lemma_controller_in_reconcile_leads_to_cm_always_exists(cr);
 
-    leads_to_trans_temp::<State>(sm_spec(simple_reconciler()), lift_state(cr_added_event_msg_sent), lift_state(controller_in_reconcile), always(lift_state(cm_exists)));
+    leads_to_trans_temp::<State<SimpleReconcileState>>(sm_spec(simple_reconciler()), lift_state(cr_added_event_msg_sent), lift_state(controller_in_reconcile), always(lift_state(cm_exists)));
 
 }
 
@@ -84,24 +87,24 @@ proof fn lemma_cr_added_event_msg_sent_leads_to_controller_in_reconcile(cr: Reso
         cr.key.kind.is_CustomResourceKind(),
     ensures
         sm_spec(simple_reconciler()).entails(
-            lift_state(|s: State| s.message_sent(form_msg(HostId::KubernetesAPI, HostId::CustomController, added_event_msg(cr))))
-                .leads_to(lift_state(|s: State| s.reconcile_state_contains(cr.key)))
+            lift_state(|s: State<SimpleReconcileState>| s.message_sent(form_msg(HostId::KubernetesAPI, HostId::CustomController, added_event_msg(cr))))
+                .leads_to(lift_state(|s: State<SimpleReconcileState>| s.reconcile_state_contains(cr.key)))
         ),
 {
     let cm = simple_reconciler::subresource_configmap(cr.key);
     let cr_added_event_msg = form_msg(HostId::KubernetesAPI, HostId::CustomController, added_event_msg(cr));
 
-    let cr_added_event_msg_sent_and_controller_not_in_reconcile = |s: State| {
+    let cr_added_event_msg_sent_and_controller_not_in_reconcile = |s: State<SimpleReconcileState>| {
         &&& s.message_sent(cr_added_event_msg)
         &&& !s.reconcile_state_contains(cr.key)
     };
-    let cr_added_event_msg_sent_and_controller_in_reconcile = |s: State| {
+    let cr_added_event_msg_sent_and_controller_in_reconcile = |s: State<SimpleReconcileState>| {
         &&& s.message_sent(cr_added_event_msg)
         &&& s.reconcile_state_contains(cr.key)
     };
-    let controller_in_reconcile = |s: State| s.reconcile_state_contains(cr.key);
+    let controller_in_reconcile = |s: State<SimpleReconcileState>| s.reconcile_state_contains(cr.key);
 
-    leads_to_weaken_auto::<State>(sm_spec(simple_reconciler()));
+    leads_to_weaken_auto::<State<SimpleReconcileState>>(sm_spec(simple_reconciler()));
 
     // It calls wf1 to get cr_added_event_msg_sent_and_controller_not_in_reconcile ~> reconcile_at_init_pc
     // which also gives us cr_added_event_msg_sent_and_controller_not_in_reconcile ~> controller_in_reconcile by weakening
@@ -109,10 +112,10 @@ proof fn lemma_cr_added_event_msg_sent_leads_to_controller_in_reconcile(cr: Reso
 
     // This lemma gives controller_in_reconcile ~> controller_in_reconcile
     // and also cr_added_event_msg_sent_and_controller_in_reconcile ~> controller_in_reconcile by weakening
-    leads_to_self::<State>(controller_in_reconcile);
+    leads_to_self::<State<SimpleReconcileState>>(controller_in_reconcile);
 
     // Combine the two leads-to above and we will get the postcondition
-    or_leads_to_combine::<State>(sm_spec(simple_reconciler()), cr_added_event_msg_sent_and_controller_not_in_reconcile, cr_added_event_msg_sent_and_controller_in_reconcile, controller_in_reconcile);
+    or_leads_to_combine::<State<SimpleReconcileState>>(sm_spec(simple_reconciler()), cr_added_event_msg_sent_and_controller_not_in_reconcile, cr_added_event_msg_sent_and_controller_in_reconcile, controller_in_reconcile);
 }
 
 proof fn lemma_controller_in_reconcile_leads_to_cm_always_exists(cr: ResourceObj)
@@ -120,31 +123,31 @@ proof fn lemma_controller_in_reconcile_leads_to_cm_always_exists(cr: ResourceObj
         cr.key.kind.is_CustomResourceKind(),
     ensures
         sm_spec(simple_reconciler()).entails(
-            lift_state(|s: State| s.reconcile_state_contains(cr.key))
-                .leads_to(always(lift_state(|s: State| s.resource_key_exists(simple_reconciler::subresource_configmap(cr.key).key))))
+            lift_state(|s: State<SimpleReconcileState>| s.reconcile_state_contains(cr.key))
+                .leads_to(always(lift_state(|s: State<SimpleReconcileState>| s.resource_key_exists(simple_reconciler::subresource_configmap(cr.key).key))))
         ),
 {
     let cm = simple_reconciler::subresource_configmap(cr.key);
 
-    let reconcile_at_init_pc = |s: State| {
+    let reconcile_at_init_pc = |s: State<SimpleReconcileState>| {
         &&& s.reconcile_state_contains(cr.key)
         &&& s.reconcile_state_of(cr.key).local_state.reconcile_pc === simple_reconciler::init_pc()
     };
-    let reconciler_at_after_get_cr_pc = |s: State| {
+    let reconciler_at_after_get_cr_pc = |s: State<SimpleReconcileState>| {
         &&& s.reconcile_state_contains(cr.key)
         &&& s.reconcile_state_of(cr.key).local_state.reconcile_pc === simple_reconciler::after_get_cr_pc()
     };
-    let reconciler_at_after_create_cm_pc = |s: State| {
+    let reconciler_at_after_create_cm_pc = |s: State<SimpleReconcileState>| {
         &&& s.reconcile_state_contains(cr.key)
         &&& s.reconcile_state_of(cr.key).local_state.reconcile_pc === simple_reconciler::after_create_cm_pc()
     };
-    let reconciler_reconcile_done = |s: State| {
+    let reconciler_reconcile_done = |s: State<SimpleReconcileState>| {
         &&& s.reconcile_state_contains(cr.key)
         &&& (simple_reconciler().reconcile_done)(s.reconcile_state_of(cr.key).local_state)
     };
-    let cm_exists = |s: State| s.resource_key_exists(cm.key);
+    let cm_exists = |s: State<SimpleReconcileState>| s.resource_key_exists(cm.key);
 
-    leads_to_weaken_auto::<State>(sm_spec(simple_reconciler()));
+    leads_to_weaken_auto::<State<SimpleReconcileState>>(sm_spec(simple_reconciler()));
 
     // This proof is also straightforward once we have proved the four following lemmas
     // The four lemmas cover all the possible values of reconcile_pc
@@ -155,14 +158,14 @@ proof fn lemma_controller_in_reconcile_leads_to_cm_always_exists(cr: ResourceObj
 
     // Now we combine the four cases together
     // and we will get s.reconcile_state_contains(cr.key) ~> []cm_exists
-    or_leads_to_combine_temp::<State>(sm_spec(simple_reconciler()), lift_state(reconcile_at_init_pc), lift_state(reconciler_at_after_get_cr_pc), always(lift_state(cm_exists)));
-    or_leads_to_combine_temp::<State>(sm_spec(simple_reconciler()), lift_state(reconciler_at_after_create_cm_pc), lift_state(reconciler_reconcile_done), always(lift_state(cm_exists)));
-    or_leads_to_combine_temp::<State>(sm_spec(simple_reconciler()),
-        lift_state(|s: State| {
+    or_leads_to_combine_temp::<State<SimpleReconcileState>>(sm_spec(simple_reconciler()), lift_state(reconcile_at_init_pc), lift_state(reconciler_at_after_get_cr_pc), always(lift_state(cm_exists)));
+    or_leads_to_combine_temp::<State<SimpleReconcileState>>(sm_spec(simple_reconciler()), lift_state(reconciler_at_after_create_cm_pc), lift_state(reconciler_reconcile_done), always(lift_state(cm_exists)));
+    or_leads_to_combine_temp::<State<SimpleReconcileState>>(sm_spec(simple_reconciler()),
+        lift_state(|s: State<SimpleReconcileState>| {
             ||| reconcile_at_init_pc(s)
             ||| reconciler_at_after_get_cr_pc(s)
         }),
-        lift_state(|s: State| {
+        lift_state(|s: State<SimpleReconcileState>| {
             ||| reconciler_at_after_create_cm_pc(s)
             ||| reconciler_reconcile_done(s)
         }),
@@ -175,33 +178,33 @@ proof fn lemma_init_pc_leads_to_cm_always_exists(cr: ResourceObj)
         cr.key.kind.is_CustomResourceKind(),
     ensures
         sm_spec(simple_reconciler()).entails(
-            lift_state(|s: State| {
+            lift_state(|s: State<SimpleReconcileState>| {
                 &&& s.reconcile_state_contains(cr.key)
                 &&& s.reconcile_state_of(cr.key).local_state.reconcile_pc === simple_reconciler::init_pc()
-            }).leads_to(always(lift_state(|s: State| s.resource_key_exists(simple_reconciler::subresource_configmap(cr.key).key))))
+            }).leads_to(always(lift_state(|s: State<SimpleReconcileState>| s.resource_key_exists(simple_reconciler::subresource_configmap(cr.key).key))))
         ),
 {
     let cm = simple_reconciler::subresource_configmap(cr.key);
 
     // Just layout all the state predicates we are going to repeatedly use later since they are so long
-    let reconcile_at_init_pc = |s: State| {
+    let reconcile_at_init_pc = |s: State<SimpleReconcileState>| {
         &&& s.reconcile_state_contains(cr.key)
         &&& s.reconcile_state_of(cr.key).local_state.reconcile_pc === simple_reconciler::init_pc()
     };
-    let reconcile_at_init_pc_and_no_pending_req = |s: State| {
+    let reconcile_at_init_pc_and_no_pending_req = |s: State<SimpleReconcileState>| {
         &&& s.reconcile_state_contains(cr.key)
         &&& s.reconcile_state_of(cr.key).local_state.reconcile_pc === simple_reconciler::init_pc()
         &&& s.reconcile_state_of(cr.key).pending_req_msg.is_None()
     };
-    let reconciler_at_after_get_cr_pc = |s: State| {
+    let reconciler_at_after_get_cr_pc = |s: State<SimpleReconcileState>| {
         &&& s.reconcile_state_contains(cr.key)
         &&& s.reconcile_state_of(cr.key).local_state.reconcile_pc === simple_reconciler::after_get_cr_pc()
     };
-    let cm_exists = |s: State| s.resource_key_exists(cm.key);
+    let cm_exists = |s: State<SimpleReconcileState>| s.resource_key_exists(cm.key);
 
-    leads_to_weaken_auto::<State>(sm_spec(simple_reconciler()));
+    leads_to_weaken_auto::<State<SimpleReconcileState>>(sm_spec(simple_reconciler()));
 
-    leads_to_self::<State>(reconcile_at_init_pc);
+    leads_to_self::<State<SimpleReconcileState>>(reconcile_at_init_pc);
     safety::lemma_always_reconcile_init_implies_no_pending_req(cr.key);
     // We get the following asserted leads-to formula by auto weakening the one from leads_to_self
     // with the always-implies formula from lemma_always_reconcile_init_implies_no_pending_req
@@ -212,10 +215,10 @@ proof fn lemma_init_pc_leads_to_cm_always_exists(cr: ResourceObj)
     ));
     // Get the leads-to formula from lemma_init_pc_leads_to_after_get_cr_pc and connect it with the above asserted one
     lemma_init_pc_leads_to_after_get_cr_pc(cr.key);
-    leads_to_trans::<State>(sm_spec(simple_reconciler()), reconcile_at_init_pc, reconcile_at_init_pc_and_no_pending_req, reconciler_at_after_get_cr_pc);
+    leads_to_trans::<State<SimpleReconcileState>>(sm_spec(simple_reconciler()), reconcile_at_init_pc, reconcile_at_init_pc_and_no_pending_req, reconciler_at_after_get_cr_pc);
     // Since we have prove that spec |= reconciler_at_after_get_cr_pc ~> []cm_exists, we will just take a shortcut here
     lemma_after_get_cr_pc_leads_to_cm_always_exists(cr);
-    leads_to_trans_temp::<State>(sm_spec(simple_reconciler()), lift_state(reconcile_at_init_pc), lift_state(reconciler_at_after_get_cr_pc), always(lift_state(cm_exists)));
+    leads_to_trans_temp::<State<SimpleReconcileState>>(sm_spec(simple_reconciler()), lift_state(reconcile_at_init_pc), lift_state(reconciler_at_after_get_cr_pc), always(lift_state(cm_exists)));
 }
 
 proof fn lemma_after_get_cr_pc_leads_to_cm_always_exists(cr: ResourceObj)
@@ -223,10 +226,10 @@ proof fn lemma_after_get_cr_pc_leads_to_cm_always_exists(cr: ResourceObj)
         cr.key.kind.is_CustomResourceKind(),
     ensures
         sm_spec(simple_reconciler()).entails(
-            lift_state(|s: State| {
+            lift_state(|s: State<SimpleReconcileState>| {
                 &&& s.reconcile_state_contains(cr.key)
                 &&& s.reconcile_state_of(cr.key).local_state.reconcile_pc === simple_reconciler::after_get_cr_pc()
-            }).leads_to(always(lift_state(|s: State| s.resource_key_exists(simple_reconciler::subresource_configmap(cr.key).key))))
+            }).leads_to(always(lift_state(|s: State<SimpleReconcileState>| s.resource_key_exists(simple_reconciler::subresource_configmap(cr.key).key))))
         ),
 {
     let get_cr_req_msg = controller_req_msg(APIRequest::GetRequest(GetRequest{key: cr.key}));
@@ -234,67 +237,67 @@ proof fn lemma_after_get_cr_pc_leads_to_cm_always_exists(cr: ResourceObj)
     let cm = simple_reconciler::subresource_configmap(cr.key);
 
     // Just layout all the state predicates we are going to repeatedly use later since they are so long
-    let reconciler_at_after_get_cr_pc = |s: State| {
+    let reconciler_at_after_get_cr_pc = |s: State<SimpleReconcileState>| {
         &&& s.reconcile_state_contains(cr.key)
         &&& s.reconcile_state_of(cr.key).local_state.reconcile_pc === simple_reconciler::after_get_cr_pc()
     };
-    let reconciler_at_after_get_cr_pc_and_pending_get_cr_req = |s: State| {
+    let reconciler_at_after_get_cr_pc_and_pending_get_cr_req = |s: State<SimpleReconcileState>| {
         &&& s.reconcile_state_contains(cr.key)
         &&& s.reconcile_state_of(cr.key).local_state.reconcile_pc === simple_reconciler::after_get_cr_pc()
         &&& s.reconcile_state_of(cr.key).pending_req_msg === Option::Some(get_cr_req_msg)
     };
-    let reconciler_at_after_create_cm_pc = |s: State| {
+    let reconciler_at_after_create_cm_pc = |s: State<SimpleReconcileState>| {
         &&& s.reconcile_state_contains(cr.key)
         &&& s.reconcile_state_of(cr.key).local_state.reconcile_pc === simple_reconciler::after_create_cm_pc()
     };
-    let get_cr_req_msg_sent = |s: State| s.message_sent(get_cr_req_msg);
-    let get_cr_resp_msg_sent = |s: State| {
+    let get_cr_req_msg_sent = |s: State<SimpleReconcileState>| s.message_sent(get_cr_req_msg);
+    let get_cr_resp_msg_sent = |s: State<SimpleReconcileState>| {
         exists |resp_msg: Message| {
             &&& #[trigger] s.message_sent(resp_msg)
             &&& resp_msg_matches_req_msg(resp_msg, get_cr_req_msg)
         }
     };
-    let cm_exists = |s: State| s.resource_key_exists(cm.key);
+    let cm_exists = |s: State<SimpleReconcileState>| s.resource_key_exists(cm.key);
 
-    leads_to_weaken_auto::<State>(sm_spec(simple_reconciler()));
+    leads_to_weaken_auto::<State<SimpleReconcileState>>(sm_spec(simple_reconciler()));
 
     safety::lemma_always_reconcile_get_cr_done_implies_pending_get_cr_req(cr.key);
-    leads_to_self::<State>(reconciler_at_after_get_cr_pc);
+    leads_to_self::<State<SimpleReconcileState>>(reconciler_at_after_get_cr_pc);
     // We get the following asserted leads-to formula by auto weakening the one from leads_to_self
     // with the always-implies formula from lemma_always_reconcile_get_cr_done_implies_pending_get_cr_req
     // We have to write down this assertion to further trigger leads_to_weaken_auto
     assert(sm_spec(simple_reconciler()).entails(
         lift_state(reconciler_at_after_get_cr_pc)
-            .leads_to(lift_state(|s: State| {
+            .leads_to(lift_state(|s: State<SimpleReconcileState>| {
                 &&& s.reconcile_state_contains(cr.key)
                 &&& s.reconcile_state_of(cr.key).local_state.reconcile_pc === simple_reconciler::after_get_cr_pc()
                 &&& s.reconcile_state_of(cr.key).pending_req_msg === Option::Some(get_cr_req_msg)
                 &&& s.message_sent(get_cr_req_msg)
             }))
     ));
-    kubernetes_api_liveness::lemma_get_req_leads_to_some_resp(simple_reconciler(), get_cr_req_msg, cr.key);
-    leads_to_trans::<State>(sm_spec(simple_reconciler()), reconciler_at_after_get_cr_pc, get_cr_req_msg_sent, get_cr_resp_msg_sent);
+    kubernetes_api_liveness::lemma_get_req_leads_to_some_resp::<SimpleReconcileState>(simple_reconciler(), get_cr_req_msg, cr.key);
+    leads_to_trans::<State<SimpleReconcileState>>(sm_spec(simple_reconciler()), reconciler_at_after_get_cr_pc, get_cr_req_msg_sent, get_cr_resp_msg_sent);
     // It is quite obvious that get_cr_resp_msg_sent is stable since we never remove a message from the network sent set
     // But we still need to prove it by providing a witness because of "exists" in get_cr_resp_msg_sent
     // Note that we want to prove it is stable because we want to use leads_to_confluence later
-    assert forall |s, s_prime: State| get_cr_resp_msg_sent(s) && #[trigger] next(simple_reconciler())(s, s_prime) implies get_cr_resp_msg_sent(s_prime) by {
+    assert forall |s, s_prime: State<SimpleReconcileState>| get_cr_resp_msg_sent(s) && #[trigger] next(simple_reconciler())(s, s_prime) implies get_cr_resp_msg_sent(s_prime) by {
         let msg = choose |m: Message| {
             &&& #[trigger] s.message_sent(m)
             &&& resp_msg_matches_req_msg(m, get_cr_req_msg)
         };
         assert(s_prime.message_sent(msg));
     };
-    leads_to_stable::<State>(sm_spec(simple_reconciler()), next(simple_reconciler()), reconciler_at_after_get_cr_pc, get_cr_resp_msg_sent);
+    leads_to_stable::<State<SimpleReconcileState>>(sm_spec(simple_reconciler()), next(simple_reconciler()), reconciler_at_after_get_cr_pc, get_cr_resp_msg_sent);
     // Now we have:
     //  spec |= reconciler_at_after_get_cr_pc ~> reconciler_at_after_get_cr_pc_and_pending_get_cr_req
     //  spec |= reconciler_at_after_get_cr_pc ~> []get_cr_resp_msg_sent
     // And to make more progress, we need to make reconciler_at_after_get_cr_pc_and_pending_get_cr_req and get_cr_resp_msg_sent
     // both true at the same time
     // This is why we use leads_to_confluence here
-    leads_to_confluence::<State>(sm_spec(simple_reconciler()), next(simple_reconciler()), reconciler_at_after_get_cr_pc, reconciler_at_after_get_cr_pc_and_pending_get_cr_req, get_cr_resp_msg_sent);
+    leads_to_confluence::<State<SimpleReconcileState>>(sm_spec(simple_reconciler()), next(simple_reconciler()), reconciler_at_after_get_cr_pc, reconciler_at_after_get_cr_pc_and_pending_get_cr_req, get_cr_resp_msg_sent);
     // Now we have all the premise to fire the leads-to formula from lemma_exists_msg_sent_and_after_get_cr_pc_leads_to_after_create_cm_pc
     lemma_exists_msg_sent_and_after_get_cr_pc_leads_to_after_create_cm_pc(cr.key);
-    leads_to_trans::<State>(sm_spec(simple_reconciler()),
+    leads_to_trans::<State<SimpleReconcileState>>(sm_spec(simple_reconciler()),
         reconciler_at_after_get_cr_pc,
         |s| {
             &&& reconciler_at_after_get_cr_pc_and_pending_get_cr_req(s)
@@ -304,7 +307,7 @@ proof fn lemma_after_get_cr_pc_leads_to_cm_always_exists(cr: ResourceObj)
     );
     // Since we have prove that spec |= reconciler_at_after_create_cm_pc ~> []cm_exists, we will just take a shortcut here
     lemma_after_create_cm_pc_leads_to_cm_always_exists(cr);
-    leads_to_trans_temp::<State>(sm_spec(simple_reconciler()), lift_state(reconciler_at_after_get_cr_pc), lift_state(reconciler_at_after_create_cm_pc), always(lift_state(cm_exists)));
+    leads_to_trans_temp::<State<SimpleReconcileState>>(sm_spec(simple_reconciler()), lift_state(reconciler_at_after_get_cr_pc), lift_state(reconciler_at_after_create_cm_pc), always(lift_state(cm_exists)));
 }
 
 proof fn lemma_after_create_cm_pc_leads_to_cm_always_exists(cr: ResourceObj)
@@ -312,35 +315,35 @@ proof fn lemma_after_create_cm_pc_leads_to_cm_always_exists(cr: ResourceObj)
         cr.key.kind.is_CustomResourceKind(),
     ensures
         sm_spec(simple_reconciler()).entails(
-            lift_state(|s: State| {
+            lift_state(|s: State<SimpleReconcileState>| {
                 &&& s.reconcile_state_contains(cr.key)
                 &&& s.reconcile_state_of(cr.key).local_state.reconcile_pc === simple_reconciler::after_create_cm_pc()
-            }).leads_to(always(lift_state(|s: State| s.resource_key_exists(simple_reconciler::subresource_configmap(cr.key).key))))
+            }).leads_to(always(lift_state(|s: State<SimpleReconcileState>| s.resource_key_exists(simple_reconciler::subresource_configmap(cr.key).key))))
         ),
 {
     let create_cm_req_msg = controller_req_msg(simple_reconciler::create_cm_req(cr.key));
     let cm = simple_reconciler::subresource_configmap(cr.key);
 
     // Just layout all the state predicates we are going to repeatedly use later since they are so long
-    let reconciler_at_after_create_cm_pc = |s: State| {
+    let reconciler_at_after_create_cm_pc = |s: State<SimpleReconcileState>| {
         &&& s.reconcile_state_contains(cr.key)
         &&& s.reconcile_state_of(cr.key).local_state.reconcile_pc === simple_reconciler::after_create_cm_pc()
     };
-    let create_cm_req_msg_sent = |s: State| s.message_sent(create_cm_req_msg);
-    let cm_exists = |s: State| {
+    let create_cm_req_msg_sent = |s: State<SimpleReconcileState>| s.message_sent(create_cm_req_msg);
+    let cm_exists = |s: State<SimpleReconcileState>| {
         s.resource_key_exists(cm.key)
     };
 
-    leads_to_weaken_auto::<State>(sm_spec(simple_reconciler()));
+    leads_to_weaken_auto::<State<SimpleReconcileState>>(sm_spec(simple_reconciler()));
 
     safety::lemma_always_reconcile_create_cm_done_implies_pending_create_cm_req(cr.key);
-    leads_to_self::<State>(reconciler_at_after_create_cm_pc);
+    leads_to_self::<State<SimpleReconcileState>>(reconciler_at_after_create_cm_pc);
     // We get the following asserted leads-to formula by auto weakening the one from leads_to_self
     // with the always-implies formula from lemma_always_reconcile_create_cm_done_implies_pending_create_cm_req
     // We have to write down this assertion to further trigger leads_to_weaken_auto
     assert(sm_spec(simple_reconciler()).entails(
         lift_state(reconciler_at_after_create_cm_pc)
-            .leads_to(lift_state(|s: State| {
+            .leads_to(lift_state(|s: State<SimpleReconcileState>| {
                 &&& s.reconcile_state_contains(cr.key)
                 &&& s.reconcile_state_of(cr.key).local_state.reconcile_pc === simple_reconciler::after_create_cm_pc()
                 &&& s.reconcile_state_of(cr.key).pending_req_msg === Option::Some(create_cm_req_msg)
@@ -349,8 +352,8 @@ proof fn lemma_after_create_cm_pc_leads_to_cm_always_exists(cr: ResourceObj)
     ));
     // lemma_create_req_leads_to_res_exists gives us spec |= create_cm_req_msg_sent ~> cm_exists
     // and then apply leads_to_trans to get spec |= reconciler_at_after_create_cm_pc ~> cm_exists
-    kubernetes_api_liveness::lemma_create_req_leads_to_res_exists(simple_reconciler(), create_cm_req_msg, cm);
-    leads_to_trans::<State>(sm_spec(simple_reconciler()), reconciler_at_after_create_cm_pc, create_cm_req_msg_sent, cm_exists);
+    kubernetes_api_liveness::lemma_create_req_leads_to_res_exists::<SimpleReconcileState>(simple_reconciler(), create_cm_req_msg, cm);
+    leads_to_trans::<State<SimpleReconcileState>>(sm_spec(simple_reconciler()), reconciler_at_after_create_cm_pc, create_cm_req_msg_sent, cm_exists);
 
     // finally prove stability: spec |= reconciler_at_after_create_cm_pc ~> []cm_exists
     lemma_p_leads_to_cm_always_exists(cr, lift_state(reconciler_at_after_create_cm_pc));
@@ -361,66 +364,66 @@ proof fn lemma_reconcile_done_leads_to_cm_always_exists(cr: ResourceObj)
         cr.key.kind.is_CustomResourceKind(),
     ensures
         sm_spec(simple_reconciler()).entails(
-            lift_state(|s: State| {
+            lift_state(|s: State<SimpleReconcileState>| {
                 &&& s.reconcile_state_contains(cr.key)
                 &&& (simple_reconciler().reconcile_done)(s.reconcile_state_of(cr.key).local_state)
-            }).leads_to(always(lift_state(|s: State| s.resource_key_exists(simple_reconciler::subresource_configmap(cr.key).key))))
+            }).leads_to(always(lift_state(|s: State<SimpleReconcileState>| s.resource_key_exists(simple_reconciler::subresource_configmap(cr.key).key))))
         ),
 {
     let cm = simple_reconciler::subresource_configmap(cr.key);
 
-    let reconciler_reconcile_done = |s: State| {
+    let reconciler_reconcile_done = |s: State<SimpleReconcileState>| {
         &&& s.reconcile_state_contains(cr.key)
         &&& (simple_reconciler().reconcile_done)(s.reconcile_state_of(cr.key).local_state)
     };
-    let reconcile_at_init_pc = |s: State| {
+    let reconcile_at_init_pc = |s: State<SimpleReconcileState>| {
         &&& s.reconcile_state_contains(cr.key)
         &&& s.reconcile_state_of(cr.key).local_state.reconcile_pc === simple_reconciler::init_pc()
     };
-    let cm_exists = |s: State| s.resource_key_exists(cm.key);
+    let cm_exists = |s: State<SimpleReconcileState>| s.resource_key_exists(cm.key);
 
-    leads_to_weaken_auto::<State>(sm_spec(simple_reconciler()));
+    leads_to_weaken_auto::<State<SimpleReconcileState>>(sm_spec(simple_reconciler()));
 
     // The key of this proof is that ending step label (Done or Error) will make the reconcile rescheduled
     // (yeah it is not super realistic but it is a good practice to always requeue your reconcile
     // and is one compromise I did in the spec to make it easier to start),
     // and the rescheduled reconcile leads to the init reconcile state,
     // which we have proved leads to cm_exists
-    controller_runtime_liveness::lemma_reconcile_done_leads_to_reconcile_triggered(simple_reconciler(), cr.key);
+    controller_runtime_liveness::lemma_reconcile_done_leads_to_reconcile_triggered::<SimpleReconcileState>(simple_reconciler(), cr.key);
     lemma_init_pc_leads_to_cm_always_exists(cr);
-    leads_to_trans_temp::<State>(sm_spec(simple_reconciler()), lift_state(reconciler_reconcile_done), lift_state(reconcile_at_init_pc), always(lift_state(cm_exists)));
+    leads_to_trans_temp::<State<SimpleReconcileState>>(sm_spec(simple_reconciler()), lift_state(reconciler_reconcile_done), lift_state(reconcile_at_init_pc), always(lift_state(cm_exists)));
 }
 
-proof fn lemma_p_leads_to_cm_always_exists(cr: ResourceObj, p: TempPred<State>)
+proof fn lemma_p_leads_to_cm_always_exists(cr: ResourceObj, p: TempPred<State<SimpleReconcileState>>)
     requires
         cr.key.kind.is_CustomResourceKind(),
         sm_spec(simple_reconciler()).entails(
-            p.leads_to(lift_state(|s: State| s.resource_key_exists(simple_reconciler::subresource_configmap(cr.key).key)))
+            p.leads_to(lift_state(|s: State<SimpleReconcileState>| s.resource_key_exists(simple_reconciler::subresource_configmap(cr.key).key)))
         ),
     ensures
         sm_spec(simple_reconciler()).entails(
-            p.leads_to(always(lift_state(|s: State| s.resource_key_exists(simple_reconciler::subresource_configmap(cr.key).key))))
+            p.leads_to(always(lift_state(|s: State<SimpleReconcileState>| s.resource_key_exists(simple_reconciler::subresource_configmap(cr.key).key))))
         ),
 {
     let cm = simple_reconciler::subresource_configmap(cr.key);
 
-    let cm_exists = |s: State| s.resource_key_exists(cm.key);
-    let delete_cm_req_msg_not_sent = |s: State| !exists |m: Message| {
+    let cm_exists = |s: State<SimpleReconcileState>| s.resource_key_exists(cm.key);
+    let delete_cm_req_msg_not_sent = |s: State<SimpleReconcileState>| !exists |m: Message| {
         &&& #[trigger] s.message_sent(m)
         &&& m.dst === HostId::KubernetesAPI
         &&& m.is_delete_request()
         &&& m.get_delete_request().key === simple_reconciler::subresource_configmap(cr.key).key
     };
     safety::lemma_delete_cm_req_msg_never_sent(cr.key);
-    let next_and_invariant = |s: State, s_prime: State| {
+    let next_and_invariant = |s: State<SimpleReconcileState>, s_prime: State<SimpleReconcileState>| {
         &&& next(simple_reconciler())(s, s_prime)
         &&& delete_cm_req_msg_not_sent(s)
     };
 
-    entails_and_temp::<State>(sm_spec(simple_reconciler()), always(lift_action(next(simple_reconciler()))), always(lift_state(delete_cm_req_msg_not_sent)));
-    always_and_equality::<State>(lift_action(next(simple_reconciler())), lift_state(delete_cm_req_msg_not_sent));
-    temp_pred_equality::<State>(lift_action(next(simple_reconciler())).and(lift_state(delete_cm_req_msg_not_sent)), lift_action(next_and_invariant));
-    leads_to_stable_temp::<State>(sm_spec(simple_reconciler()), lift_action(next_and_invariant), p, lift_state(cm_exists));
+    entails_and_temp::<State<SimpleReconcileState>>(sm_spec(simple_reconciler()), always(lift_action(next(simple_reconciler()))), always(lift_state(delete_cm_req_msg_not_sent)));
+    always_and_equality::<State<SimpleReconcileState>>(lift_action(next(simple_reconciler())), lift_state(delete_cm_req_msg_not_sent));
+    temp_pred_equality::<State<SimpleReconcileState>>(lift_action(next(simple_reconciler())).and(lift_state(delete_cm_req_msg_not_sent)), lift_action(next_and_invariant));
+    leads_to_stable_temp::<State<SimpleReconcileState>>(sm_spec(simple_reconciler()), lift_action(next_and_invariant), p, lift_state(cm_exists));
 }
 
 proof fn lemma_relevant_event_sent_leads_to_init_pc(msg: Message, cr_key: ResourceKey)
@@ -428,22 +431,22 @@ proof fn lemma_relevant_event_sent_leads_to_init_pc(msg: Message, cr_key: Resour
         cr_key.kind.is_CustomResourceKind(),
     ensures
         sm_spec(simple_reconciler()).entails(
-            lift_state(|s: State| {
+            lift_state(|s: State<SimpleReconcileState>| {
                 &&& s.message_sent(msg)
                 &&& msg.dst === HostId::CustomController
                 &&& msg.content.is_WatchEvent()
                 &&& simple_reconciler::reconcile_trigger(msg) === Option::Some(cr_key)
                 &&& !s.reconcile_state_contains(cr_key)
             })
-                .leads_to(lift_state(|s: State| {
+                .leads_to(lift_state(|s: State<SimpleReconcileState>| {
                     &&& s.reconcile_state_contains(cr_key)
                     &&& s.reconcile_state_of(cr_key).local_state.reconcile_pc === simple_reconciler::init_pc()
                     &&& s.reconcile_state_of(cr_key).pending_req_msg.is_None()
                 }))
         ),
 {
-    leads_to_weaken_auto::<State>(sm_spec(simple_reconciler()));
-    controller_runtime_liveness::lemma_relevant_event_sent_leads_to_reconcile_triggered(simple_reconciler(), msg, cr_key);
+    leads_to_weaken_auto::<State<SimpleReconcileState>>(sm_spec(simple_reconciler()));
+    controller_runtime_liveness::lemma_relevant_event_sent_leads_to_reconcile_triggered::<SimpleReconcileState>(simple_reconciler(), msg, cr_key);
 }
 
 proof fn lemma_init_pc_leads_to_after_get_cr_pc(cr_key: ResourceKey)
@@ -451,11 +454,11 @@ proof fn lemma_init_pc_leads_to_after_get_cr_pc(cr_key: ResourceKey)
         cr_key.kind.is_CustomResourceKind(),
     ensures
         sm_spec(simple_reconciler()).entails(
-            lift_state(|s: State| {
+            lift_state(|s: State<SimpleReconcileState>| {
                 &&& s.reconcile_state_contains(cr_key)
                 &&& s.reconcile_state_of(cr_key).local_state.reconcile_pc === simple_reconciler::init_pc()
                 &&& s.reconcile_state_of(cr_key).pending_req_msg.is_None()
-            }).leads_to(lift_state(|s: State| {
+            }).leads_to(lift_state(|s: State<SimpleReconcileState>| {
                     &&& s.reconcile_state_contains(cr_key)
                     &&& s.reconcile_state_of(cr_key).local_state.reconcile_pc === simple_reconciler::after_get_cr_pc()
                     &&& s.reconcile_state_of(cr_key).pending_req_msg === Option::Some(controller_req_msg(APIRequest::GetRequest(GetRequest{key: cr_key})))
@@ -463,12 +466,12 @@ proof fn lemma_init_pc_leads_to_after_get_cr_pc(cr_key: ResourceKey)
                 }))
         ),
 {
-    let pre = |s: State| {
+    let pre = |s: State<SimpleReconcileState>| {
         &&& s.reconcile_state_contains(cr_key)
         &&& s.reconcile_state_of(cr_key).local_state.reconcile_pc === simple_reconciler::init_pc()
         &&& s.reconcile_state_of(cr_key).pending_req_msg.is_None()
     };
-    let post = |s: State| {
+    let post = |s: State<SimpleReconcileState>| {
         &&& s.reconcile_state_contains(cr_key)
         &&& s.reconcile_state_of(cr_key).local_state.reconcile_pc === simple_reconciler::after_get_cr_pc()
         &&& s.reconcile_state_of(cr_key).pending_req_msg === Option::Some(controller_req_msg(APIRequest::GetRequest(GetRequest{key: cr_key})))
@@ -478,7 +481,7 @@ proof fn lemma_init_pc_leads_to_after_get_cr_pc(cr_key: ResourceKey)
         recv: Option::None,
         scheduled_cr_key: Option::Some(cr_key),
     };
-    controller_runtime_liveness::lemma_pre_leads_to_post_by_controller(simple_reconciler(), input, continue_reconcile(simple_reconciler()), pre, post);
+    controller_runtime_liveness::lemma_pre_leads_to_post_by_controller::<SimpleReconcileState>(simple_reconciler(), input, continue_reconcile(simple_reconciler()), pre, post);
 }
 
 proof fn lemma_msg_sent_and_after_get_cr_pc_leads_to_after_create_cm_pc(msg: Message, cr_key: ResourceKey)
@@ -486,13 +489,13 @@ proof fn lemma_msg_sent_and_after_get_cr_pc_leads_to_after_create_cm_pc(msg: Mes
         cr_key.kind.is_CustomResourceKind(),
     ensures
         sm_spec(simple_reconciler()).entails(
-            lift_state(|s: State| {
+            lift_state(|s: State<SimpleReconcileState>| {
                 &&& s.message_sent(msg)
                 &&& resp_msg_matches_req_msg(msg, controller_req_msg(APIRequest::GetRequest(GetRequest{key: cr_key})))
                 &&& s.reconcile_state_contains(cr_key)
                 &&& s.reconcile_state_of(cr_key).local_state.reconcile_pc === simple_reconciler::after_get_cr_pc()
                 &&& s.reconcile_state_of(cr_key).pending_req_msg === Option::Some(controller_req_msg(APIRequest::GetRequest(GetRequest{key: cr_key})))
-            }).leads_to(lift_state(|s: State| {
+            }).leads_to(lift_state(|s: State<SimpleReconcileState>| {
                     &&& s.reconcile_state_contains(cr_key)
                     &&& s.reconcile_state_of(cr_key).local_state.reconcile_pc === simple_reconciler::after_create_cm_pc()
                     &&& s.reconcile_state_of(cr_key).pending_req_msg === Option::Some(controller_req_msg(simple_reconciler::create_cm_req(cr_key)))
@@ -500,14 +503,14 @@ proof fn lemma_msg_sent_and_after_get_cr_pc_leads_to_after_create_cm_pc(msg: Mes
                 }))
         ),
 {
-    let pre = |s: State| {
+    let pre = |s: State<SimpleReconcileState>| {
         &&& s.message_sent(msg)
         &&& resp_msg_matches_req_msg(msg, controller_req_msg(APIRequest::GetRequest(GetRequest{key: cr_key})))
         &&& s.reconcile_state_contains(cr_key)
         &&& s.reconcile_state_of(cr_key).local_state.reconcile_pc === simple_reconciler::after_get_cr_pc()
         &&& s.reconcile_state_of(cr_key).pending_req_msg === Option::Some(controller_req_msg(APIRequest::GetRequest(GetRequest{key: cr_key})))
     };
-    let post = |s: State| {
+    let post = |s: State<SimpleReconcileState>| {
         &&& s.reconcile_state_contains(cr_key)
         &&& s.reconcile_state_of(cr_key).local_state.reconcile_pc === simple_reconciler::after_create_cm_pc()
         &&& s.reconcile_state_of(cr_key).pending_req_msg === Option::Some(controller_req_msg(simple_reconciler::create_cm_req(cr_key)))
@@ -517,7 +520,7 @@ proof fn lemma_msg_sent_and_after_get_cr_pc_leads_to_after_create_cm_pc(msg: Mes
         recv: Option::Some(msg),
         scheduled_cr_key: Option::Some(cr_key),
     };
-    controller_runtime_liveness::lemma_pre_leads_to_post_by_controller(simple_reconciler(), input, continue_reconcile(simple_reconciler()), pre, post);
+    controller_runtime_liveness::lemma_pre_leads_to_post_by_controller::<SimpleReconcileState>(simple_reconciler(), input, continue_reconcile(simple_reconciler()), pre, post);
 }
 
 proof fn lemma_exists_msg_sent_and_after_get_cr_pc_leads_to_after_create_cm_pc(cr_key: ResourceKey)
@@ -525,16 +528,16 @@ proof fn lemma_exists_msg_sent_and_after_get_cr_pc_leads_to_after_create_cm_pc(c
         cr_key.kind.is_CustomResourceKind(),
     ensures
         sm_spec(simple_reconciler()).entails(
-            lift_state(|s: State| {
+            lift_state(|s: State<SimpleReconcileState>| {
                 exists |m: Message| {
                     &&& #[trigger] s.message_sent(m)
                     &&& resp_msg_matches_req_msg(m, controller_req_msg(APIRequest::GetRequest(GetRequest{key: cr_key})))
                 }
-            }).and(lift_state(|s: State| {
+            }).and(lift_state(|s: State<SimpleReconcileState>| {
                 &&& s.reconcile_state_contains(cr_key)
                 &&& s.reconcile_state_of(cr_key).local_state.reconcile_pc === simple_reconciler::after_get_cr_pc()
                 &&& s.reconcile_state_of(cr_key).pending_req_msg === Option::Some(controller_req_msg(APIRequest::GetRequest(GetRequest{key: cr_key})))
-            })).leads_to(lift_state(|s: State| {
+            })).leads_to(lift_state(|s: State<SimpleReconcileState>| {
                     &&& s.reconcile_state_contains(cr_key)
                     &&& s.reconcile_state_of(cr_key).local_state.reconcile_pc === simple_reconciler::after_create_cm_pc()
                     &&& s.reconcile_state_of(cr_key).pending_req_msg === Option::Some(controller_req_msg(simple_reconciler::create_cm_req(cr_key)))
@@ -542,16 +545,16 @@ proof fn lemma_exists_msg_sent_and_after_get_cr_pc_leads_to_after_create_cm_pc(c
                 }))
         ),
 {
-    let m_to_pre1 = |m: Message| lift_state(|s: State| {
+    let m_to_pre1 = |m: Message| lift_state(|s: State<SimpleReconcileState>| {
         &&& s.message_sent(m)
         &&& resp_msg_matches_req_msg(m, controller_req_msg(APIRequest::GetRequest(GetRequest{key: cr_key})))
     });
-    let pre2 = lift_state(|s: State| {
+    let pre2 = lift_state(|s: State<SimpleReconcileState>| {
         &&& s.reconcile_state_contains(cr_key)
         &&& s.reconcile_state_of(cr_key).local_state.reconcile_pc === simple_reconciler::after_get_cr_pc()
         &&& s.reconcile_state_of(cr_key).pending_req_msg === Option::Some(controller_req_msg(APIRequest::GetRequest(GetRequest{key: cr_key})))
     });
-    let post = lift_state(|s: State| {
+    let post = lift_state(|s: State<SimpleReconcileState>| {
         &&& s.reconcile_state_contains(cr_key)
         &&& s.reconcile_state_of(cr_key).local_state.reconcile_pc === simple_reconciler::after_create_cm_pc()
         &&& s.reconcile_state_of(cr_key).pending_req_msg === Option::Some(controller_req_msg(simple_reconciler::create_cm_req(cr_key)))
@@ -559,21 +562,21 @@ proof fn lemma_exists_msg_sent_and_after_get_cr_pc_leads_to_after_create_cm_pc(c
     });
     assert forall |msg: Message| #[trigger] sm_spec(simple_reconciler()).entails(m_to_pre1(msg).and(pre2).leads_to(post)) by {
         lemma_msg_sent_and_after_get_cr_pc_leads_to_after_create_cm_pc(msg, cr_key);
-        let pre = lift_state(|s: State| {
+        let pre = lift_state(|s: State<SimpleReconcileState>| {
             &&& s.message_sent(msg)
             &&& resp_msg_matches_req_msg(msg, controller_req_msg(APIRequest::GetRequest(GetRequest{key: cr_key})))
             &&& s.reconcile_state_contains(cr_key)
             &&& s.reconcile_state_of(cr_key).local_state.reconcile_pc === simple_reconciler::after_get_cr_pc()
             &&& s.reconcile_state_of(cr_key).pending_req_msg === Option::Some(controller_req_msg(APIRequest::GetRequest(GetRequest{key: cr_key})))
         });
-        temp_pred_equality::<State>(pre, m_to_pre1(msg).and(pre2));
+        temp_pred_equality::<State<SimpleReconcileState>>(pre, m_to_pre1(msg).and(pre2));
     };
-    leads_to_exists_intro::<State, Message>(sm_spec(simple_reconciler()), |m| m_to_pre1(m).and(pre2), post);
-    tla_exists_and_equality::<State, Message>(m_to_pre1, pre2);
+    leads_to_exists_intro::<State<SimpleReconcileState>, Message>(sm_spec(simple_reconciler()), |m| m_to_pre1(m).and(pre2), post);
+    tla_exists_and_equality::<State<SimpleReconcileState>, Message>(m_to_pre1, pre2);
 
     // This is very tedious proof to show exists_m_to_pre1 === tla_exists(m_to_pre1)
     // I hope we can encapsulate this as a lemma
-    let exists_m_to_pre1 = lift_state(|s: State| {
+    let exists_m_to_pre1 = lift_state(|s: State<SimpleReconcileState>| {
         exists |m: Message| {
             &&& #[trigger] s.message_sent(m)
             &&& resp_msg_matches_req_msg(m, controller_req_msg(APIRequest::GetRequest(GetRequest{key: cr_key})))
@@ -586,7 +589,7 @@ proof fn lemma_exists_msg_sent_and_after_get_cr_pc_leads_to_after_create_cm_pc(c
         };
         assert(m_to_pre1(m).satisfied_by(ex));
     };
-    temp_pred_equality::<State>(exists_m_to_pre1, tla_exists(m_to_pre1));
+    temp_pred_equality::<State<SimpleReconcileState>>(exists_m_to_pre1, tla_exists(m_to_pre1));
 }
 
 }

--- a/src/simple_controller/proof/safety.rs
+++ b/src/simple_controller/proof/safety.rs
@@ -7,7 +7,10 @@ use crate::kubernetes_cluster::spec::{
     distributed_system::*,
 };
 use crate::pervasive::{option::*, result::*};
-use crate::simple_controller::spec::{simple_reconciler, simple_reconciler::simple_reconciler};
+use crate::simple_controller::spec::{
+    simple_reconciler,
+    simple_reconciler::{simple_reconciler, SimpleReconcileState},
+};
 use crate::temporal_logic::{defs::*, rules::*};
 use builtin::*;
 use builtin_macros::*;
@@ -17,37 +20,37 @@ verus! {
 pub proof fn lemma_always_reconcile_init_implies_no_pending_req(cr_key: ResourceKey)
     ensures
         sm_spec(simple_reconciler()).entails(always(
-            lift_state(|s: State| {
+            lift_state(|s: State<SimpleReconcileState>| {
                 &&& s.reconcile_state_contains(cr_key)
                 &&& s.reconcile_state_of(cr_key).local_state.reconcile_pc === simple_reconciler::init_pc()
             })
-                .implies(lift_state(|s: State| {
+                .implies(lift_state(|s: State<SimpleReconcileState>| {
                     &&& s.reconcile_state_contains(cr_key)
                     &&& s.reconcile_state_of(cr_key).local_state.reconcile_pc === simple_reconciler::init_pc()
                     &&& s.reconcile_state_of(cr_key).pending_req_msg.is_None()
             }))
         )),
 {
-    let invariant = |s: State| {
+    let invariant = |s: State<SimpleReconcileState>| {
         s.reconcile_state_contains(cr_key)
         && s.reconcile_state_of(cr_key).local_state.reconcile_pc === simple_reconciler::init_pc()
         ==> s.reconcile_state_contains(cr_key)
             && s.reconcile_state_of(cr_key).local_state.reconcile_pc === simple_reconciler::init_pc()
             && s.reconcile_state_of(cr_key).pending_req_msg.is_None()
     };
-    init_invariant::<State>(sm_spec(simple_reconciler()), init(simple_reconciler()), next(simple_reconciler()), invariant);
+    init_invariant::<State<SimpleReconcileState>>(sm_spec(simple_reconciler()), init(simple_reconciler()), next(simple_reconciler()), invariant);
 
     // We intentionally write the safety property in a form that is friendly to liveness reasoning
     // There is no need to do this if we only want to prove safety
-    let invariant_temp_pred = lift_state(|s: State| {
+    let invariant_temp_pred = lift_state(|s: State<SimpleReconcileState>| {
         &&& s.reconcile_state_contains(cr_key)
         &&& s.reconcile_state_of(cr_key).local_state.reconcile_pc === simple_reconciler::init_pc()
-    }).implies(lift_state(|s: State| {
+    }).implies(lift_state(|s: State<SimpleReconcileState>| {
         &&& s.reconcile_state_contains(cr_key)
         &&& s.reconcile_state_of(cr_key).local_state.reconcile_pc === simple_reconciler::init_pc()
         &&& s.reconcile_state_of(cr_key).pending_req_msg.is_None()
     }));
-    temp_pred_equality::<State>(lift_state(invariant), invariant_temp_pred);
+    temp_pred_equality::<State<SimpleReconcileState>>(lift_state(invariant), invariant_temp_pred);
 }
 
 pub proof fn lemma_always_reconcile_get_cr_done_implies_pending_get_cr_req(cr_key: ResourceKey)
@@ -55,11 +58,11 @@ pub proof fn lemma_always_reconcile_get_cr_done_implies_pending_get_cr_req(cr_ke
         cr_key.kind.is_CustomResourceKind(),
     ensures
         sm_spec(simple_reconciler()).entails(always(
-            lift_state(|s: State| {
+            lift_state(|s: State<SimpleReconcileState>| {
                 &&& s.reconcile_state_contains(cr_key)
                 &&& s.reconcile_state_of(cr_key).local_state.reconcile_pc === simple_reconciler::after_get_cr_pc()
             })
-                .implies(lift_state(|s: State| {
+                .implies(lift_state(|s: State<SimpleReconcileState>| {
                     &&& s.reconcile_state_contains(cr_key)
                     &&& s.reconcile_state_of(cr_key).local_state.reconcile_pc === simple_reconciler::after_get_cr_pc()
                     &&& s.reconcile_state_of(cr_key).pending_req_msg === Option::Some(controller_req_msg(APIRequest::GetRequest(GetRequest{key: cr_key})))
@@ -67,7 +70,7 @@ pub proof fn lemma_always_reconcile_get_cr_done_implies_pending_get_cr_req(cr_ke
                 }))
         )),
 {
-    let invariant = |s: State| {
+    let invariant = |s: State<SimpleReconcileState>| {
         s.reconcile_state_contains(cr_key)
         && s.reconcile_state_of(cr_key).local_state.reconcile_pc === simple_reconciler::after_get_cr_pc()
         ==> s.reconcile_state_contains(cr_key)
@@ -75,18 +78,18 @@ pub proof fn lemma_always_reconcile_get_cr_done_implies_pending_get_cr_req(cr_ke
             && s.reconcile_state_of(cr_key).pending_req_msg === Option::Some(controller_req_msg(APIRequest::GetRequest(GetRequest{key: cr_key})))
             && s.message_sent(controller_req_msg(APIRequest::GetRequest(GetRequest{key: cr_key})))
     };
-    init_invariant::<State>(sm_spec(simple_reconciler()), init(simple_reconciler()), next(simple_reconciler()), invariant);
+    init_invariant::<State<SimpleReconcileState>>(sm_spec(simple_reconciler()), init(simple_reconciler()), next(simple_reconciler()), invariant);
 
-    let invariant_temp_pred = lift_state(|s: State| {
+    let invariant_temp_pred = lift_state(|s: State<SimpleReconcileState>| {
         &&& s.reconcile_state_contains(cr_key)
         &&& s.reconcile_state_of(cr_key).local_state.reconcile_pc === simple_reconciler::after_get_cr_pc()
-    }).implies(lift_state(|s: State| {
+    }).implies(lift_state(|s: State<SimpleReconcileState>| {
         &&& s.reconcile_state_contains(cr_key)
         &&& s.reconcile_state_of(cr_key).local_state.reconcile_pc === simple_reconciler::after_get_cr_pc()
         &&& s.reconcile_state_of(cr_key).pending_req_msg === Option::Some(controller_req_msg(APIRequest::GetRequest(GetRequest{key: cr_key})))
         &&& s.message_sent(controller_req_msg(APIRequest::GetRequest(GetRequest{key: cr_key})))
     }));
-    temp_pred_equality::<State>(lift_state(invariant), invariant_temp_pred);
+    temp_pred_equality::<State<SimpleReconcileState>>(lift_state(invariant), invariant_temp_pred);
 }
 
 pub proof fn lemma_always_reconcile_create_cm_done_implies_pending_create_cm_req(cr_key: ResourceKey)
@@ -94,11 +97,11 @@ pub proof fn lemma_always_reconcile_create_cm_done_implies_pending_create_cm_req
         cr_key.kind.is_CustomResourceKind(),
     ensures
         sm_spec(simple_reconciler()).entails(always(
-            lift_state(|s: State| {
+            lift_state(|s: State<SimpleReconcileState>| {
                 &&& s.reconcile_state_contains(cr_key)
                 &&& s.reconcile_state_of(cr_key).local_state.reconcile_pc === simple_reconciler::after_create_cm_pc()
             })
-                .implies(lift_state(|s: State| {
+                .implies(lift_state(|s: State<SimpleReconcileState>| {
                     &&& s.reconcile_state_contains(cr_key)
                     &&& s.reconcile_state_of(cr_key).local_state.reconcile_pc === simple_reconciler::after_create_cm_pc()
                     &&& s.reconcile_state_of(cr_key).pending_req_msg === Option::Some(controller_req_msg(simple_reconciler::create_cm_req(cr_key)))
@@ -106,7 +109,7 @@ pub proof fn lemma_always_reconcile_create_cm_done_implies_pending_create_cm_req
                 }))
         )),
 {
-    let invariant = |s: State| {
+    let invariant = |s: State<SimpleReconcileState>| {
         s.reconcile_state_contains(cr_key)
         && s.reconcile_state_of(cr_key).local_state.reconcile_pc === simple_reconciler::after_create_cm_pc()
         ==> s.reconcile_state_contains(cr_key)
@@ -114,18 +117,18 @@ pub proof fn lemma_always_reconcile_create_cm_done_implies_pending_create_cm_req
             && s.reconcile_state_of(cr_key).pending_req_msg === Option::Some(controller_req_msg(simple_reconciler::create_cm_req(cr_key)))
             && s.message_sent(controller_req_msg(simple_reconciler::create_cm_req(cr_key)))
     };
-    init_invariant::<State>(sm_spec(simple_reconciler()), init(simple_reconciler()), next(simple_reconciler()), invariant);
+    init_invariant::<State<SimpleReconcileState>>(sm_spec(simple_reconciler()), init(simple_reconciler()), next(simple_reconciler()), invariant);
 
-    let invariant_temp_pred = lift_state(|s: State| {
+    let invariant_temp_pred = lift_state(|s: State<SimpleReconcileState>| {
         &&& s.reconcile_state_contains(cr_key)
         &&& s.reconcile_state_of(cr_key).local_state.reconcile_pc === simple_reconciler::after_create_cm_pc()
-    }).implies(lift_state(|s: State| {
+    }).implies(lift_state(|s: State<SimpleReconcileState>| {
         &&& s.reconcile_state_contains(cr_key)
         &&& s.reconcile_state_of(cr_key).local_state.reconcile_pc === simple_reconciler::after_create_cm_pc()
         &&& s.reconcile_state_of(cr_key).pending_req_msg === Option::Some(controller_req_msg(simple_reconciler::create_cm_req(cr_key)))
         &&& s.message_sent(controller_req_msg(simple_reconciler::create_cm_req(cr_key)))
     }));
-    temp_pred_equality::<State>(lift_state(invariant), invariant_temp_pred);
+    temp_pred_equality::<State<SimpleReconcileState>>(lift_state(invariant), invariant_temp_pred);
 }
 
 pub proof fn lemma_delete_cm_req_msg_never_sent(cr_key: ResourceKey)
@@ -133,7 +136,7 @@ pub proof fn lemma_delete_cm_req_msg_never_sent(cr_key: ResourceKey)
         cr_key.kind.is_CustomResourceKind(),
     ensures
         sm_spec(simple_reconciler()).entails(always(
-            lift_state(|s: State| !exists |m: Message| {
+            lift_state(|s: State<SimpleReconcileState>| !exists |m: Message| {
                 &&& #[trigger] s.message_sent(m)
                 &&& m.dst === HostId::KubernetesAPI
                 &&& m.is_delete_request()
@@ -141,13 +144,13 @@ pub proof fn lemma_delete_cm_req_msg_never_sent(cr_key: ResourceKey)
             })
         )),
 {
-    let invariant = |s: State| !exists |m: Message| {
+    let invariant = |s: State<SimpleReconcileState>| !exists |m: Message| {
         &&& #[trigger] s.message_sent(m)
         &&& m.dst === HostId::KubernetesAPI
         &&& m.is_delete_request()
         &&& m.get_delete_request().key === simple_reconciler::subresource_configmap(cr_key).key
     };
-    init_invariant::<State>(sm_spec(simple_reconciler()), init(simple_reconciler()), next(simple_reconciler()), invariant);
+    init_invariant::<State<SimpleReconcileState>>(sm_spec(simple_reconciler()), init(simple_reconciler()), next(simple_reconciler()), invariant);
 }
 
 }

--- a/src/simple_controller/spec/simple_reconciler.rs
+++ b/src/simple_controller/spec/simple_reconciler.rs
@@ -11,19 +11,28 @@ use builtin_macros::*;
 
 verus! {
 
+/// SimpleReconcileState describes the local state with which the reconcile functions makes decisions.
+pub struct SimpleReconcileState {
+    // reconcile_pc, like a program counter, is used to track the progress of reconcile_core
+    // since reconcile_core is frequently "trapped" into the controller_runtime spec.
+    // nat is not the idea way of representing pc, but we cannot use enum here
+    // because the enum type will be specific to the reconciler.
+    pub reconcile_pc: nat,
+}
+
 /// We use Reconciler to pack up everything specific to the custom controller,
 /// including reconcile function (reconcile_core) and triggering conditions (reconcile_trigger)
-pub open spec fn simple_reconciler() -> Reconciler {
+pub open spec fn simple_reconciler() -> Reconciler<SimpleReconcileState> {
     Reconciler {
         reconcile_init_state: || reconcile_init_state(),
         reconcile_trigger: |msg: Message| reconcile_trigger(msg),
-        reconcile_core: |cr_key: ResourceKey, resp_o: Option<APIResponse>, state: ReconcileState| reconcile_core(cr_key, resp_o, state),
-        reconcile_done: |state: ReconcileState| reconcile_done(state),
+        reconcile_core: |cr_key: ResourceKey, resp_o: Option<APIResponse>, state: SimpleReconcileState| reconcile_core(cr_key, resp_o, state),
+        reconcile_done: |state: SimpleReconcileState| reconcile_done(state),
     }
 }
 
-pub open spec fn reconcile_init_state() -> ReconcileState {
-    ReconcileState {
+pub open spec fn reconcile_init_state() -> SimpleReconcileState {
+    SimpleReconcileState {
         reconcile_pc: 0,
     }
 }
@@ -51,19 +60,19 @@ pub open spec fn reconcile_trigger(msg: Message) -> Option<ResourceKey>
 /// This is a highly simplified reconcile core spec:
 /// it sends requests to create a configmap for the cr.
 /// TODO: make the reconcile_core create more resources such as a statefulset
-pub open spec fn reconcile_core(cr_key: ResourceKey, resp_o: Option<APIResponse>, state: ReconcileState) -> (ReconcileState, Option<APIRequest>)
+pub open spec fn reconcile_core(cr_key: ResourceKey, resp_o: Option<APIResponse>, state: SimpleReconcileState) -> (SimpleReconcileState, Option<APIRequest>)
     recommends
         cr_key.kind.is_CustomResourceKind(),
 {
     let pc = state.reconcile_pc;
     if pc === init_pc() {
-        let state_prime = ReconcileState {
+        let state_prime = SimpleReconcileState {
             reconcile_pc: after_get_cr_pc(),
         };
         let req_o = Option::Some(APIRequest::GetRequest(GetRequest{key: cr_key}));
         (state_prime, req_o)
     } else if pc === after_get_cr_pc() {
-        let state_prime = ReconcileState {
+        let state_prime = SimpleReconcileState {
             reconcile_pc: after_create_cm_pc(),
         };
         let req_o = Option::Some(create_cm_req(cr_key));
@@ -73,7 +82,7 @@ pub open spec fn reconcile_core(cr_key: ResourceKey, resp_o: Option<APIResponse>
     }
 }
 
-pub open spec fn reconcile_done(state: ReconcileState) -> bool {
+pub open spec fn reconcile_done(state: SimpleReconcileState) -> bool {
     &&& state.reconcile_pc !== init_pc()
     &&& state.reconcile_pc !== after_get_cr_pc()
 }

--- a/src/simple_controller/spec/simple_reconciler.rs
+++ b/src/simple_controller/spec/simple_reconciler.rs
@@ -15,8 +15,6 @@ verus! {
 pub struct SimpleReconcileState {
     // reconcile_pc, like a program counter, is used to track the progress of reconcile_core
     // since reconcile_core is frequently "trapped" into the controller_runtime spec.
-    // nat is not the idea way of representing pc, but we cannot use enum here
-    // because the enum type will be specific to the reconciler.
     pub reconcile_pc: nat,
 }
 


### PR DESCRIPTION
ReconcileState was used to describe the local state of each Reconcile round and was previously a hardcoded type.
This PR makes it a generic type called T.

Signed-off-by: Xudong Sun <xudongs1@vmware.com>