### PR TITLE
Use `==` for spec eq

### DIFF
--- a/src/kubernetes_cluster/proof/controller_runtime_liveness.rs
+++ b/src/kubernetes_cluster/proof/controller_runtime_liveness.rs
@@ -65,28 +65,28 @@ pub proof fn lemma_relevant_event_sent_leads_to_reconcile_triggered<T>(reconcile
         sm_spec(reconciler).entails(
             lift_state(|s: State<T>| {
                 &&& s.message_in_flight(msg)
-                &&& msg.dst === HostId::CustomController
+                &&& msg.dst == HostId::CustomController
                 &&& msg.content.is_WatchEvent()
-                &&& (reconciler.reconcile_trigger)(msg) === Option::Some(cr_key)
+                &&& (reconciler.reconcile_trigger)(msg) == Option::Some(cr_key)
                 &&& !s.reconcile_state_contains(cr_key)
             })
                 .leads_to(lift_state(|s: State<T>| {
                     &&& s.reconcile_state_contains(cr_key)
-                    &&& s.reconcile_state_of(cr_key).local_state === (reconciler.reconcile_init_state)()
+                    &&& s.reconcile_state_of(cr_key).local_state == (reconciler.reconcile_init_state)()
                     &&& s.reconcile_state_of(cr_key).pending_req_msg.is_None()
                 }))
         ),
 {
     let pre = |s: State<T>| {
         &&& s.message_in_flight(msg)
-        &&& msg.dst === HostId::CustomController
+        &&& msg.dst == HostId::CustomController
         &&& msg.content.is_WatchEvent()
-        &&& (reconciler.reconcile_trigger)(msg) === Option::Some(cr_key)
+        &&& (reconciler.reconcile_trigger)(msg) == Option::Some(cr_key)
         &&& !s.reconcile_state_contains(cr_key)
     };
     let post = |s: State<T>| {
         &&& s.reconcile_state_contains(cr_key)
-        &&& s.reconcile_state_of(cr_key).local_state === (reconciler.reconcile_init_state)()
+        &&& s.reconcile_state_of(cr_key).local_state == (reconciler.reconcile_init_state)()
         &&& s.reconcile_state_of(cr_key).pending_req_msg.is_None()
     };
     let input = ControllerActionInput {
@@ -167,7 +167,7 @@ pub proof fn lemma_reconcile_idle_and_scheduled_leads_to_reconcile_init<T>(recon
             })
                 .leads_to(lift_state(|s: State<T>| {
                     &&& s.reconcile_state_contains(cr_key)
-                    &&& s.reconcile_state_of(cr_key).local_state === (reconciler.reconcile_init_state)()
+                    &&& s.reconcile_state_of(cr_key).local_state == (reconciler.reconcile_init_state)()
                     &&& s.reconcile_state_of(cr_key).pending_req_msg.is_None()
                 }))
         ),
@@ -178,7 +178,7 @@ pub proof fn lemma_reconcile_idle_and_scheduled_leads_to_reconcile_init<T>(recon
     };
     let post = |s: State<T>| {
         &&& s.reconcile_state_contains(cr_key)
-        &&& s.reconcile_state_of(cr_key).local_state === (reconciler.reconcile_init_state)()
+        &&& s.reconcile_state_of(cr_key).local_state == (reconciler.reconcile_init_state)()
         &&& s.reconcile_state_of(cr_key).pending_req_msg.is_None()
     };
     let input = ControllerActionInput {
@@ -199,7 +199,7 @@ pub proof fn lemma_reconcile_done_leads_to_reconcile_init<T>(reconciler: Reconci
             })
                 .leads_to(lift_state(|s: State<T>| {
                     &&& s.reconcile_state_contains(cr_key)
-                    &&& s.reconcile_state_of(cr_key).local_state === (reconciler.reconcile_init_state)()
+                    &&& s.reconcile_state_of(cr_key).local_state == (reconciler.reconcile_init_state)()
                     &&& s.reconcile_state_of(cr_key).pending_req_msg.is_None()
                 }))
         ),
@@ -216,7 +216,7 @@ pub proof fn lemma_reconcile_done_leads_to_reconcile_init<T>(reconciler: Reconci
     };
     let reconcile_at_init = |s: State<T>| {
         &&& s.reconcile_state_contains(cr_key)
-        &&& s.reconcile_state_of(cr_key).local_state === (reconciler.reconcile_init_state)()
+        &&& s.reconcile_state_of(cr_key).local_state == (reconciler.reconcile_init_state)()
         &&& s.reconcile_state_of(cr_key).pending_req_msg.is_None()
     };
     leads_to_trans::<State<T>>(sm_spec(reconciler), reconcile_ended, reconcile_idle_and_scheduled, reconcile_at_init);
@@ -233,7 +233,7 @@ pub proof fn lemma_reconcile_error_leads_to_reconcile_init<T>(reconciler: Reconc
             })
                 .leads_to(lift_state(|s: State<T>| {
                     &&& s.reconcile_state_contains(cr_key)
-                    &&& s.reconcile_state_of(cr_key).local_state === (reconciler.reconcile_init_state)()
+                    &&& s.reconcile_state_of(cr_key).local_state == (reconciler.reconcile_init_state)()
                     &&& s.reconcile_state_of(cr_key).pending_req_msg.is_None()
                 }))
         ),
@@ -250,7 +250,7 @@ pub proof fn lemma_reconcile_error_leads_to_reconcile_init<T>(reconciler: Reconc
     };
     let reconcile_at_init = |s: State<T>| {
         &&& s.reconcile_state_contains(cr_key)
-        &&& s.reconcile_state_of(cr_key).local_state === (reconciler.reconcile_init_state)()
+        &&& s.reconcile_state_of(cr_key).local_state == (reconciler.reconcile_init_state)()
         &&& s.reconcile_state_of(cr_key).pending_req_msg.is_None()
     };
     leads_to_trans::<State<T>>(sm_spec(reconciler), reconcile_ended, reconcile_idle_and_scheduled, reconcile_at_init);

--- a/src/kubernetes_cluster/proof/kubernetes_api_liveness.rs
+++ b/src/kubernetes_cluster/proof/kubernetes_api_liveness.rs
@@ -60,7 +60,7 @@ pub proof fn lemma_create_req_leads_to_ok_resp<T>(reconciler: Reconciler<T>, msg
         sm_spec(reconciler).entails(
             lift_state(|s: State<T>| {
                 &&& s.message_in_flight(msg)
-                &&& msg.dst === HostId::KubernetesAPI
+                &&& msg.dst == HostId::KubernetesAPI
                 &&& msg.is_create_request()
                 &&& !s.resource_key_exists(msg.get_create_request().obj.key)
             })
@@ -68,9 +68,9 @@ pub proof fn lemma_create_req_leads_to_ok_resp<T>(reconciler: Reconciler<T>, msg
                 forall |other: Message|
                     #[trigger] s.message_in_flight(other)
                     && other.is_create_request()
-                    && other.get_create_request() === msg.get_create_request()
-                    && other.dst === msg.dst
-                        ==> other === msg
+                    && other.get_create_request() == msg.get_create_request()
+                    && other.dst == msg.dst
+                        ==> other == msg
             })))
                 .leads_to(
                     lift_state(|s: State<T>| {
@@ -84,13 +84,13 @@ pub proof fn lemma_create_req_leads_to_ok_resp<T>(reconciler: Reconciler<T>, msg
         forall |other: Message|
             #[trigger] s.message_in_flight(other)
             && other.is_create_request()
-            && other.get_create_request() === msg.get_create_request()
-            && other.dst === msg.dst
-                ==> other === msg
+            && other.get_create_request() == msg.get_create_request()
+            && other.dst == msg.dst
+                ==> other == msg
     };
     let pre = |s: State<T>| {
         &&& s.message_in_flight(msg)
-        &&& msg.dst === HostId::KubernetesAPI
+        &&& msg.dst == HostId::KubernetesAPI
         &&& msg.is_create_request()
         &&& !s.resource_key_exists(msg.get_create_request().obj.key)
     };
@@ -106,9 +106,9 @@ pub proof fn lemma_get_req_leads_to_some_resp<T>(reconciler: Reconciler<T>, msg:
         sm_spec(reconciler).entails(
             lift_state(|s: State<T>| {
                     &&& s.message_in_flight(msg)
-                    &&& msg.dst === HostId::KubernetesAPI
+                    &&& msg.dst == HostId::KubernetesAPI
                     &&& msg.is_get_request()
-                    &&& msg.get_get_request().key === key
+                    &&& msg.get_get_request().key == key
                 })
                 .leads_to(
                     lift_state(|s: State<T>|
@@ -123,9 +123,9 @@ pub proof fn lemma_get_req_leads_to_some_resp<T>(reconciler: Reconciler<T>, msg:
     let input = Option::Some(msg);
     let pre = |s: State<T>| {
         &&& s.message_in_flight(msg)
-        &&& msg.dst === HostId::KubernetesAPI
+        &&& msg.dst == HostId::KubernetesAPI
         &&& msg.is_get_request()
-        &&& msg.get_get_request().key === key
+        &&& msg.get_get_request().key == key
     };
     let post = |s: State<T>| exists |resp_msg: Message| {
         &&& #[trigger] s.message_in_flight(resp_msg)
@@ -151,9 +151,9 @@ pub proof fn lemma_get_req_leads_to_ok_or_err_resp<T>(reconciler: Reconciler<T>,
         sm_spec(reconciler).entails(
             lift_state(|s: State<T>| {
                 &&& s.message_in_flight(msg)
-                &&& msg.dst === HostId::KubernetesAPI
+                &&& msg.dst == HostId::KubernetesAPI
                 &&& msg.is_get_request()
-                &&& msg.get_get_request().key === key
+                &&& msg.get_get_request().key == key
             })
                 .leads_to(
                     lift_state(|s: State<T>| s.message_in_flight(form_get_resp_msg(msg, Result::Ok(s.resource_obj_of(key)), msg.get_req_id())))
@@ -163,9 +163,9 @@ pub proof fn lemma_get_req_leads_to_ok_or_err_resp<T>(reconciler: Reconciler<T>,
 {
     let pre = |s: State<T>| {
         &&& s.message_in_flight(msg)
-        &&& msg.dst === HostId::KubernetesAPI
+        &&& msg.dst == HostId::KubernetesAPI
         &&& msg.is_get_request()
-        &&& msg.get_get_request().key === key
+        &&& msg.get_get_request().key == key
     };
     let post = |s: State<T>| {
         ||| s.message_in_flight(form_get_resp_msg(msg, Result::Ok(s.resource_obj_of(key)), msg.get_req_id()))
@@ -184,18 +184,18 @@ pub proof fn lemma_get_req_leads_to_ok_resp_if_never_delete<T>(reconciler: Recon
         sm_spec(reconciler).entails(
             lift_state(|s: State<T>| {
                 &&& s.message_in_flight(msg)
-                &&& msg.dst === HostId::KubernetesAPI
+                &&& msg.dst == HostId::KubernetesAPI
                 &&& msg.is_get_request()
-                &&& msg.get_get_request().key === res.key
+                &&& msg.get_get_request().key == res.key
                 &&& s.resource_obj_exists(res)
             })
             .and(always(lift_state(|s: State<T>| {
                 forall |other: Message|
                 !{
                     &&& #[trigger] s.message_in_flight(other)
-                    &&& other.dst === HostId::KubernetesAPI
+                    &&& other.dst == HostId::KubernetesAPI
                     &&& other.is_delete_request()
-                    &&& other.get_delete_request().key === res.key
+                    &&& other.get_delete_request().key == res.key
                 }
             })))
                 .leads_to(lift_state(|s: State<T>| s.message_in_flight(form_get_resp_msg(msg, Result::Ok(res), msg.get_req_id()))))
@@ -203,18 +203,18 @@ pub proof fn lemma_get_req_leads_to_ok_resp_if_never_delete<T>(reconciler: Recon
 {
     let pre = |s: State<T>| {
         &&& s.message_in_flight(msg)
-        &&& msg.dst === HostId::KubernetesAPI
+        &&& msg.dst == HostId::KubernetesAPI
         &&& msg.is_get_request()
-        &&& msg.get_get_request().key === res.key
+        &&& msg.get_get_request().key == res.key
         &&& s.resource_obj_exists(res)
     };
     let assumption = |s: State<T>| {
         forall |other: Message|
             !{
                 &&& #[trigger] s.message_in_flight(other)
-                &&& other.dst === HostId::KubernetesAPI
+                &&& other.dst == HostId::KubernetesAPI
                 &&& other.is_delete_request()
-                &&& other.get_delete_request().key === res.key
+                &&& other.get_delete_request().key == res.key
             }
     };
     let post = |s: State<T>| s.message_in_flight(form_get_resp_msg(msg, Result::Ok(res), msg.get_req_id()));
@@ -226,9 +226,9 @@ pub proof fn lemma_get_req_leads_to_ok_resp_if_res_always_exists<T>(reconciler: 
         sm_spec(reconciler).entails(
             lift_state(|s: State<T>| {
                 &&& s.message_in_flight(msg)
-                &&& msg.dst === HostId::KubernetesAPI
+                &&& msg.dst == HostId::KubernetesAPI
                 &&& msg.is_get_request()
-                &&& msg.get_get_request().key === res.key
+                &&& msg.get_get_request().key == res.key
             })
             .and(always(lift_state(|s: State<T>| s.resource_obj_exists(res))))
                 .leads_to(lift_state(|s: State<T>| s.message_in_flight(form_get_resp_msg(msg, Result::Ok(res), msg.get_req_id()))))
@@ -238,25 +238,25 @@ pub proof fn lemma_get_req_leads_to_ok_resp_if_res_always_exists<T>(reconciler: 
 
     let get_req_msg_sent = |s: State<T>| {
         &&& s.message_in_flight(msg)
-        &&& msg.dst === HostId::KubernetesAPI
+        &&& msg.dst == HostId::KubernetesAPI
         &&& msg.is_get_request()
-        &&& msg.get_get_request().key === res.key
+        &&& msg.get_get_request().key == res.key
     };
     let res_exists = |s: State<T>| s.resource_obj_exists(res);
     let get_req_msg_sent_and_res_exists = |s: State<T>| {
         &&& s.message_in_flight(msg)
-        &&& msg.dst === HostId::KubernetesAPI
+        &&& msg.dst == HostId::KubernetesAPI
         &&& msg.is_get_request()
-        &&& msg.get_get_request().key === res.key
+        &&& msg.get_get_request().key == res.key
         &&& s.resource_obj_exists(res)
     };
     let delete_req_never_sent = |s: State<T>| {
         forall |other: Message|
         !{
             &&& #[trigger] s.message_in_flight(other)
-            &&& other.dst === HostId::KubernetesAPI
+            &&& other.dst == HostId::KubernetesAPI
             &&& other.is_delete_request()
-            &&& other.get_delete_request().key === res.key
+            &&& other.get_delete_request().key == res.key
         }
     };
     let ok_resp_msg_sent = |s: State<T>| s.message_in_flight(form_get_resp_msg(msg, Result::Ok(res), msg.get_req_id()));
@@ -296,18 +296,18 @@ pub proof fn lemma_create_req_leads_to_res_exists<T>(reconciler: Reconciler<T>, 
         sm_spec(reconciler).entails(
             lift_state(|s: State<T>| {
                 &&& s.message_in_flight(msg)
-                &&& msg.dst === HostId::KubernetesAPI
+                &&& msg.dst == HostId::KubernetesAPI
                 &&& msg.is_create_request()
-                &&& msg.get_create_request().obj === res
+                &&& msg.get_create_request().obj == res
             })
                 .leads_to(lift_state(|s: State<T>| s.resource_key_exists(res.key)))
         ),
 {
     let pre = |s: State<T>| {
         &&& s.message_in_flight(msg)
-        &&& msg.dst === HostId::KubernetesAPI
+        &&& msg.dst == HostId::KubernetesAPI
         &&& msg.is_create_request()
-        &&& msg.get_create_request().obj === res
+        &&& msg.get_create_request().obj == res
     };
     let post = |s: State<T>| {
         s.resource_key_exists(res.key)
@@ -320,18 +320,18 @@ pub proof fn lemma_delete_req_leads_to_res_not_exists<T>(reconciler: Reconciler<
         sm_spec(reconciler).entails(
             lift_state(|s: State<T>| {
                 &&& s.message_in_flight(msg)
-                &&& msg.dst === HostId::KubernetesAPI
+                &&& msg.dst == HostId::KubernetesAPI
                 &&& msg.is_delete_request()
-                &&& msg.get_delete_request().key === res.key
+                &&& msg.get_delete_request().key == res.key
             })
                 .leads_to(lift_state(|s: State<T>| !s.resource_obj_exists(res)))
         ),
 {
     let pre = |s: State<T>| {
         &&& s.message_in_flight(msg)
-        &&& msg.dst === HostId::KubernetesAPI
+        &&& msg.dst == HostId::KubernetesAPI
         &&& msg.is_delete_request()
-        &&& msg.get_delete_request().key === res.key
+        &&& msg.get_delete_request().key == res.key
     };
     let post = |s: State<T>| {
         !s.resource_obj_exists(res)
@@ -346,9 +346,9 @@ pub proof fn lemma_always_res_always_exists_implies_delete_never_sent<T>(reconci
                 .implies(always(lift_state(|s: State<T>| {
                     !{
                         &&& s.message_in_flight(msg)
-                        &&& msg.dst === HostId::KubernetesAPI
+                        &&& msg.dst == HostId::KubernetesAPI
                         &&& msg.is_delete_request()
-                        &&& msg.get_delete_request().key === res.key
+                        &&& msg.get_delete_request().key == res.key
                     }
                 })))
         )),
@@ -357,9 +357,9 @@ pub proof fn lemma_always_res_always_exists_implies_delete_never_sent<T>(reconci
     leads_to_contraposition::<State<T>>(sm_spec(reconciler),
         |s: State<T>| {
             &&& s.message_in_flight(msg)
-            &&& msg.dst === HostId::KubernetesAPI
+            &&& msg.dst == HostId::KubernetesAPI
             &&& msg.is_delete_request()
-            &&& msg.get_delete_request().key === res.key
+            &&& msg.get_delete_request().key == res.key
         },
         |s: State<T>| !s.resource_obj_exists(res)
     );
@@ -370,16 +370,16 @@ pub proof fn lemma_always_res_always_exists_implies_delete_never_sent<T>(reconci
     temp_pred_equality::<State<T>>(
         not(lift_state(|s: State<T>| {
             &&& s.message_in_flight(msg)
-            &&& msg.dst === HostId::KubernetesAPI
+            &&& msg.dst == HostId::KubernetesAPI
             &&& msg.is_delete_request()
-            &&& msg.get_delete_request().key === res.key
+            &&& msg.get_delete_request().key == res.key
         })),
         lift_state(|s: State<T>| {
             !{
                 &&& s.message_in_flight(msg)
-                &&& msg.dst === HostId::KubernetesAPI
+                &&& msg.dst == HostId::KubernetesAPI
                 &&& msg.is_delete_request()
-                &&& msg.get_delete_request().key === res.key
+                &&& msg.get_delete_request().key == res.key
             }
         })
     );
@@ -394,9 +394,9 @@ pub proof fn lemma_always_res_always_exists_implies_forall_delete_never_sent<T>(
                     forall |msg: Message|
                     !{
                         &&& #[trigger] s.message_in_flight(msg)
-                        &&& msg.dst === HostId::KubernetesAPI
+                        &&& msg.dst == HostId::KubernetesAPI
                         &&& msg.is_delete_request()
-                        &&& msg.get_delete_request().key === res.key
+                        &&& msg.get_delete_request().key == res.key
                     }
                 })))
         )),
@@ -405,9 +405,9 @@ pub proof fn lemma_always_res_always_exists_implies_forall_delete_never_sent<T>(
     let m_to_always_m_not_sent = |msg: Message| always(lift_state(|s: State<T>| {
         !{
             &&& s.message_in_flight(msg)
-            &&& msg.dst === HostId::KubernetesAPI
+            &&& msg.dst == HostId::KubernetesAPI
             &&& msg.is_delete_request()
-            &&& msg.get_delete_request().key === res.key
+            &&& msg.get_delete_request().key == res.key
         }
     }));
     assert forall |msg: Message| sm_spec(reconciler).entails(#[trigger] always(pre.implies(m_to_always_m_not_sent(msg)))) by {
@@ -418,9 +418,9 @@ pub proof fn lemma_always_res_always_exists_implies_forall_delete_never_sent<T>(
     let m_to_m_not_sent = |msg: Message| lift_state(|s: State<T>| {
         !{
             &&& s.message_in_flight(msg)
-            &&& msg.dst === HostId::KubernetesAPI
+            &&& msg.dst == HostId::KubernetesAPI
             &&& msg.is_delete_request()
-            &&& msg.get_delete_request().key === res.key
+            &&& msg.get_delete_request().key == res.key
         }
     });
     tla_forall_always_equality_variant::<State<T>, Message>(m_to_always_m_not_sent, m_to_m_not_sent);
@@ -429,18 +429,18 @@ pub proof fn lemma_always_res_always_exists_implies_forall_delete_never_sent<T>(
         forall |msg: Message|
         !{
             &&& #[trigger] s.message_in_flight(msg)
-            &&& msg.dst === HostId::KubernetesAPI
+            &&& msg.dst == HostId::KubernetesAPI
             &&& msg.is_delete_request()
-            &&& msg.get_delete_request().key === res.key
+            &&& msg.get_delete_request().key == res.key
         }
     });
     assert forall |ex| #[trigger] tla_forall(m_to_m_not_sent).satisfied_by(ex) implies forall_m_to_m_not_sent.satisfied_by(ex) by {
         assert forall |msg: Message|
             !{
                 &&& #[trigger] ex.head().message_in_flight(msg)
-                &&& msg.dst === HostId::KubernetesAPI
+                &&& msg.dst == HostId::KubernetesAPI
                 &&& msg.is_delete_request()
-                &&& msg.get_delete_request().key === res.key
+                &&& msg.get_delete_request().key == res.key
             }
         by {
             assert(m_to_m_not_sent(msg).satisfied_by(ex));

--- a/src/kubernetes_cluster/proof/wf1_assistant.rs
+++ b/src/kubernetes_cluster/proof/wf1_assistant.rs
@@ -66,13 +66,13 @@ pub proof fn exists_next_controller_step<T>(reconciler: Reconciler<T>, action: C
     ensures
         exists |step| (#[trigger] (controller(reconciler).step_to_action)(step).precondition)(input, s),
 {
-    if action === trigger_reconcile(reconciler) {
+    if action == trigger_reconcile(reconciler) {
         let step = ControllerStep::TriggerReconcile;
         assert(((controller(reconciler).step_to_action)(step).precondition)(input, s));
-    } else if action === run_scheduled_reconcile(reconciler) {
+    } else if action == run_scheduled_reconcile(reconciler) {
         let step = ControllerStep::RunScheduledReconcile;
         assert(((controller(reconciler).step_to_action)(step).precondition)(input, s));
-    } else if action === continue_reconcile(reconciler) {
+    } else if action == continue_reconcile(reconciler) {
         let step = ControllerStep::ContinueReconcile;
         assert(((controller(reconciler).step_to_action)(step).precondition)(input, s));
     } else {

--- a/src/kubernetes_cluster/spec/client.rs
+++ b/src/kubernetes_cluster/spec/client.rs
@@ -62,7 +62,7 @@ pub open spec fn send_delete_cr() -> ClientAction {
 pub open spec fn client() -> ClientStateMachine {
     StateMachine {
         init: |s: ClientState| {
-            s === ClientState {
+            s == ClientState {
                 req_id: 0,
             }
         },

--- a/src/kubernetes_cluster/spec/common.rs
+++ b/src/kubernetes_cluster/spec/common.rs
@@ -139,8 +139,8 @@ impl Message {
     pub open spec fn is_write_request_of_kind(self, kind: ResourceKind) -> bool {
         &&& self.is_write_request()
         &&& match self.content.get_APIRequest_0() {
-            APIRequest::CreateRequest(req) => req.obj.key.kind === kind,
-            APIRequest::DeleteRequest(req) => req.key.kind === kind,
+            APIRequest::CreateRequest(req) => req.obj.key.kind == kind,
+            APIRequest::DeleteRequest(req) => req.key.kind == kind,
             _ => false,
         }
     }
@@ -246,9 +246,9 @@ impl Message {
     pub open spec fn is_watch_event_of_kind(self, kind: ResourceKind) -> bool {
         &&& self.content.is_WatchEvent()
         &&& match self.content.get_WatchEvent_0() {
-            WatchEvent::AddedEvent(added) => added.obj.key.kind === kind,
-            WatchEvent::ModifiedEvent(modified) => modified.obj.key.kind === kind,
-            WatchEvent::DeletedEvent(deleted) => deleted.obj.key.kind === kind,
+            WatchEvent::AddedEvent(added) => added.obj.key.kind == kind,
+            WatchEvent::ModifiedEvent(modified) => modified.obj.key.kind == kind,
+            WatchEvent::DeletedEvent(deleted) => deleted.obj.key.kind == kind,
         }
     }
 
@@ -307,19 +307,19 @@ pub open spec fn resp_matches_req(resp: APIResponse, req: APIRequest) -> bool {
     match resp {
         APIResponse::GetResponse(get_resp) => {
             &&& req.is_GetRequest()
-            &&& get_resp.req === req.get_GetRequest_0()
+            &&& get_resp.req == req.get_GetRequest_0()
         },
         APIResponse::ListResponse(list_resp) => {
             &&& req.is_ListRequest()
-            &&& list_resp.req === req.get_ListRequest_0()
+            &&& list_resp.req == req.get_ListRequest_0()
         },
         APIResponse::CreateResponse(create_resp) => {
             &&& req.is_CreateRequest()
-            &&& create_resp.req === req.get_CreateRequest_0()
+            &&& create_resp.req == req.get_CreateRequest_0()
         },
         APIResponse::DeleteResponse(delete_resp) => {
             &&& req.is_DeleteRequest()
-            &&& delete_resp.req === req.get_DeleteRequest_0()
+            &&& delete_resp.req == req.get_DeleteRequest_0()
         },
     }
 }
@@ -328,10 +328,10 @@ pub open spec fn resp_matches_req(resp: APIResponse, req: APIRequest) -> bool {
 pub open spec fn resp_msg_matches_req_msg(resp_msg: Message, req_msg: Message) -> bool {
     &&& resp_msg.content.is_APIResponse()
     &&& req_msg.content.is_APIRequest()
-    &&& resp_msg.dst === req_msg.src
-    &&& resp_msg.src === req_msg.dst
+    &&& resp_msg.dst == req_msg.src
+    &&& resp_msg.src == req_msg.dst
     &&& resp_matches_req(resp_msg.content.get_APIResponse_0(), req_msg.content.get_APIRequest_0())
-    &&& resp_msg.content.get_APIResponse_1() === req_msg.content.get_APIRequest_1()
+    &&& resp_msg.content.get_APIResponse_1() == req_msg.content.get_APIRequest_1()
 }
 
 pub open spec fn cm_suffix() -> Seq<char> {

--- a/src/kubernetes_cluster/spec/controller/controller_runtime.rs
+++ b/src/kubernetes_cluster/spec/controller/controller_runtime.rs
@@ -28,7 +28,7 @@ pub open spec fn trigger_reconcile<T>(reconciler: Reconciler<T>) -> ControllerAc
             // Each queue stores the event relates to the same cr key.
             &&& input.scheduled_cr_key.is_None()
             &&& input.recv.is_Some()
-            &&& input.recv.get_Some_0().dst === HostId::CustomController
+            &&& input.recv.get_Some_0().dst == HostId::CustomController
             &&& input.recv.get_Some_0().content.is_WatchEvent()
             &&& (reconciler.reconcile_trigger)(input.recv.get_Some_0()).is_Some()
             &&& !s.ongoing_reconciles.dom().contains((reconciler.reconcile_trigger)(input.recv.get_Some_0()).get_Some_0())

--- a/src/kubernetes_cluster/spec/controller/state_machine.rs
+++ b/src/kubernetes_cluster/spec/controller/state_machine.rs
@@ -16,7 +16,7 @@ verus! {
 pub open spec fn controller<T>(reconciler: Reconciler<T>) -> ControllerStateMachine<T> {
     StateMachine {
         init: |s: ControllerState<T>| {
-            s === ControllerState {
+            s == ControllerState::<T> {
                 req_id: 0,
                 ongoing_reconciles: Map::empty(),
                 scheduled_reconciles: Set::empty(),

--- a/src/kubernetes_cluster/spec/distributed_system.rs
+++ b/src/kubernetes_cluster/spec/distributed_system.rs
@@ -43,7 +43,7 @@ impl<T> State<T> {
 
     pub open spec fn resource_obj_exists(self, obj: ResourceObj) -> bool {
         &&& self.kubernetes_api_state.resources.dom().contains(obj.key)
-        &&& self.kubernetes_api_state.resources[obj.key] === obj
+        &&& self.kubernetes_api_state.resources[obj.key] == obj
     }
 
     pub open spec fn resource_obj_of(self, key: ResourceKey) -> ResourceObj
@@ -79,7 +79,7 @@ pub open spec fn init<T>(reconciler: Reconciler<T>) -> StatePred<State<T>> {
 
 pub open spec fn received_msg_destined_for(recv: Option<Message>, host_id: HostId) -> bool {
     if recv.is_Some() {
-        recv.get_Some_0().dst === host_id
+        recv.get_Some_0().dst == host_id
     } else {
         true
     }

--- a/src/kubernetes_cluster/spec/kubernetes_api/state_machine.rs
+++ b/src/kubernetes_cluster/spec/kubernetes_api/state_machine.rs
@@ -117,7 +117,7 @@ pub open spec fn handle_request() -> KubernetesAPIAction {
             &&& input.is_Some()
             &&& input.get_Some_0().content.is_APIRequest()
             // This dst check is redundant since the compound state machine has checked it
-            &&& input.get_Some_0().dst === HostId::KubernetesAPI
+            &&& input.get_Some_0().dst == HostId::KubernetesAPI
         },
         transition: |input: KubernetesAPIActionInput, s: KubernetesAPIState| {
             // This transition describes how Kubernetes API server handles requests,
@@ -163,7 +163,7 @@ pub open spec fn handle_request() -> KubernetesAPIAction {
 
 pub open spec fn kubernetes_api() -> KubernetesAPIStateMachine {
     StateMachine {
-        init: |s: KubernetesAPIState| s === KubernetesAPIState {
+        init: |s: KubernetesAPIState| s == KubernetesAPIState {
             req_id: 0,
             resources: Map::empty(),
         },

--- a/src/kubernetes_cluster/spec/network.rs
+++ b/src/kubernetes_cluster/spec/network.rs
@@ -43,7 +43,7 @@ pub open spec fn deliver() -> Action<NetworkState, MessageOps, ()> {
 
 pub open spec fn network() -> NetworkStateMachine<NetworkState, MessageOps> {
     NetworkStateMachine {
-        init: |s: NetworkState| s.in_flight === Multiset::empty(),
+        init: |s: NetworkState| s.in_flight == Multiset::<Message>::empty(),
         deliver: deliver(),
     }
 }

--- a/src/pervasive_lemmas/seq_lemmas.rs
+++ b/src/pervasive_lemmas/seq_lemmas.rs
@@ -15,7 +15,7 @@ pub proof fn seq_unequal_preserved_by_add<A>(s1: Seq<A>, s2: Seq<A>, suffix: Seq
         s1 + suffix !== s2 + suffix
 {
     assert(!s1.ext_equal(s2));
-    if s1.len() === s2.len() {
+    if s1.len() == s2.len() {
         let witness_idx = choose |i: int| 0 <= i < s1.len() && s1[i] !== s2[i];
         assert((s1 + suffix)[witness_idx] !== (s2 + suffix)[witness_idx]);
     } else {

--- a/src/simple_controller/proof/liveness.rs
+++ b/src/simple_controller/proof/liveness.rs
@@ -243,7 +243,7 @@ proof fn lemma_after_get_cr_pc_leads_to_cm_always_exists(cr: ResourceObj)
 
             let get_cr_req_msg = choose |req_msg: Message| {
                 &&& is_controller_get_cr_request_msg(req_msg, cr.key)
-                &&& ex.suffix(i).head().reconcile_state_of(cr.key).pending_req_msg === Option::Some(req_msg)
+                &&& ex.suffix(i).head().reconcile_state_of(cr.key).pending_req_msg == Option::Some(req_msg)
                 &&& {
                     ||| #[trigger] ex.suffix(i).head().message_in_flight(req_msg)
                     ||| exists |resp_msg: Message| {
@@ -292,7 +292,7 @@ proof fn lemma_after_create_cm_pc_leads_to_cm_always_exists(cr: ResourceObj)
 
             let create_cm_req_msg = choose |m: Message| {
                 #[trigger] is_controller_create_cm_request_msg(m, cr.key)
-                && ex.suffix(i).head().reconcile_state_of(cr.key).pending_req_msg === Option::Some(m)
+                && ex.suffix(i).head().reconcile_state_of(cr.key).pending_req_msg == Option::Some(m)
                 && (ex.suffix(i).head().message_in_flight(m) || ex.suffix(i).head().resource_key_exists(simple_reconciler::subresource_configmap(cr.key).key))
             };
 
@@ -402,9 +402,9 @@ proof fn lemma_relevant_event_sent_leads_to_init_pc(msg: Message, cr_key: Resour
         sm_spec(simple_reconciler()).entails(
             lift_state(|s: State<SimpleReconcileState>| {
                 &&& s.message_in_flight(msg)
-                &&& msg.dst === HostId::CustomController
+                &&& msg.dst == HostId::CustomController
                 &&& msg.content.is_WatchEvent()
-                &&& simple_reconciler::reconcile_trigger(msg) === Option::Some(cr_key)
+                &&& simple_reconciler::reconcile_trigger(msg) == Option::Some(cr_key)
                 &&& !s.reconcile_state_contains(cr_key)
             })
                 .leads_to(lift_state(reconciler_at_init_pc_and_no_pending_req(cr_key)))
@@ -538,7 +538,7 @@ proof fn lemma_exists_resp_msg_sent_and_after_get_cr_pc_leads_to_after_create_cm
     leads_to_exists_intro::<State<SimpleReconcileState>, Message>(sm_spec(simple_reconciler()), |m| m_to_pre1(m).and(pre2), post);
     tla_exists_and_equality::<State<SimpleReconcileState>, Message>(m_to_pre1, pre2);
 
-    // This is very tedious proof to show exists_m_to_pre1 === tla_exists(m_to_pre1)
+    // This is very tedious proof to show exists_m_to_pre1 == tla_exists(m_to_pre1)
     // I hope we can encapsulate this as a lemma
     let exists_m_to_pre1 = lift_state(|s: State<SimpleReconcileState>| {
         exists |m: Message| {

--- a/src/simple_controller/proof/shared.rs
+++ b/src/simple_controller/proof/shared.rs
@@ -26,7 +26,7 @@ pub open spec fn reconciler_at_init_pc(cr_key: ResourceKey) -> StatePred<State<S
 {
     |s: State<SimpleReconcileState>| {
         &&& s.reconcile_state_contains(cr_key)
-        &&& s.reconcile_state_of(cr_key).local_state.reconcile_pc === simple_reconciler::init_pc()
+        &&& s.reconcile_state_of(cr_key).local_state.reconcile_pc == simple_reconciler::init_pc()
     }
 }
 
@@ -36,7 +36,7 @@ pub open spec fn reconciler_at_init_pc_and_no_pending_req(cr_key: ResourceKey) -
 {
     |s: State<SimpleReconcileState>| {
         &&& s.reconcile_state_contains(cr_key)
-        &&& s.reconcile_state_of(cr_key).local_state.reconcile_pc === simple_reconciler::init_pc()
+        &&& s.reconcile_state_of(cr_key).local_state.reconcile_pc == simple_reconciler::init_pc()
         &&& s.reconcile_state_of(cr_key).pending_req_msg.is_None()
     }
 }
@@ -47,7 +47,7 @@ pub open spec fn reconciler_at_after_get_cr_pc(cr_key: ResourceKey) -> StatePred
 {
     |s: State<SimpleReconcileState>| {
         &&& s.reconcile_state_contains(cr_key)
-        &&& s.reconcile_state_of(cr_key).local_state.reconcile_pc === simple_reconciler::after_get_cr_pc()
+        &&& s.reconcile_state_of(cr_key).local_state.reconcile_pc == simple_reconciler::after_get_cr_pc()
     }
 }
 
@@ -57,8 +57,8 @@ pub open spec fn reconciler_at_after_get_cr_pc_and_pending_req(msg: Message, cr_
 {
     |s: State<SimpleReconcileState>| {
         &&& s.reconcile_state_contains(cr_key)
-        &&& s.reconcile_state_of(cr_key).local_state.reconcile_pc === simple_reconciler::after_get_cr_pc()
-        &&& s.reconcile_state_of(cr_key).pending_req_msg === Option::Some(msg)
+        &&& s.reconcile_state_of(cr_key).local_state.reconcile_pc == simple_reconciler::after_get_cr_pc()
+        &&& s.reconcile_state_of(cr_key).pending_req_msg == Option::Some(msg)
         &&& is_controller_get_cr_request_msg(msg, cr_key)
     }
 }
@@ -69,8 +69,8 @@ pub open spec fn reconciler_at_after_get_cr_pc_and_pending_req_and_req_in_flight
 {
     |s: State<SimpleReconcileState>| {
         &&& s.reconcile_state_contains(cr_key)
-        &&& s.reconcile_state_of(cr_key).local_state.reconcile_pc === simple_reconciler::after_get_cr_pc()
-        &&& s.reconcile_state_of(cr_key).pending_req_msg === Option::Some(msg)
+        &&& s.reconcile_state_of(cr_key).local_state.reconcile_pc == simple_reconciler::after_get_cr_pc()
+        &&& s.reconcile_state_of(cr_key).pending_req_msg == Option::Some(msg)
         &&& is_controller_get_cr_request_msg(msg, cr_key)
         &&& s.message_in_flight(msg)
     }
@@ -82,8 +82,8 @@ pub open spec fn reconciler_at_after_get_cr_pc_and_pending_req_and_resp_in_fligh
 {
     |s: State<SimpleReconcileState>| {
         &&& s.reconcile_state_contains(cr_key)
-        &&& s.reconcile_state_of(cr_key).local_state.reconcile_pc === simple_reconciler::after_get_cr_pc()
-        &&& s.reconcile_state_of(cr_key).pending_req_msg === Option::Some(msg)
+        &&& s.reconcile_state_of(cr_key).local_state.reconcile_pc == simple_reconciler::after_get_cr_pc()
+        &&& s.reconcile_state_of(cr_key).pending_req_msg == Option::Some(msg)
         &&& is_controller_get_cr_request_msg(msg, cr_key)
         &&& exists |resp_msg: Message| {
             &&& #[trigger] s.message_in_flight(resp_msg)
@@ -109,7 +109,7 @@ pub open spec fn reconciler_at_after_create_cm_pc(cr_key: ResourceKey) -> StateP
 {
     |s: State<SimpleReconcileState>| {
         &&& s.reconcile_state_contains(cr_key)
-        &&& s.reconcile_state_of(cr_key).local_state.reconcile_pc === simple_reconciler::after_create_cm_pc()
+        &&& s.reconcile_state_of(cr_key).local_state.reconcile_pc == simple_reconciler::after_create_cm_pc()
     }
 }
 
@@ -119,9 +119,9 @@ pub open spec fn reconciler_at_after_create_cm_pc_and_pending_req_and_req_in_fli
 {
     |s: State<SimpleReconcileState>| {
         &&& s.reconcile_state_contains(cr_key)
-        &&& s.reconcile_state_of(cr_key).local_state.reconcile_pc === simple_reconciler::after_create_cm_pc()
+        &&& s.reconcile_state_of(cr_key).local_state.reconcile_pc == simple_reconciler::after_create_cm_pc()
         &&& is_controller_create_cm_request_msg(msg, cr_key)
-        &&& s.reconcile_state_of(cr_key).pending_req_msg === Option::Some(msg)
+        &&& s.reconcile_state_of(cr_key).pending_req_msg == Option::Some(msg)
         &&& s.message_in_flight(msg)
     }
 }
@@ -154,17 +154,17 @@ pub open spec fn cm_exists(cr_key: ResourceKey) -> StatePred<State<SimpleReconci
 }
 
 pub open spec fn is_controller_get_cr_request_msg(msg: Message, cr_key: ResourceKey) -> bool {
-    &&& msg.src === HostId::CustomController
-    &&& msg.dst === HostId::KubernetesAPI
+    &&& msg.src == HostId::CustomController
+    &&& msg.dst == HostId::KubernetesAPI
     &&& msg.is_get_request()
-    &&& msg.get_get_request().key === cr_key
+    &&& msg.get_get_request().key == cr_key
 }
 
 pub open spec fn is_controller_create_cm_request_msg(msg: Message, cr_key: ResourceKey) -> bool {
-    &&& msg.src === HostId::CustomController
-    &&& msg.dst === HostId::KubernetesAPI
+    &&& msg.src == HostId::CustomController
+    &&& msg.dst == HostId::KubernetesAPI
     &&& msg.is_create_request()
-    &&& msg.get_create_request().obj === simple_reconciler::subresource_configmap(cr_key)
+    &&& msg.get_create_request().obj == simple_reconciler::subresource_configmap(cr_key)
 }
 
 }

--- a/src/simple_controller/spec/simple_reconciler.rs
+++ b/src/simple_controller/spec/simple_reconciler.rs
@@ -64,13 +64,13 @@ pub open spec fn reconcile_core(cr_key: ResourceKey, resp_o: Option<APIResponse>
         cr_key.kind.is_CustomResourceKind(),
 {
     let pc = state.reconcile_pc;
-    if pc === init_pc() {
+    if pc == init_pc() {
         let state_prime = SimpleReconcileState {
             reconcile_pc: after_get_cr_pc(),
         };
         let req_o = Option::Some(APIRequest::GetRequest(GetRequest{key: cr_key}));
         (state_prime, req_o)
-    } else if pc === after_get_cr_pc() {
+    } else if pc == after_get_cr_pc() {
         let state_prime = SimpleReconcileState {
             reconcile_pc: after_create_cm_pc(),
         };
@@ -82,7 +82,7 @@ pub open spec fn reconcile_core(cr_key: ResourceKey, resp_o: Option<APIResponse>
 }
 
 pub open spec fn reconcile_done(state: SimpleReconcileState) -> bool {
-    state.reconcile_pc === after_create_cm_pc()
+    state.reconcile_pc == after_create_cm_pc()
 }
 
 pub open spec fn reconcile_error(state: SimpleReconcileState) -> bool {

--- a/src/state_machine/action.rs
+++ b/src/state_machine/action.rs
@@ -25,7 +25,7 @@ impl<State, Input, Output> Action<State, Input, Output> {
     pub open spec fn forward(self, input: Input) -> ActionPred<State> {
         |s: State, s_prime: State| {
             &&& (self.precondition)(input, s)
-            &&& s_prime === (self.transition)(input, s).0
+            &&& s_prime == (self.transition)(input, s).0
         }
     }
 

--- a/src/temporal_logic/rules.rs
+++ b/src/temporal_logic/rules.rs
@@ -482,7 +482,7 @@ proof fn confluence_at_some_point<T>(ex: Execution<T>, next: TempPred<T>, p: Tem
     decreases
         i,
 {
-    if i === 0 {
+    if i == 0 {
         execution_equality::<T>(ex, ex.suffix(0));
         assert(p.and(q).satisfied_by(ex.suffix(0)));
     } else {
@@ -535,9 +535,9 @@ pub proof fn instantiate_entailed_leads_to<T>(ex: Execution<T>, i: nat, spec: Te
 
 pub proof fn execution_equality<T>(ex1: Execution<T>, ex2: Execution<T>)
     requires
-        forall |i: nat| #[trigger] (ex1.nat_to_state)(i) === (ex2.nat_to_state)(i),
+        forall |i: nat| #[trigger] (ex1.nat_to_state)(i) == (ex2.nat_to_state)(i),
     ensures
-        ex1 === ex2,
+        ex1 == ex2,
 {
     fun_ext::<nat, T>(ex1.nat_to_state, ex2.nat_to_state);
 }
@@ -546,9 +546,9 @@ pub proof fn temp_pred_equality<T>(p: TempPred<T>, q: TempPred<T>)
     requires
         valid(p.equals(q)),
     ensures
-        p === q,
+        p == q,
 {
-    assert forall |ex: Execution<T>| #[trigger] (p.pred)(ex) === (q.pred)(ex) by {
+    assert forall |ex: Execution<T>| #[trigger] (p.pred)(ex) == (q.pred)(ex) by {
         valid_equals_to_valid_implies::<T>(p, q);
         if (p.pred)(ex) {
             implies_apply::<T>(ex, p, q);
@@ -561,7 +561,7 @@ pub proof fn temp_pred_equality<T>(p: TempPred<T>, q: TempPred<T>)
 
 pub proof fn always_and_equality<T>(p: TempPred<T>, q: TempPred<T>)
     ensures
-        always(p.and(q)) === always(p).and(always(q)),
+        always(p.and(q)) == always(p).and(always(q)),
 {
     assert forall |ex| #[trigger] always(p.and(q)).satisfied_by(ex) implies always(p).and(always(q)).satisfied_by(ex) by {
         assert forall |i| #[trigger] p.satisfied_by(ex.suffix(i)) by {
@@ -578,7 +578,7 @@ pub proof fn always_and_equality<T>(p: TempPred<T>, q: TempPred<T>)
 
 pub proof fn p_and_always_p_equals_always_p<T>(p: TempPred<T>)
     ensures
-        p.and(always(p)) === always(p),
+        p.and(always(p)) == always(p),
 {
     assert forall |ex| #[trigger] always(p).satisfied_by(ex) implies p.and(always(p)).satisfied_by(ex) by {
         always_to_current::<T>(ex, p);
@@ -590,9 +590,9 @@ pub proof fn a_to_temp_pred_equality<T, A>(p: FnSpec(A) -> TempPred<T>, q: FnSpe
     requires
         forall |a: A| #[trigger] valid(p(a).equals(q(a))),
     ensures
-        p === q,
+        p == q,
 {
-    assert forall |a: A| #[trigger] p(a) === q(a) by {
+    assert forall |a: A| #[trigger] p(a) == q(a) by {
         temp_pred_equality::<T>(p(a), q(a));
     };
     fun_ext::<A, TempPred<T>>(p, q);
@@ -600,7 +600,7 @@ pub proof fn a_to_temp_pred_equality<T, A>(p: FnSpec(A) -> TempPred<T>, q: FnSpe
 
 pub proof fn tla_exists_equality<T, A>(f: FnSpec(A, T) -> bool)
     ensures
-        lift_state(|t| exists |a| #[trigger] f(a, t)) === tla_exists(|a| lift_state(|t| f(a, t))),
+        lift_state(|t| exists |a| #[trigger] f(a, t)) == tla_exists(|a| lift_state(|t| f(a, t))),
 {
     let p = lift_state(|t| exists |a| #[trigger] f(a, t));
     let q = tla_exists(|a| lift_state(|t| f(a, t)));
@@ -619,7 +619,7 @@ pub proof fn tla_exists_equality<T, A>(f: FnSpec(A, T) -> bool)
 
 pub proof fn tla_forall_always_equality<T, A>(a_to_p: FnSpec(A) -> TempPred<T>)
     ensures
-        tla_forall(|a: A| always(a_to_p(a))) === always(tla_forall(a_to_p)),
+        tla_forall(|a: A| always(a_to_p(a))) == always(tla_forall(a_to_p)),
 {
     let a_to_always_p = |a: A| always(a_to_p(a));
 
@@ -651,7 +651,7 @@ pub proof fn tla_forall_always_equality_variant<T, A>(a_to_always: FnSpec(A) -> 
     requires
         forall |a: A| #![trigger a_to_always(a)] valid(a_to_always(a).equals((|a: A| always(a_to_p(a)))(a))),
     ensures
-        tla_forall(a_to_always) === always(tla_forall(a_to_p)),
+        tla_forall(a_to_always) == always(tla_forall(a_to_p)),
 {
     a_to_temp_pred_equality::<T, A>(a_to_always, |a: A| always(a_to_p(a)));
     temp_pred_equality::<T>(tla_forall(a_to_always), tla_forall(|a: A| always(a_to_p(a))));
@@ -660,7 +660,7 @@ pub proof fn tla_forall_always_equality_variant<T, A>(a_to_always: FnSpec(A) -> 
 
 pub proof fn tla_forall_not_equality<T, A>(a_to_p: FnSpec(A) -> TempPred<T>)
     ensures
-        tla_forall(|a: A| not(a_to_p(a))) === not(tla_exists(a_to_p)),
+        tla_forall(|a: A| not(a_to_p(a))) == not(tla_exists(a_to_p)),
 {
     let a_to_not_p = |a: A| not(a_to_p(a));
     assert forall |ex| #[trigger] tla_forall(a_to_not_p).satisfied_by(ex)
@@ -676,7 +676,7 @@ pub proof fn tla_forall_not_equality<T, A>(a_to_p: FnSpec(A) -> TempPred<T>)
 
 pub proof fn tla_forall_and_equality<T, A>(a_to_p: FnSpec(A) -> TempPred<T>, q: TempPred<T>)
     ensures
-        tla_forall(|a: A| a_to_p(a).and(q)) === tla_forall(a_to_p).and(q),
+        tla_forall(|a: A| a_to_p(a).and(q)) == tla_forall(a_to_p).and(q),
 {
     let a_to_p_and_q = |a: A| a_to_p(a).and(q);
     assert forall |ex| #[trigger] tla_forall(a_to_p_and_q).satisfied_by(ex)
@@ -697,7 +697,7 @@ pub proof fn tla_forall_and_equality<T, A>(a_to_p: FnSpec(A) -> TempPred<T>, q: 
 
 pub proof fn tla_forall_or_equality<T, A>(a_to_p: FnSpec(A) -> TempPred<T>, q: TempPred<T>)
     ensures
-        tla_forall(|a: A| a_to_p(a).or(q)) === tla_forall(a_to_p).or(q),
+        tla_forall(|a: A| a_to_p(a).or(q)) == tla_forall(a_to_p).or(q),
 {
     let a_to_p_or_q = |a: A| a_to_p(a).or(q);
     assert forall |ex| #[trigger] tla_forall(a_to_p_or_q).satisfied_by(ex)
@@ -715,7 +715,7 @@ pub proof fn tla_forall_or_equality<T, A>(a_to_p: FnSpec(A) -> TempPred<T>, q: T
 
 pub proof fn tla_exists_and_equality<T, A>(a_to_p: FnSpec(A) -> TempPred<T>, q: TempPred<T>)
     ensures
-        tla_exists(|a: A| a_to_p(a).and(q)) === tla_exists(a_to_p).and(q),
+        tla_exists(|a: A| a_to_p(a).and(q)) == tla_exists(a_to_p).and(q),
 {
     let a_to_p_and_q = |a: A| a_to_p(a).and(q);
     assert forall |ex| #[trigger] (tla_exists(a_to_p).and(q)).satisfied_by(ex)
@@ -729,7 +729,7 @@ pub proof fn tla_exists_and_equality<T, A>(a_to_p: FnSpec(A) -> TempPred<T>, q: 
 
 pub proof fn tla_exists_or_equality<T, A>(a_to_p: FnSpec(A) -> TempPred<T>, q: TempPred<T>)
     ensures
-        tla_exists(|a: A| a_to_p(a).or(q)) === tla_exists(a_to_p).or(q),
+        tla_exists(|a: A| a_to_p(a).or(q)) == tla_exists(a_to_p).or(q),
 {
     let a_to_p_or_q = |a: A| a_to_p(a).or(q);
     assert forall |ex| #[trigger] (tla_exists(a_to_p).or(q)).satisfied_by(ex)
@@ -747,7 +747,7 @@ pub proof fn tla_exists_or_equality<T, A>(a_to_p: FnSpec(A) -> TempPred<T>, q: T
 
 pub proof fn tla_forall_implies_equality1<T, A>(a_to_p: FnSpec(A) -> TempPred<T>, q: TempPred<T>)
     ensures
-        tla_forall(|a: A| a_to_p(a).implies(q)) === tla_exists(a_to_p).implies(q),
+        tla_forall(|a: A| a_to_p(a).implies(q)) == tla_exists(a_to_p).implies(q),
 {
     let a_to_not_p = |a: A| not(a_to_p(a));
     a_to_temp_pred_equality::<T, A>(|a: A| a_to_p(a).implies(q), |a: A| a_to_not_p(a).or(q));
@@ -759,7 +759,7 @@ pub proof fn tla_forall_implies_equality1<T, A>(a_to_p: FnSpec(A) -> TempPred<T>
 
 pub proof fn tla_forall_implies_equality2<T, A>(p: TempPred<T>, a_to_q: FnSpec(A) -> TempPred<T>)
     ensures
-        tla_forall(|a: A| p.implies(a_to_q(a))) === p.implies(tla_forall(a_to_q)),
+        tla_forall(|a: A| p.implies(a_to_q(a))) == p.implies(tla_forall(a_to_q)),
 {
     a_to_temp_pred_equality::<T, A>(|a: A| p.implies(a_to_q(a)), |a: A| a_to_q(a).or(not(p)));
     temp_pred_equality::<T>(tla_forall(|a: A| p.implies(a_to_q(a))), tla_forall(|a: A| a_to_q(a).or(not(p))));
@@ -769,7 +769,7 @@ pub proof fn tla_forall_implies_equality2<T, A>(p: TempPred<T>, a_to_q: FnSpec(A
 
 pub proof fn tla_exists_implies_equality1<T, A>(p: TempPred<T>, a_to_q: FnSpec(A) -> TempPred<T>)
     ensures
-        tla_exists(|a: A| p.implies(a_to_q(a))) === p.implies(tla_exists(a_to_q)),
+        tla_exists(|a: A| p.implies(a_to_q(a))) == p.implies(tla_exists(a_to_q)),
 {
     a_to_temp_pred_equality::<T, A>(|a: A| p.implies(a_to_q(a)), |a: A| a_to_q(a).or(not(p)));
     temp_pred_equality::<T>(tla_exists(|a: A| p.implies(a_to_q(a))), tla_exists(|a: A| a_to_q(a).or(not(p))));
@@ -779,7 +779,7 @@ pub proof fn tla_exists_implies_equality1<T, A>(p: TempPred<T>, a_to_q: FnSpec(A
 
 pub proof fn tla_forall_leads_to_equality1<T, A>(a_to_p: FnSpec(A) -> TempPred<T>, q: TempPred<T>)
     ensures
-        tla_forall(|a: A| a_to_p(a).leads_to(q)) === tla_exists(a_to_p).leads_to(q),
+        tla_forall(|a: A| a_to_p(a).leads_to(q)) == tla_exists(a_to_p).leads_to(q),
 {
     tla_forall_always_equality_variant::<T, A>(|a: A| a_to_p(a).leads_to(q), |a: A| a_to_p(a).implies(eventually(q)));
     tla_forall_implies_equality1::<T, A>(a_to_p, eventually(q));
@@ -787,7 +787,7 @@ pub proof fn tla_forall_leads_to_equality1<T, A>(a_to_p: FnSpec(A) -> TempPred<T
 
 pub proof fn tla_forall_always_implies_equality2<T, A>(p: TempPred<T>, a_to_q: FnSpec(A) -> TempPred<T>)
     ensures
-        tla_forall(|a: A| always(p.implies(a_to_q(a)))) === always(p.implies(tla_forall(a_to_q))),
+        tla_forall(|a: A| always(p.implies(a_to_q(a)))) == always(p.implies(tla_forall(a_to_q))),
 {
     tla_forall_always_equality_variant::<T, A>(|a: A| always(p.implies(a_to_q(a))), |a: A| p.implies(a_to_q(a)));
     tla_forall_implies_equality2::<T, A>(p, a_to_q);

--- a/src/tla_examples/abc/liveness.rs
+++ b/src/tla_examples/abc/liveness.rs
@@ -15,12 +15,12 @@ proof fn eventually_c()
             eventually(lift_state(c()))
         ),
 {
-    // a_b_enabled() gives a witness to convince Verus that x === A enables a_b()
+    // a_b_enabled() gives a witness to convince Verus that x == A enables a_b()
     a_b_enabled();
     // wf1 gives us a leads_to
     wf1::<SimpleState>(sm_spec(), next(), a_b(), a(), b());
 
-    // a_b_enabled() gives a witness to convince Verus that x === B enables b_c()
+    // a_b_enabled() gives a witness to convince Verus that x == B enables b_c()
     b_c_enabled();
     // wf1 gives us another leads_to
     wf1::<SimpleState>(sm_spec(), next(), b_c(), b(), c());

--- a/src/tla_examples/abc/state_machine.rs
+++ b/src/tla_examples/abc/state_machine.rs
@@ -20,28 +20,28 @@ pub struct SimpleState {
 
 pub open spec fn init() -> StatePred<SimpleState> {
     |s: SimpleState| {
-        &&& s.x === ABC::A
+        &&& s.x == ABC::A
         &&& s.happy
     }
 }
 
 pub open spec fn a() -> StatePred<SimpleState> {
-    |s: SimpleState| s.x === ABC::A
+    |s: SimpleState| s.x == ABC::A
 }
 
 
 pub open spec fn b() -> StatePred<SimpleState> {
-    |s: SimpleState| s.x === ABC::B
+    |s: SimpleState| s.x == ABC::B
 }
 
 pub open spec fn c() -> StatePred<SimpleState> {
-    |s: SimpleState| s.x === ABC::C
+    |s: SimpleState| s.x == ABC::C
 }
 
 pub open spec fn a_b() -> ActionPred<SimpleState> {
     |s, s_prime: SimpleState| {
         &&& a()(s)
-        &&& s_prime === SimpleState{
+        &&& s_prime == SimpleState{
             x: ABC::B,
             happy: s.happy
         }
@@ -51,7 +51,7 @@ pub open spec fn a_b() -> ActionPred<SimpleState> {
 pub open spec fn b_c() -> ActionPred<SimpleState> {
     |s, s_prime: SimpleState| {
         &&& b()(s)
-        &&& s_prime === SimpleState{
+        &&& s_prime == SimpleState{
             x: ABC::C,
             happy: s.happy
         }
@@ -59,7 +59,7 @@ pub open spec fn b_c() -> ActionPred<SimpleState> {
 }
 
 pub open spec fn stutter() -> ActionPred<SimpleState> {
-    |s, s_prime: SimpleState| s === s_prime
+    |s, s_prime: SimpleState| s == s_prime
 }
 
 pub open spec fn next() -> ActionPred<SimpleState> {

--- a/src/tla_examples/compound/controller.rs
+++ b/src/tla_examples/compound/controller.rs
@@ -79,7 +79,7 @@ pub proof fn exists_next_step(action: ControllerAction, recv: Option<Message>, s
     ensures
         exists |step| (#[trigger] (controller().step_to_action)(step).precondition)(recv, s),
 {
-    if action === send_create_sts() {
+    if action == send_create_sts() {
         assert(((controller().step_to_action)(Step::SendCreateStsStep).precondition)(recv, s));
     } else {
         assert(((controller().step_to_action)(Step::SendDeleteStsStep).precondition)(recv, s));

--- a/src/tla_examples/compound/distributed_system.rs
+++ b/src/tla_examples/compound/distributed_system.rs
@@ -120,7 +120,7 @@ pub open spec fn next_step(s: State, s_prime: State, step: Step) -> bool {
         Step::KubernetesAPIStep(recv) => kubernetes_api_next().forward(recv)(s, s_prime),
         Step::ControllerStep(recv) => controller_next().forward(recv)(s, s_prime),
         Step::ClientStep(recv) => client_next().forward(recv)(s, s_prime),
-        Step::StutterStep => s === s_prime,
+        Step::StutterStep => s == s_prime,
     }
 }
 

--- a/src/tla_examples/compound/kubernetes_api.rs
+++ b/src/tla_examples/compound/kubernetes_api.rs
@@ -85,7 +85,7 @@ pub open spec fn handle_request() -> KubernetesAPIAction {
 
 pub open spec fn kubernetes_api() -> KubernetesAPIStateMachine {
     StateMachine {
-        init: |s: State| s.resources === Map::empty(),
+        init: |s: State| s.resources == Map::<ResourceKey, ResourceObj>::empty(),
         actions: set![handle_request()],
         step_to_action: |step: Step| {
             match step {

--- a/src/tla_examples/compound/network.rs
+++ b/src/tla_examples/compound/network.rs
@@ -30,7 +30,7 @@ pub open spec fn deliver() -> Action<State, MessageOps, ()> {
 
 pub open spec fn network() -> NetworkStateMachine<State, MessageOps> {
     NetworkStateMachine {
-        init: |s: State| s.sent_messages === Set::empty(),
+        init: |s: State| s.sent_messages == Set::<Message>::empty(),
         deliver: deliver(),
     }
 }

--- a/src/tla_examples/concurrent/liveness.rs
+++ b/src/tla_examples/concurrent/liveness.rs
@@ -257,8 +257,8 @@ proof fn lemma_k8s_create_sts_req_sent_leads_to(msg: Message, sub_res_msg: Messa
         msg.is_CreateRequest(),
         msg.get_CreateRequest_0().obj.key.kind.is_StatefulSetKind(),
         sub_res_msg.is_CreateRequest(),
-        sub_res_msg.get_CreateRequest_0().obj.key === (ResourceKey{name: msg.get_CreateRequest_0().obj.key.name + pod_suffix(), kind: ResourceKind::PodKind})
-        || sub_res_msg.get_CreateRequest_0().obj.key === (ResourceKey{name: msg.get_CreateRequest_0().obj.key.name + vol_suffix(), kind: ResourceKind::VolumeKind}),
+        sub_res_msg.get_CreateRequest_0().obj.key == (ResourceKey{name: msg.get_CreateRequest_0().obj.key.name + pod_suffix(), kind: ResourceKind::PodKind})
+        || sub_res_msg.get_CreateRequest_0().obj.key == (ResourceKey{name: msg.get_CreateRequest_0().obj.key.name + vol_suffix(), kind: ResourceKind::VolumeKind}),
     ensures
         sm_spec()
             .entails(lift_state(|s| message_sent(s, msg))

--- a/src/tla_examples/concurrent/state_machine.rs
+++ b/src/tla_examples/concurrent/state_machine.rs
@@ -143,16 +143,16 @@ pub open spec fn delete_resp_msg(key: ResourceKey) -> Message {
 
 pub open spec fn init() -> StatePred<CState> {
     |s: CState| {
-        &&& s.resources === Map::empty()
-        &&& s.messages === Set::empty()
-        &&& s.attached === Set::empty()
+        &&& s.resources == Map::<ResourceKey, ResourceObj>::empty()
+        &&& s.messages == Set::<Message>::empty()
+        &&& s.attached == Set::<Seq<char>>::empty()
     }
 }
 
 pub open spec fn external_send_create_cr(res: ResourceObj) -> ActionPred<CState> {
     |s: CState, s_prime: CState| {
         &&& res.key.kind.is_CustomResourceKind()
-        &&& s_prime === CState {
+        &&& s_prime == CState {
             messages: s.messages.insert(create_req_msg(res.key)),
             ..s
         }
@@ -162,7 +162,7 @@ pub open spec fn external_send_create_cr(res: ResourceObj) -> ActionPred<CState>
 pub open spec fn external_send_delete_cr(res: ResourceObj) -> ActionPred<CState> {
     |s: CState, s_prime: CState| {
         &&& res.key.kind.is_CustomResourceKind()
-        &&& s_prime === CState {
+        &&& s_prime == CState {
             messages: s.messages.insert(delete_req_msg(res.key)),
             ..s
         }
@@ -180,7 +180,7 @@ pub open spec fn controller_send_create_sts_pre(msg: Message) -> StatePred<CStat
 pub open spec fn controller_send_create_sts(msg: Message) -> ActionPred<CState> {
     |s, s_prime| {
         &&& controller_send_create_sts_pre(msg)(s)
-        &&& s_prime === CState {
+        &&& s_prime == CState {
             messages: s.messages.insert(create_req_msg(ResourceKey{name: msg.get_CreateResponse_0().obj.key.name + sts_suffix(), kind: ResourceKind::StatefulSetKind})),
             ..s
         }
@@ -198,7 +198,7 @@ pub open spec fn controller_send_delete_sts_pre(msg: Message) -> StatePred<CStat
 pub open spec fn controller_send_delete_sts(msg: Message) -> ActionPred<CState> {
     |s, s_prime| {
         &&& controller_send_delete_sts_pre(msg)(s)
-        &&& s_prime === CState {
+        &&& s_prime == CState {
             messages: s.messages.insert(delete_req_msg(ResourceKey{name: msg.get_DeleteResponse_0().key.name + sts_suffix(), kind: ResourceKind::StatefulSetKind})),
             ..s
         }
@@ -257,7 +257,7 @@ pub open spec fn update_messages_with(s: CState, msg: Message) -> Set<Message>
 pub open spec fn k8s_handle_request(msg: Message) -> ActionPred<CState> {
     |s, s_prime| {
         &&& k8s_handle_request_pre(msg)(s)
-        &&& s_prime === CState {
+        &&& s_prime == CState {
             resources: update_resources_with(s, msg),
             messages: update_messages_with(s, msg),
             ..s
@@ -280,7 +280,7 @@ pub open spec fn k8s_attach_vol_to_pod_pre(sts_name: Seq<char>) -> StatePred<CSt
 pub open spec fn k8s_attach_vol_to_pod(sts_name: Seq<char>) -> ActionPred<CState> {
     |s, s_prime| {
         &&& k8s_attach_vol_to_pod_pre(sts_name)(s)
-        &&& s_prime === CState {
+        &&& s_prime == CState {
             attached: s.attached.insert(sts_name),
             ..s
         }
@@ -288,7 +288,7 @@ pub open spec fn k8s_attach_vol_to_pod(sts_name: Seq<char>) -> ActionPred<CState
 }
 
 pub open spec fn stutter() -> ActionPred<CState> {
-    |s, s_prime| s === s_prime
+    |s, s_prime| s == s_prime
 }
 
 pub enum ActionLabel {

--- a/src/tla_examples/sequential/state_machine.rs
+++ b/src/tla_examples/sequential/state_machine.rs
@@ -26,7 +26,7 @@ pub open spec fn init() -> StatePred<CState> {
         &&& !s.sent_2_create
         &&& !s.obj_1_exists
         &&& !s.obj_2_exists
-        &&& s.messages === Set::empty()
+        &&& s.messages == Set::<Message>::empty()
     }
 }
 
@@ -40,7 +40,7 @@ pub open spec fn send1_pre() -> StatePred<CState> {
 pub open spec fn send1() -> ActionPred<CState> {
     |s, s_prime: CState| {
         &&& send1_pre()(s)
-        &&& s_prime === CState {
+        &&& s_prime == CState {
             sent_1_create: true,
             messages: s.messages.insert(Message::CreateReq{id: 1}),
             ..s
@@ -59,7 +59,7 @@ pub open spec fn send2_pre() -> StatePred<CState> {
 pub open spec fn send2() -> ActionPred<CState> {
     |s, s_prime: CState| {
         &&& send2_pre()(s)
-        &&& s_prime === CState {
+        &&& s_prime == CState {
             sent_2_create: true,
             messages: s.messages.insert(Message::CreateReq{id: 2}),
             ..s
@@ -81,7 +81,7 @@ pub open spec fn create1_pre() -> StatePred<CState> {
 pub open spec fn create1() -> ActionPred<CState> {
     |s, s_prime: CState| {
         &&& create1_pre()(s)
-        &&& s_prime === CState {
+        &&& s_prime == CState {
             obj_1_exists: true,
             ..s
         }
@@ -95,7 +95,7 @@ pub open spec fn create2_pre() -> StatePred<CState> {
 pub open spec fn create2() -> ActionPred<CState> {
     |s, s_prime: CState| {
         &&& create2_pre()(s)
-        &&& s_prime === CState {
+        &&& s_prime == CState {
             obj_2_exists: true,
             ..s
         }
@@ -110,7 +110,7 @@ pub open spec fn cluster() -> ActionPred<CState> {
 }
 
 pub open spec fn stutter() -> ActionPred<CState> {
-    |s, s_prime: CState| s === s_prime
+    |s, s_prime: CState| s == s_prime
 }
 
 pub open spec fn next() -> ActionPred<CState> {


### PR DESCRIPTION
Since Verus supports ghost `==` https://github.com/verus-lang/verus/pull/352, we can stop using `===` and start to use `==` in spec and proof code. This PR simply replaces all the `===` with `==` and adds a few type annotations as Verus requires.