### PR TITLE
Prove lemmas to unpack assumption

### DIFF
--- a/src/temporal_logic/defs.rs
+++ b/src/temporal_logic/defs.rs
@@ -169,4 +169,8 @@ pub open spec fn valid<T>(temp_pred: TempPred<T>) -> bool {
     forall |ex: Execution<T>| temp_pred.satisfied_by(ex)
 }
 
+pub open spec fn true_pred<T>() -> TempPred<T> {
+    lift_state(|s: T| true)
+}
+
 }

--- a/src/temporal_logic/defs.rs
+++ b/src/temporal_logic/defs.rs
@@ -132,6 +132,10 @@ pub open spec fn tla_exists<T, A>(a_to_temp_pred: FnSpec(A) -> TempPred<T>) -> T
     TempPred::new(|ex: Execution<T>| exists |a: A| #[trigger] a_to_temp_pred(a).satisfied_by(ex))
 }
 
+pub open spec fn stable<T>(temp_pred: TempPred<T>) -> TempPred<T> {
+    TempPred::new(|ex: Execution<T>| temp_pred.implies(always(temp_pred)).satisfied_by(ex))
+}
+
 /// Returns a state predicate that is satisfied
 /// iff `action_pred` can be satisfied by any possible following state and the current state
 ///

--- a/src/temporal_logic/rules.rs
+++ b/src/temporal_logic/rules.rs
@@ -37,6 +37,13 @@ proof fn not_eventually_unfold<T>(ex: Execution<T>, p: TempPred<T>)
         forall |i| !p.satisfied_by(#[trigger] ex.suffix(i))
 {}
 
+proof fn stable_unfold<T>(ex: Execution<T>, p: TempPred<T>)
+    requires
+        stable(p).satisfied_by(ex),
+    ensures
+        p.satisfied_by(ex) ==> forall |i| p.satisfied_by(#[trigger] ex.suffix(i)),
+{}
+
 proof fn leads_to_unfold<T>(ex: Execution<T>, p: TempPred<T>, q: TempPred<T>)
     requires
         p.leads_to(q).satisfied_by(ex),
@@ -891,19 +898,21 @@ pub proof fn entails_and_temp<T>(spec: TempPred<T>, p: TempPred<T>, q: TempPred<
 
 /// Unpack the assumption from left to the right side of |=
 /// pre:
-///     []next /\ asm |= True ~> p
+///     |= stable(partial_spec)
+///     partial_spec /\ asm |= True ~> p
 /// post:
-///     init /\ []next |= asm ~> p
-pub proof fn unpack_assumption<T>(init: TempPred<T>, next: TempPred<T>, asm: TempPred<T>, p: TempPred<T>)
+///     init /\ partial_spec |= asm ~> p
+pub proof fn unpack_assumption_from_spec<T>(init: TempPred<T>, partial_spec: TempPred<T>, asm: TempPred<T>, p: TempPred<T>)
     requires
-        always(next).and(asm).entails(true_pred().leads_to(p)),
+        valid(stable(partial_spec)),
+        partial_spec.and(asm).entails(true_pred().leads_to(p)),
     ensures
-        init.and(always(next)).entails(asm.leads_to(p)),
+        init.and(partial_spec).entails(asm.leads_to(p)),
 {
-    assert forall |ex| #[trigger] init.and(always(next)).satisfied_by(ex) implies asm.leads_to(p).satisfied_by(ex) by {
+    assert forall |ex| #[trigger] init.and(partial_spec).satisfied_by(ex) implies asm.leads_to(p).satisfied_by(ex) by {
         assert forall |i| #[trigger] asm.satisfied_by(ex.suffix(i)) implies eventually(p).satisfied_by(ex.suffix(i)) by {
-            always_propagate_forwards::<T>(ex, next, i);
-            implies_apply::<T>(ex.suffix(i), always(next).and(asm), true_pred().leads_to(p));
+            stable_unfold::<T>(ex, partial_spec);
+            implies_apply::<T>(ex.suffix(i), partial_spec.and(asm), true_pred().leads_to(p));
             leads_to_unfold::<T>(ex.suffix(i), true_pred(), p);
             execution_equality::<T>(ex.suffix(i), ex.suffix(i).suffix(0));
             implies_apply::<T>(ex.suffix(i), true_pred(), eventually(p));

--- a/src/temporal_logic/rules.rs
+++ b/src/temporal_logic/rules.rs
@@ -902,6 +902,7 @@ pub proof fn entails_and_temp<T>(spec: TempPred<T>, p: TempPred<T>, q: TempPred<
 ///     partial_spec /\ asm |= True ~> p
 /// post:
 ///     init /\ partial_spec |= asm ~> p
+/// TODO: discuss how to prove "safety" invariants that depend on asm
 pub proof fn unpack_assumption_from_spec<T>(init: TempPred<T>, partial_spec: TempPred<T>, asm: TempPred<T>, p: TempPred<T>)
     requires
         valid(stable(partial_spec)),


### PR DESCRIPTION
Implement a lemma `unpack_assumption_from_spec` to conveniently unpack assumption from the spec.

This will simplify our liveness proof later: we will pack the assumption into the spec and drop init, and use the new spec `partial_spec /\ assumption` through the liveness proof. For any safety invariant we will need during the liveness proof, we will merge them into `partial_spec`. The liveness proof will try to prove `partial_spec /\ assumption |= True ~> p`. We will also need to prove `spec |= init /\ partial_spec`. Finally, by applying this lemma we will get `init /\ partial_spec |= assumption ~> []match(cr)`, and conclude `spec |= assumption ~> []match(cr)`. Here `assumption` is `[]exists(cr)`.