### PR TITLE
Add channel manager to allocate channel id for each controller request

### DIFF
--- a/src/kubernetes_cluster/proof/controller_runtime_safety.rs
+++ b/src/kubernetes_cluster/proof/controller_runtime_safety.rs
@@ -51,7 +51,7 @@ pub open spec fn pending_req_has_lower_req_id<T>() -> StatePred<State<T>> {
         forall |cr_key: ObjectRef|
             #[trigger] s.reconcile_state_contains(cr_key)
             && s.reconcile_state_of(cr_key).pending_req_msg.is_Some()
-            ==> s.reconcile_state_of(cr_key).pending_req_msg.get_Some_0().content.get_req_id() < s.controller_state.req_id
+            ==> s.reconcile_state_of(cr_key).pending_req_msg.get_Some_0().content.get_req_id() < s.controller_state.chan_manager.cur_chan_id
     }
 }
 

--- a/src/kubernetes_cluster/spec/channel.rs
+++ b/src/kubernetes_cluster/spec/channel.rs
@@ -1,0 +1,28 @@
+// Copyright 2022 VMware, Inc.
+// SPDX-License-Identifier: MIT
+#![allow(unused_imports)]
+use crate::pervasive::prelude::*;
+use builtin::*;
+use builtin_macros::*;
+
+verus! {
+
+pub struct ChannelManager {
+    pub cur_chan_id: nat,
+}
+
+impl ChannelManager {
+    pub open spec fn init() -> Self {
+        ChannelManager {
+            cur_chan_id: 0,
+        }
+    }
+
+    pub open spec fn allocate(self) -> (Self, nat) {
+        (ChannelManager {
+            cur_chan_id: self.cur_chan_id + 1,
+        }, self.cur_chan_id)
+    }
+}
+
+}

--- a/src/kubernetes_cluster/spec/channel.rs
+++ b/src/kubernetes_cluster/spec/channel.rs
@@ -7,6 +7,10 @@ use builtin_macros::*;
 
 verus! {
 
+/// ChannelManager allocates new channel id for each request sent by the controller.
+/// The response will carry the same channel id.
+
+// TODO: the concept of channel should be modeled inside the network state machine
 pub struct ChannelManager {
     pub cur_chan_id: nat,
 }
@@ -17,6 +21,8 @@ impl ChannelManager {
             cur_chan_id: 0,
         }
     }
+
+    /// allocate returns cur_chan_id and another ChannelManager with an incremented cur_chan_id
 
     pub open spec fn allocate(self) -> (Self, nat) {
         (ChannelManager {

--- a/src/kubernetes_cluster/spec/controller/common.rs
+++ b/src/kubernetes_cluster/spec/controller/common.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MIT
 #![allow(unused_imports)]
 use crate::kubernetes_api_objects::{api_method::*, common::*};
-use crate::kubernetes_cluster::spec::{message::*, reconciler::*};
+use crate::kubernetes_cluster::spec::{channel::*, message::*, reconciler::*};
 use crate::pervasive::{map::*, multiset::*, option::*, seq::*, set::*};
 use crate::state_machine::action::*;
 use crate::state_machine::state_machine::*;
@@ -12,7 +12,7 @@ use builtin_macros::*;
 verus! {
 
 pub struct ControllerState<T> {
-    pub req_id: nat,
+    pub chan_manager: ChannelManager,
     pub ongoing_reconciles: Map<ObjectRef, OngoingReconcile<T>>,
     pub scheduled_reconciles: Set<ObjectRef>,
 }

--- a/src/kubernetes_cluster/spec/controller/controller_runtime.rs
+++ b/src/kubernetes_cluster/spec/controller/controller_runtime.rs
@@ -68,10 +68,10 @@ pub open spec fn continue_reconcile<T>(reconciler: Reconciler<T>) -> ControllerA
 
             let (local_state_prime, req_o) = (reconciler.reconcile_core)(cr_key, resp_o, reconcile_state.local_state);
 
-            let pending_req_msg = if req_o.is_Some() {
-                Option::Some(controller_req_msg(req_o.get_Some_0(), s.req_id))
+            let (chan_manager_prime, pending_req_msg) = if req_o.is_Some() {
+                (s.chan_manager.allocate().0, Option::Some(controller_req_msg(req_o.get_Some_0(), s.chan_manager.allocate().1)))
             } else {
-                Option::None
+                (s.chan_manager, Option::None)
             };
 
             let reconcile_state_prime = OngoingReconcile {
@@ -79,8 +79,8 @@ pub open spec fn continue_reconcile<T>(reconciler: Reconciler<T>) -> ControllerA
                 local_state: local_state_prime,
             };
             let s_prime = ControllerState {
+                chan_manager: chan_manager_prime,
                 ongoing_reconciles: s.ongoing_reconciles.insert(cr_key, reconcile_state_prime),
-                req_id: s.req_id + 1,
                 ..s
             };
             let send = if pending_req_msg.is_Some() {

--- a/src/kubernetes_cluster/spec/controller/state_machine.rs
+++ b/src/kubernetes_cluster/spec/controller/state_machine.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MIT
 #![allow(unused_imports)]
 use crate::kubernetes_cluster::spec::{
-    controller::common::*, controller::controller_runtime::*, message::*, reconciler::*,
+    channel::*, controller::common::*, controller::controller_runtime::*, message::*, reconciler::*,
 };
 use crate::pervasive::{map::*, option::*, seq::*, set::*, string::*};
 use crate::state_machine::action::*;
@@ -17,7 +17,7 @@ pub open spec fn controller<T>(reconciler: Reconciler<T>) -> ControllerStateMach
     StateMachine {
         init: |s: ControllerState<T>| {
             s == ControllerState::<T> {
-                req_id: 0,
+                chan_manager: ChannelManager::init(),
                 ongoing_reconciles: Map::empty(),
                 scheduled_reconciles: Set::empty(),
             }

--- a/src/kubernetes_cluster/spec/kubernetes_api/builtin_controllers/statefulset_controller.rs
+++ b/src/kubernetes_cluster/spec/kubernetes_api/builtin_controllers/statefulset_controller.rs
@@ -1,7 +1,7 @@
 // Copyright 2022 VMware, Inc.
 // SPDX-License-Identifier: MIT
 #![allow(unused_imports)]
-use crate::kubernetes_cluster::spec::{kubernetes_api::common::*, message::*};
+use crate::kubernetes_cluster::spec::{channel::*, kubernetes_api::common::*, message::*};
 use crate::pervasive::{map::*, multiset::*, option::*, result::*, seq::*};
 use builtin::*;
 use builtin_macros::*;
@@ -9,7 +9,7 @@ use builtin_macros::*;
 verus! {
 
 // TODO: complete the statefulset controller spec
-pub open spec fn transition_by_statefulset_controller(event: WatchEvent, s: KubernetesAPIState) -> Multiset<Message> {
+pub open spec fn transition_by_statefulset_controller(event: WatchEvent, s: KubernetesAPIState) -> (ChannelManager, Multiset<Message>) {
     let src = HostId::KubernetesAPI;
     // Here dst is also KubernetesAPI because etcd, apiserver and built-in controllers are all in the same state machine.
     // In reality, the message is sent from the built-in controller to apiserver then to etcd.
@@ -32,7 +32,7 @@ pub open spec fn transition_by_statefulset_controller(event: WatchEvent, s: Kube
     // } else {
     //     Multiset::empty()
     // }
-    Multiset::empty()
+    (s.chan_manager, Multiset::empty())
 }
 
 }

--- a/src/kubernetes_cluster/spec/kubernetes_api/common.rs
+++ b/src/kubernetes_cluster/spec/kubernetes_api/common.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MIT
 #![allow(unused_imports)]
 use crate::kubernetes_api_objects::{api_method::*, common::*, object::*};
-use crate::kubernetes_cluster::spec::message::*;
+use crate::kubernetes_cluster::spec::{channel::*, message::*};
 use crate::pervasive::{map::*, multiset::*, option::*, result::*, seq::*, string::*};
 use crate::state_machine::action::*;
 use crate::state_machine::state_machine::*;
@@ -15,7 +15,7 @@ verus! {
 pub type EtcdState = Map<ObjectRef, KubernetesObject>;
 
 pub struct KubernetesAPIState {
-    pub req_id: nat,
+    pub chan_manager: ChannelManager,
     pub resources: EtcdState,
 }
 

--- a/src/kubernetes_cluster/spec/mod.rs
+++ b/src/kubernetes_cluster/spec/mod.rs
@@ -1,5 +1,6 @@
 // Copyright 2022 VMware, Inc.
 // SPDX-License-Identifier: MIT
+pub mod channel;
 pub mod client;
 pub mod controller;
 pub mod distributed_system;

--- a/src/simple_controller/proof/safety.rs
+++ b/src/simple_controller/proof/safety.rs
@@ -129,7 +129,7 @@ proof fn next_preserves_reconcile_get_cr_done_implies_pending_req_in_flight_or_r
         } else {
             // If reconcile state is not at after_get_cr_pc for s, then this in transition reconcile_core advances the reconcile state to after_get_cr_pc
             // which means the req_msg is just sent to the network, so of course it is in flight
-            let req_msg = controller_req_msg(APIRequest::GetRequest(GetRequest{key: cr.object_ref()}), s.controller_state.req_id);
+            let req_msg = controller_req_msg(APIRequest::GetRequest(GetRequest{key: cr.object_ref()}), s.controller_state.chan_manager.cur_chan_id);
             assert(is_controller_get_cr_request_msg(req_msg, cr)
                 && s_prime.reconcile_state_of(cr.object_ref()).pending_req_msg == Option::Some(req_msg)
                 && s_prime.message_in_flight(req_msg)
@@ -198,7 +198,7 @@ proof fn next_preserves_reconcile_create_cm_done_implies_pending_create_cm_req_i
                 assert(s_prime.resource_key_exists(simple_reconciler::subresource_configmap(cr.object_ref()).object_ref()));
             }
         } else {
-            let req_msg = controller_req_msg(simple_reconciler::create_cm_req(cr.object_ref()), s.controller_state.req_id);
+            let req_msg = controller_req_msg(simple_reconciler::create_cm_req(cr.object_ref()), s.controller_state.chan_manager.cur_chan_id);
             assert(is_controller_create_cm_request_msg(req_msg, cr)
                 && s_prime.reconcile_state_of(cr.object_ref()).pending_req_msg == Option::Some(req_msg)
                 && s_prime.message_in_flight(req_msg)


### PR DESCRIPTION
Use ChannelManager to wrap around the channel id. ChannelManager is part of the host state machine and allocates a new channel id when sending a new request.

Ideally, the concept of channel should be modeled in the network state machine, but I found that will complicate the spec a lot. For example, we will need to differentiate whether the host is sending to an existing channel or sending to a new channel, and when a new channel is created in the network, the host somehow needs to know the channel id and waits for the message sent back to that channel. We will need to revisit the design of network state machine later.