### PR TITLE
Specify the controller's list-then-watch pattern

### DIFF
--- a/src/kubernetes_cluster/proof/wf1_assistant.rs
+++ b/src/kubernetes_cluster/proof/wf1_assistant.rs
@@ -8,7 +8,8 @@ use crate::kubernetes_cluster::spec::{
         ControllerAction, ControllerActionInput, ControllerState, ControllerStep,
     },
     controller::controller_runtime::{
-        continue_reconcile, end_reconcile, run_scheduled_reconcile, trigger_reconcile,
+        continue_reconcile, end_reconcile, issue_initial_list, run_scheduled_reconcile,
+        start_watching, trigger_reconcile, trigger_reconcile_with_list_resp,
     },
     controller::state_machine::controller,
     distributed_system::*,
@@ -74,6 +75,15 @@ pub proof fn exists_next_controller_step<T>(reconciler: Reconciler<T>, action: C
         assert(((controller(reconciler).step_to_action)(step).precondition)(input, s));
     } else if action == continue_reconcile(reconciler) {
         let step = ControllerStep::ContinueReconcile;
+        assert(((controller(reconciler).step_to_action)(step).precondition)(input, s));
+    } else if action == issue_initial_list(reconciler) {
+        let step = ControllerStep::IssueInitialList;
+        assert(((controller(reconciler).step_to_action)(step).precondition)(input, s));
+    } else if action == trigger_reconcile_with_list_resp(reconciler) {
+        let step = ControllerStep::TriggerReconcileWithListResp;
+        assert(((controller(reconciler).step_to_action)(step).precondition)(input, s));
+    } else if action == start_watching(reconciler) {
+        let step = ControllerStep::StartWatching;
         assert(((controller(reconciler).step_to_action)(step).precondition)(input, s));
     } else {
         let step = ControllerStep::EndReconcile;

--- a/src/kubernetes_cluster/spec/common.rs
+++ b/src/kubernetes_cluster/spec/common.rs
@@ -236,6 +236,18 @@ impl Message {
         self.content.get_APIResponse_0().get_DeleteResponse_0()
     }
 
+    pub open spec fn is_list_response(self) -> bool {
+        &&& self.content.is_APIResponse()
+        &&& self.content.get_APIResponse_0().is_ListResponse()
+    }
+
+    pub open spec fn get_list_response(self) -> ListResponse
+        recommends
+            self.is_list_response()
+    {
+        self.content.get_APIResponse_0().get_ListResponse_0()
+    }
+
     pub open spec fn get_resp_id(self) -> nat
         recommends
             self.content.is_APIResponse()
@@ -366,6 +378,12 @@ pub open spec fn form_get_resp_msg(req_msg: Message, result: Result<ResourceObj,
     recommends req_msg.is_get_request(),
 {
     form_msg(req_msg.dst, req_msg.src, get_resp_msg(result, req_msg.get_get_request(), resp_id))
+}
+
+pub open spec fn form_list_resp_msg(req_msg: Message, result: Result<Seq<ResourceObj>, APIError>, resp_id: nat) -> Message
+    recommends req_msg.is_list_request(),
+{
+    form_msg(req_msg.dst, req_msg.src, list_resp_msg(result, req_msg.get_list_request(), resp_id))
 }
 
 pub open spec fn added_event_msg(obj: ResourceObj) -> MessageContent {

--- a/src/kubernetes_cluster/spec/controller/common.rs
+++ b/src/kubernetes_cluster/spec/controller/common.rs
@@ -42,6 +42,9 @@ pub enum WatcherState {
 
 #[is_variant]
 pub enum ControllerStep {
+    IssueInitialList,
+    TriggerReconcileWithListResp,
+    StartWatching,
     TriggerReconcile,
     RunScheduledReconcile,
     ContinueReconcile,

--- a/src/kubernetes_cluster/spec/controller/common.rs
+++ b/src/kubernetes_cluster/spec/controller/common.rs
@@ -10,20 +10,34 @@ use builtin_macros::*;
 
 verus! {
 
+pub struct ControllerState<T> {
+    pub req_id: nat,
+    pub ongoing_reconciles: Map<ResourceKey, OngoingReconcile<T>>,
+    pub scheduled_reconciles: Set<ResourceKey>,
+    pub self_watcher: Watcher,
+    // TODO: there should be watchers for `owns_with` and `watches_with`
+}
+
 pub struct OngoingReconcile<T> {
     pub pending_req_msg: Option<Message>,
     pub local_state: T,
 }
 
-pub struct ControllerState<T> {
-    pub req_id: nat,
-    pub ongoing_reconciles: Map<ResourceKey, OngoingReconcile<T>>,
-    pub scheduled_reconciles: Set<ResourceKey>,
+pub struct Watcher {
+    pub state: WatcherState,
+    pub pending_req_msg: Option<Message>, // This should either the initial list or the watch
 }
 
 pub struct ControllerActionInput {
     pub recv: Option<Message>,
     pub scheduled_cr_key: Option<ResourceKey>,
+}
+
+#[is_variant]
+pub enum WatcherState {
+    Empty,
+    InitListed,
+    Watching,
 }
 
 #[is_variant]

--- a/src/kubernetes_cluster/spec/controller/controller_runtime.rs
+++ b/src/kubernetes_cluster/spec/controller/controller_runtime.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MIT
 #![allow(unused_imports)]
 use crate::kubernetes_cluster::spec::{common::*, controller::common::*, reconciler::*};
-use crate::pervasive::{map::*, multiset::*, option::*, seq::*};
+use crate::pervasive::{map::*, multiset::*, option::*, seq::*, set::*};
 use crate::state_machine::action::*;
 use crate::state_machine::state_machine::*;
 use crate::temporal_logic::defs::*;
@@ -11,36 +11,113 @@ use builtin_macros::*;
 
 verus! {
 
-/// This action specifies how the watcher triggers reconcile.
-/// It is highly simplified compared to the actual watcher implementation in kube-rs:
-/// (1) The triggering condition should come from the developer. Currently we hardcode it in
-/// reconcile_trigger.
-/// (2) The watcher and reconciler run concurrently: the watcher can take incoming events while
-/// the reconciler is in reconcile. If the reconciler is working on object X, all the incoming
-/// events related to X will stay pending in a queue.
-/// (3) The watcher deduplicates triggering events for the same object: if an event for object X
-/// comes but there is already another pending event for the same object, the incoming event is
-/// discarded.
+pub open spec fn issue_initial_list<T>(reconciler: Reconciler<T>) -> ControllerAction<T> {
+    Action {
+        precondition: |input: ControllerActionInput, s: ControllerState<T>| {
+            &&& input.scheduled_cr_key.is_None()
+            &&& input.recv.is_None()
+            &&& s.self_watcher.state.is_Empty() // Only issue the initial list at Empty state
+            &&& s.self_watcher.pending_req_msg.is_None() // and the initial list is not issued yet
+        },
+        transition: |input: ControllerActionInput, s: ControllerState<T>| {
+            let list_req_msg = controller_req_msg(APIRequest::ListRequest(ListRequest {
+                kind: ResourceKind::CustomResourceKind,
+            }), s.req_id);
+            let s_prime = ControllerState {
+                self_watcher: Watcher{
+                    pending_req_msg: Option::Some(list_req_msg),
+                    ..s.self_watcher
+                },
+                req_id: s.req_id + 1,
+                ..s
+            };
+            let send = Multiset::singleton(list_req_msg);
+            (s_prime, send)
+        },
+    }
+}
+
+pub open spec fn get_key_set_from_list_result(list: Seq<ResourceObj>) -> Set<ResourceKey> {
+    // TODO: the returned set should contain all the keys of objects in the list
+    Set::empty()
+}
+
+pub open spec fn trigger_reconcile_with_list_resp<T>(reconciler: Reconciler<T>) -> ControllerAction<T> {
+    Action {
+        precondition: |input: ControllerActionInput, s: ControllerState<T>| {
+            &&& input.scheduled_cr_key.is_None()
+            &&& input.recv.is_Some()
+            &&& input.recv.get_Some_0().dst == HostId::CustomController
+            &&& input.recv.get_Some_0().is_list_response()
+            &&& s.self_watcher.state.is_Empty() // Only issue the initial list at Empty state
+            &&& s.self_watcher.pending_req_msg.is_Some() // and the initial list is already issued
+            &&& resp_msg_matches_req_msg(input.recv.get_Some_0(), s.self_watcher.pending_req_msg.get_Some_0()) // and, of course, the resp matches the request
+        },
+        transition: |input: ControllerActionInput, s: ControllerState<T>| {
+            let list_resp = input.recv.get_Some_0().get_list_response();
+            if list_resp.res.is_Ok() {
+                let s_prime = ControllerState {
+                    self_watcher: Watcher {
+                        state: WatcherState::InitListed,
+                        pending_req_msg: Option::None,
+                    },
+                    scheduled_reconciles: s.scheduled_reconciles + get_key_set_from_list_result(list_resp.res.get_Ok_0()),
+                    ..s
+                };
+                let send = Multiset::empty();
+                (s_prime, send)
+            } else {
+                let s_prime = ControllerState {
+                    self_watcher: Watcher {
+                        state: WatcherState::Empty,
+                        pending_req_msg: Option::None,
+                    },
+                    ..s
+                };
+                let send = Multiset::empty();
+                (s_prime, send)
+            }
+        },
+    }
+}
+
+pub open spec fn start_watching<T>(reconciler: Reconciler<T>) -> ControllerAction<T> {
+    Action {
+        precondition: |input: ControllerActionInput, s: ControllerState<T>| {
+            &&& input.scheduled_cr_key.is_None()
+            &&& input.recv.is_None()
+            &&& s.self_watcher.state.is_InitListed()
+        },
+        transition: |input: ControllerActionInput, s: ControllerState<T>| {
+            let s_prime =  ControllerState {
+                self_watcher: Watcher {
+                    state: WatcherState::Watching,
+                    ..s.self_watcher
+                },
+                ..s
+            };
+            // TODO: the controller should send a watch request with the rv returned by the previous list
+            let send = Multiset::empty();
+            (s_prime, send)
+        },
+    }
+}
+
+// TODO: this trigger_reconcile only considers self_watcher
 pub open spec fn trigger_reconcile<T>(reconciler: Reconciler<T>) -> ControllerAction<T> {
     Action {
         precondition: |input: ControllerActionInput, s: ControllerState<T>| {
-            // TODO: We should have multiple queues for storing triggering events.
-            // Each queue stores the event relates to the same cr key.
             &&& input.scheduled_cr_key.is_None()
             &&& input.recv.is_Some()
             &&& input.recv.get_Some_0().dst == HostId::CustomController
             &&& input.recv.get_Some_0().content.is_WatchEvent()
             &&& (reconciler.reconcile_trigger)(input.recv.get_Some_0()).is_Some()
-            &&& !s.ongoing_reconciles.dom().contains((reconciler.reconcile_trigger)(input.recv.get_Some_0()).get_Some_0())
+            &&& s.self_watcher.state.is_Watching() // Only receive notification at Watching state
         },
         transition: |input: ControllerActionInput, s: ControllerState<T>| {
             let cr_key = (reconciler.reconcile_trigger)(input.recv.get_Some_0()).get_Some_0();
-            let initialized_ongoing_reconcile = OngoingReconcile {
-                pending_req_msg: Option::None,
-                local_state: (reconciler.reconcile_init_state)(),
-            };
             let s_prime = ControllerState {
-                ongoing_reconciles: s.ongoing_reconciles.insert(cr_key, initialized_ongoing_reconcile),
+                scheduled_reconciles: s.scheduled_reconciles.insert(cr_key),
                 ..s
             };
             let send = Multiset::empty();

--- a/src/kubernetes_cluster/spec/controller/state_machine.rs
+++ b/src/kubernetes_cluster/spec/controller/state_machine.rs
@@ -20,6 +20,10 @@ pub open spec fn controller<T>(reconciler: Reconciler<T>) -> ControllerStateMach
                 req_id: 0,
                 ongoing_reconciles: Map::empty(),
                 scheduled_reconciles: Set::empty(),
+                self_watcher: Watcher {
+                    state: WatcherState::Empty,
+                    pending_req_msg: Option::None,
+                }
             }
         },
         actions: set![trigger_reconcile(reconciler), run_scheduled_reconcile(reconciler), continue_reconcile(reconciler), end_reconcile(reconciler)],

--- a/src/kubernetes_cluster/spec/controller/state_machine.rs
+++ b/src/kubernetes_cluster/spec/controller/state_machine.rs
@@ -26,9 +26,20 @@ pub open spec fn controller<T>(reconciler: Reconciler<T>) -> ControllerStateMach
                 }
             }
         },
-        actions: set![trigger_reconcile(reconciler), run_scheduled_reconcile(reconciler), continue_reconcile(reconciler), end_reconcile(reconciler)],
+        actions: set![
+            issue_initial_list(reconciler),
+            trigger_reconcile_with_list_resp(reconciler),
+            start_watching(reconciler),
+            trigger_reconcile(reconciler),
+            run_scheduled_reconcile(reconciler),
+            continue_reconcile(reconciler),
+            end_reconcile(reconciler)
+        ],
         step_to_action: |step: ControllerStep| {
             match step {
+                ControllerStep::IssueInitialList => issue_initial_list(reconciler),
+                ControllerStep::TriggerReconcileWithListResp => trigger_reconcile_with_list_resp(reconciler),
+                ControllerStep::StartWatching => start_watching(reconciler),
                 ControllerStep::TriggerReconcile => trigger_reconcile(reconciler),
                 ControllerStep::RunScheduledReconcile => run_scheduled_reconcile(reconciler),
                 ControllerStep::ContinueReconcile => continue_reconcile(reconciler),

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,7 +4,7 @@
 pub mod kubernetes_cluster;
 pub mod pervasive;
 pub mod pervasive_lemmas;
-pub mod simple_controller;
+// pub mod simple_controller;
 pub mod state_machine;
 pub mod temporal_logic;
 pub mod tla_examples;


### PR DESCRIPTION
Specify the controller's list-then-watch pattern.

Controllers use the list-then-watch pattern to observe the cluster state: it first issues a list to read the current cluster state, and the list returns a resource version indicating the "version" of the cluster state the controller just reads. Every single update to any object in the cluster state will increment the resource version number. After the list returns, the controller issues a watch request to continuously receive updates to the cluster state. When issuing the watch request, the controller specifies the resource version number returned by the list, which asks the apiserver to stream updates starting from the resource version.

The current specification is much more simplified than the above: since we have not specified resource version, list will not return any resource version. The watch request is also not specified yet so after the initial list returns the controller will enter a watching state and starts to receive whatever update notifications that are pending in the network.

This liveness proof of the simple controller is broken since the controller spec changes a lot. I will leave the proof there before the spec gets stable and fix all the broken proofs in one batch later.