### PR TITLE
Prove true leads to reconcile scheduled under the assumption that cr always exists

### DIFF
--- a/src/kubernetes_cluster/proof/controller_runtime_liveness.rs
+++ b/src/kubernetes_cluster/proof/controller_runtime_liveness.rs
@@ -164,9 +164,9 @@ pub proof fn lemma_true_leads_to_reconcile_scheduled_by_assumption<T>(reconciler
         &&& cr_key_exists(s)
     };
     strengthen_next::<State<T>>(spec, next(reconciler), cr_key_exists, next_and_cr_exists);
-    temp_pred_equality::<State<T>>(lift_state(cr_key_exists), lift_state(schedule_controller_reconcile(reconciler).pre(cr_key)));
-    use_tla_forall::<State<T>, ObjectRef>(spec, |key| schedule_controller_reconcile(reconciler).weak_fairness(key), cr_key);
-    schedule_controller_reconcile(reconciler).wf1(cr_key, spec, next_and_cr_exists, pre, post);
+    temp_pred_equality::<State<T>>(lift_state(cr_key_exists), lift_state(schedule_controller_reconcile().pre(cr_key)));
+    use_tla_forall::<State<T>, ObjectRef>(spec, |key| schedule_controller_reconcile().weak_fairness(key), cr_key);
+    schedule_controller_reconcile().wf1(cr_key, spec, next_and_cr_exists, pre, post);
 }
 
 }

--- a/src/kubernetes_cluster/proof/controller_runtime_liveness.rs
+++ b/src/kubernetes_cluster/proof/controller_runtime_liveness.rs
@@ -147,6 +147,26 @@ pub proof fn lemma_reconcile_idle_and_scheduled_leads_to_reconcile_init<T>(recon
     lemma_pre_leads_to_post_by_controller::<T>(reconciler, input, next(reconciler), run_scheduled_reconcile(reconciler), pre, post);
 }
 
-// TODO: we need a lemma that says with the assumption that cr always exists, true ~> reconcile_scheduled_for_cr
+pub proof fn lemma_true_leads_to_reconcile_scheduled_by_assumption<T>(reconciler: Reconciler<T>, cr_key: ObjectRef)
+    requires
+        cr_key.kind.is_CustomResourceKind(),
+    ensures
+        sm_partial_spec(reconciler).and(always(lift_state(|s: State<T>| s.resource_key_exists(cr_key)))).entails(
+            true_pred().leads_to(lift_state(|s: State<T>| s.reconcile_scheduled_for(cr_key)))
+        ),
+{
+    let cr_key_exists = |s: State<T>| s.resource_key_exists(cr_key);
+    let spec = sm_partial_spec(reconciler).and(always(lift_state(cr_key_exists)));
+    let pre = |s: State<T>| true;
+    let post = |s: State<T>| s.reconcile_scheduled_for(cr_key);
+    let next_and_cr_exists = |s, s_prime: State<T>| {
+        &&& next(reconciler)(s, s_prime)
+        &&& cr_key_exists(s)
+    };
+    strengthen_next::<State<T>>(spec, next(reconciler), cr_key_exists, next_and_cr_exists);
+    temp_pred_equality::<State<T>>(lift_state(cr_key_exists), lift_state(schedule_controller_reconcile(reconciler).pre(cr_key)));
+    use_tla_forall::<State<T>, ObjectRef>(spec, |key| schedule_controller_reconcile(reconciler).weak_fairness(key), cr_key);
+    schedule_controller_reconcile(reconciler).wf1(cr_key, spec, next_and_cr_exists, pre, post);
+}
 
 }

--- a/src/kubernetes_cluster/spec/distributed_system.rs
+++ b/src/kubernetes_cluster/spec/distributed_system.rs
@@ -147,7 +147,7 @@ pub open spec fn controller_next<T>(reconciler: Reconciler<T>) -> Action<State<T
 ///
 /// Note this action abstracts away a lot of implementation details in the Kubernetes API and controller runtime framework,
 /// such as the list-then-watch pattern.
-pub open spec fn schedule_controller_reconcile<T>(reconciler: Reconciler<T>) -> Action<State<T>, ObjectRef, ()> {
+pub open spec fn schedule_controller_reconcile<T>() -> Action<State<T>, ObjectRef, ()> {
     Action {
         precondition: |input: ObjectRef, s: State<T>| {
             &&& s.resource_key_exists(input)
@@ -213,7 +213,7 @@ pub open spec fn next_step<T>(reconciler: Reconciler<T>, s: State<T>, s_prime: S
     match step {
         Step::KubernetesAPIStep(input) => kubernetes_api_next().forward(input)(s, s_prime),
         Step::ControllerStep(input) => controller_next(reconciler).forward(input)(s, s_prime),
-        Step::ScheduleControllerReconcileStep(input) => schedule_controller_reconcile(reconciler).forward(input)(s, s_prime),
+        Step::ScheduleControllerReconcileStep(input) => schedule_controller_reconcile().forward(input)(s, s_prime),
         Step::ClientStep(input) => client_next().forward(input)(s, s_prime),
         Step::StutterStep(input) => stutter().forward(input)(s, s_prime),
     }
@@ -237,7 +237,7 @@ pub open spec fn sm_partial_spec<T>(reconciler: Reconciler<T>) -> TempPred<State
     always(lift_action(next(reconciler)))
     .and(tla_forall(|input| kubernetes_api_next().weak_fairness(input)))
     .and(tla_forall(|input| controller_next(reconciler).weak_fairness(input)))
-    .and(tla_forall(|input| schedule_controller_reconcile(reconciler).weak_fairness(input)))
+    .and(tla_forall(|input| schedule_controller_reconcile().weak_fairness(input)))
 }
 
 pub open spec fn kubernetes_api_action_pre<T>(action: KubernetesAPIAction, input: KubernetesAPIActionInput) -> StatePred<State<T>> {


### PR DESCRIPTION
Prove `[]next /\ []fair /\ []cr_exists |= true ~> reconcile_scheduled_for_cr`. This is way simpler than the previous reasoning about watch events and it will be the starting point of our liveness proof.