### PR TITLE
Prove simple controller liveness except the reconcile error case

### DIFF
--- a/src/kubernetes_cluster/proof/cluster.rs
+++ b/src/kubernetes_cluster/proof/cluster.rs
@@ -1,0 +1,54 @@
+// Copyright 2022 VMware, Inc.
+// SPDX-License-Identifier: MIT
+#![allow(unused_imports)]
+use crate::kubernetes_api_objects::{api_method::*, common::*, object::*};
+use crate::kubernetes_cluster::spec::{
+    client,
+    client::{client, ClientActionInput, ClientState},
+    distributed_system::*,
+    controller::common::{
+        insert_scheduled_reconcile, ControllerAction, ControllerActionInput, ControllerState,
+        OngoingReconcile,
+    },
+    controller::state_machine::controller,
+    kubernetes_api::common::{KubernetesAPIAction, KubernetesAPIActionInput, KubernetesAPIState},
+    kubernetes_api::state_machine::kubernetes_api,
+    message::*,
+    network,
+    network::{multiset_contains_msg, network, NetworkState},
+    reconciler::Reconciler,
+};
+use crate::pervasive::{map::*, option::*, seq::*, set::*};
+use crate::state_machine::action::*;
+use crate::state_machine::state_machine::*;
+use crate::temporal_logic::defs::*;
+use crate::temporal_logic::rules::*;
+use builtin::*;
+use builtin_macros::*;
+
+verus! {
+
+proof fn valid_stable_tla_forall_action_weak_fairness<T, Input, Output>(action: Action<State<T>, Input, Output>)
+    ensures
+        valid(stable(tla_forall(|input| action.weak_fairness(input)))),
+{
+    let split_always = |input| always(lift_state(action.pre(input))).implies(eventually(lift_action(action.forward(input))));
+    tla_forall_always_equality_variant::<State<T>, Input>(|input| action.weak_fairness(input), split_always);
+    always_p_stable::<State<T>>(tla_forall(split_always));
+}
+
+pub proof fn valid_stable_sm_partial_spec<T>(reconciler: Reconciler<T>)
+    ensures
+        valid(stable(sm_partial_spec(reconciler))),
+{
+    always_p_stable::<State<T>>(lift_action(next(reconciler)));
+    valid_stable_tla_forall_action_weak_fairness::<T, KubernetesAPIActionInput, ()>(kubernetes_api_next());
+    valid_stable_tla_forall_action_weak_fairness::<T, ControllerActionInput, ()>(controller_next(reconciler));
+    valid_stable_tla_forall_action_weak_fairness::<T, ObjectRef, ()>(schedule_controller_reconcile());
+    stable_and_temp::<State<T>>(always(lift_action(next(reconciler))), tla_forall(|input| kubernetes_api_next().weak_fairness(input)));
+    stable_and_temp::<State<T>>(always(lift_action(next(reconciler))).and(tla_forall(|input| kubernetes_api_next().weak_fairness(input)))
+    , tla_forall(|input| controller_next(reconciler).weak_fairness(input)));
+    stable_and_temp(always(lift_action(next(reconciler))).and(tla_forall(|input| kubernetes_api_next().weak_fairness(input))).and(tla_forall(|input| controller_next(reconciler).weak_fairness(input))), tla_forall(|input| schedule_controller_reconcile().weak_fairness(input)));
+}
+
+}

--- a/src/kubernetes_cluster/proof/mod.rs
+++ b/src/kubernetes_cluster/proof/mod.rs
@@ -1,5 +1,6 @@
 // Copyright 2022 VMware, Inc.
 // SPDX-License-Identifier: MIT
+pub mod cluster;
 pub mod controller_runtime_liveness;
 pub mod controller_runtime_safety;
 pub mod kubernetes_api_liveness;

--- a/src/kubernetes_cluster/spec/distributed_system.rs
+++ b/src/kubernetes_cluster/spec/distributed_system.rs
@@ -21,7 +21,6 @@ use crate::pervasive::{map::*, option::*, seq::*, set::*};
 use crate::state_machine::action::*;
 use crate::state_machine::state_machine::*;
 use crate::temporal_logic::defs::*;
-use crate::temporal_logic::rules::*;
 use builtin::*;
 use builtin_macros::*;
 
@@ -269,29 +268,6 @@ pub open spec fn controller_action_pre<T>(reconciler: Reconciler<T>, action: Con
         &&& host_result.is_Enabled()
         &&& network_result.is_Enabled()
     }
-}
-
-proof fn valid_stable_tla_forall_action_weak_fairness<T, Input, Output>(action: Action<State<T>, Input, Output>)
-    ensures
-        valid(stable(tla_forall(|input| action.weak_fairness(input)))),
-{
-    let split_always = |input| always(lift_state(action.pre(input))).implies(eventually(lift_action(action.forward(input))));
-    tla_forall_always_equality_variant::<State<T>, Input>(|input| action.weak_fairness(input), split_always);
-    always_p_stable::<State<T>>(tla_forall(split_always));
-}
-
-pub proof fn valid_stable_sm_partial_spec<T>(reconciler: Reconciler<T>)
-    ensures
-        valid(stable(sm_partial_spec(reconciler))),
-{
-    always_p_stable::<State<T>>(lift_action(next(reconciler)));
-    valid_stable_tla_forall_action_weak_fairness::<T, KubernetesAPIActionInput, ()>(kubernetes_api_next());
-    valid_stable_tla_forall_action_weak_fairness::<T, ControllerActionInput, ()>(controller_next(reconciler));
-    valid_stable_tla_forall_action_weak_fairness::<T, ObjectRef, ()>(schedule_controller_reconcile());
-    stable_and_temp::<State<T>>(always(lift_action(next(reconciler))), tla_forall(|input| kubernetes_api_next().weak_fairness(input)));
-    stable_and_temp::<State<T>>(always(lift_action(next(reconciler))).and(tla_forall(|input| kubernetes_api_next().weak_fairness(input)))
-    , tla_forall(|input| controller_next(reconciler).weak_fairness(input)));
-    stable_and_temp(always(lift_action(next(reconciler))).and(tla_forall(|input| kubernetes_api_next().weak_fairness(input))).and(tla_forall(|input| controller_next(reconciler).weak_fairness(input))), tla_forall(|input| schedule_controller_reconcile().weak_fairness(input)));
 }
 
 }

--- a/src/kubernetes_cluster/spec/distributed_system.rs
+++ b/src/kubernetes_cluster/spec/distributed_system.rs
@@ -21,6 +21,7 @@ use crate::pervasive::{map::*, option::*, seq::*, set::*};
 use crate::state_machine::action::*;
 use crate::state_machine::state_machine::*;
 use crate::temporal_logic::defs::*;
+use crate::temporal_logic::rules::*;
 use builtin::*;
 use builtin_macros::*;
 
@@ -268,6 +269,29 @@ pub open spec fn controller_action_pre<T>(reconciler: Reconciler<T>, action: Con
         &&& host_result.is_Enabled()
         &&& network_result.is_Enabled()
     }
+}
+
+proof fn valid_stable_tla_forall_action_weak_fairness<T, Input, Output>(action: Action<State<T>, Input, Output>)
+    ensures
+        valid(stable(tla_forall(|input| action.weak_fairness(input)))),
+{
+    let split_always = |input| always(lift_state(action.pre(input))).implies(eventually(lift_action(action.forward(input))));
+    tla_forall_always_equality_variant::<State<T>, Input>(|input| action.weak_fairness(input), split_always);
+    always_p_stable::<State<T>>(tla_forall(split_always));
+}
+
+pub proof fn valid_stable_sm_partial_spec<T>(reconciler: Reconciler<T>)
+    ensures
+        valid(stable(sm_partial_spec(reconciler))),
+{
+    always_p_stable::<State<T>>(lift_action(next(reconciler)));
+    valid_stable_tla_forall_action_weak_fairness::<T, KubernetesAPIActionInput, ()>(kubernetes_api_next());
+    valid_stable_tla_forall_action_weak_fairness::<T, ControllerActionInput, ()>(controller_next(reconciler));
+    valid_stable_tla_forall_action_weak_fairness::<T, ObjectRef, ()>(schedule_controller_reconcile());
+    stable_and_temp::<State<T>>(always(lift_action(next(reconciler))), tla_forall(|input| kubernetes_api_next().weak_fairness(input)));
+    stable_and_temp::<State<T>>(always(lift_action(next(reconciler))).and(tla_forall(|input| kubernetes_api_next().weak_fairness(input)))
+    , tla_forall(|input| controller_next(reconciler).weak_fairness(input)));
+    stable_and_temp(always(lift_action(next(reconciler))).and(tla_forall(|input| kubernetes_api_next().weak_fairness(input))).and(tla_forall(|input| controller_next(reconciler).weak_fairness(input))), tla_forall(|input| schedule_controller_reconcile().weak_fairness(input)));
 }
 
 }

--- a/src/simple_controller/proof/liveness.rs
+++ b/src/simple_controller/proof/liveness.rs
@@ -101,15 +101,6 @@ proof fn lemma_reconcile_scheduled_leads_to_cm_always_exists(cr: CustomResourceV
 }
 
 #[verifier(external_body)]
-proof fn lemma_reconcile_not_ongoing_leads_to_cm_always_exists(cr: CustomResourceView)
-    ensures
-        sm_spec(simple_reconciler()).entails(
-            lift_state(|s: State<SimpleReconcileState>| !s.reconcile_state_contains(cr.object_ref()))
-                .leads_to(always(lift_state(cm_exists(cr))))
-        ),
-{}
-
-#[verifier(external_body)]
 proof fn lemma_reconcile_ongoing_leads_to_cm_always_exists(cr: CustomResourceView)
     ensures
         sm_spec(simple_reconciler()).entails(

--- a/src/simple_controller/proof/liveness.rs
+++ b/src/simple_controller/proof/liveness.rs
@@ -6,6 +6,7 @@ use crate::kubernetes_cluster::{
     proof::{
         controller_runtime_liveness, controller_runtime_safety, kubernetes_api_liveness,
         kubernetes_api_safety,
+        cluster::*,
     },
     spec::{
         controller::common::{controller_req_msg, ControllerActionInput},

--- a/src/simple_controller/proof/liveness.rs
+++ b/src/simple_controller/proof/liveness.rs
@@ -58,6 +58,22 @@ proof fn liveness_proof(cr: CustomResourceView)
         ),
 {}
 
+proof fn lemma_cr_always_exists_leads_to_reconcile_scheduled(cr: CustomResourceView)
+    ensures
+        sm_spec(simple_reconciler()).entails(
+            always(cr_exists(cr)).leads_to(lift_state(|s: State<SimpleReconcileState>| s.reconcile_scheduled_for(cr.object_ref())))
+        ),
+{
+    let scheduled = lift_state(|s: State<SimpleReconcileState>| s.reconcile_scheduled_for(cr.object_ref()));
+    let cr_key_exists = lift_state(|s: State<SimpleReconcileState>| s.resource_key_exists(cr.object_ref()));
+    valid_stable_sm_partial_spec::<SimpleReconcileState>(simple_reconciler());
+    controller_runtime_liveness::lemma_true_leads_to_reconcile_scheduled_by_assumption::<SimpleReconcileState>(simple_reconciler(), cr.object_ref());
+    unpack_assumption_from_spec::<State<SimpleReconcileState>>(lift_state(init(simple_reconciler())), sm_partial_spec(simple_reconciler()), always(cr_key_exists), scheduled);
+    implies_preserved_by_always_temp::<State<SimpleReconcileState>>(cr_exists(cr), cr_key_exists);
+    valid_implies_implies_leads_to::<State<SimpleReconcileState>>(sm_spec(simple_reconciler()), always(cr_exists(cr)), always(cr_key_exists));
+    leads_to_trans_auto(sm_spec(simple_reconciler()));
+}
+
 #[verifier(external_body)]
 proof fn lemma_reconcile_not_ongoing_leads_to_cm_always_exists(cr: CustomResourceView)
     ensures
@@ -74,16 +90,25 @@ proof fn lemma_reconcile_ongoing_leads_to_cm_always_exists(cr: CustomResourceVie
             lift_state(|s: State<SimpleReconcileState>| s.reconcile_state_contains(cr.object_ref()))
                 .leads_to(always(lift_state(cm_exists(cr))))
         ),
-{}
+{
+    lemma_init_pc_leads_to_cm_always_exists(cr);
+    lemma_after_get_cr_pc_leads_to_cm_always_exists(cr);
+    lemma_after_create_cm_pc_leads_to_cm_always_exists(cr);
+}
 
-#[verifier(external_body)]
 proof fn lemma_init_pc_leads_to_cm_always_exists(cr: CustomResourceView)
     ensures
         sm_spec(simple_reconciler()).entails(
             lift_state(reconciler_at_init_pc(cr))
             .leads_to(always(lift_state(cm_exists(cr))))
         ),
-{}
+{
+    safety::lemma_always_reconcile_init_implies_no_pending_req(cr);
+    lemma_init_pc_leads_to_after_get_cr_pc(cr);
+    lemma_after_get_cr_pc_leads_to_cm_always_exists(cr);
+    leads_to_trans_auto::<State<SimpleReconcileState>>(sm_spec(simple_reconciler()));
+    leads_to_weaken_auto::<State<SimpleReconcileState>>(sm_spec(simple_reconciler()));
+}
 
 proof fn lemma_after_get_cr_pc_leads_to_cm_always_exists(cr: CustomResourceView)
     ensures

--- a/src/temporal_logic/rules.rs
+++ b/src/temporal_logic/rules.rs
@@ -317,6 +317,17 @@ proof fn valid_implies_to_valid_equals<T>(p: TempPred<T>, q: TempPred<T>)
     };
 }
 
+proof fn valid_p_implies_always_p<T>(p: TempPred<T>)
+    requires
+        valid(p),
+    ensures
+        valid(always(p)),
+{
+    assert forall |ex| #[trigger] always(p).satisfied_by(ex) by {
+        assert(forall |i| #[trigger] p.satisfied_by(ex.suffix(i)));
+    };
+}
+
 proof fn implies_to_leads_to<T>(spec: TempPred<T>, p: TempPred<T>, q: TempPred<T>)
     requires
         spec.entails(always(p.implies(q))),
@@ -1324,6 +1335,22 @@ pub proof fn valid_implies_trans<T>(p: TempPred<T>, q: TempPred<T>, r: TempPred<
         implies_apply::<T>(ex, p, q);
         implies_apply::<T>(ex, q, r);
     };
+}
+
+/// If p implies q for all executions, p will leads to q anyway.
+/// pre:
+///     |= p => q
+/// post:
+///     spec |= p ~> q
+/// Note: there is no constraint on spec, it can be true_pred().
+pub proof fn valid_implies_implies_leads_to<T>(spec: TempPred<T>, p: TempPred<T>, q: TempPred<T>)
+    requires
+        valid(p.implies(q)),
+    ensures
+        spec.entails(p.leads_to(q)),
+{
+    valid_p_implies_always_p(p.implies(q));
+    implies_to_leads_to(spec, p, q);
 }
 
 /// Weaken entails by implies.

--- a/src/temporal_logic/rules.rs
+++ b/src/temporal_logic/rules.rs
@@ -896,6 +896,39 @@ pub proof fn entails_and_temp<T>(spec: TempPred<T>, p: TempPred<T>, q: TempPred<
     };
 }
 
+/// An always predicate is stable.
+/// post:
+///     |= stable(always(p))
+pub proof fn always_p_stable<T>(p: TempPred<T>)
+    ensures
+        valid(stable(always(p))),
+{
+    assert forall |ex| #[trigger] always(p).satisfied_by(ex) implies always(always(p)).satisfied_by(ex) by {
+        assert forall |i| #[trigger] always(p).satisfied_by(ex.suffix(i)) by {
+            always_propagate_forwards::<T>(ex, p, i);
+        }
+    }
+}
+
+/// p and q is stable if both p and q are stable.
+/// pre:
+///     |= stable(p)
+///     |= stable(q)
+/// post:
+///     |= stable(p /\ q)
+pub proof fn stable_and_temp<T>(p: TempPred<T>, q: TempPred<T>)
+    requires
+        valid(stable(p)),
+        valid(stable(q)),
+    ensures
+        valid(stable(p.and(q))),
+{
+    assert forall |ex| #[trigger] p.and(q).satisfied_by(ex) implies always(p.and(q)).satisfied_by(ex) by {
+        stable_unfold::<T>(ex, p);
+        stable_unfold::<T>(ex, q);
+    }
+}
+
 /// Unpack the assumption from left to the right side of |=
 /// pre:
 ///     |= stable(partial_spec)


### PR DESCRIPTION
Assume that `spec |= reconcile_ongoing ~> []cr_matched`, I complete the liveness proof. If we want to make `spec |= reconcile_ongoing ~> []cr_matched` verified as well, we have to prove `spec |= reconcile_error ~> []cr_matched`, since the other three cases (`init`, `get_cr`, `create_cm`) have all been proved. But considering it may not be possible to prove `spec |= reconcile_error ~> []cr_matched` under current specifications, another proof strategy is needed.