### PR TITLE
Assume the controller's reconcile is infinitely frequently triggered

### DIFF
--- a/src/kubernetes_cluster/proof/controller_runtime_safety.rs
+++ b/src/kubernetes_cluster/proof/controller_runtime_safety.rs
@@ -7,9 +7,6 @@ use crate::kubernetes_cluster::{
     spec::{
         common::*,
         controller::common::{ControllerAction, ControllerActionInput},
-        controller::controller_runtime::{
-            continue_reconcile, end_reconcile, run_scheduled_reconcile, trigger_reconcile,
-        },
         controller::state_machine::controller,
         distributed_system::*,
         reconciler::Reconciler,

--- a/src/kubernetes_cluster/proof/kubernetes_api_safety.rs
+++ b/src/kubernetes_cluster/proof/kubernetes_api_safety.rs
@@ -15,39 +15,4 @@ pub open spec fn added_event_msg_to_controller(res: KubernetesObject) -> Message
     form_msg(HostId::KubernetesAPI, HostId::CustomController, added_event_msg_content(res))
 }
 
-/// If res exists and res can trigger reconcile, then
-/// (1) its added event message is in flight, or
-/// (2) the controller is running reconcile, or
-/// (3) the reconcile is scheduled.
-///
-/// This is based on an assumption that controller always re-queues the reconcile when reconcile finishes in the controller spec.
-pub proof fn always_res_exists_implies_added_in_flight_or_reconcile_ongoing_or_reconcile_scheduled<T>(reconciler: Reconciler<T>, res: KubernetesObject)
-    requires
-        (reconciler.reconcile_trigger)(added_event_msg_to_controller(res)).is_Some(),
-    ensures
-        sm_spec(reconciler).entails(
-            always(
-                lift_state(|s: State<T>| s.resource_obj_exists(res)).implies(lift_state(|s: State<T>| {
-                    ||| s.message_in_flight(added_event_msg_to_controller(res))
-                    ||| s.reconcile_state_contains((reconciler.reconcile_trigger)(added_event_msg_to_controller(res)).get_Some_0())
-                    ||| s.reconcile_scheduled_for((reconciler.reconcile_trigger)(added_event_msg_to_controller(res)).get_Some_0())
-                }))
-            )
-        ),
-{
-    let invariant = |s: State<T>| {
-        s.resource_obj_exists(res)
-        ==> s.message_in_flight(added_event_msg_to_controller(res))
-            || s.reconcile_state_contains((reconciler.reconcile_trigger)(added_event_msg_to_controller(res)).get_Some_0())
-            || s.reconcile_scheduled_for((reconciler.reconcile_trigger)(added_event_msg_to_controller(res)).get_Some_0())
-    };
-    init_invariant::<State<T>>(sm_spec(reconciler), init(reconciler), next(reconciler), invariant);
-    let invariant_temp_pred = lift_state(|s: State<T>| s.resource_obj_exists(res)).implies(lift_state(|s: State<T>| {
-        ||| s.message_in_flight(added_event_msg_to_controller(res))
-        ||| s.reconcile_state_contains((reconciler.reconcile_trigger)(added_event_msg_to_controller(res)).get_Some_0())
-        ||| s.reconcile_scheduled_for((reconciler.reconcile_trigger)(added_event_msg_to_controller(res)).get_Some_0())
-    }));
-    temp_pred_equality::<State<T>>(lift_state(invariant), invariant_temp_pred);
-}
-
 }

--- a/src/kubernetes_cluster/proof/wf1_assistant.rs
+++ b/src/kubernetes_cluster/proof/wf1_assistant.rs
@@ -7,10 +7,7 @@ use crate::kubernetes_cluster::spec::{
     controller::common::{
         ControllerAction, ControllerActionInput, ControllerState, ControllerStep,
     },
-    controller::controller_runtime::{
-        continue_reconcile, end_reconcile, issue_initial_list, run_scheduled_reconcile,
-        start_watching, trigger_reconcile, trigger_reconcile_with_list_resp,
-    },
+    controller::controller_runtime::{continue_reconcile, end_reconcile, run_scheduled_reconcile},
     controller::state_machine::controller,
     distributed_system::*,
     kubernetes_api::common::{
@@ -67,23 +64,11 @@ pub proof fn exists_next_controller_step<T>(reconciler: Reconciler<T>, action: C
     ensures
         exists |step| (#[trigger] (controller(reconciler).step_to_action)(step).precondition)(input, s),
 {
-    if action == trigger_reconcile(reconciler) {
-        let step = ControllerStep::TriggerReconcile;
-        assert(((controller(reconciler).step_to_action)(step).precondition)(input, s));
-    } else if action == run_scheduled_reconcile(reconciler) {
+    if action == run_scheduled_reconcile(reconciler) {
         let step = ControllerStep::RunScheduledReconcile;
         assert(((controller(reconciler).step_to_action)(step).precondition)(input, s));
     } else if action == continue_reconcile(reconciler) {
         let step = ControllerStep::ContinueReconcile;
-        assert(((controller(reconciler).step_to_action)(step).precondition)(input, s));
-    } else if action == issue_initial_list(reconciler) {
-        let step = ControllerStep::IssueInitialList;
-        assert(((controller(reconciler).step_to_action)(step).precondition)(input, s));
-    } else if action == trigger_reconcile_with_list_resp(reconciler) {
-        let step = ControllerStep::TriggerReconcileWithListResp;
-        assert(((controller(reconciler).step_to_action)(step).precondition)(input, s));
-    } else if action == start_watching(reconciler) {
-        let step = ControllerStep::StartWatching;
         assert(((controller(reconciler).step_to_action)(step).precondition)(input, s));
     } else {
         let step = ControllerStep::EndReconcile;

--- a/src/kubernetes_cluster/spec/controller/state_machine.rs
+++ b/src/kubernetes_cluster/spec/controller/state_machine.rs
@@ -20,27 +20,15 @@ pub open spec fn controller<T>(reconciler: Reconciler<T>) -> ControllerStateMach
                 req_id: 0,
                 ongoing_reconciles: Map::empty(),
                 scheduled_reconciles: Set::empty(),
-                self_watcher: Watcher {
-                    state: WatcherState::Empty,
-                    pending_req_msg: Option::None,
-                }
             }
         },
         actions: set![
-            issue_initial_list(reconciler),
-            trigger_reconcile_with_list_resp(reconciler),
-            start_watching(reconciler),
-            trigger_reconcile(reconciler),
             run_scheduled_reconcile(reconciler),
             continue_reconcile(reconciler),
             end_reconcile(reconciler)
         ],
         step_to_action: |step: ControllerStep| {
             match step {
-                ControllerStep::IssueInitialList => issue_initial_list(reconciler),
-                ControllerStep::TriggerReconcileWithListResp => trigger_reconcile_with_list_resp(reconciler),
-                ControllerStep::StartWatching => start_watching(reconciler),
-                ControllerStep::TriggerReconcile => trigger_reconcile(reconciler),
                 ControllerStep::RunScheduledReconcile => run_scheduled_reconcile(reconciler),
                 ControllerStep::ContinueReconcile => continue_reconcile(reconciler),
                 ControllerStep::EndReconcile => end_reconcile(reconciler),

--- a/src/kubernetes_cluster/spec/kubernetes_api/state_machine.rs
+++ b/src/kubernetes_cluster/spec/kubernetes_api/state_machine.rs
@@ -158,7 +158,7 @@ pub open spec fn handle_request() -> KubernetesAPIAction {
                     req_id: s_after_etcd_transition.req_id + controller_requests.len(),
                     ..s_after_etcd_transition
                 };
-                (s_prime, Multiset::empty().insert(etcd_resp).insert(etcd_notify_o.get_Some_0()).add(controller_requests))
+                (s_prime, Multiset::empty().insert(etcd_resp).add(controller_requests))
             } else {
                 let s_prime = s_after_etcd_transition;
                 (s_prime, Multiset::singleton(etcd_resp))


### PR DESCRIPTION
Add an action that checks if a cr exists in the Kubernetes API and, if so, inserts a reconcile request for that cr to the controller and assumes weak fairness on this action.

This allows us to set up the assumption that reconcile is infinitely frequently scheduled without modeling all the details about list-then-watch and resource versions.

Some of the existing lemmas for proving `p ~> reconcile_triggered` become deprecated and we will need to write new lemmas by packing the assumption into the spec and prove `true ~> reconcile_triggered`.