### PR TITLE
Use k8s openapi objects in spec and proof

### DIFF
--- a/src/kubernetes_api_objects/common.rs
+++ b/src/kubernetes_api_objects/common.rs
@@ -1,0 +1,23 @@
+// Copyright 2022 VMware, Inc.
+// SPDX-License-Identifier: MIT
+use crate::pervasive::prelude::*;
+
+verus! {
+
+#[is_variant]
+pub enum Kind {
+    ConfigMapKind,
+    CustomResourceKind,
+    PersistentVolumeClaimKind,
+    PodKind,
+    StatefulSetKind,
+    ServiceKind,
+}
+
+pub struct ObjectRef {
+    pub kind: Kind,
+    pub name: Seq<char>,
+    pub namespace: Seq<char>,
+}
+
+}

--- a/src/kubernetes_api_objects/config_map.rs
+++ b/src/kubernetes_api_objects/config_map.rs
@@ -1,5 +1,6 @@
 // Copyright 2022 VMware, Inc.
 // SPDX-License-Identifier: MIT
+use crate::kubernetes_api_objects::common::*;
 use crate::kubernetes_api_objects::object_meta::*;
 use crate::pervasive::prelude::*;
 use crate::pervasive_ext::string_map;
@@ -60,6 +61,22 @@ impl ConfigMap {
 }
 
 impl ConfigMapView {
+    pub open spec fn kind(self) -> Kind {
+        Kind::ConfigMapKind
+    }
+
+    pub open spec fn object_ref(self) -> ObjectRef
+        recommends
+            self.metadata.name.is_Some(),
+            self.metadata.namespace.is_Some(),
+    {
+        ObjectRef {
+            kind: self.kind(),
+            name: self.metadata.name.get_Some_0(),
+            namespace: self.metadata.namespace.get_Some_0(),
+        }
+    }
+
     pub open spec fn is_default(self) -> bool {
         &&& self.metadata.is_default()
         &&& self.data.is_None()

--- a/src/kubernetes_api_objects/custom_resource.rs
+++ b/src/kubernetes_api_objects/custom_resource.rs
@@ -4,34 +4,29 @@ use crate::kubernetes_api_objects::common::*;
 use crate::kubernetes_api_objects::object_meta::*;
 use crate::pervasive::prelude::*;
 
-use k8s_openapi::api::apps::v1::StatefulSet as K8SStatefulSet;
-use k8s_openapi::api::apps::v1::StatefulSetSpec as K8SStatefulSetSpec;
-use k8s_openapi::api::apps::v1::StatefulSetStatus as K8SStatefulSetStatus;
-
 verus! {
 
+// TODO: CustomResource should be a generic type
 #[verifier(external_body)]
-pub struct StatefulSet {
-    inner: K8SStatefulSet,
+pub struct CustomResource {
+    // the content is specific to the controller
 }
 
-pub struct StatefulSetView {
+pub struct CustomResourceView {
     pub metadata: ObjectMetaView,
-    pub spec: Option<StatefulSetSpecView>,
-    pub status: Option<StatefulSetStatusView>,
+    pub spec: Option<CustomResourceSpecView>,
+    pub status: Option<CustomResourceStatusView>,
 }
 
-impl StatefulSet {
-    pub spec fn view(&self) -> StatefulSetView;
+impl CustomResource {
+    pub spec fn view(&self) -> CustomResourceView;
 
     #[verifier(external_body)]
-    pub fn default() -> (stateful_set: StatefulSet)
+    pub fn default() -> (cr: CustomResource)
         ensures
-            stateful_set@.is_default(),
+            cr@.is_default(),
     {
-        StatefulSet {
-            inner: K8SStatefulSet::default(),
-        }
+        CustomResource {}
     }
 
     #[verifier(external_body)]
@@ -44,7 +39,7 @@ impl StatefulSet {
 
     // is it OK to name it spec?
     #[verifier(external_body)]
-    pub fn spec(&self) -> (spec: Option<StatefulSetSpec>)
+    pub fn spec(&self) -> (spec: Option<CustomResourceSpec>)
         ensures
             self@.spec.is_Some() == spec.is_Some(),
             spec.is_Some() ==> spec.get_Some_0()@ == self@.spec.get_Some_0(),
@@ -53,7 +48,7 @@ impl StatefulSet {
     }
 
     #[verifier(external_body)]
-    pub fn status(&self) -> (status: Option<StatefulSetStatus>)
+    pub fn status(&self) -> (status: Option<CustomResourceStatus>)
         ensures
             self@.status.is_Some() == status.is_Some(),
             status.is_Some() ==> status.get_Some_0()@ == self@.status.get_Some_0(),
@@ -62,9 +57,9 @@ impl StatefulSet {
     }
 }
 
-impl StatefulSetView {
+impl CustomResourceView {
     pub open spec fn kind(self) -> Kind {
-        Kind::StatefulSetKind
+        Kind::CustomResourceKind
     }
 
     pub open spec fn object_ref(self) -> ObjectRef
@@ -87,29 +82,27 @@ impl StatefulSetView {
 }
 
 #[verifier(external_body)]
-pub struct StatefulSetSpec {
-    inner: K8SStatefulSetSpec,
+pub struct CustomResourceSpec {
+    // the content is specific to the controller
 }
 
-pub struct StatefulSetSpecView {
+pub struct CustomResourceSpecView {
     // A lot more fields to specify...
 }
 
-impl StatefulSetSpec {
-    pub spec fn view(&self) -> StatefulSetSpecView;
+impl CustomResourceSpec {
+    pub spec fn view(&self) -> CustomResourceSpecView;
 
     #[verifier(external_body)]
-    pub fn default() -> (stateful_set_spec: StatefulSetSpec)
+    pub fn default() -> (cr_spec: CustomResourceSpec)
         ensures
-            stateful_set_spec@.is_default(),
+            cr_spec@.is_default(),
     {
-        StatefulSetSpec {
-            inner: K8SStatefulSetSpec::default(),
-        }
+        CustomResourceSpec {}
     }
 }
 
-impl StatefulSetSpecView {
+impl CustomResourceSpecView {
     pub open spec fn is_default(self) -> bool {
        true
        // The condition depends on how default() is implemented
@@ -117,29 +110,27 @@ impl StatefulSetSpecView {
 }
 
 #[verifier(external_body)]
-pub struct StatefulSetStatus {
-    inner: K8SStatefulSetStatus,
+pub struct CustomResourceStatus {
+    // the content is specific to the controller
 }
 
-pub struct StatefulSetStatusView {
+pub struct CustomResourceStatusView {
     // A lot more fields to specify...
 }
 
-impl StatefulSetStatus {
-    pub spec fn view(&self) -> StatefulSetStatusView;
+impl CustomResourceStatus {
+    pub spec fn view(&self) -> CustomResourceStatusView;
 
     #[verifier(external_body)]
-    pub fn default() -> (stateful_set_status: StatefulSetStatus)
+    pub fn default() -> (cr_status: CustomResourceStatus)
         ensures
-            stateful_set_status@.is_default(),
+            cr_status@.is_default(),
     {
-        StatefulSetStatus {
-            inner: K8SStatefulSetStatus::default(),
-        }
+        CustomResourceStatus {}
     }
 }
 
-impl StatefulSetStatusView {
+impl CustomResourceStatusView {
     pub open spec fn is_default(self) -> bool {
        true
        // The condition depends on how default() is implemented

--- a/src/kubernetes_api_objects/mod.rs
+++ b/src/kubernetes_api_objects/mod.rs
@@ -1,6 +1,9 @@
 // Copyright 2022 VMware, Inc.
 // SPDX-License-Identifier: MIT
+pub mod common;
 pub mod config_map;
+pub mod custom_resource;
+pub mod object;
 pub mod object_meta;
 pub mod persistent_volume_claim;
 pub mod pod;

--- a/src/kubernetes_api_objects/object.rs
+++ b/src/kubernetes_api_objects/object.rs
@@ -1,0 +1,65 @@
+// Copyright 2022 VMware, Inc.
+// SPDX-License-Identifier: MIT
+#[allow(unused_imports)]
+use builtin::*;
+#[allow(unused_imports)]
+use builtin_macros::*;
+
+use crate::kubernetes_api_objects::common::*;
+use crate::kubernetes_api_objects::config_map::ConfigMapView;
+use crate::kubernetes_api_objects::custom_resource::CustomResourceView;
+use crate::kubernetes_api_objects::object_meta::ObjectMetaView;
+use crate::kubernetes_api_objects::persistent_volume_claim::PersistentVolumeClaimView;
+use crate::kubernetes_api_objects::pod::PodView;
+use crate::kubernetes_api_objects::service::ServiceView;
+use crate::kubernetes_api_objects::stateful_set::StatefulSetView;
+
+verus! {
+
+#[is_variant]
+pub enum KubernetesObject {
+    ConfigMap(ConfigMapView),
+    CustomResource(CustomResourceView),
+    PersistentVolumeClaim(PersistentVolumeClaimView),
+    Pod(PodView),
+    StatefulSet(StatefulSetView),
+    Service(ServiceView),
+}
+
+impl KubernetesObject {
+    pub open spec fn kind(self) -> Kind {
+        match self {
+            KubernetesObject::ConfigMap(obj) => obj.kind(),
+            KubernetesObject::CustomResource(obj) => obj.kind(),
+            KubernetesObject::PersistentVolumeClaim(obj) => obj.kind(),
+            KubernetesObject::Pod(obj) => obj.kind(),
+            KubernetesObject::StatefulSet(obj) => obj.kind(),
+            KubernetesObject::Service(obj) => obj.kind(),
+        }
+    }
+
+    pub open spec fn metadata(self) -> ObjectMetaView {
+        match self {
+            KubernetesObject::ConfigMap(obj) => obj.metadata,
+            KubernetesObject::CustomResource(obj) => obj.metadata,
+            KubernetesObject::PersistentVolumeClaim(obj) => obj.metadata,
+            KubernetesObject::Pod(obj) => obj.metadata,
+            KubernetesObject::StatefulSet(obj) => obj.metadata,
+            KubernetesObject::Service(obj) => obj.metadata,
+        }
+    }
+
+    pub open spec fn object_ref(self) -> ObjectRef
+        recommends
+            self.metadata().name.is_Some(),
+            self.metadata().namespace.is_Some(),
+    {
+        ObjectRef {
+            kind: self.kind(),
+            name: self.metadata().name.get_Some_0(),
+            namespace: self.metadata().namespace.get_Some_0(),
+        }
+    }
+}
+
+}

--- a/src/kubernetes_api_objects/persistent_volume_claim.rs
+++ b/src/kubernetes_api_objects/persistent_volume_claim.rs
@@ -1,5 +1,6 @@
 // Copyright 2022 VMware, Inc.
 // SPDX-License-Identifier: MIT
+use crate::kubernetes_api_objects::common::*;
 use crate::kubernetes_api_objects::object_meta::*;
 use crate::pervasive::prelude::*;
 
@@ -24,9 +25,9 @@ impl PersistentVolumeClaim {
     pub spec fn view(&self) -> PersistentVolumeClaimView;
 
     #[verifier(external_body)]
-    pub fn default() -> (pod: PersistentVolumeClaim)
+    pub fn default() -> (pvc: PersistentVolumeClaim)
         ensures
-            pod@.is_default(),
+            pvc@.is_default(),
     {
         PersistentVolumeClaim {
             inner: K8SPersistentVolumeClaim::default(),
@@ -62,6 +63,22 @@ impl PersistentVolumeClaim {
 }
 
 impl PersistentVolumeClaimView {
+    pub open spec fn kind(self) -> Kind {
+        Kind::PersistentVolumeClaimKind
+    }
+
+    pub open spec fn object_ref(self) -> ObjectRef
+        recommends
+            self.metadata.name.is_Some(),
+            self.metadata.namespace.is_Some(),
+    {
+        ObjectRef {
+            kind: self.kind(),
+            name: self.metadata.name.get_Some_0(),
+            namespace: self.metadata.namespace.get_Some_0(),
+        }
+    }
+
     pub open spec fn is_default(self) -> bool {
         &&& self.metadata.is_default()
         &&& self.spec.is_None()
@@ -82,9 +99,9 @@ impl PersistentVolumeClaimSpec {
     pub spec fn view(&self) -> PersistentVolumeClaimSpecView;
 
     #[verifier(external_body)]
-    pub fn default() -> (pod_spec: PersistentVolumeClaimSpec)
+    pub fn default() -> (pvc_spec: PersistentVolumeClaimSpec)
         ensures
-            pod_spec@.is_default(),
+            pvc_spec@.is_default(),
     {
         PersistentVolumeClaimSpec {
             inner: K8SPersistentVolumeClaimSpec::default(),
@@ -112,9 +129,9 @@ impl PersistentVolumeClaimStatus {
     pub spec fn view(&self) -> PersistentVolumeClaimStatusView;
 
     #[verifier(external_body)]
-    pub fn default() -> (pod_status: PersistentVolumeClaimStatus)
+    pub fn default() -> (pvc_status: PersistentVolumeClaimStatus)
         ensures
-            pod_status@.is_default(),
+            pvc_status@.is_default(),
     {
         PersistentVolumeClaimStatus {
             inner: K8SPersistentVolumeClaimStatus::default(),

--- a/src/kubernetes_api_objects/pod.rs
+++ b/src/kubernetes_api_objects/pod.rs
@@ -1,5 +1,6 @@
 // Copyright 2022 VMware, Inc.
 // SPDX-License-Identifier: MIT
+use crate::kubernetes_api_objects::common::*;
 use crate::kubernetes_api_objects::object_meta::*;
 use crate::pervasive::prelude::*;
 
@@ -62,6 +63,22 @@ impl Pod {
 }
 
 impl PodView {
+    pub open spec fn kind(self) -> Kind {
+        Kind::PodKind
+    }
+
+    pub open spec fn object_ref(self) -> ObjectRef
+        recommends
+            self.metadata.name.is_Some(),
+            self.metadata.namespace.is_Some(),
+    {
+        ObjectRef {
+            kind: self.kind(),
+            name: self.metadata.name.get_Some_0(),
+            namespace: self.metadata.namespace.get_Some_0(),
+        }
+    }
+
     pub open spec fn is_default(self) -> bool {
         &&& self.metadata.is_default()
         &&& self.spec.is_None()

--- a/src/kubernetes_api_objects/service.rs
+++ b/src/kubernetes_api_objects/service.rs
@@ -1,5 +1,6 @@
 // Copyright 2022 VMware, Inc.
 // SPDX-License-Identifier: MIT
+use crate::kubernetes_api_objects::common::*;
 use crate::kubernetes_api_objects::object_meta::*;
 use crate::pervasive::prelude::*;
 
@@ -24,9 +25,9 @@ impl Service {
     pub spec fn view(&self) -> ServiceView;
 
     #[verifier(external_body)]
-    pub fn default() -> (pod: Service)
+    pub fn default() -> (service: Service)
         ensures
-            pod@.is_default(),
+            service@.is_default(),
     {
         Service {
             inner: K8SService::default(),
@@ -62,6 +63,22 @@ impl Service {
 }
 
 impl ServiceView {
+    pub open spec fn kind(self) -> Kind {
+        Kind::ServiceKind
+    }
+
+    pub open spec fn object_ref(self) -> ObjectRef
+        recommends
+            self.metadata.name.is_Some(),
+            self.metadata.namespace.is_Some(),
+    {
+        ObjectRef {
+            kind: self.kind(),
+            name: self.metadata.name.get_Some_0(),
+            namespace: self.metadata.namespace.get_Some_0(),
+        }
+    }
+
     pub open spec fn is_default(self) -> bool {
         &&& self.metadata.is_default()
         &&& self.spec.is_None()
@@ -82,9 +99,9 @@ impl ServiceSpec {
     pub spec fn view(&self) -> ServiceSpecView;
 
     #[verifier(external_body)]
-    pub fn default() -> (pod_spec: ServiceSpec)
+    pub fn default() -> (service_spec: ServiceSpec)
         ensures
-            pod_spec@.is_default(),
+            service_spec@.is_default(),
     {
         ServiceSpec {
             inner: K8SServiceSpec::default(),
@@ -112,9 +129,9 @@ impl ServiceStatus {
     pub spec fn view(&self) -> ServiceStatusView;
 
     #[verifier(external_body)]
-    pub fn default() -> (pod_status: ServiceStatus)
+    pub fn default() -> (service_status: ServiceStatus)
         ensures
-            pod_status@.is_default(),
+            service_status@.is_default(),
     {
         ServiceStatus {
             inner: K8SServiceStatus::default(),

--- a/src/kubernetes_cluster/proof/controller_runtime_liveness.rs
+++ b/src/kubernetes_cluster/proof/controller_runtime_liveness.rs
@@ -1,6 +1,7 @@
 // Copyright 2022 VMware, Inc.
 // SPDX-License-Identifier: MIT
 #![allow(unused_imports)]
+use crate::kubernetes_api_objects::common::*;
 use crate::kubernetes_cluster::{
     proof::{kubernetes_api_safety, wf1_assistant::controller_action_pre_implies_next_pre},
     spec::{
@@ -58,7 +59,7 @@ pub proof fn lemma_pre_leads_to_post_with_assumption_by_controller<T>(reconciler
     controller_next(reconciler).wf1_assume(input, sm_spec(reconciler), next, assumption, pre, post);
 }
 
-pub proof fn lemma_relevant_event_sent_leads_to_reconcile_scheduled<T>(reconciler: Reconciler<T>, msg: Message, cr_key: ResourceKey)
+pub proof fn lemma_relevant_event_sent_leads_to_reconcile_scheduled<T>(reconciler: Reconciler<T>, msg: Message, cr_key: ObjectRef)
     requires
         cr_key.kind.is_CustomResourceKind(),
     ensures
@@ -92,7 +93,7 @@ pub proof fn lemma_relevant_event_sent_leads_to_reconcile_scheduled<T>(reconcile
     lemma_pre_leads_to_post_by_controller::<T>(reconciler, input, next(reconciler), trigger_reconcile(reconciler), pre, post);
 }
 
-pub proof fn lemma_reconcile_done_leads_to_reconcile_idle_and_scheduled<T>(reconciler: Reconciler<T>, cr_key: ResourceKey)
+pub proof fn lemma_reconcile_done_leads_to_reconcile_idle_and_scheduled<T>(reconciler: Reconciler<T>, cr_key: ObjectRef)
     requires
         cr_key.kind.is_CustomResourceKind(),
     ensures
@@ -122,7 +123,7 @@ pub proof fn lemma_reconcile_done_leads_to_reconcile_idle_and_scheduled<T>(recon
     lemma_pre_leads_to_post_by_controller::<T>(reconciler, input, next(reconciler), end_reconcile(reconciler), pre, post);
 }
 
-pub proof fn lemma_reconcile_error_leads_to_reconcile_idle_and_scheduled<T>(reconciler: Reconciler<T>, cr_key: ResourceKey)
+pub proof fn lemma_reconcile_error_leads_to_reconcile_idle_and_scheduled<T>(reconciler: Reconciler<T>, cr_key: ObjectRef)
     requires
         cr_key.kind.is_CustomResourceKind(),
     ensures
@@ -152,7 +153,7 @@ pub proof fn lemma_reconcile_error_leads_to_reconcile_idle_and_scheduled<T>(reco
     lemma_pre_leads_to_post_by_controller::<T>(reconciler, input, next(reconciler), end_reconcile(reconciler), pre, post);
 }
 
-pub proof fn lemma_reconcile_idle_and_scheduled_leads_to_reconcile_init<T>(reconciler: Reconciler<T>, cr_key: ResourceKey)
+pub proof fn lemma_reconcile_idle_and_scheduled_leads_to_reconcile_init<T>(reconciler: Reconciler<T>, cr_key: ObjectRef)
     requires
         cr_key.kind.is_CustomResourceKind(),
     ensures
@@ -184,7 +185,7 @@ pub proof fn lemma_reconcile_idle_and_scheduled_leads_to_reconcile_init<T>(recon
     lemma_pre_leads_to_post_by_controller::<T>(reconciler, input, next(reconciler), run_scheduled_reconcile(reconciler), pre, post);
 }
 
-pub proof fn lemma_reconcile_done_leads_to_reconcile_init<T>(reconciler: Reconciler<T>, cr_key: ResourceKey)
+pub proof fn lemma_reconcile_done_leads_to_reconcile_init<T>(reconciler: Reconciler<T>, cr_key: ObjectRef)
     requires
         cr_key.kind.is_CustomResourceKind(),
     ensures
@@ -218,7 +219,7 @@ pub proof fn lemma_reconcile_done_leads_to_reconcile_init<T>(reconciler: Reconci
     leads_to_trans::<State<T>>(sm_spec(reconciler), reconcile_ended, reconcile_idle_and_scheduled, reconcile_at_init);
 }
 
-pub proof fn lemma_reconcile_error_leads_to_reconcile_init<T>(reconciler: Reconciler<T>, cr_key: ResourceKey)
+pub proof fn lemma_reconcile_error_leads_to_reconcile_init<T>(reconciler: Reconciler<T>, cr_key: ObjectRef)
     requires
         cr_key.kind.is_CustomResourceKind(),
     ensures

--- a/src/kubernetes_cluster/proof/kubernetes_api_safety.rs
+++ b/src/kubernetes_cluster/proof/kubernetes_api_safety.rs
@@ -1,6 +1,7 @@
 // Copyright 2022 VMware, Inc.
 // SPDX-License-Identifier: MIT
 #![allow(unused_imports)]
+use crate::kubernetes_api_objects::{common::*, object::*};
 use crate::kubernetes_cluster::spec::{common::*, distributed_system::*, reconciler::Reconciler};
 use crate::pervasive::seq::*;
 use crate::temporal_logic::defs::*;
@@ -10,7 +11,7 @@ use builtin_macros::*;
 
 verus! {
 
-pub open spec fn added_event_msg_to_controller(res: ResourceObj) -> Message {
+pub open spec fn added_event_msg_to_controller(res: KubernetesObject) -> Message {
     form_msg(HostId::KubernetesAPI, HostId::CustomController, added_event_msg_content(res))
 }
 
@@ -20,7 +21,7 @@ pub open spec fn added_event_msg_to_controller(res: ResourceObj) -> Message {
 /// (3) the reconcile is scheduled.
 ///
 /// This is based on an assumption that controller always re-queues the reconcile when reconcile finishes in the controller spec.
-pub proof fn always_res_exists_implies_added_in_flight_or_reconcile_ongoing_or_reconcile_scheduled<T>(reconciler: Reconciler<T>, res: ResourceObj)
+pub proof fn always_res_exists_implies_added_in_flight_or_reconcile_ongoing_or_reconcile_scheduled<T>(reconciler: Reconciler<T>, res: KubernetesObject)
     requires
         (reconciler.reconcile_trigger)(added_event_msg_to_controller(res)).is_Some(),
     ensures

--- a/src/kubernetes_cluster/spec/client.rs
+++ b/src/kubernetes_cluster/spec/client.rs
@@ -1,6 +1,7 @@
 // Copyright 2022 VMware, Inc.
 // SPDX-License-Identifier: MIT
 #![allow(unused_imports)]
+use crate::kubernetes_api_objects::{custom_resource::*, object::*};
 use crate::kubernetes_cluster::spec::common::*;
 use crate::pervasive::{multiset::*, option::*, seq::*, set::*};
 use crate::state_machine::action::*;
@@ -17,7 +18,7 @@ pub struct ClientState {
 
 pub struct ClientActionInput {
     pub recv: Option<Message>,
-    pub cr: ResourceObj,
+    pub cr: CustomResourceView,
 }
 
 pub enum Step {
@@ -38,11 +39,10 @@ pub open spec fn client_req_msg(msg_content: MessageContent) -> Message {
 pub open spec fn send_create_cr() -> ClientAction {
     Action {
         precondition: |input: ClientActionInput, s: ClientState| {
-            &&& input.cr.key.kind.is_CustomResourceKind()
             &&& input.recv.is_None()
         },
         transition: |input: ClientActionInput, s: ClientState| {
-            (ClientState {req_id: s.req_id + 1}, Multiset::singleton(client_req_msg(create_req_msg_content(ResourceObj{key: input.cr.key}, s.req_id))))
+            (ClientState {req_id: s.req_id + 1}, Multiset::singleton(client_req_msg(create_req_msg_content(KubernetesObject::CustomResource(input.cr), s.req_id))))
         },
     }
 }
@@ -50,11 +50,10 @@ pub open spec fn send_create_cr() -> ClientAction {
 pub open spec fn send_delete_cr() -> ClientAction {
     Action {
         precondition: |input: ClientActionInput, s: ClientState| {
-            &&& input.cr.key.kind.is_CustomResourceKind()
             &&& input.recv.is_None()
         },
         transition: |input: ClientActionInput, s: ClientState| {
-            (ClientState {req_id: s.req_id + 1}, Multiset::singleton(client_req_msg(delete_req_msg_content(input.cr.key, s.req_id))))
+            (ClientState {req_id: s.req_id + 1}, Multiset::singleton(client_req_msg(delete_req_msg_content(input.cr.object_ref(), s.req_id))))
         },
     }
 }

--- a/src/kubernetes_cluster/spec/controller/common.rs
+++ b/src/kubernetes_cluster/spec/controller/common.rs
@@ -1,6 +1,7 @@
 // Copyright 2022 VMware, Inc.
 // SPDX-License-Identifier: MIT
 #![allow(unused_imports)]
+use crate::kubernetes_api_objects::common::*;
 use crate::kubernetes_cluster::spec::{common::*, reconciler::*};
 use crate::pervasive::{map::*, multiset::*, option::*, seq::*, set::*};
 use crate::state_machine::action::*;
@@ -12,8 +13,8 @@ verus! {
 
 pub struct ControllerState<T> {
     pub req_id: nat,
-    pub ongoing_reconciles: Map<ResourceKey, OngoingReconcile<T>>,
-    pub scheduled_reconciles: Set<ResourceKey>,
+    pub ongoing_reconciles: Map<ObjectRef, OngoingReconcile<T>>,
+    pub scheduled_reconciles: Set<ObjectRef>,
     pub self_watcher: Watcher,
     // TODO: there should be watchers for `owns_with` and `watches_with`
 }
@@ -30,7 +31,7 @@ pub struct Watcher {
 
 pub struct ControllerActionInput {
     pub recv: Option<Message>,
-    pub scheduled_cr_key: Option<ResourceKey>,
+    pub scheduled_cr_key: Option<ObjectRef>,
 }
 
 #[is_variant]

--- a/src/kubernetes_cluster/spec/controller/controller_runtime.rs
+++ b/src/kubernetes_cluster/spec/controller/controller_runtime.rs
@@ -1,6 +1,7 @@
 // Copyright 2022 VMware, Inc.
 // SPDX-License-Identifier: MIT
 #![allow(unused_imports)]
+use crate::kubernetes_api_objects::{common::*, object::*};
 use crate::kubernetes_cluster::spec::{common::*, controller::common::*, reconciler::*};
 use crate::pervasive::{map::*, multiset::*, option::*, seq::*, set::*};
 use crate::state_machine::action::*;
@@ -21,7 +22,7 @@ pub open spec fn issue_initial_list<T>(reconciler: Reconciler<T>) -> ControllerA
         },
         transition: |input: ControllerActionInput, s: ControllerState<T>| {
             let list_req_msg = controller_req_msg(APIRequest::ListRequest(ListRequest {
-                kind: ResourceKind::CustomResourceKind,
+                kind: Kind::CustomResourceKind,
             }), s.req_id);
             let s_prime = ControllerState {
                 self_watcher: Watcher{
@@ -37,7 +38,7 @@ pub open spec fn issue_initial_list<T>(reconciler: Reconciler<T>) -> ControllerA
     }
 }
 
-pub open spec fn get_key_set_from_list_result(list: Seq<ResourceObj>) -> Set<ResourceKey> {
+pub open spec fn get_key_set_from_list_result(list: Seq<KubernetesObject>) -> Set<ObjectRef> {
     // TODO: the returned set should contain all the keys of objects in the list
     Set::empty()
 }

--- a/src/kubernetes_cluster/spec/distributed_system.rs
+++ b/src/kubernetes_cluster/spec/distributed_system.rs
@@ -1,6 +1,7 @@
 // Copyright 2022 VMware, Inc.
 // SPDX-License-Identifier: MIT
 #![allow(unused_imports)]
+use crate::kubernetes_api_objects::{common::*, object::*};
 use crate::kubernetes_cluster::spec::{
     client,
     client::{client, ClientActionInput, ClientState},
@@ -37,33 +38,33 @@ impl<T> State<T> {
         multiset_contains_msg(self.network_state.in_flight, msg)
     }
 
-    pub open spec fn resource_key_exists(self, key: ResourceKey) -> bool {
+    pub open spec fn resource_key_exists(self, key: ObjectRef) -> bool {
         self.kubernetes_api_state.resources.dom().contains(key)
     }
 
-    pub open spec fn resource_obj_exists(self, obj: ResourceObj) -> bool {
-        &&& self.kubernetes_api_state.resources.dom().contains(obj.key)
-        &&& self.kubernetes_api_state.resources[obj.key] == obj
+    pub open spec fn resource_obj_exists(self, obj: KubernetesObject) -> bool {
+        &&& self.kubernetes_api_state.resources.dom().contains(obj.object_ref())
+        &&& self.kubernetes_api_state.resources[obj.object_ref()] == obj
     }
 
-    pub open spec fn resource_obj_of(self, key: ResourceKey) -> ResourceObj
+    pub open spec fn resource_obj_of(self, key: ObjectRef) -> KubernetesObject
         recommends self.resource_key_exists(key)
     {
         self.kubernetes_api_state.resources[key]
     }
 
     #[verifier(inline)]
-    pub open spec fn reconcile_state_contains(self, key: ResourceKey) -> bool {
+    pub open spec fn reconcile_state_contains(self, key: ObjectRef) -> bool {
         self.controller_state.ongoing_reconciles.dom().contains(key)
     }
 
-    pub open spec fn reconcile_state_of(self, key: ResourceKey) -> OngoingReconcile<T>
+    pub open spec fn reconcile_state_of(self, key: ObjectRef) -> OngoingReconcile<T>
         recommends self.reconcile_state_contains(key)
     {
         self.controller_state.ongoing_reconciles[key]
     }
 
-    pub open spec fn reconcile_scheduled_for(self, key: ResourceKey) -> bool {
+    pub open spec fn reconcile_scheduled_for(self, key: ObjectRef) -> bool {
         self.controller_state.scheduled_reconciles.contains(key)
     }
 }

--- a/src/kubernetes_cluster/spec/kubernetes_api/builtin_controllers/statefulset_controller.rs
+++ b/src/kubernetes_cluster/spec/kubernetes_api/builtin_controllers/statefulset_controller.rs
@@ -8,6 +8,7 @@ use builtin_macros::*;
 
 verus! {
 
+// TODO: complete the statefulset controller spec
 pub open spec fn transition_by_statefulset_controller(msg: Message, s: KubernetesAPIState) -> Multiset<Message>
     recommends
         msg.content.is_WatchEvent(),
@@ -17,23 +18,24 @@ pub open spec fn transition_by_statefulset_controller(msg: Message, s: Kubernete
     // In reality, the message is sent from the built-in controller to apiserver then to etcd.
 
     let dst = HostId::KubernetesAPI;
-    if msg.content.is_watch_event_of_kind(ResourceKind::StatefulSetKind) {
-        if msg.content.is_added_event() {
-            let obj = msg.content.get_added_event().obj;
-            Multiset::empty()
-                .insert(form_msg(src, dst, create_req_msg_content(ResourceObj{key: ResourceKey{name: obj.key.name + pod_suffix(), namespace: obj.key.namespace, kind: ResourceKind::PodKind}}, s.req_id)))
-                .insert(form_msg(src, dst, create_req_msg_content(ResourceObj{key: ResourceKey{name: obj.key.name + vol_suffix(), namespace: obj.key.namespace, kind: ResourceKind::VolumeKind}}, s.req_id + 1)))
-        } else if msg.content.is_modified_event() {
-            Multiset::empty()
-        } else {
-            let obj = msg.content.get_deleted_event().obj;
-            Multiset::empty()
-                .insert(form_msg(src, dst, delete_req_msg_content(ResourceKey{name: obj.key.name + pod_suffix(), namespace: obj.key.namespace, kind: ResourceKind::PodKind}, s.req_id)))
-                .insert(form_msg(src, dst, delete_req_msg_content(ResourceKey{name: obj.key.name + vol_suffix(), namespace: obj.key.namespace, kind: ResourceKind::VolumeKind}, s.req_id + 1)))
-        }
-    } else {
-        Multiset::empty()
-    }
+    // if msg.content.is_watch_event_of_kind(Kind::StatefulSetKind) {
+    //     if msg.content.is_added_event() {
+    //         let obj = msg.content.get_added_event().obj;
+    //         Multiset::empty()
+    //             .insert(form_msg(src, dst, create_req_msg_content(KubernetesObject{key: ObjectRef{name: obj.key.name + pod_suffix(), namespace: obj.key.namespace, kind: Kind::PodKind}}, s.req_id)))
+    //             .insert(form_msg(src, dst, create_req_msg_content(KubernetesObject{key: ObjectRef{name: obj.key.name + vol_suffix(), namespace: obj.key.namespace, kind: Kind::VolumeKind}}, s.req_id + 1)))
+    //     } else if msg.content.is_modified_event() {
+    //         Multiset::empty()
+    //     } else {
+    //         let obj = msg.content.get_deleted_event().obj;
+    //         Multiset::empty()
+    //             .insert(form_msg(src, dst, delete_req_msg_content(ObjectRef{name: obj.key.name + pod_suffix(), namespace: obj.key.namespace, kind: Kind::PodKind}, s.req_id)))
+    //             .insert(form_msg(src, dst, delete_req_msg_content(ObjectRef{name: obj.key.name + vol_suffix(), namespace: obj.key.namespace, kind: Kind::VolumeKind}, s.req_id + 1)))
+    //     }
+    // } else {
+    //     Multiset::empty()
+    // }
+    Multiset::empty()
 }
 
 }

--- a/src/kubernetes_cluster/spec/kubernetes_api/common.rs
+++ b/src/kubernetes_cluster/spec/kubernetes_api/common.rs
@@ -1,6 +1,7 @@
 // Copyright 2022 VMware, Inc.
 // SPDX-License-Identifier: MIT
 #![allow(unused_imports)]
+use crate::kubernetes_api_objects::{common::*, object::*};
 use crate::kubernetes_cluster::spec::common::*;
 use crate::pervasive::{map::*, multiset::*, option::*, result::*, seq::*, string::*};
 use crate::state_machine::action::*;
@@ -11,7 +12,7 @@ use builtin_macros::*;
 
 verus! {
 
-pub type EtcdState = Map<ResourceKey, ResourceObj>;
+pub type EtcdState = Map<ObjectRef, KubernetesObject>;
 
 pub struct KubernetesAPIState {
     pub req_id: nat,

--- a/src/kubernetes_cluster/spec/reconciler.rs
+++ b/src/kubernetes_cluster/spec/reconciler.rs
@@ -1,6 +1,7 @@
 // Copyright 2022 VMware, Inc.
 // SPDX-License-Identifier: MIT
 #![allow(unused_imports)]
+use crate::kubernetes_api_objects::common::*;
 use crate::kubernetes_cluster::spec::common::*;
 use crate::pervasive::option::*;
 use builtin::*;
@@ -40,9 +41,9 @@ pub struct Reconciler<#[verifier(maybe_negative)] T> {
 
 pub type ReconcileInitState<T> = FnSpec() -> T;
 
-pub type ReconcileTrigger = FnSpec(Message) -> Option<ResourceKey>;
+pub type ReconcileTrigger = FnSpec(Message) -> Option<ObjectRef>;
 
-pub type ReconcileCore<T> = FnSpec(ResourceKey, Option<APIResponse>, T) -> (T, Option<APIRequest>);
+pub type ReconcileCore<T> = FnSpec(ObjectRef, Option<APIResponse>, T) -> (T, Option<APIRequest>);
 
 pub type ReconcileDone<T> = FnSpec(T) -> bool;
 


### PR DESCRIPTION
Replace all the toy k8s object definitions with the newly implemented k8s openapi objects in spec and proof.