### PR TITLE
Add unique id to request/response pair

### DIFF
--- a/src/kubernetes_cluster/spec/controller/common.rs
+++ b/src/kubernetes_cluster/spec/controller/common.rs
@@ -16,6 +16,7 @@ pub struct OngoingReconcile<T> {
 }
 
 pub struct ControllerState<T> {
+    pub req_id: nat,
     pub ongoing_reconciles: Map<ResourceKey, OngoingReconcile<T>>,
     pub scheduled_reconciles: Set<ResourceKey>,
 }
@@ -39,8 +40,8 @@ pub type ControllerAction<T> = Action<ControllerState<T>, ControllerActionInput,
 
 pub type ControllerActionResult<T> = ActionResult<ControllerState<T>, Set<Message>>;
 
-pub open spec fn controller_req_msg(req: APIRequest) -> Message {
-    form_msg(HostId::CustomController, HostId::KubernetesAPI, MessageContent::APIRequest(req))
+pub open spec fn controller_req_msg(req: APIRequest, req_id: nat) -> Message {
+    form_msg(HostId::CustomController, HostId::KubernetesAPI, MessageContent::APIRequest(req, req_id))
 }
 
 }

--- a/src/kubernetes_cluster/spec/controller/controller_runtime.rs
+++ b/src/kubernetes_cluster/spec/controller/controller_runtime.rs
@@ -105,7 +105,7 @@ pub open spec fn continue_reconcile<T>(reconciler: Reconciler<T>) -> ControllerA
             let (local_state_prime, req_o) = (reconciler.reconcile_core)(cr_key, resp_o, reconcile_state.local_state);
 
             let pending_req_msg = if req_o.is_Some() {
-                Option::Some(controller_req_msg(req_o.get_Some_0()))
+                Option::Some(controller_req_msg(req_o.get_Some_0(), s.req_id))
             } else {
                 Option::None
             };
@@ -116,6 +116,7 @@ pub open spec fn continue_reconcile<T>(reconciler: Reconciler<T>) -> ControllerA
             };
             let s_prime = ControllerState {
                 ongoing_reconciles: s.ongoing_reconciles.insert(cr_key, reconcile_state_prime),
+                req_id: s.req_id + 1,
                 ..s
             };
             let send = if pending_req_msg.is_Some() {

--- a/src/kubernetes_cluster/spec/controller/controller_runtime.rs
+++ b/src/kubernetes_cluster/spec/controller/controller_runtime.rs
@@ -82,6 +82,7 @@ pub open spec fn continue_reconcile<T>(reconciler: Reconciler<T>) -> ControllerA
 
                 &&& s.ongoing_reconciles.dom().contains(cr_key)
                 &&& !(reconciler.reconcile_done)(s.ongoing_reconciles[cr_key].local_state)
+                &&& !(reconciler.reconcile_error)(s.ongoing_reconciles[cr_key].local_state)
                 &&& if input.recv.is_Some() {
                     &&& input.recv.get_Some_0().content.is_APIResponse()
                     &&& s.ongoing_reconciles[cr_key].pending_req_msg.is_Some()
@@ -136,7 +137,7 @@ pub open spec fn end_reconcile<T>(reconciler: Reconciler<T>) -> ControllerAction
                 let cr_key = input.scheduled_cr_key.get_Some_0();
 
                 &&& s.ongoing_reconciles.dom().contains(cr_key)
-                &&& (reconciler.reconcile_done)(s.ongoing_reconciles[cr_key].local_state)
+                &&& ((reconciler.reconcile_done)(s.ongoing_reconciles[cr_key].local_state) || (reconciler.reconcile_error)(s.ongoing_reconciles[cr_key].local_state))
                 &&& input.recv.is_None()
             } else {
                 false

--- a/src/kubernetes_cluster/spec/controller/state_machine.rs
+++ b/src/kubernetes_cluster/spec/controller/state_machine.rs
@@ -17,6 +17,7 @@ pub open spec fn controller<T>(reconciler: Reconciler<T>) -> ControllerStateMach
     StateMachine {
         init: |s: ControllerState<T>| {
             s === ControllerState {
+                req_id: 0,
                 ongoing_reconciles: Map::empty(),
                 scheduled_reconciles: Set::empty(),
             }

--- a/src/kubernetes_cluster/spec/kubernetes_api/builtin_controllers/statefulset_controller.rs
+++ b/src/kubernetes_cluster/spec/kubernetes_api/builtin_controllers/statefulset_controller.rs
@@ -15,21 +15,23 @@ pub open spec fn transition_by_statefulset_controller(msg: Message, s: Kubernete
     let src = HostId::KubernetesAPI;
     // Here dst is also KubernetesAPI because etcd, apiserver and built-in controllers are all in the same state machine.
     // In reality, the message is sent from the built-in controller to apiserver then to etcd.
+
+    // TODO: assign req id to the requests
     let dst = HostId::KubernetesAPI;
     if msg.is_watch_event_of_kind(ResourceKind::StatefulSetKind) {
         if msg.is_added_event() {
             let obj = msg.get_added_event().obj;
             set![
-                form_msg(src, dst, create_req_msg(ResourceObj{key: ResourceKey{name: obj.key.name + pod_suffix(), namespace: obj.key.namespace, kind: ResourceKind::PodKind}})),
-                form_msg(src, dst, create_req_msg(ResourceObj{key: ResourceKey{name: obj.key.name + vol_suffix(), namespace: obj.key.namespace, kind: ResourceKind::VolumeKind}}))
+                form_msg(src, dst, create_req_msg(ResourceObj{key: ResourceKey{name: obj.key.name + pod_suffix(), namespace: obj.key.namespace, kind: ResourceKind::PodKind}}, 0)),
+                form_msg(src, dst, create_req_msg(ResourceObj{key: ResourceKey{name: obj.key.name + vol_suffix(), namespace: obj.key.namespace, kind: ResourceKind::VolumeKind}}, 0))
             ]
         } else if msg.is_modified_event() {
             set![]
         } else {
             let obj = msg.get_deleted_event().obj;
             set![
-                    form_msg(src, dst, delete_req_msg(ResourceKey{name: obj.key.name + pod_suffix(), namespace: obj.key.namespace, kind: ResourceKind::PodKind})),
-                    form_msg(src, dst, delete_req_msg(ResourceKey{name: obj.key.name + vol_suffix(), namespace: obj.key.namespace, kind: ResourceKind::VolumeKind}))
+                    form_msg(src, dst, delete_req_msg(ResourceKey{name: obj.key.name + pod_suffix(), namespace: obj.key.namespace, kind: ResourceKind::PodKind}, 0)),
+                    form_msg(src, dst, delete_req_msg(ResourceKey{name: obj.key.name + vol_suffix(), namespace: obj.key.namespace, kind: ResourceKind::VolumeKind}, 0))
                 ]
         }
     } else {

--- a/src/kubernetes_cluster/spec/kubernetes_api/common.rs
+++ b/src/kubernetes_cluster/spec/kubernetes_api/common.rs
@@ -1,9 +1,9 @@
 // Copyright 2022 VMware, Inc.
 // SPDX-License-Identifier: MIT
 #![allow(unused_imports)]
-use crate::state_machine::action::*;
 use crate::kubernetes_cluster::spec::common::*;
 use crate::pervasive::{map::*, option::*, result::*, seq::*, set::*, string::*};
+use crate::state_machine::action::*;
 use crate::state_machine::state_machine::*;
 use crate::temporal_logic::defs::*;
 use builtin::*;
@@ -11,8 +11,11 @@ use builtin_macros::*;
 
 verus! {
 
+pub type EtcdState = Map<ResourceKey, ResourceObj>;
+
 pub struct KubernetesAPIState {
-    pub resources: Map<ResourceKey, ResourceObj>,
+    pub req_id: nat,
+    pub resources: EtcdState,
 }
 
 pub enum KubernetesAPIStep {

--- a/src/kubernetes_cluster/spec/reconciler.rs
+++ b/src/kubernetes_cluster/spec/reconciler.rs
@@ -29,9 +29,13 @@ pub struct Reconciler<#[verifier(maybe_negative)] T> {
     // and outputs the next local state and the request to send to Kubernetes API (if any).
     pub reconcile_core: ReconcileCore<T>,
 
-    // reconcile_done is used to tell the controller_runtime whether the reconcile function finishes.
-    // If it is true, controller_runtime will cleans up its local state and probably requeue the reconcile.
+    // reconcile_done is used to tell the controller_runtime whether this reconcile round is done.
+    // If it is true, controller_runtime will probably requeue the reconcile.
     pub reconcile_done: ReconcileDone<T>,
+
+    // reconcile_error is used to tell the controller_runtime whether this reconcile round returns with error.
+    // If it is true, controller_runtime will requeue the reconcile.
+    pub reconcile_error: ReconcileError<T>,
 }
 
 pub type ReconcileInitState<T> = FnSpec() -> T;
@@ -41,5 +45,7 @@ pub type ReconcileTrigger = FnSpec(Message) -> Option<ResourceKey>;
 pub type ReconcileCore<T> = FnSpec(ResourceKey, Option<APIResponse>, T) -> (T, Option<APIRequest>);
 
 pub type ReconcileDone<T> = FnSpec(T) -> bool;
+
+pub type ReconcileError<T> = FnSpec(T) -> bool;
 
 }

--- a/src/simple_controller/proof/liveness.rs
+++ b/src/simple_controller/proof/liveness.rs
@@ -204,6 +204,7 @@ proof fn lemma_after_get_cr_pc_leads_to_cm_always_exists(cr: ResourceObj)
 
     let reconciler_at_after_get_cr_pc_implies_pending_req_and_req_sent = safety::lemma_always_reconcile_get_cr_done_implies_pending_get_cr_req(cr.key);
 
+    // TODO: there should be a way to avoid unfolding here using some lemma. Will investigate later
     assert forall |ex| #[trigger] sm_spec(simple_reconciler()).satisfied_by(ex) implies lift_state(reconciler_at_after_get_cr_pc(cr.key)).leads_to(lift_state(reconciler_at_after_create_cm_pc(cr.key))).satisfied_by(ex) by {
         assert forall |i| #[trigger] lift_state(reconciler_at_after_get_cr_pc(cr.key)).satisfied_by(ex.suffix(i)) implies eventually(lift_state(reconciler_at_after_create_cm_pc(cr.key))).satisfied_by(ex.suffix(i)) by {
             let pre = |req_msg: Message| reconciler_at_after_get_cr_pc_and_pending_req_and_req_sent(req_msg, cr.key);

--- a/src/simple_controller/proof/liveness.rs
+++ b/src/simple_controller/proof/liveness.rs
@@ -68,19 +68,18 @@ proof fn lemma_cr_added_event_msg_sent_leads_to_cm_always_exists(cr: ResourceObj
     ensures
         sm_spec(simple_reconciler()).entails(
             lift_state(|s: State<SimpleReconcileState>| s.message_sent(form_msg(HostId::KubernetesAPI, HostId::CustomController, added_event_msg(cr))))
-                .leads_to(always(lift_state(|s: State<SimpleReconcileState>| s.resource_key_exists(simple_reconciler::subresource_configmap(cr.key).key))))
+                .leads_to(always(lift_state(cm_exists(cr.key))))
         ),
 {
     let cr_added_event_msg_sent = |s: State<SimpleReconcileState>| s.message_sent(form_msg(HostId::KubernetesAPI, HostId::CustomController, added_event_msg(cr)));
     let controller_in_reconcile = |s: State<SimpleReconcileState>| s.reconcile_state_contains(cr.key);
-    let cm_exists = |s: State<SimpleReconcileState>| s.resource_key_exists(simple_reconciler::subresource_configmap(cr.key).key);
 
     leads_to_weaken_auto::<State<SimpleReconcileState>>(sm_spec(simple_reconciler()));
 
     lemma_cr_added_event_msg_sent_leads_to_controller_in_reconcile(cr);
     lemma_controller_in_reconcile_leads_to_cm_always_exists(cr);
 
-    leads_to_trans_temp::<State<SimpleReconcileState>>(sm_spec(simple_reconciler()), lift_state(cr_added_event_msg_sent), lift_state(controller_in_reconcile), always(lift_state(cm_exists)));
+    leads_to_trans_temp::<State<SimpleReconcileState>>(sm_spec(simple_reconciler()), lift_state(cr_added_event_msg_sent), lift_state(controller_in_reconcile), always(lift_state(cm_exists(cr.key))));
 
 }
 
@@ -126,29 +125,9 @@ proof fn lemma_controller_in_reconcile_leads_to_cm_always_exists(cr: ResourceObj
     ensures
         sm_spec(simple_reconciler()).entails(
             lift_state(|s: State<SimpleReconcileState>| s.reconcile_state_contains(cr.key))
-                .leads_to(always(lift_state(|s: State<SimpleReconcileState>| s.resource_key_exists(simple_reconciler::subresource_configmap(cr.key).key))))
+                .leads_to(always(lift_state(cm_exists(cr.key))))
         ),
 {
-    let cm = simple_reconciler::subresource_configmap(cr.key);
-
-    let reconcile_at_init_pc = |s: State<SimpleReconcileState>| {
-        &&& s.reconcile_state_contains(cr.key)
-        &&& s.reconcile_state_of(cr.key).local_state.reconcile_pc === simple_reconciler::init_pc()
-    };
-    let reconciler_at_after_get_cr_pc = |s: State<SimpleReconcileState>| {
-        &&& s.reconcile_state_contains(cr.key)
-        &&& s.reconcile_state_of(cr.key).local_state.reconcile_pc === simple_reconciler::after_get_cr_pc()
-    };
-    let reconciler_at_after_create_cm_pc = |s: State<SimpleReconcileState>| {
-        &&& s.reconcile_state_contains(cr.key)
-        &&& s.reconcile_state_of(cr.key).local_state.reconcile_pc === simple_reconciler::after_create_cm_pc()
-    };
-    let reconciler_reconcile_done = |s: State<SimpleReconcileState>| {
-        &&& s.reconcile_state_contains(cr.key)
-        &&& (simple_reconciler().reconcile_done)(s.reconcile_state_of(cr.key).local_state)
-    };
-    let cm_exists = |s: State<SimpleReconcileState>| s.resource_key_exists(cm.key);
-
     leads_to_weaken_auto::<State<SimpleReconcileState>>(sm_spec(simple_reconciler()));
 
     // This proof is also straightforward once we have proved the four following lemmas
@@ -160,18 +139,18 @@ proof fn lemma_controller_in_reconcile_leads_to_cm_always_exists(cr: ResourceObj
 
     // Now we combine the four cases together
     // and we will get s.reconcile_state_contains(cr.key) ~> []cm_exists
-    or_leads_to_combine_temp::<State<SimpleReconcileState>>(sm_spec(simple_reconciler()), lift_state(reconcile_at_init_pc), lift_state(reconciler_at_after_get_cr_pc), always(lift_state(cm_exists)));
-    or_leads_to_combine_temp::<State<SimpleReconcileState>>(sm_spec(simple_reconciler()), lift_state(reconciler_at_after_create_cm_pc), lift_state(reconciler_reconcile_done), always(lift_state(cm_exists)));
+    or_leads_to_combine_temp::<State<SimpleReconcileState>>(sm_spec(simple_reconciler()), lift_state(reconciler_at_init_pc(cr.key)), lift_state(reconciler_at_after_get_cr_pc(cr.key)), always(lift_state(cm_exists(cr.key))));
+    or_leads_to_combine_temp::<State<SimpleReconcileState>>(sm_spec(simple_reconciler()), lift_state(reconciler_at_after_create_cm_pc(cr.key)), lift_state(reconciler_reconcile_done(cr.key)), always(lift_state(cm_exists(cr.key))));
     or_leads_to_combine_temp::<State<SimpleReconcileState>>(sm_spec(simple_reconciler()),
         lift_state(|s: State<SimpleReconcileState>| {
-            ||| reconcile_at_init_pc(s)
-            ||| reconciler_at_after_get_cr_pc(s)
+            ||| reconciler_at_init_pc(cr.key)(s)
+            ||| reconciler_at_after_get_cr_pc(cr.key)(s)
         }),
         lift_state(|s: State<SimpleReconcileState>| {
-            ||| reconciler_at_after_create_cm_pc(s)
-            ||| reconciler_reconcile_done(s)
+            ||| reconciler_at_after_create_cm_pc(cr.key)(s)
+            ||| reconciler_reconcile_done(cr.key)(s)
         }),
-        always(lift_state(cm_exists))
+        always(lift_state(cm_exists(cr.key)))
     );
 }
 
@@ -180,47 +159,24 @@ proof fn lemma_init_pc_leads_to_cm_always_exists(cr: ResourceObj)
         cr.key.kind.is_CustomResourceKind(),
     ensures
         sm_spec(simple_reconciler()).entails(
-            lift_state(|s: State<SimpleReconcileState>| {
-                &&& s.reconcile_state_contains(cr.key)
-                &&& s.reconcile_state_of(cr.key).local_state.reconcile_pc === simple_reconciler::init_pc()
-            }).leads_to(always(lift_state(|s: State<SimpleReconcileState>| s.resource_key_exists(simple_reconciler::subresource_configmap(cr.key).key))))
+            lift_state(reconciler_at_init_pc(cr.key))
+            .leads_to(always(lift_state(cm_exists(cr.key))))
         ),
 {
-    let cm = simple_reconciler::subresource_configmap(cr.key);
-
-    // Just layout all the state predicates we are going to repeatedly use later since they are so long
-    let reconcile_at_init_pc = |s: State<SimpleReconcileState>| {
-        &&& s.reconcile_state_contains(cr.key)
-        &&& s.reconcile_state_of(cr.key).local_state.reconcile_pc === simple_reconciler::init_pc()
-    };
-    let reconcile_at_init_pc_and_no_pending_req = |s: State<SimpleReconcileState>| {
-        &&& s.reconcile_state_contains(cr.key)
-        &&& s.reconcile_state_of(cr.key).local_state.reconcile_pc === simple_reconciler::init_pc()
-        &&& s.reconcile_state_of(cr.key).pending_req_msg.is_None()
-    };
-    let reconciler_at_after_get_cr_pc = |s: State<SimpleReconcileState>| {
-        &&& s.reconcile_state_contains(cr.key)
-        &&& s.reconcile_state_of(cr.key).local_state.reconcile_pc === simple_reconciler::after_get_cr_pc()
-    };
-    let cm_exists = |s: State<SimpleReconcileState>| s.resource_key_exists(cm.key);
-
     leads_to_weaken_auto::<State<SimpleReconcileState>>(sm_spec(simple_reconciler()));
 
-    leads_to_self::<State<SimpleReconcileState>>(reconcile_at_init_pc);
+    leads_to_self::<State<SimpleReconcileState>>(reconciler_at_init_pc(cr.key));
     safety::lemma_always_reconcile_init_implies_no_pending_req(cr.key);
     // We get the following asserted leads-to formula by auto weakening the one from leads_to_self
     // with the always-implies formula from lemma_always_reconcile_init_implies_no_pending_req
     // We have to write down this assertion to further trigger leads_to_weaken_auto
-    assert(sm_spec(simple_reconciler()).entails(
-        lift_state(reconcile_at_init_pc)
-            .leads_to(lift_state(reconcile_at_init_pc_and_no_pending_req))
-    ));
+    assert(sm_spec(simple_reconciler()).entails(lift_state(reconciler_at_init_pc(cr.key)).leads_to(lift_state(reconciler_at_init_pc_and_no_pending_req(cr.key)))));
     // Get the leads-to formula from lemma_init_pc_leads_to_after_get_cr_pc and connect it with the above asserted one
     lemma_init_pc_leads_to_after_get_cr_pc(cr.key);
-    leads_to_trans::<State<SimpleReconcileState>>(sm_spec(simple_reconciler()), reconcile_at_init_pc, reconcile_at_init_pc_and_no_pending_req, reconciler_at_after_get_cr_pc);
+    leads_to_trans::<State<SimpleReconcileState>>(sm_spec(simple_reconciler()), reconciler_at_init_pc(cr.key), reconciler_at_init_pc_and_no_pending_req(cr.key), reconciler_at_after_get_cr_pc(cr.key));
     // Since we have prove that spec |= reconciler_at_after_get_cr_pc ~> []cm_exists, we will just take a shortcut here
     lemma_after_get_cr_pc_leads_to_cm_always_exists(cr);
-    leads_to_trans_temp::<State<SimpleReconcileState>>(sm_spec(simple_reconciler()), lift_state(reconcile_at_init_pc), lift_state(reconciler_at_after_get_cr_pc), always(lift_state(cm_exists)));
+    leads_to_trans_temp::<State<SimpleReconcileState>>(sm_spec(simple_reconciler()), lift_state(reconciler_at_init_pc(cr.key)), lift_state(reconciler_at_after_get_cr_pc(cr.key)), always(lift_state(cm_exists(cr.key))));
 }
 
 proof fn lemma_after_get_cr_pc_leads_to_cm_always_exists(cr: ResourceObj)
@@ -228,41 +184,18 @@ proof fn lemma_after_get_cr_pc_leads_to_cm_always_exists(cr: ResourceObj)
         cr.key.kind.is_CustomResourceKind(),
     ensures
         sm_spec(simple_reconciler()).entails(
-            lift_state(|s: State<SimpleReconcileState>| {
-                &&& s.reconcile_state_contains(cr.key)
-                &&& s.reconcile_state_of(cr.key).local_state.reconcile_pc === simple_reconciler::after_get_cr_pc()
-            }).leads_to(always(lift_state(|s: State<SimpleReconcileState>| s.resource_key_exists(simple_reconciler::subresource_configmap(cr.key).key))))
+            lift_state(reconciler_at_after_get_cr_pc(cr.key))
+                .leads_to(always(lift_state(cm_exists(cr.key))))
         ),
 {
-    let cm = simple_reconciler::subresource_configmap(cr.key);
-
-    let reconciler_at_after_get_cr_pc = |s: State<SimpleReconcileState>| {
-        &&& s.reconcile_state_contains(cr.key)
-        &&& s.reconcile_state_of(cr.key).local_state.reconcile_pc === simple_reconciler::after_get_cr_pc()
-    };
-    let reconciler_at_after_create_cm_pc = |s: State<SimpleReconcileState>| {
-        &&& s.reconcile_state_contains(cr.key)
-        &&& s.reconcile_state_of(cr.key).local_state.reconcile_pc === simple_reconciler::after_create_cm_pc()
-    };
-
-    let cm_exists = |s: State<SimpleReconcileState>| s.resource_key_exists(cm.key);
-
     leads_to_weaken_auto::<State<SimpleReconcileState>>(sm_spec(simple_reconciler()));
     always_implies_weaken_auto::<State<SimpleReconcileState>>(sm_spec(simple_reconciler()));
 
     let safety_invariant = safety::lemma_always_reconcile_get_cr_done_implies_pending_get_cr_req(cr.key);
 
-    assert forall |ex| #[trigger] sm_spec(simple_reconciler()).satisfied_by(ex) implies lift_state(reconciler_at_after_get_cr_pc).leads_to(lift_state(reconciler_at_after_create_cm_pc)).satisfied_by(ex) by {
-        assert forall |i| #[trigger] lift_state(reconciler_at_after_get_cr_pc).satisfied_by(ex.suffix(i)) implies eventually(lift_state(reconciler_at_after_create_cm_pc)).satisfied_by(ex.suffix(i)) by {
-            let pre = |req_msg: Message| {
-                |s: State<SimpleReconcileState>| {
-                    &&& s.reconcile_state_contains(cr.key)
-                    &&& s.reconcile_state_of(cr.key).local_state.reconcile_pc === simple_reconciler::after_get_cr_pc()
-                    &&& s.reconcile_state_of(cr.key).pending_req_msg === Option::Some(req_msg)
-                    &&& is_controller_get_cr_request_msg(req_msg, cr.key)
-                    &&& s.message_sent(req_msg)
-                }
-            };
+    assert forall |ex| #[trigger] sm_spec(simple_reconciler()).satisfied_by(ex) implies lift_state(reconciler_at_after_get_cr_pc(cr.key)).leads_to(lift_state(reconciler_at_after_create_cm_pc(cr.key))).satisfied_by(ex) by {
+        assert forall |i| #[trigger] lift_state(reconciler_at_after_get_cr_pc(cr.key)).satisfied_by(ex.suffix(i)) implies eventually(lift_state(reconciler_at_after_create_cm_pc(cr.key))).satisfied_by(ex.suffix(i)) by {
+            let pre = |req_msg: Message| reconciler_at_after_get_cr_pc_and_pending_req_and_req_sent(req_msg, cr.key);
 
             instantiate_entailed_always::<State<SimpleReconcileState>>(ex, i, sm_spec(simple_reconciler()), safety_invariant);
 
@@ -274,13 +207,13 @@ proof fn lemma_after_get_cr_pc_leads_to_cm_always_exists(cr: ResourceObj)
             assert(lift_state(pre(get_cr_req_msg)).satisfied_by(ex.suffix(i)));
 
             lemma_req_msg_sent_and_after_get_cr_pc_leads_to_after_create_cm_pc(get_cr_req_msg, cr.key);
-            instantiate_entailed_leads_to::<State<SimpleReconcileState>>(ex, i, sm_spec(simple_reconciler()), lift_state(pre(get_cr_req_msg)), lift_state(reconciler_at_after_create_cm_pc));
+            instantiate_entailed_leads_to::<State<SimpleReconcileState>>(ex, i, sm_spec(simple_reconciler()), lift_state(pre(get_cr_req_msg)), lift_state(reconciler_at_after_create_cm_pc(cr.key)));
         };
     };
 
     // Since we have prove that spec |= reconciler_at_after_create_cm_pc ~> []cm_exists, we will just take a shortcut here
     lemma_after_create_cm_pc_leads_to_cm_always_exists(cr);
-    leads_to_trans_temp::<State<SimpleReconcileState>>(sm_spec(simple_reconciler()), lift_state(reconciler_at_after_get_cr_pc), lift_state(reconciler_at_after_create_cm_pc), always(lift_state(cm_exists)));
+    leads_to_trans_temp::<State<SimpleReconcileState>>(sm_spec(simple_reconciler()), lift_state(reconciler_at_after_get_cr_pc(cr.key)), lift_state(reconciler_at_after_create_cm_pc(cr.key)), always(lift_state(cm_exists(cr.key))));
 }
 
 proof fn lemma_after_create_cm_pc_leads_to_cm_always_exists(cr: ResourceObj)
@@ -288,37 +221,19 @@ proof fn lemma_after_create_cm_pc_leads_to_cm_always_exists(cr: ResourceObj)
         cr.key.kind.is_CustomResourceKind(),
     ensures
         sm_spec(simple_reconciler()).entails(
-            lift_state(|s: State<SimpleReconcileState>| {
-                &&& s.reconcile_state_contains(cr.key)
-                &&& s.reconcile_state_of(cr.key).local_state.reconcile_pc === simple_reconciler::after_create_cm_pc()
-            }).leads_to(always(lift_state(|s: State<SimpleReconcileState>| s.resource_key_exists(simple_reconciler::subresource_configmap(cr.key).key))))
+            lift_state(reconciler_at_after_create_cm_pc(cr.key))
+                .leads_to(always(lift_state(cm_exists(cr.key))))
         ),
 {
-    let cm = simple_reconciler::subresource_configmap(cr.key);
-
-    let reconciler_at_after_create_cm_pc = |s: State<SimpleReconcileState>| {
-        &&& s.reconcile_state_contains(cr.key)
-        &&& s.reconcile_state_of(cr.key).local_state.reconcile_pc === simple_reconciler::after_create_cm_pc()
-    };
-
-    let cm_exists = |s: State<SimpleReconcileState>| {
-        s.resource_key_exists(cm.key)
-    };
-
     leads_to_weaken_auto::<State<SimpleReconcileState>>(sm_spec(simple_reconciler()));
     always_implies_weaken_auto::<State<SimpleReconcileState>>(sm_spec(simple_reconciler()));
 
+    let cm = simple_reconciler::subresource_configmap(cr.key);
     let safety_invariant = safety::lemma_always_reconcile_create_cm_done_implies_pending_create_cm_req(cr.key);
 
-    assert forall |ex| #[trigger] sm_spec(simple_reconciler()).satisfied_by(ex) implies lift_state(reconciler_at_after_create_cm_pc).leads_to(lift_state(cm_exists)).satisfied_by(ex) by {
-        assert forall |i| #[trigger] lift_state(reconciler_at_after_create_cm_pc).satisfied_by(ex.suffix(i)) implies eventually(lift_state(cm_exists)).satisfied_by(ex.suffix(i)) by {
-            let create_cm_req_msg_sent = |msg: Message| {
-                |s: State<SimpleReconcileState>| {
-                    &&& is_controller_create_cm_request_msg(msg, cr.key)
-                    &&& s.reconcile_state_of(cr.key).pending_req_msg === Option::Some(msg)
-                    &&& s.message_sent(msg)
-                }
-            };
+    assert forall |ex| #[trigger] sm_spec(simple_reconciler()).satisfied_by(ex) implies lift_state(reconciler_at_after_create_cm_pc(cr.key)).leads_to(lift_state(cm_exists(cr.key))).satisfied_by(ex) by {
+        assert forall |i| #[trigger] lift_state(reconciler_at_after_create_cm_pc(cr.key)).satisfied_by(ex.suffix(i)) implies eventually(lift_state(cm_exists(cr.key))).satisfied_by(ex.suffix(i)) by {
+            let pre = |msg: Message| reconciler_at_after_create_cm_pc_and_pending_req_and_req_sent(msg, cr.key);
             instantiate_entailed_always::<State<SimpleReconcileState>>(ex, i, sm_spec(simple_reconciler()), safety_invariant);
 
             let create_cm_req_msg = choose |m: Message| {
@@ -326,15 +241,15 @@ proof fn lemma_after_create_cm_pc_leads_to_cm_always_exists(cr: ResourceObj)
                 &&& ex.suffix(i).head().reconcile_state_of(cr.key).pending_req_msg === Option::Some(m)
                 &&& #[trigger] ex.suffix(i).head().message_sent(m)
             };
-            assert(lift_state(create_cm_req_msg_sent(create_cm_req_msg)).satisfied_by(ex.suffix(i)));
+            assert(lift_state(pre(create_cm_req_msg)).satisfied_by(ex.suffix(i)));
 
             kubernetes_api_liveness::lemma_create_req_leads_to_res_exists::<SimpleReconcileState>(simple_reconciler(), create_cm_req_msg, cm);
-            instantiate_entailed_leads_to::<State<SimpleReconcileState>>(ex, i, sm_spec(simple_reconciler()), lift_state(create_cm_req_msg_sent(create_cm_req_msg)), lift_state(cm_exists));
+            instantiate_entailed_leads_to::<State<SimpleReconcileState>>(ex, i, sm_spec(simple_reconciler()), lift_state(pre(create_cm_req_msg)), lift_state(cm_exists(cr.key)));
         };
     };
 
     // finally prove stability: spec |= reconciler_at_after_create_cm_pc ~> []cm_exists
-    lemma_p_leads_to_cm_always_exists(cr, lift_state(reconciler_at_after_create_cm_pc));
+    lemma_p_leads_to_cm_always_exists(cr, lift_state(reconciler_at_after_create_cm_pc(cr.key)));
 }
 
 proof fn lemma_reconcile_done_leads_to_cm_always_exists(cr: ResourceObj)
@@ -342,24 +257,10 @@ proof fn lemma_reconcile_done_leads_to_cm_always_exists(cr: ResourceObj)
         cr.key.kind.is_CustomResourceKind(),
     ensures
         sm_spec(simple_reconciler()).entails(
-            lift_state(|s: State<SimpleReconcileState>| {
-                &&& s.reconcile_state_contains(cr.key)
-                &&& (simple_reconciler().reconcile_done)(s.reconcile_state_of(cr.key).local_state)
-            }).leads_to(always(lift_state(|s: State<SimpleReconcileState>| s.resource_key_exists(simple_reconciler::subresource_configmap(cr.key).key))))
+            lift_state(reconciler_reconcile_done(cr.key))
+            .leads_to(always(lift_state(|s: State<SimpleReconcileState>| s.resource_key_exists(simple_reconciler::subresource_configmap(cr.key).key))))
         ),
 {
-    let cm = simple_reconciler::subresource_configmap(cr.key);
-
-    let reconciler_reconcile_done = |s: State<SimpleReconcileState>| {
-        &&& s.reconcile_state_contains(cr.key)
-        &&& (simple_reconciler().reconcile_done)(s.reconcile_state_of(cr.key).local_state)
-    };
-    let reconcile_at_init_pc = |s: State<SimpleReconcileState>| {
-        &&& s.reconcile_state_contains(cr.key)
-        &&& s.reconcile_state_of(cr.key).local_state.reconcile_pc === simple_reconciler::init_pc()
-    };
-    let cm_exists = |s: State<SimpleReconcileState>| s.resource_key_exists(cm.key);
-
     leads_to_weaken_auto::<State<SimpleReconcileState>>(sm_spec(simple_reconciler()));
 
     // The key of this proof is that ending step label (Done or Error) will make the reconcile rescheduled
@@ -369,7 +270,7 @@ proof fn lemma_reconcile_done_leads_to_cm_always_exists(cr: ResourceObj)
     // which we have proved leads to cm_exists
     controller_runtime_liveness::lemma_reconcile_done_leads_to_reconcile_triggered::<SimpleReconcileState>(simple_reconciler(), cr.key);
     lemma_init_pc_leads_to_cm_always_exists(cr);
-    leads_to_trans_temp::<State<SimpleReconcileState>>(sm_spec(simple_reconciler()), lift_state(reconciler_reconcile_done), lift_state(reconcile_at_init_pc), always(lift_state(cm_exists)));
+    leads_to_trans_temp::<State<SimpleReconcileState>>(sm_spec(simple_reconciler()), lift_state(reconciler_reconcile_done(cr.key)), lift_state(reconciler_at_init_pc(cr.key)), always(lift_state(cm_exists(cr.key))));
 }
 
 proof fn lemma_p_leads_to_cm_always_exists(cr: ResourceObj, p: TempPred<State<SimpleReconcileState>>)
@@ -383,9 +284,6 @@ proof fn lemma_p_leads_to_cm_always_exists(cr: ResourceObj, p: TempPred<State<Si
             p.leads_to(always(lift_state(|s: State<SimpleReconcileState>| s.resource_key_exists(simple_reconciler::subresource_configmap(cr.key).key))))
         ),
 {
-    let cm = simple_reconciler::subresource_configmap(cr.key);
-
-    let cm_exists = |s: State<SimpleReconcileState>| s.resource_key_exists(cm.key);
     let delete_cm_req_msg_not_sent = |s: State<SimpleReconcileState>| !exists |m: Message| {
         &&& #[trigger] s.message_sent(m)
         &&& m.dst === HostId::KubernetesAPI
@@ -401,7 +299,7 @@ proof fn lemma_p_leads_to_cm_always_exists(cr: ResourceObj, p: TempPred<State<Si
     entails_and_temp::<State<SimpleReconcileState>>(sm_spec(simple_reconciler()), always(lift_action(next(simple_reconciler()))), always(lift_state(delete_cm_req_msg_not_sent)));
     always_and_equality::<State<SimpleReconcileState>>(lift_action(next(simple_reconciler())), lift_state(delete_cm_req_msg_not_sent));
     temp_pred_equality::<State<SimpleReconcileState>>(lift_action(next(simple_reconciler())).and(lift_state(delete_cm_req_msg_not_sent)), lift_action(next_and_invariant));
-    leads_to_stable_temp::<State<SimpleReconcileState>>(sm_spec(simple_reconciler()), lift_action(next_and_invariant), p, lift_state(cm_exists));
+    leads_to_stable_temp::<State<SimpleReconcileState>>(sm_spec(simple_reconciler()), lift_action(next_and_invariant), p, lift_state(cm_exists(cr.key)));
 }
 
 proof fn lemma_relevant_event_sent_leads_to_init_pc(msg: Message, cr_key: ResourceKey)
@@ -416,11 +314,7 @@ proof fn lemma_relevant_event_sent_leads_to_init_pc(msg: Message, cr_key: Resour
                 &&& simple_reconciler::reconcile_trigger(msg) === Option::Some(cr_key)
                 &&& !s.reconcile_state_contains(cr_key)
             })
-                .leads_to(lift_state(|s: State<SimpleReconcileState>| {
-                    &&& s.reconcile_state_contains(cr_key)
-                    &&& s.reconcile_state_of(cr_key).local_state.reconcile_pc === simple_reconciler::init_pc()
-                    &&& s.reconcile_state_of(cr_key).pending_req_msg.is_None()
-                }))
+                .leads_to(lift_state(reconciler_at_init_pc_and_no_pending_req(cr_key)))
         ),
 {
     leads_to_weaken_auto::<State<SimpleReconcileState>>(sm_spec(simple_reconciler()));
@@ -432,25 +326,11 @@ proof fn lemma_init_pc_leads_to_after_get_cr_pc(cr_key: ResourceKey)
         cr_key.kind.is_CustomResourceKind(),
     ensures
         sm_spec(simple_reconciler()).entails(
-            lift_state(|s: State<SimpleReconcileState>| {
-                &&& s.reconcile_state_contains(cr_key)
-                &&& s.reconcile_state_of(cr_key).local_state.reconcile_pc === simple_reconciler::init_pc()
-                &&& s.reconcile_state_of(cr_key).pending_req_msg.is_None()
-            }).leads_to(lift_state(|s: State<SimpleReconcileState>| {
-                    &&& s.reconcile_state_contains(cr_key)
-                    &&& s.reconcile_state_of(cr_key).local_state.reconcile_pc === simple_reconciler::after_get_cr_pc()
-                }))
+            lift_state(reconciler_at_init_pc_and_no_pending_req(cr_key)).leads_to(lift_state(reconciler_at_after_get_cr_pc(cr_key)))
         ),
 {
-    let pre = |s: State<SimpleReconcileState>| {
-        &&& s.reconcile_state_contains(cr_key)
-        &&& s.reconcile_state_of(cr_key).local_state.reconcile_pc === simple_reconciler::init_pc()
-        &&& s.reconcile_state_of(cr_key).pending_req_msg.is_None()
-    };
-    let post = |s: State<SimpleReconcileState>| {
-        &&& s.reconcile_state_contains(cr_key)
-        &&& s.reconcile_state_of(cr_key).local_state.reconcile_pc === simple_reconciler::after_get_cr_pc()
-    };
+    let pre = reconciler_at_init_pc_and_no_pending_req(cr_key);
+    let post = reconciler_at_after_get_cr_pc(cr_key);
     let input = ControllerActionInput {
         recv: Option::None,
         scheduled_cr_key: Option::Some(cr_key),
@@ -463,41 +343,18 @@ proof fn lemma_req_msg_sent_and_after_get_cr_pc_leads_to_after_create_cm_pc(req_
         cr_key.kind.is_CustomResourceKind(),
     ensures
         sm_spec(simple_reconciler()).entails(
-            lift_state(|s: State<SimpleReconcileState>| {
-                &&& s.reconcile_state_contains(cr_key)
-                &&& s.reconcile_state_of(cr_key).local_state.reconcile_pc === simple_reconciler::after_get_cr_pc()
-                &&& s.reconcile_state_of(cr_key).pending_req_msg === Option::Some(req_msg)
-                &&& is_controller_get_cr_request_msg(req_msg, cr_key)
-                &&& s.message_sent(req_msg)
-            }).leads_to(lift_state(|s: State<SimpleReconcileState>| {
-                &&& s.reconcile_state_contains(cr_key)
-                &&& s.reconcile_state_of(cr_key).local_state.reconcile_pc === simple_reconciler::after_create_cm_pc()
-            }))
+            lift_state(reconciler_at_after_get_cr_pc_and_pending_req_and_req_sent(req_msg, cr_key))
+                .leads_to(lift_state(reconciler_at_after_create_cm_pc(cr_key)))
         ),
 {
-    let pre = |s: State<SimpleReconcileState>| {
-        &&& s.reconcile_state_contains(cr_key)
-        &&& s.reconcile_state_of(cr_key).local_state.reconcile_pc === simple_reconciler::after_get_cr_pc()
-        &&& s.reconcile_state_of(cr_key).pending_req_msg === Option::Some(req_msg)
-        &&& is_controller_get_cr_request_msg(req_msg, cr_key)
-        &&& s.message_sent(req_msg)
-    };
-    let reconciler_at_after_get_cr_pc_and_pending_get_cr_req = |s: State<SimpleReconcileState>| {
-        &&& s.reconcile_state_contains(cr_key)
-        &&& s.reconcile_state_of(cr_key).local_state.reconcile_pc === simple_reconciler::after_get_cr_pc()
-        &&& s.reconcile_state_of(cr_key).pending_req_msg === Option::Some(req_msg)
-        &&& is_controller_get_cr_request_msg(req_msg, cr_key)
-    };
+    let pre = reconciler_at_after_get_cr_pc_and_pending_req_and_req_sent(req_msg, cr_key);
     let get_cr_resp_msg_sent = |s: State<SimpleReconcileState>| {
         exists |resp_msg: Message| {
             &&& #[trigger] s.message_sent(resp_msg)
             &&& resp_msg_matches_req_msg(resp_msg, req_msg)
         }
     };
-    let reconciler_at_after_create_cm_pc = |s: State<SimpleReconcileState>| {
-        &&& s.reconcile_state_contains(cr_key)
-        &&& s.reconcile_state_of(cr_key).local_state.reconcile_pc === simple_reconciler::after_create_cm_pc()
-    };
+    let reconciler_at_after_create_cm_pc = reconciler_at_after_create_cm_pc(cr_key);
 
     leads_to_weaken_auto::<State<SimpleReconcileState>>(sm_spec(simple_reconciler()));
 
@@ -516,18 +373,18 @@ proof fn lemma_req_msg_sent_and_after_get_cr_pc_leads_to_after_create_cm_pc(req_
     };
     leads_to_stable::<State<SimpleReconcileState>>(sm_spec(simple_reconciler()), next(simple_reconciler()), pre, get_cr_resp_msg_sent);
     // Now we have:
-    //  spec |= reconciler_at_after_get_cr_pc ~> reconciler_at_after_get_cr_pc_and_pending_get_cr_req
+    //  spec |= reconciler_at_after_get_cr_pc ~> reconciler_at_after_get_cr_pc_and_pending_req
     //  spec |= reconciler_at_after_get_cr_pc ~> []get_cr_resp_msg_sent
-    // And to make more progress, we need to make reconciler_at_after_get_cr_pc_and_pending_get_cr_req and get_cr_resp_msg_sent
+    // And to make more progress, we need to make reconciler_at_after_get_cr_pc_and_pending_req and get_cr_resp_msg_sent
     // both true at the same time
     // This is why we use leads_to_confluence here
-    leads_to_confluence::<State<SimpleReconcileState>>(sm_spec(simple_reconciler()), next(simple_reconciler()), pre, reconciler_at_after_get_cr_pc_and_pending_get_cr_req, get_cr_resp_msg_sent);
+    leads_to_confluence::<State<SimpleReconcileState>>(sm_spec(simple_reconciler()), next(simple_reconciler()), pre, reconciler_at_after_get_cr_pc_and_pending_req(req_msg, cr_key), get_cr_resp_msg_sent);
     // Now we have all the premise to fire the leads-to formula from lemma_exists_resp_msg_sent_and_after_get_cr_pc_leads_to_after_create_cm_pc
     lemma_exists_resp_msg_sent_and_after_get_cr_pc_leads_to_after_create_cm_pc(req_msg, cr_key);
     leads_to_trans::<State<SimpleReconcileState>>(sm_spec(simple_reconciler()),
         pre,
         |s| {
-            &&& reconciler_at_after_get_cr_pc_and_pending_get_cr_req(s)
+            &&& reconciler_at_after_get_cr_pc_and_pending_req(req_msg, cr_key)(s)
             &&& get_cr_resp_msg_sent(s)
         },
         reconciler_at_after_create_cm_pc
@@ -542,28 +399,16 @@ proof fn lemma_resp_msg_sent_and_after_get_cr_pc_leads_to_after_create_cm_pc(res
             lift_state(|s: State<SimpleReconcileState>| {
                 &&& s.message_sent(resp_msg)
                 &&& resp_msg_matches_req_msg(resp_msg, req_msg)
-                &&& is_controller_get_cr_request_msg(req_msg, cr_key)
-                &&& s.reconcile_state_contains(cr_key)
-                &&& s.reconcile_state_of(cr_key).local_state.reconcile_pc === simple_reconciler::after_get_cr_pc()
-                &&& s.reconcile_state_of(cr_key).pending_req_msg === Option::Some(req_msg)
-            }).leads_to(lift_state(|s: State<SimpleReconcileState>| {
-                    &&& s.reconcile_state_contains(cr_key)
-                    &&& s.reconcile_state_of(cr_key).local_state.reconcile_pc === simple_reconciler::after_create_cm_pc()
-                }))
+                &&& reconciler_at_after_get_cr_pc_and_pending_req(req_msg, cr_key)(s)
+            }).leads_to(lift_state(reconciler_at_after_create_cm_pc(cr_key)))
         ),
 {
     let pre = |s: State<SimpleReconcileState>| {
         &&& s.message_sent(resp_msg)
         &&& resp_msg_matches_req_msg(resp_msg, req_msg)
-        &&& is_controller_get_cr_request_msg(req_msg, cr_key)
-        &&& s.reconcile_state_contains(cr_key)
-        &&& s.reconcile_state_of(cr_key).local_state.reconcile_pc === simple_reconciler::after_get_cr_pc()
-        &&& s.reconcile_state_of(cr_key).pending_req_msg === Option::Some(req_msg)
+        &&& reconciler_at_after_get_cr_pc_and_pending_req(req_msg, cr_key)(s)
     };
-    let post = |s: State<SimpleReconcileState>| {
-        &&& s.reconcile_state_contains(cr_key)
-        &&& s.reconcile_state_of(cr_key).local_state.reconcile_pc === simple_reconciler::after_create_cm_pc()
-    };
+    let post = reconciler_at_after_create_cm_pc(cr_key);
     let input = ControllerActionInput {
         recv: Option::Some(resp_msg),
         scheduled_cr_key: Option::Some(cr_key),
@@ -581,40 +426,22 @@ proof fn lemma_exists_resp_msg_sent_and_after_get_cr_pc_leads_to_after_create_cm
                     &&& #[trigger] s.message_sent(m)
                     &&& resp_msg_matches_req_msg(m, req_msg)
                 }
-            }).and(lift_state(|s: State<SimpleReconcileState>| {
-                &&& is_controller_get_cr_request_msg(req_msg, cr_key)
-                &&& s.reconcile_state_contains(cr_key)
-                &&& s.reconcile_state_of(cr_key).local_state.reconcile_pc === simple_reconciler::after_get_cr_pc()
-                &&& s.reconcile_state_of(cr_key).pending_req_msg === Option::Some(req_msg)
-            })).leads_to(lift_state(|s: State<SimpleReconcileState>| {
-                    &&& s.reconcile_state_contains(cr_key)
-                    &&& s.reconcile_state_of(cr_key).local_state.reconcile_pc === simple_reconciler::after_create_cm_pc()
-                }))
+            }).and(lift_state(reconciler_at_after_get_cr_pc_and_pending_req(req_msg, cr_key)))
+            .leads_to(lift_state(reconciler_at_after_create_cm_pc(cr_key)))
         ),
 {
     let m_to_pre1 = |m: Message| lift_state(|s: State<SimpleReconcileState>| {
         &&& s.message_sent(m)
         &&& resp_msg_matches_req_msg(m, req_msg)
     });
-    let pre2 = lift_state(|s: State<SimpleReconcileState>| {
-        &&& is_controller_get_cr_request_msg(req_msg, cr_key)
-        &&& s.reconcile_state_contains(cr_key)
-        &&& s.reconcile_state_of(cr_key).local_state.reconcile_pc === simple_reconciler::after_get_cr_pc()
-        &&& s.reconcile_state_of(cr_key).pending_req_msg === Option::Some(req_msg)
-    });
-    let post = lift_state(|s: State<SimpleReconcileState>| {
-        &&& s.reconcile_state_contains(cr_key)
-        &&& s.reconcile_state_of(cr_key).local_state.reconcile_pc === simple_reconciler::after_create_cm_pc()
-    });
+    let pre2 = lift_state(reconciler_at_after_get_cr_pc_and_pending_req(req_msg, cr_key));
+    let post = lift_state(reconciler_at_after_create_cm_pc(cr_key));
     assert forall |msg: Message| #[trigger] sm_spec(simple_reconciler()).entails(m_to_pre1(msg).and(pre2).leads_to(post)) by {
         lemma_resp_msg_sent_and_after_get_cr_pc_leads_to_after_create_cm_pc(msg, req_msg, cr_key);
         let pre = lift_state(|s: State<SimpleReconcileState>| {
             &&& s.message_sent(msg)
             &&& resp_msg_matches_req_msg(msg, req_msg)
-            &&& is_controller_get_cr_request_msg(req_msg, cr_key)
-            &&& s.reconcile_state_contains(cr_key)
-            &&& s.reconcile_state_of(cr_key).local_state.reconcile_pc === simple_reconciler::after_get_cr_pc()
-            &&& s.reconcile_state_of(cr_key).pending_req_msg === Option::Some(req_msg)
+            &&& reconciler_at_after_get_cr_pc_and_pending_req(req_msg, cr_key)(s)
         });
         temp_pred_equality::<State<SimpleReconcileState>>(pre, m_to_pre1(msg).and(pre2));
     };

--- a/src/simple_controller/proof/mod.rs
+++ b/src/simple_controller/proof/mod.rs
@@ -2,3 +2,4 @@
 // SPDX-License-Identifier: MIT
 pub mod liveness;
 pub mod safety;
+pub mod shared;

--- a/src/simple_controller/proof/safety.rs
+++ b/src/simple_controller/proof/safety.rs
@@ -7,6 +7,7 @@ use crate::kubernetes_cluster::spec::{
     distributed_system::*,
 };
 use crate::pervasive::{option::*, result::*};
+use crate::simple_controller::proof::shared::*;
 use crate::simple_controller::spec::{
     simple_reconciler,
     simple_reconciler::{simple_reconciler, SimpleReconcileState},
@@ -23,8 +24,7 @@ pub proof fn lemma_always_reconcile_init_implies_no_pending_req(cr_key: Resource
             lift_state(|s: State<SimpleReconcileState>| {
                 &&& s.reconcile_state_contains(cr_key)
                 &&& s.reconcile_state_of(cr_key).local_state.reconcile_pc === simple_reconciler::init_pc()
-            })
-                .implies(lift_state(|s: State<SimpleReconcileState>| {
+            }).implies(lift_state(|s: State<SimpleReconcileState>| {
                     &&& s.reconcile_state_contains(cr_key)
                     &&& s.reconcile_state_of(cr_key).local_state.reconcile_pc === simple_reconciler::init_pc()
                     &&& s.reconcile_state_of(cr_key).pending_req_msg.is_None()
@@ -53,82 +53,135 @@ pub proof fn lemma_always_reconcile_init_implies_no_pending_req(cr_key: Resource
     temp_pred_equality::<State<SimpleReconcileState>>(lift_state(invariant), invariant_temp_pred);
 }
 
-pub proof fn lemma_always_reconcile_get_cr_done_implies_pending_get_cr_req(cr_key: ResourceKey)
+
+pub proof fn lemma_always_reconcile_get_cr_done_implies_pending_get_cr_req(cr_key: ResourceKey) -> (inv: TempPred<State<SimpleReconcileState>>)
     requires
         cr_key.kind.is_CustomResourceKind(),
     ensures
-        sm_spec(simple_reconciler()).entails(always(
-            lift_state(|s: State<SimpleReconcileState>| {
-                &&& s.reconcile_state_contains(cr_key)
-                &&& s.reconcile_state_of(cr_key).local_state.reconcile_pc === simple_reconciler::after_get_cr_pc()
-            })
-                .implies(lift_state(|s: State<SimpleReconcileState>| {
-                    &&& s.reconcile_state_contains(cr_key)
-                    &&& s.reconcile_state_of(cr_key).local_state.reconcile_pc === simple_reconciler::after_get_cr_pc()
-                    &&& s.reconcile_state_of(cr_key).pending_req_msg === Option::Some(controller_req_msg(APIRequest::GetRequest(GetRequest{key: cr_key})))
-                    &&& s.message_sent(controller_req_msg(APIRequest::GetRequest(GetRequest{key: cr_key})))
-                }))
-        )),
+        inv === lift_state(|s: State<SimpleReconcileState>| {
+            &&& s.reconcile_state_contains(cr_key)
+            &&& s.reconcile_state_of(cr_key).local_state.reconcile_pc === simple_reconciler::after_get_cr_pc()
+        }).implies(lift_state(|s: State<SimpleReconcileState>| {
+            exists |m| {
+                &&& is_controller_get_cr_request_msg(m, cr_key)
+                &&& s.reconcile_state_of(cr_key).pending_req_msg === Option::Some(m)
+                &&& #[trigger] s.message_sent(m)
+            }
+        })),
+        sm_spec(simple_reconciler()).entails(always(inv)),
 {
     let invariant = |s: State<SimpleReconcileState>| {
         s.reconcile_state_contains(cr_key)
         && s.reconcile_state_of(cr_key).local_state.reconcile_pc === simple_reconciler::after_get_cr_pc()
-        ==> s.reconcile_state_contains(cr_key)
-            && s.reconcile_state_of(cr_key).local_state.reconcile_pc === simple_reconciler::after_get_cr_pc()
-            && s.reconcile_state_of(cr_key).pending_req_msg === Option::Some(controller_req_msg(APIRequest::GetRequest(GetRequest{key: cr_key})))
-            && s.message_sent(controller_req_msg(APIRequest::GetRequest(GetRequest{key: cr_key})))
+        ==> exists |m| {
+                is_controller_get_cr_request_msg(m, cr_key)
+                && s.reconcile_state_of(cr_key).pending_req_msg === Option::Some(m)
+                && #[trigger] s.message_sent(m)
+            }
     };
+
+    assert forall |s, s_prime: State<SimpleReconcileState>| invariant(s) && #[trigger] next(simple_reconciler())(s, s_prime) implies invariant(s_prime) by {
+        if s.reconcile_state_contains(cr_key) && s.reconcile_state_of(cr_key).local_state.reconcile_pc === simple_reconciler::after_get_cr_pc() {
+            if s_prime.reconcile_state_contains(cr_key) && s_prime.reconcile_state_of(cr_key).local_state.reconcile_pc === simple_reconciler::after_get_cr_pc() {
+                let m = choose |m| is_controller_get_cr_request_msg(m, cr_key)
+                    && s.reconcile_state_of(cr_key).pending_req_msg === Option::Some(m)
+                    && #[trigger] s.message_sent(m);
+                assert(is_controller_get_cr_request_msg(m, cr_key)
+                    && s_prime.reconcile_state_of(cr_key).pending_req_msg === Option::Some(m)
+                    && s_prime.message_sent(m)
+                );
+            }
+        } else {
+            if s_prime.reconcile_state_contains(cr_key) && s_prime.reconcile_state_of(cr_key).local_state.reconcile_pc === simple_reconciler::after_get_cr_pc() {
+                let m = controller_req_msg(APIRequest::GetRequest(GetRequest{key: cr_key}), s.controller_state.req_id);
+                assert(is_controller_get_cr_request_msg(m, cr_key)
+                    && s_prime.reconcile_state_of(cr_key).pending_req_msg === Option::Some(m)
+                    && s_prime.message_sent(m)
+                );
+            }
+        }
+    };
+
     init_invariant::<State<SimpleReconcileState>>(sm_spec(simple_reconciler()), init(simple_reconciler()), next(simple_reconciler()), invariant);
 
     let invariant_temp_pred = lift_state(|s: State<SimpleReconcileState>| {
         &&& s.reconcile_state_contains(cr_key)
         &&& s.reconcile_state_of(cr_key).local_state.reconcile_pc === simple_reconciler::after_get_cr_pc()
     }).implies(lift_state(|s: State<SimpleReconcileState>| {
-        &&& s.reconcile_state_contains(cr_key)
-        &&& s.reconcile_state_of(cr_key).local_state.reconcile_pc === simple_reconciler::after_get_cr_pc()
-        &&& s.reconcile_state_of(cr_key).pending_req_msg === Option::Some(controller_req_msg(APIRequest::GetRequest(GetRequest{key: cr_key})))
-        &&& s.message_sent(controller_req_msg(APIRequest::GetRequest(GetRequest{key: cr_key})))
+        exists |m| {
+            &&& is_controller_get_cr_request_msg(m, cr_key)
+            &&& s.reconcile_state_of(cr_key).pending_req_msg === Option::Some(m)
+            &&& #[trigger] s.message_sent(m)
+        }
     }));
     temp_pred_equality::<State<SimpleReconcileState>>(lift_state(invariant), invariant_temp_pred);
+
+    invariant_temp_pred
 }
 
-pub proof fn lemma_always_reconcile_create_cm_done_implies_pending_create_cm_req(cr_key: ResourceKey)
+pub proof fn lemma_always_reconcile_create_cm_done_implies_pending_create_cm_req(cr_key: ResourceKey) -> (inv: TempPred<State<SimpleReconcileState>>)
     requires
         cr_key.kind.is_CustomResourceKind(),
     ensures
-        sm_spec(simple_reconciler()).entails(always(
-            lift_state(|s: State<SimpleReconcileState>| {
-                &&& s.reconcile_state_contains(cr_key)
-                &&& s.reconcile_state_of(cr_key).local_state.reconcile_pc === simple_reconciler::after_create_cm_pc()
-            })
-                .implies(lift_state(|s: State<SimpleReconcileState>| {
-                    &&& s.reconcile_state_contains(cr_key)
-                    &&& s.reconcile_state_of(cr_key).local_state.reconcile_pc === simple_reconciler::after_create_cm_pc()
-                    &&& s.reconcile_state_of(cr_key).pending_req_msg === Option::Some(controller_req_msg(simple_reconciler::create_cm_req(cr_key)))
-                    &&& s.message_sent(controller_req_msg(simple_reconciler::create_cm_req(cr_key)))
-                }))
-        )),
+        inv === lift_state(|s: State<SimpleReconcileState>| {
+            &&& s.reconcile_state_contains(cr_key)
+            &&& s.reconcile_state_of(cr_key).local_state.reconcile_pc === simple_reconciler::after_create_cm_pc()
+        }).implies(lift_state(|s: State<SimpleReconcileState>| {
+            exists |m| {
+                &&& is_controller_create_cm_request_msg(m, cr_key)
+                &&& s.reconcile_state_of(cr_key).pending_req_msg === Option::Some(m)
+                &&& #[trigger] s.message_sent(m)
+            }
+        })),
+        sm_spec(simple_reconciler()).entails(always(inv)),
 {
     let invariant = |s: State<SimpleReconcileState>| {
         s.reconcile_state_contains(cr_key)
         && s.reconcile_state_of(cr_key).local_state.reconcile_pc === simple_reconciler::after_create_cm_pc()
-        ==> s.reconcile_state_contains(cr_key)
-            && s.reconcile_state_of(cr_key).local_state.reconcile_pc === simple_reconciler::after_create_cm_pc()
-            && s.reconcile_state_of(cr_key).pending_req_msg === Option::Some(controller_req_msg(simple_reconciler::create_cm_req(cr_key)))
-            && s.message_sent(controller_req_msg(simple_reconciler::create_cm_req(cr_key)))
+        ==> exists |m| {
+                is_controller_create_cm_request_msg(m, cr_key)
+                && s.reconcile_state_of(cr_key).pending_req_msg === Option::Some(m)
+                && #[trigger] s.message_sent(m)
+            }
     };
+
+    assert forall |s, s_prime: State<SimpleReconcileState>| invariant(s) && #[trigger] next(simple_reconciler())(s, s_prime) implies invariant(s_prime) by {
+        if s.reconcile_state_contains(cr_key) && s.reconcile_state_of(cr_key).local_state.reconcile_pc === simple_reconciler::after_create_cm_pc() {
+            if s_prime.reconcile_state_contains(cr_key) && s_prime.reconcile_state_of(cr_key).local_state.reconcile_pc === simple_reconciler::after_create_cm_pc() {
+                let m = choose |m| is_controller_create_cm_request_msg(m, cr_key)
+                    && s.reconcile_state_of(cr_key).pending_req_msg === Option::Some(m)
+                    && #[trigger] s.message_sent(m);
+                assert(is_controller_create_cm_request_msg(m, cr_key)
+                    && s_prime.reconcile_state_of(cr_key).pending_req_msg === Option::Some(m)
+                    && s_prime.message_sent(m)
+                );
+            }
+        } else {
+            if s_prime.reconcile_state_contains(cr_key) && s_prime.reconcile_state_of(cr_key).local_state.reconcile_pc === simple_reconciler::after_create_cm_pc() {
+                let m = controller_req_msg(simple_reconciler::create_cm_req(cr_key), s.controller_state.req_id);
+                assert(is_controller_create_cm_request_msg(m, cr_key)
+                    && s_prime.reconcile_state_of(cr_key).pending_req_msg === Option::Some(m)
+                    && s_prime.message_sent(m)
+                );
+            }
+        }
+    };
+
     init_invariant::<State<SimpleReconcileState>>(sm_spec(simple_reconciler()), init(simple_reconciler()), next(simple_reconciler()), invariant);
 
     let invariant_temp_pred = lift_state(|s: State<SimpleReconcileState>| {
         &&& s.reconcile_state_contains(cr_key)
         &&& s.reconcile_state_of(cr_key).local_state.reconcile_pc === simple_reconciler::after_create_cm_pc()
     }).implies(lift_state(|s: State<SimpleReconcileState>| {
-        &&& s.reconcile_state_contains(cr_key)
-        &&& s.reconcile_state_of(cr_key).local_state.reconcile_pc === simple_reconciler::after_create_cm_pc()
-        &&& s.reconcile_state_of(cr_key).pending_req_msg === Option::Some(controller_req_msg(simple_reconciler::create_cm_req(cr_key)))
-        &&& s.message_sent(controller_req_msg(simple_reconciler::create_cm_req(cr_key)))
+        exists |m| {
+            &&& is_controller_create_cm_request_msg(m, cr_key)
+            &&& s.reconcile_state_of(cr_key).pending_req_msg === Option::Some(m)
+            &&& #[trigger] s.message_sent(m)
+        }
     }));
     temp_pred_equality::<State<SimpleReconcileState>>(lift_state(invariant), invariant_temp_pred);
+
+    invariant_temp_pred
 }
 
 pub proof fn lemma_delete_cm_req_msg_never_sent(cr_key: ResourceKey)

--- a/src/simple_controller/proof/shared.rs
+++ b/src/simple_controller/proof/shared.rs
@@ -1,0 +1,49 @@
+// Copyright 2022 VMware, Inc.
+// SPDX-License-Identifier: MIT
+#![allow(unused_imports)]
+use crate::kubernetes_cluster::spec::{
+    common::*,
+    controller::common::{controller_req_msg, ControllerAction, ControllerActionInput},
+    distributed_system::*,
+};
+use crate::pervasive::*;
+use crate::pervasive::{option::*, result::*};
+use crate::simple_controller::spec::{
+    simple_reconciler,
+    simple_reconciler::{simple_reconciler, SimpleReconcileState},
+};
+use builtin::*;
+use builtin_macros::*;
+
+verus! {
+
+pub closed spec fn dummy_trigger<A>(x: A);
+
+pub open spec fn is_controller_get_cr_request_msg(msg: Message, cr_key: ResourceKey) -> bool {
+    &&& msg.src === HostId::CustomController
+    &&& msg.dst === HostId::KubernetesAPI
+    &&& msg.is_get_request()
+    &&& msg.get_get_request().key === cr_key
+}
+
+pub open spec fn is_controller_create_cm_request_msg(msg: Message, cr_key: ResourceKey) -> bool {
+    &&& msg.src === HostId::CustomController
+    &&& msg.dst === HostId::KubernetesAPI
+    &&& msg.is_create_request()
+    &&& msg.get_create_request().obj === simple_reconciler::subresource_configmap(cr_key)
+    // === simple_reconciler::create_cm_req(cr_key)
+}
+
+pub type ChosenMessage = FnSpec(State<SimpleReconcileState>) -> Message;
+
+pub open spec fn choose_pending_controller_get_cr_request_msg(cr_key: ResourceKey) -> ChosenMessage {
+    |s: State<SimpleReconcileState>| {
+        choose |m| {
+            &&& is_controller_get_cr_request_msg(m, cr_key)
+            &&& #[trigger] s.message_sent(m)
+            &&& s.reconcile_state_of(cr_key).pending_req_msg === Option::Some(m)
+        }
+    }
+}
+
+}

--- a/src/simple_controller/proof/shared.rs
+++ b/src/simple_controller/proof/shared.rs
@@ -130,16 +130,4 @@ pub open spec fn is_controller_create_cm_request_msg(msg: Message, cr_key: Resou
     &&& msg.get_create_request().obj === simple_reconciler::subresource_configmap(cr_key)
 }
 
-pub type ChosenMessage = FnSpec(State<SimpleReconcileState>) -> Message;
-
-pub open spec fn choose_pending_controller_get_cr_request_msg(cr_key: ResourceKey) -> ChosenMessage {
-    |s: State<SimpleReconcileState>| {
-        choose |m| {
-            &&& is_controller_get_cr_request_msg(m, cr_key)
-            &&& #[trigger] s.message_sent(m)
-            &&& s.reconcile_state_of(cr_key).pending_req_msg === Option::Some(m)
-        }
-    }
-}
-
 }

--- a/src/simple_controller/proof/shared.rs
+++ b/src/simple_controller/proof/shared.rs
@@ -12,12 +12,109 @@ use crate::simple_controller::spec::{
     simple_reconciler,
     simple_reconciler::{simple_reconciler, SimpleReconcileState},
 };
+use crate::temporal_logic::defs::*;
 use builtin::*;
 use builtin_macros::*;
 
 verus! {
 
 pub closed spec fn dummy_trigger<A>(x: A);
+
+pub open spec fn reconciler_at_init_pc(cr_key: ResourceKey) -> StatePred<State<SimpleReconcileState>>
+    recommends
+        cr_key.kind.is_CustomResourceKind(),
+{
+    |s: State<SimpleReconcileState>| {
+        &&& s.reconcile_state_contains(cr_key)
+        &&& s.reconcile_state_of(cr_key).local_state.reconcile_pc === simple_reconciler::init_pc()
+    }
+}
+
+pub open spec fn reconciler_at_init_pc_and_no_pending_req(cr_key: ResourceKey) -> StatePred<State<SimpleReconcileState>>
+    recommends
+        cr_key.kind.is_CustomResourceKind(),
+{
+    |s: State<SimpleReconcileState>| {
+        &&& s.reconcile_state_contains(cr_key)
+        &&& s.reconcile_state_of(cr_key).local_state.reconcile_pc === simple_reconciler::init_pc()
+        &&& s.reconcile_state_of(cr_key).pending_req_msg.is_None()
+    }
+}
+
+pub open spec fn reconciler_at_after_get_cr_pc(cr_key: ResourceKey) -> StatePred<State<SimpleReconcileState>>
+    recommends
+        cr_key.kind.is_CustomResourceKind(),
+{
+    |s: State<SimpleReconcileState>| {
+        &&& s.reconcile_state_contains(cr_key)
+        &&& s.reconcile_state_of(cr_key).local_state.reconcile_pc === simple_reconciler::after_get_cr_pc()
+    }
+}
+
+pub open spec fn reconciler_at_after_get_cr_pc_and_pending_req(msg: Message, cr_key: ResourceKey) -> StatePred<State<SimpleReconcileState>>
+    recommends
+        cr_key.kind.is_CustomResourceKind(),
+{
+    |s: State<SimpleReconcileState>| {
+        &&& s.reconcile_state_contains(cr_key)
+        &&& s.reconcile_state_of(cr_key).local_state.reconcile_pc === simple_reconciler::after_get_cr_pc()
+        &&& s.reconcile_state_of(cr_key).pending_req_msg === Option::Some(msg)
+        &&& is_controller_get_cr_request_msg(msg, cr_key)
+    }
+}
+
+pub open spec fn reconciler_at_after_get_cr_pc_and_pending_req_and_req_sent(msg: Message, cr_key: ResourceKey) -> StatePred<State<SimpleReconcileState>>
+    recommends
+        cr_key.kind.is_CustomResourceKind(),
+{
+    |s: State<SimpleReconcileState>| {
+        &&& s.reconcile_state_contains(cr_key)
+        &&& s.reconcile_state_of(cr_key).local_state.reconcile_pc === simple_reconciler::after_get_cr_pc()
+        &&& s.reconcile_state_of(cr_key).pending_req_msg === Option::Some(msg)
+        &&& is_controller_get_cr_request_msg(msg, cr_key)
+        &&& s.message_sent(msg)
+    }
+}
+
+pub open spec fn reconciler_at_after_create_cm_pc(cr_key: ResourceKey) -> StatePred<State<SimpleReconcileState>>
+    recommends
+        cr_key.kind.is_CustomResourceKind(),
+{
+    |s: State<SimpleReconcileState>| {
+        &&& s.reconcile_state_contains(cr_key)
+        &&& s.reconcile_state_of(cr_key).local_state.reconcile_pc === simple_reconciler::after_create_cm_pc()
+    }
+}
+
+pub open spec fn reconciler_at_after_create_cm_pc_and_pending_req_and_req_sent(msg: Message, cr_key: ResourceKey) -> StatePred<State<SimpleReconcileState>>
+    recommends
+        cr_key.kind.is_CustomResourceKind(),
+{
+    |s: State<SimpleReconcileState>| {
+        &&& s.reconcile_state_contains(cr_key)
+        &&& s.reconcile_state_of(cr_key).local_state.reconcile_pc === simple_reconciler::after_create_cm_pc()
+        &&& is_controller_create_cm_request_msg(msg, cr_key)
+        &&& s.reconcile_state_of(cr_key).pending_req_msg === Option::Some(msg)
+        &&& s.message_sent(msg)
+    }
+}
+
+pub open spec fn reconciler_reconcile_done(cr_key: ResourceKey) -> StatePred<State<SimpleReconcileState>>
+    recommends
+        cr_key.kind.is_CustomResourceKind(),
+{
+    |s: State<SimpleReconcileState>| {
+        &&& s.reconcile_state_contains(cr_key)
+        &&& (simple_reconciler().reconcile_done)(s.reconcile_state_of(cr_key).local_state)
+    }
+}
+
+pub open spec fn cm_exists(cr_key: ResourceKey) -> StatePred<State<SimpleReconcileState>>
+    recommends
+        cr_key.kind.is_CustomResourceKind(),
+{
+    |s: State<SimpleReconcileState>| s.resource_key_exists(simple_reconciler::subresource_configmap(cr_key).key)
+}
 
 pub open spec fn is_controller_get_cr_request_msg(msg: Message, cr_key: ResourceKey) -> bool {
     &&& msg.src === HostId::CustomController
@@ -31,7 +128,6 @@ pub open spec fn is_controller_create_cm_request_msg(msg: Message, cr_key: Resou
     &&& msg.dst === HostId::KubernetesAPI
     &&& msg.is_create_request()
     &&& msg.get_create_request().obj === simple_reconciler::subresource_configmap(cr_key)
-    // === simple_reconciler::create_cm_req(cr_key)
 }
 
 pub type ChosenMessage = FnSpec(State<SimpleReconcileState>) -> Message;

--- a/src/simple_controller/proof/shared.rs
+++ b/src/simple_controller/proof/shared.rs
@@ -109,6 +109,16 @@ pub open spec fn reconciler_reconcile_done(cr_key: ResourceKey) -> StatePred<Sta
     }
 }
 
+pub open spec fn reconciler_reconcile_error(cr_key: ResourceKey) -> StatePred<State<SimpleReconcileState>>
+    recommends
+        cr_key.kind.is_CustomResourceKind(),
+{
+    |s: State<SimpleReconcileState>| {
+        &&& s.reconcile_state_contains(cr_key)
+        &&& (simple_reconciler().reconcile_error)(s.reconcile_state_of(cr_key).local_state)
+    }
+}
+
 pub open spec fn cm_exists(cr_key: ResourceKey) -> StatePred<State<SimpleReconcileState>>
     recommends
         cr_key.kind.is_CustomResourceKind(),

--- a/src/simple_controller/spec/simple_reconciler.rs
+++ b/src/simple_controller/spec/simple_reconciler.rs
@@ -26,6 +26,7 @@ pub open spec fn simple_reconciler() -> Reconciler<SimpleReconcileState> {
         reconcile_trigger: |msg: Message| reconcile_trigger(msg),
         reconcile_core: |cr_key: ResourceKey, resp_o: Option<APIResponse>, state: SimpleReconcileState| reconcile_core(cr_key, resp_o, state),
         reconcile_done: |state: SimpleReconcileState| reconcile_done(state),
+        reconcile_error: |state: SimpleReconcileState| reconcile_error(state),
     }
 }
 
@@ -81,8 +82,13 @@ pub open spec fn reconcile_core(cr_key: ResourceKey, resp_o: Option<APIResponse>
 }
 
 pub open spec fn reconcile_done(state: SimpleReconcileState) -> bool {
+    state.reconcile_pc === after_create_cm_pc()
+}
+
+pub open spec fn reconcile_error(state: SimpleReconcileState) -> bool {
     &&& state.reconcile_pc !== init_pc()
     &&& state.reconcile_pc !== after_get_cr_pc()
+    &&& state.reconcile_pc !== after_create_cm_pc()
 }
 
 pub open spec fn init_pc() -> nat { 0 }


### PR DESCRIPTION
To match the response (from the k8s API) and the request (sent to the k8s API), this PR adds a req_id to each request and the k8s API state machine will attach the same id to the response after handling each request. This req_id only applies to <request, response> pairs, and watch event messages do not have any such id.

The req_id has to be unique to differentiate responses for different requests. The controller, k8s API and client state machine maintains a req_id variable respectively which always increments after sending out one request. An alternative is to let the top-level k8s cluster state machine maintain the req_id and pass it to each individual state machine, but that requires the k8s cluster state machine to know how many requests each individual state machine sends out in each step so that it can increment the id properly.

The liveness proof was broken after introducing the req_id and now it is fixed. An important difference is that we now have the `[]exists |msg| P(msg)` pattern (e.g., see `lemma_always_reconcile_get_cr_done_implies_pending_get_cr_req`) in the proof and sometimes we need to unfold the temporal predicate to continue the proof (e.g., in `lemma_after_get_cr_pc_leads_to_cm_always_exists`). There should be a way to simplify this process with some lemma.

Note that we have not changed the simple controller spec to have branches for different response results. I will leave that for the next PR.