### PR TITLE
Complete simple controller liveness proof

### DIFF
--- a/src/kubernetes_cluster/proof/controller_runtime_liveness.rs
+++ b/src/kubernetes_cluster/proof/controller_runtime_liveness.rs
@@ -178,7 +178,7 @@ pub proof fn lemma_reconcile_idle_leads_to_reconcile_idle_and_scheduled_by_assum
         cr_key.kind.is_CustomResourceKind(),
     ensures
         sm_partial_spec(reconciler).and(always(lift_state(|s: State<T>| s.resource_key_exists(cr_key)))).entails(
-            lift_state(|s: State<T>| { !s.reconcile_state_contains(cr_key)})
+            lift_state(|s: State<T>| !s.reconcile_state_contains(cr_key))
                 .leads_to(lift_state(|s: State<T>| {
                     &&& !s.reconcile_state_contains(cr_key)
                     &&& s.reconcile_scheduled_for(cr_key)})
@@ -198,11 +198,11 @@ pub proof fn lemma_reconcile_idle_leads_to_reconcile_idle_and_scheduled_by_assum
 }
 
 pub proof fn lemma_cr_always_exists_entails_reconcile_idle_leads_to_reconcile_init_and_no_pending_req<T>(reconciler: Reconciler<T>, cr_key: ObjectRef)
-requires
-    cr_key.kind.is_CustomResourceKind(),
-ensures
-    sm_partial_spec(reconciler).and(always(lift_state(|s: State<T>| s.resource_key_exists(cr_key)))).entails(
-        lift_state(|s: State<T>| {!s.reconcile_state_contains(cr_key)})
+    requires
+        cr_key.kind.is_CustomResourceKind(),
+    ensures
+        sm_partial_spec(reconciler).and(always(lift_state(|s: State<T>| s.resource_key_exists(cr_key)))).entails(
+            lift_state(|s: State<T>| {!s.reconcile_state_contains(cr_key)})
             .leads_to(lift_state(|s: State<T>| {
                 &&& s.reconcile_state_contains(cr_key)
                 &&& s.reconcile_state_of(cr_key).local_state == (reconciler.reconcile_init_state)()

--- a/src/kubernetes_cluster/proof/controller_runtime_liveness.rs
+++ b/src/kubernetes_cluster/proof/controller_runtime_liveness.rs
@@ -23,40 +23,42 @@ use builtin_macros::*;
 
 verus! {
 
-pub proof fn lemma_pre_leads_to_post_by_controller<T>(reconciler: Reconciler<T>, input: ControllerActionInput, next: ActionPred<State<T>>, action: ControllerAction<T>, pre: StatePred<State<T>>, post: StatePred<State<T>>)
+pub proof fn lemma_pre_leads_to_post_by_controller<T>(spec: TempPred<State<T>>, reconciler: Reconciler<T>, input: ControllerActionInput, next: ActionPred<State<T>>, action: ControllerAction<T>, pre: StatePred<State<T>>, post: StatePred<State<T>>)
     requires
         controller(reconciler).actions.contains(action),
         forall |s, s_prime: State<T>| pre(s) && #[trigger] next(s, s_prime) ==> pre(s_prime) || post(s_prime),
         forall |s, s_prime: State<T>| pre(s) && #[trigger] next(s, s_prime) && controller_next(reconciler).forward(input)(s, s_prime) ==> post(s_prime),
         forall |s: State<T>| #[trigger] pre(s) ==> controller_action_pre(reconciler, action, input)(s),
-        sm_spec(reconciler).entails(always(lift_action(next))),
+        spec.entails(always(lift_action(next))),
+        spec.entails(tla_forall(|i| controller_next(reconciler).weak_fairness(i))),
     ensures
-        sm_spec(reconciler).entails(lift_state(pre).leads_to(lift_state(post))),
+        spec.entails(lift_state(pre).leads_to(lift_state(post))),
 {
-    use_tla_forall::<State<T>, ControllerActionInput>(sm_spec(reconciler), |i| controller_next(reconciler).weak_fairness(i), input);
+    use_tla_forall::<State<T>, ControllerActionInput>(spec, |i| controller_next(reconciler).weak_fairness(i), input);
 
     controller_action_pre_implies_next_pre::<T>(reconciler, action, input);
     valid_implies_trans::<State<T>>(lift_state(pre), lift_state(controller_action_pre(reconciler, action, input)), lift_state(controller_next(reconciler).pre(input)));
 
-    controller_next(reconciler).wf1(input, sm_spec(reconciler), next, pre, post);
+    controller_next(reconciler).wf1(input, spec, next, pre, post);
 }
 
-pub proof fn lemma_pre_leads_to_post_with_assumption_by_controller<T>(reconciler: Reconciler<T>, input: ControllerActionInput, next: ActionPred<State<T>>, action: ControllerAction<T>, assumption: StatePred<State<T>>, pre: StatePred<State<T>>, post: StatePred<State<T>>)
+pub proof fn lemma_pre_leads_to_post_with_assumption_by_controller<T>(spec: TempPred<State<T>>, reconciler: Reconciler<T>, input: ControllerActionInput, next: ActionPred<State<T>>, action: ControllerAction<T>, assumption: StatePred<State<T>>, pre: StatePred<State<T>>, post: StatePred<State<T>>)
     requires
         controller(reconciler).actions.contains(action),
         forall |s, s_prime: State<T>| pre(s) && #[trigger] next(s, s_prime) && assumption(s) ==> pre(s_prime) || post(s_prime),
         forall |s, s_prime: State<T>| pre(s) && #[trigger] next(s, s_prime) && controller_next(reconciler).forward(input)(s, s_prime) ==> post(s_prime),
         forall |s: State<T>| #[trigger] pre(s) ==> controller_action_pre(reconciler, action, input)(s),
-        sm_spec(reconciler).entails(always(lift_action(next))),
+        spec.entails(always(lift_action(next))),
+        spec.entails(tla_forall(|i| controller_next(reconciler).weak_fairness(i))),
     ensures
-        sm_spec(reconciler).entails(lift_state(pre).and(always(lift_state(assumption))).leads_to(lift_state(post))),
+        spec.entails(lift_state(pre).and(always(lift_state(assumption))).leads_to(lift_state(post))),
 {
-    use_tla_forall::<State<T>, ControllerActionInput>(sm_spec(reconciler), |i| controller_next(reconciler).weak_fairness(i), input);
+    use_tla_forall::<State<T>, ControllerActionInput>(spec, |i| controller_next(reconciler).weak_fairness(i), input);
 
     controller_action_pre_implies_next_pre::<T>(reconciler, action, input);
     valid_implies_trans::<State<T>>(lift_state(pre), lift_state(controller_action_pre(reconciler, action, input)), lift_state(controller_next(reconciler).pre(input)));
 
-    controller_next(reconciler).wf1_assume(input, sm_spec(reconciler), next, assumption, pre, post);
+    controller_next(reconciler).wf1_assume(input, spec, next, assumption, pre, post);
 }
 
 pub proof fn lemma_reconcile_done_leads_to_reconcile_idle<T>(reconciler: Reconciler<T>, cr_key: ObjectRef)
@@ -84,14 +86,14 @@ pub proof fn lemma_reconcile_done_leads_to_reconcile_idle<T>(reconciler: Reconci
         recv: Option::None,
         scheduled_cr_key: Option::Some(cr_key),
     };
-    lemma_pre_leads_to_post_by_controller::<T>(reconciler, input, next(reconciler), end_reconcile(reconciler), pre, post);
+    lemma_pre_leads_to_post_by_controller::<T>(sm_spec(reconciler), reconciler, input, next(reconciler), end_reconcile(reconciler), pre, post);
 }
 
 pub proof fn lemma_reconcile_error_leads_to_reconcile_idle<T>(reconciler: Reconciler<T>, cr_key: ObjectRef)
     requires
         cr_key.kind.is_CustomResourceKind(),
     ensures
-        sm_spec(reconciler).entails(
+        sm_partial_spec(reconciler).entails(
             lift_state(|s: State<T>| {
                 &&& s.reconcile_state_contains(cr_key)
                 &&& (reconciler.reconcile_error)(s.reconcile_state_of(cr_key).local_state)
@@ -112,14 +114,16 @@ pub proof fn lemma_reconcile_error_leads_to_reconcile_idle<T>(reconciler: Reconc
         recv: Option::None,
         scheduled_cr_key: Option::Some(cr_key),
     };
-    lemma_pre_leads_to_post_by_controller::<T>(reconciler, input, next(reconciler), end_reconcile(reconciler), pre, post);
+    lemma_pre_leads_to_post_by_controller::<T>(sm_partial_spec(reconciler), reconciler, input, next(reconciler), end_reconcile(reconciler), pre, post);
 }
 
-pub proof fn lemma_reconcile_idle_and_scheduled_leads_to_reconcile_init<T>(reconciler: Reconciler<T>, cr_key: ObjectRef)
+pub proof fn lemma_reconcile_idle_and_scheduled_leads_to_reconcile_init<T>(spec: TempPred<State<T>>, reconciler: Reconciler<T>, cr_key: ObjectRef)
     requires
         cr_key.kind.is_CustomResourceKind(),
+        spec.entails(always(lift_action(next(reconciler)))),
+        spec.entails(tla_forall(|i| controller_next(reconciler).weak_fairness(i))),
     ensures
-        sm_spec(reconciler).entails(
+        spec.entails(
             lift_state(|s: State<T>| {
                 &&& !s.reconcile_state_contains(cr_key)
                 &&& s.reconcile_scheduled_for(cr_key)
@@ -144,7 +148,7 @@ pub proof fn lemma_reconcile_idle_and_scheduled_leads_to_reconcile_init<T>(recon
         recv: Option::None,
         scheduled_cr_key: Option::Some(cr_key),
     };
-    lemma_pre_leads_to_post_by_controller::<T>(reconciler, input, next(reconciler), run_scheduled_reconcile(reconciler), pre, post);
+    lemma_pre_leads_to_post_by_controller::<T>(spec, reconciler, input, next(reconciler), run_scheduled_reconcile(reconciler), pre, post);
 }
 
 pub proof fn lemma_true_leads_to_reconcile_scheduled_by_assumption<T>(reconciler: Reconciler<T>, cr_key: ObjectRef)
@@ -167,6 +171,100 @@ pub proof fn lemma_true_leads_to_reconcile_scheduled_by_assumption<T>(reconciler
     temp_pred_equality::<State<T>>(lift_state(cr_key_exists), lift_state(schedule_controller_reconcile().pre(cr_key)));
     use_tla_forall::<State<T>, ObjectRef>(spec, |key| schedule_controller_reconcile().weak_fairness(key), cr_key);
     schedule_controller_reconcile().wf1(cr_key, spec, next_and_cr_exists, pre, post);
+}
+
+pub proof fn lemma_reconcile_idle_leads_to_reconcile_idle_and_scheduled_by_assumption<T>(reconciler: Reconciler<T>, cr_key: ObjectRef)
+    requires
+        cr_key.kind.is_CustomResourceKind(),
+    ensures
+        sm_partial_spec(reconciler).and(always(lift_state(|s: State<T>| s.resource_key_exists(cr_key)))).entails(
+            lift_state(|s: State<T>| { !s.reconcile_state_contains(cr_key)})
+                .leads_to(lift_state(|s: State<T>| {
+                    &&& !s.reconcile_state_contains(cr_key)
+                    &&& s.reconcile_scheduled_for(cr_key)})
+            ),
+        )
+{
+    let spec = sm_partial_spec(reconciler).and(always(lift_state(|s: State<T>| s.resource_key_exists(cr_key))));
+    let reconcile_idle = lift_state(|s: State<T>| { !s.reconcile_state_contains(cr_key) });
+    let reconcile_scheduled = lift_state(|s: State<T>| { s.reconcile_scheduled_for(cr_key) });
+    valid_implies_implies_leads_to(spec, reconcile_idle, true_pred());
+    lemma_true_leads_to_reconcile_scheduled_by_assumption::<T>(reconciler, cr_key);
+    leads_to_trans_temp(spec, reconcile_idle, true_pred(), reconcile_scheduled);
+    leads_to_confluence_self_temp::<State<T>>(spec, lift_action(next(reconciler)), reconcile_idle, reconcile_scheduled);
+    temp_pred_equality::<State<T>>(reconcile_idle.and(reconcile_scheduled), lift_state(|s: State<T>| {
+        &&& !s.reconcile_state_contains(cr_key)
+        &&& s.reconcile_scheduled_for(cr_key)}));
+}
+
+pub proof fn lemma_cr_always_exists_entails_reconcile_idle_leads_to_reconcile_init_and_no_pending_req<T>(reconciler: Reconciler<T>, cr_key: ObjectRef)
+requires
+    cr_key.kind.is_CustomResourceKind(),
+ensures
+    sm_partial_spec(reconciler).and(always(lift_state(|s: State<T>| s.resource_key_exists(cr_key)))).entails(
+        lift_state(|s: State<T>| {!s.reconcile_state_contains(cr_key)})
+            .leads_to(lift_state(|s: State<T>| {
+                &&& s.reconcile_state_contains(cr_key)
+                &&& s.reconcile_state_of(cr_key).local_state == (reconciler.reconcile_init_state)()
+                &&& s.reconcile_state_of(cr_key).pending_req_msg.is_None()
+            }))
+    ),
+{
+    lemma_reconcile_idle_leads_to_reconcile_idle_and_scheduled_by_assumption::<T>(reconciler, cr_key);
+    lemma_reconcile_idle_and_scheduled_leads_to_reconcile_init::<T>(sm_partial_spec(reconciler), reconciler, cr_key);
+    strengthen_spec::<State<T>>(sm_partial_spec(reconciler), always(lift_state(|s: State<T>| s.resource_key_exists(cr_key))), 
+        lift_state(|s: State<T>| {
+            &&& !s.reconcile_state_contains(cr_key)
+            &&& s.reconcile_scheduled_for(cr_key)
+        })
+        .leads_to(lift_state(|s: State<T>| {
+            &&& s.reconcile_state_contains(cr_key)
+            &&& s.reconcile_state_of(cr_key).local_state == (reconciler.reconcile_init_state)()
+            &&& s.reconcile_state_of(cr_key).pending_req_msg.is_None()
+        })));
+
+    leads_to_trans_auto::<State<T>>(sm_partial_spec(reconciler).and(always(lift_state(|s: State<T>| s.resource_key_exists(cr_key)))));
+}
+
+
+pub proof fn lemma_cr_always_exists_entails_reconcile_error_leads_to_reconcile_init_and_no_pending_req<T>(reconciler: Reconciler<T>, cr_key: ObjectRef)
+    requires
+        cr_key.kind.is_CustomResourceKind(),
+    ensures
+        sm_partial_spec(reconciler).and(always(lift_state(|s: State<T>| s.resource_key_exists(cr_key)))).entails(
+            lift_state(|s: State<T>| {
+                &&& s.reconcile_state_contains(cr_key)
+                &&& (reconciler.reconcile_error)(s.reconcile_state_of(cr_key).local_state)
+            })
+                .leads_to(lift_state(|s: State<T>| {
+                    &&& s.reconcile_state_contains(cr_key)
+                    &&& s.reconcile_state_of(cr_key).local_state == (reconciler.reconcile_init_state)()
+                    &&& s.reconcile_state_of(cr_key).pending_req_msg.is_None()
+                }))
+        ),
+{
+    lemma_reconcile_error_leads_to_reconcile_idle::<T>(reconciler, cr_key);
+    strengthen_spec::<State<T>>(sm_partial_spec(reconciler), always(lift_state(|s: State<T>| s.resource_key_exists(cr_key))), lift_state(|s: State<T>| {
+        &&& s.reconcile_state_contains(cr_key)
+        &&& (reconciler.reconcile_error)(s.reconcile_state_of(cr_key).local_state)
+    })
+        .leads_to(lift_state(|s: State<T>| {
+            &&& !s.reconcile_state_contains(cr_key)
+        })));
+    lemma_reconcile_idle_leads_to_reconcile_idle_and_scheduled_by_assumption::<T>(reconciler, cr_key);
+    lemma_reconcile_idle_and_scheduled_leads_to_reconcile_init::<T>(sm_partial_spec(reconciler), reconciler, cr_key);
+    strengthen_spec::<State<T>>(sm_partial_spec(reconciler), always(lift_state(|s: State<T>| s.resource_key_exists(cr_key))), 
+    lift_state(|s: State<T>| {
+        &&& !s.reconcile_state_contains(cr_key)
+        &&& s.reconcile_scheduled_for(cr_key)
+        })
+        .leads_to(lift_state(|s: State<T>| {
+            &&& s.reconcile_state_contains(cr_key)
+            &&& s.reconcile_state_of(cr_key).local_state == (reconciler.reconcile_init_state)()
+            &&& s.reconcile_state_of(cr_key).pending_req_msg.is_None()
+        })));
+    
+    leads_to_trans_auto::<State<T>>(sm_partial_spec(reconciler).and(always(lift_state(|s: State<T>| s.resource_key_exists(cr_key)))));
 }
 
 }

--- a/src/kubernetes_cluster/proof/controller_runtime_safety.rs
+++ b/src/kubernetes_cluster/proof/controller_runtime_safety.rs
@@ -105,12 +105,11 @@ pub proof fn lemma_always_forall_resp_matches_at_most_one_pending_req<T>(reconci
     ensures
         sm_spec(reconciler).entails(tla_forall(|msg| always(lift_state(resp_matches_at_most_one_pending_req(msg, cr_key))))),
 {
-    assert forall |ex| #[trigger] sm_spec(reconciler).satisfied_by(ex) implies tla_forall(|msg| always(lift_state(resp_matches_at_most_one_pending_req(msg, cr_key)))).satisfied_by(ex) by {
-        assert forall |msg| #[trigger] always(lift_state(resp_matches_at_most_one_pending_req(msg, cr_key))).satisfied_by(ex) by {
-            lemma_always_resp_matches_at_most_one_pending_req::<T>(reconciler, msg, cr_key);
-            entails_apply::<State<T>>(ex, sm_spec(reconciler), always(lift_state(resp_matches_at_most_one_pending_req(msg, cr_key))));
-        }
+    let m_to_p = |msg| always(lift_state(resp_matches_at_most_one_pending_req(msg, cr_key)));
+    assert forall |msg| #[trigger] sm_spec(reconciler).entails(m_to_p(msg)) by {
+        lemma_always_resp_matches_at_most_one_pending_req::<T>(reconciler, msg, cr_key);
     };
+    spec_entails_tla_forall(sm_spec(reconciler), m_to_p);
 }
 
 pub open spec fn each_resp_matches_at_most_one_pending_req<T>(cr_key: ObjectRef) -> StatePred<State<T>>

--- a/src/simple_controller/proof/liveness.rs
+++ b/src/simple_controller/proof/liveness.rs
@@ -18,7 +18,7 @@ use crate::kubernetes_cluster::{
 };
 use crate::pervasive::*;
 use crate::pervasive::{option::*, result::*};
-use crate::simple_controller::proof::safety;
+use crate::simple_controller::proof::safety::*;
 use crate::simple_controller::proof::shared::*;
 use crate::simple_controller::spec::{
     simple_reconciler,
@@ -38,6 +38,15 @@ spec fn cr_matched(cr: CustomResourceView) -> TempPred<State<SimpleReconcileStat
     lift_state(|s: State<SimpleReconcileState>| s.resource_key_exists(simple_reconciler::subresource_configmap(cr.object_ref()).object_ref()))
 }
 
+spec fn partial_spec_with_invariants_and_cr_always_exists(cr: CustomResourceView) -> TempPred<State<SimpleReconcileState>>{
+    sm_partial_spec(simple_reconciler())
+    .and(always(lift_state(reconcile_create_cm_done_implies_pending_create_cm_req_in_flight_or_cm_exists(cr))))
+    .and(tla_forall(|msg| always(lift_state(controller_runtime_safety::resp_matches_at_most_one_pending_req(msg, cr.object_ref())))))
+    .and(always(lift_state(reconcile_get_cr_done_implies_pending_req_in_flight_or_resp_in_flight(cr))))
+    .and(always(lift_state(reconciler_at_init_pc(cr)).implies(lift_state(reconcile_init_pc_and_no_pending_req(cr)))))
+    .and(always(cr_exists(cr)))
+} 
+
 spec fn liveness(cr: CustomResourceView) -> TempPred<State<SimpleReconcileState>> {
     always(cr_exists(cr)).leads_to(always(cr_matched(cr)))
 }
@@ -51,93 +60,203 @@ proof fn liveness_proof_forall_cr()
     };
 }
 
+// TODO: Write a spec to hold the variants
+
 proof fn liveness_proof(cr: CustomResourceView)
     ensures
         sm_spec(simple_reconciler()).entails(
             always(cr_exists(cr)).leads_to(always(cr_matched(cr)))
         ),
 {
-    lemma_cr_always_exists_leads_to_reconcile_scheduled(cr);
-    lemma_reconcile_scheduled_leads_to_cm_always_exists(cr);
-    leads_to_trans_temp(sm_spec(simple_reconciler()), always(cr_exists(cr)), lift_state(|s: State<SimpleReconcileState>| s.reconcile_scheduled_for(cr.object_ref())), always(cr_matched(cr)));
+    lemma_valid_stable_sm_partial_spec_and_invariants(cr);
+    lemma_true_leads_to_cm_exists_with_invariant(cr);
+
+    temp_pred_equality::<State<SimpleReconcileState>>(lift_state(init(simple_reconciler())).and(sm_partial_spec(simple_reconciler()).and(always(lift_state(reconcile_create_cm_done_implies_pending_create_cm_req_in_flight_or_cm_exists(cr)))).and(tla_forall(|msg| always(lift_state(controller_runtime_safety::resp_matches_at_most_one_pending_req(msg, cr.object_ref()))))).and(always(lift_state(reconcile_get_cr_done_implies_pending_req_in_flight_or_resp_in_flight(cr)))).and(always(lift_state(reconciler_at_init_pc(cr)).implies(lift_state(reconcile_init_pc_and_no_pending_req(cr)))))), sm_spec(simple_reconciler()).and(always(lift_state(reconcile_create_cm_done_implies_pending_create_cm_req_in_flight_or_cm_exists(cr))).and(tla_forall(|msg| always(lift_state(controller_runtime_safety::resp_matches_at_most_one_pending_req(msg, cr.object_ref()))))).and(always(lift_state(reconcile_get_cr_done_implies_pending_req_in_flight_or_resp_in_flight(cr)))).and(always(lift_state(reconciler_at_init_pc(cr)).implies(lift_state(reconcile_init_pc_and_no_pending_req(cr)))))));
+
+    unpack_assumption_from_spec::<State<SimpleReconcileState>>(lift_state(init(simple_reconciler())), sm_partial_spec(simple_reconciler()).and(always(lift_state(reconcile_create_cm_done_implies_pending_create_cm_req_in_flight_or_cm_exists(cr)))).and(tla_forall(|msg| always(lift_state(controller_runtime_safety::resp_matches_at_most_one_pending_req(msg, cr.object_ref()))))).and(always(lift_state(reconcile_get_cr_done_implies_pending_req_in_flight_or_resp_in_flight(cr)))).and(always(lift_state(reconciler_at_init_pc(cr)).implies(lift_state(reconcile_init_pc_and_no_pending_req(cr))))), always(cr_exists(cr)), lift_state(cm_exists(cr)));
+
+    assert(sm_spec(simple_reconciler()).and(always(lift_state(reconcile_create_cm_done_implies_pending_create_cm_req_in_flight_or_cm_exists(cr))).and(tla_forall(|msg| always(lift_state(controller_runtime_safety::resp_matches_at_most_one_pending_req(msg, cr.object_ref()))))).and(always(lift_state(reconcile_get_cr_done_implies_pending_req_in_flight_or_resp_in_flight(cr)))).and(always(lift_state(reconciler_at_init_pc(cr)).implies(lift_state(reconcile_init_pc_and_no_pending_req(cr)))))).entails(always(cr_exists(cr)).leads_to(lift_state(cm_exists(cr)))));
+
+    lemma_sm_spec_entails_all_invariants(cr);
+
+    minimize_spec::<State<SimpleReconcileState>>(sm_spec(simple_reconciler()), always(lift_state(reconcile_create_cm_done_implies_pending_create_cm_req_in_flight_or_cm_exists(cr))).and(tla_forall(|msg| always(lift_state(controller_runtime_safety::resp_matches_at_most_one_pending_req(msg, cr.object_ref()))))).and(always(lift_state(reconcile_get_cr_done_implies_pending_req_in_flight_or_resp_in_flight(cr)))).and(always(lift_state(reconciler_at_init_pc(cr)).implies(lift_state(reconcile_init_pc_and_no_pending_req(cr))))), always(cr_exists(cr)).leads_to(lift_state(cm_exists(cr))));
+
+    lemma_p_leads_to_cm_always_exists(cr, always(cr_exists(cr)));
+
 }
 
-proof fn lemma_cr_always_exists_leads_to_reconcile_scheduled(cr: CustomResourceView)
+proof fn lemma_sm_spec_entails_all_invariants(cr: CustomResourceView)
     ensures
         sm_spec(simple_reconciler()).entails(
-            always(cr_exists(cr)).leads_to(lift_state(|s: State<SimpleReconcileState>| s.reconcile_scheduled_for(cr.object_ref())))
-        ),
+            always(lift_state(reconcile_create_cm_done_implies_pending_create_cm_req_in_flight_or_cm_exists(cr)))
+            .and(tla_forall(|msg| always(lift_state(controller_runtime_safety::resp_matches_at_most_one_pending_req(msg, cr.object_ref())))))
+            .and(always(lift_state(reconcile_get_cr_done_implies_pending_req_in_flight_or_resp_in_flight(cr))))
+            .and(always(lift_state(reconciler_at_init_pc(cr)).implies(lift_state(reconcile_init_pc_and_no_pending_req(cr))))))
 {
-    let scheduled = lift_state(|s: State<SimpleReconcileState>| s.reconcile_scheduled_for(cr.object_ref()));
-    let cr_key_exists = lift_state(|s: State<SimpleReconcileState>| s.resource_key_exists(cr.object_ref()));
+    lemma_always_reconcile_create_cm_done_implies_pending_create_cm_req_in_flight_or_cm_exists(cr);
+    controller_runtime_safety::lemma_always_forall_resp_matches_at_most_one_pending_req(simple_reconciler(), cr.object_ref());
+    lemma_always_reconcile_get_cr_done_implies_pending_req_in_flight_or_resp_in_flight(cr);
+    lemma_always_reconcile_init_pc_and_no_pending_req(cr);
+
+    entails_and_temp::<State<SimpleReconcileState>>(sm_spec(simple_reconciler()), always(lift_state(reconcile_create_cm_done_implies_pending_create_cm_req_in_flight_or_cm_exists(cr))), tla_forall(|msg| always(lift_state(controller_runtime_safety::resp_matches_at_most_one_pending_req(msg, cr.object_ref())))));
+
+    entails_and_temp::<State<SimpleReconcileState>>(sm_spec(simple_reconciler()), always(lift_state(reconcile_create_cm_done_implies_pending_create_cm_req_in_flight_or_cm_exists(cr))).and(tla_forall(|msg| always(lift_state(controller_runtime_safety::resp_matches_at_most_one_pending_req(msg, cr.object_ref()))))), always(lift_state(reconcile_get_cr_done_implies_pending_req_in_flight_or_resp_in_flight(cr))));
+
+    entails_and_temp::<State<SimpleReconcileState>>(sm_spec(simple_reconciler()), always(lift_state(reconcile_create_cm_done_implies_pending_create_cm_req_in_flight_or_cm_exists(cr))).and(tla_forall(|msg| always(lift_state(controller_runtime_safety::resp_matches_at_most_one_pending_req(msg, cr.object_ref()))))).and(always(lift_state(reconcile_get_cr_done_implies_pending_req_in_flight_or_resp_in_flight(cr)))), always(lift_state(reconciler_at_init_pc(cr)).implies(lift_state(reconcile_init_pc_and_no_pending_req(cr)))));
+}
+
+proof fn lemma_valid_stable_sm_partial_spec_and_invariants(cr: CustomResourceView)
+    ensures
+        valid(stable(sm_partial_spec(simple_reconciler()).and(always(lift_state(reconcile_create_cm_done_implies_pending_create_cm_req_in_flight_or_cm_exists(cr)))).and(tla_forall(|msg| always(lift_state(controller_runtime_safety::resp_matches_at_most_one_pending_req(msg, cr.object_ref()))))).and(always(lift_state(reconcile_get_cr_done_implies_pending_req_in_flight_or_resp_in_flight(cr)))).and(always(lift_state(reconciler_at_init_pc(cr)).implies(lift_state(reconcile_init_pc_and_no_pending_req(cr))))))),
+{
     valid_stable_sm_partial_spec::<SimpleReconcileState>(simple_reconciler());
-    controller_runtime_liveness::lemma_true_leads_to_reconcile_scheduled_by_assumption::<SimpleReconcileState>(simple_reconciler(), cr.object_ref());
-    unpack_assumption_from_spec::<State<SimpleReconcileState>>(lift_state(init(simple_reconciler())), sm_partial_spec(simple_reconciler()), always(cr_key_exists), scheduled);
-    implies_preserved_by_always_temp::<State<SimpleReconcileState>>(cr_exists(cr), cr_key_exists);
-    valid_implies_implies_leads_to::<State<SimpleReconcileState>>(sm_spec(simple_reconciler()), always(cr_exists(cr)), always(cr_key_exists));
-    leads_to_trans_auto(sm_spec(simple_reconciler()));
+
+    always_p_stable::<State<SimpleReconcileState>>(lift_state(reconcile_create_cm_done_implies_pending_create_cm_req_in_flight_or_cm_exists(cr)));
+    always_p_stable::<State<SimpleReconcileState>>(lift_state(reconcile_get_cr_done_implies_pending_req_in_flight_or_resp_in_flight(cr)));
+    always_p_stable::<State<SimpleReconcileState>>(tla_forall(|msg| lift_state(controller_runtime_safety::resp_matches_at_most_one_pending_req(msg, cr.object_ref()))));
+    always_p_stable::<State<SimpleReconcileState>>(lift_state(reconciler_at_init_pc(cr)).implies(lift_state(reconcile_init_pc_and_no_pending_req(cr))));
+
+    stable_and_temp::<State<SimpleReconcileState>>(sm_partial_spec(simple_reconciler()), always(lift_state(reconcile_create_cm_done_implies_pending_create_cm_req_in_flight_or_cm_exists(cr))));
+    stable_and_temp::<State<SimpleReconcileState>>(sm_partial_spec(simple_reconciler()).and(always(lift_state(reconcile_create_cm_done_implies_pending_create_cm_req_in_flight_or_cm_exists(cr)))), always(tla_forall(|msg| lift_state(controller_runtime_safety::resp_matches_at_most_one_pending_req(msg, cr.object_ref())))));
+    stable_and_temp::<State<SimpleReconcileState>>(sm_partial_spec(simple_reconciler()).and(always(lift_state(reconcile_create_cm_done_implies_pending_create_cm_req_in_flight_or_cm_exists(cr)))).and(always(tla_forall(|msg| lift_state(controller_runtime_safety::resp_matches_at_most_one_pending_req(msg, cr.object_ref()))))), always(lift_state(reconcile_get_cr_done_implies_pending_req_in_flight_or_resp_in_flight(cr))));
+    stable_and_temp::<State<SimpleReconcileState>>(sm_partial_spec(simple_reconciler()).and(always(lift_state(reconcile_create_cm_done_implies_pending_create_cm_req_in_flight_or_cm_exists(cr)))).and(always(tla_forall(|msg| lift_state(controller_runtime_safety::resp_matches_at_most_one_pending_req(msg, cr.object_ref()))))).and(always(lift_state(reconcile_get_cr_done_implies_pending_req_in_flight_or_resp_in_flight(cr)))), always(lift_state(reconciler_at_init_pc(cr)).implies(lift_state(reconcile_init_pc_and_no_pending_req(cr)))));
+
+    let a_to_p = |msg| lift_state(controller_runtime_safety::resp_matches_at_most_one_pending_req::<SimpleReconcileState>(msg, cr.object_ref()));
+    let a_to_always = |msg| always(lift_state(controller_runtime_safety::resp_matches_at_most_one_pending_req::<SimpleReconcileState>(msg, cr.object_ref())));
+    tla_forall_always_equality_variant::<State<SimpleReconcileState>, Message>(a_to_always, a_to_p);
 }
 
-proof fn lemma_reconcile_scheduled_leads_to_cm_always_exists(cr: CustomResourceView)
+proof fn lemma_true_leads_to_cm_exists_with_invariant(cr: CustomResourceView)
     ensures
-        sm_spec(simple_reconciler()).entails(
-            lift_state(|s: State<SimpleReconcileState>| s.reconcile_scheduled_for(cr.object_ref())).leads_to(always(lift_state(cm_exists(cr))))
+        partial_spec_with_invariants_and_cr_always_exists(cr).entails(
+            true_pred::<State<SimpleReconcileState>>().leads_to(lift_state(cm_exists(cr)))
         ),
 {
-    lemma_reconcile_idle_and_scheduled_leads_to_cm_always_exists(cr);
-    let reconcile_idle_and_scheduled = lift_state(|s: State<SimpleReconcileState>| {
-        &&& !s.reconcile_state_contains(cr.object_ref())
-        &&& s.reconcile_scheduled_for(cr.object_ref())
-    });
-    let reconcile_ongoing_and_scheduled = lift_state(|s: State<SimpleReconcileState>| {
+    lemma_reconcile_idle_leads_to_cm_exists_with_invariant(cr);
+    lemma_reconcile_ongoing_leads_to_cm_exists_with_invariant(cr);
+
+    temp_pred_equality::<State<SimpleReconcileState>>(true_pred::<State<SimpleReconcileState>>(), lift_state(|s: State<SimpleReconcileState>| s.reconcile_state_contains(cr.object_ref())).or(lift_state(|s: State<SimpleReconcileState>| !s.reconcile_state_contains(cr.object_ref()))));
+
+    or_leads_to_combine_temp(sm_partial_spec(simple_reconciler()).and(always(lift_state(reconcile_create_cm_done_implies_pending_create_cm_req_in_flight_or_cm_exists(cr)))).and(tla_forall(|msg| always(lift_state(controller_runtime_safety::resp_matches_at_most_one_pending_req(msg, cr.object_ref()))))).and(always(lift_state(reconcile_get_cr_done_implies_pending_req_in_flight_or_resp_in_flight(cr)))).and(always(lift_state(reconciler_at_init_pc(cr)).implies(lift_state(reconcile_init_pc_and_no_pending_req(cr))))).and(always(cr_exists(cr))), lift_state(|s: State<SimpleReconcileState>| s.reconcile_state_contains(cr.object_ref())), lift_state(|s: State<SimpleReconcileState>| !s.reconcile_state_contains(cr.object_ref())), lift_state(cm_exists(cr)));
+}
+
+proof fn lemma_reconcile_idle_leads_to_cm_exists_with_invariant(cr: CustomResourceView)
+    ensures
+        partial_spec_with_invariants_and_cr_always_exists(cr).entails(
+        lift_state(|s: State<SimpleReconcileState>| !s.reconcile_state_contains(cr.object_ref()))
+            .leads_to(lift_state(cm_exists(cr)))
+        ),
+{
+    controller_runtime_liveness::lemma_cr_always_exists_entails_reconcile_idle_leads_to_reconcile_init_and_no_pending_req::<SimpleReconcileState>(simple_reconciler(), cr.object_ref());
+
+    temp_pred_equality::<State<SimpleReconcileState>>(lift_state(reconcile_init_pc_and_no_pending_req(cr)), lift_state(|s: State<SimpleReconcileState>| {
         &&& s.reconcile_state_contains(cr.object_ref())
-        &&& s.reconcile_scheduled_for(cr.object_ref())
-    });
-    valid_implies_implies_leads_to(sm_spec(simple_reconciler()), reconcile_ongoing_and_scheduled, lift_state(|s: State<SimpleReconcileState>| s.reconcile_state_contains(cr.object_ref())));
-    lemma_reconcile_ongoing_leads_to_cm_always_exists(cr);
-    leads_to_trans_temp(sm_spec(simple_reconciler()), reconcile_ongoing_and_scheduled, lift_state(|s: State<SimpleReconcileState>| s.reconcile_state_contains(cr.object_ref())), always(lift_state(cm_exists(cr))));
-    temp_pred_equality(reconcile_idle_and_scheduled.or(reconcile_ongoing_and_scheduled), lift_state(|s: State<SimpleReconcileState>| s.reconcile_scheduled_for(cr.object_ref())));
-    or_leads_to_combine_temp(sm_spec(simple_reconciler()), reconcile_idle_and_scheduled, reconcile_ongoing_and_scheduled, always(lift_state(cm_exists(cr))));
+        &&& s.reconcile_state_of(cr.object_ref()).local_state == (simple_reconciler().reconcile_init_state)()
+        &&& s.reconcile_state_of(cr.object_ref()).pending_req_msg.is_None()
+    }));
+    
+    assert(sm_partial_spec(simple_reconciler()).and(always(lift_state(|s: State<SimpleReconcileState>| s.resource_key_exists(cr.object_ref())))).entails(lift_state(|s: State<SimpleReconcileState>| {!s.reconcile_state_contains(cr.object_ref())}).leads_to(lift_state(reconcile_init_pc_and_no_pending_req(cr)))));
+
+    implies_preserved_by_always_temp::<State<SimpleReconcileState>>(cr_exists(cr), lift_state(|s: State<SimpleReconcileState>| s.resource_key_exists(cr.object_ref())));
+    assert(valid(always(cr_exists(cr)).implies(always(lift_state(|s: State<SimpleReconcileState>| s.resource_key_exists(cr.object_ref()))))));
+
+    partially_strengthen_spec::<State<SimpleReconcileState>>(sm_partial_spec(simple_reconciler()), always(cr_exists(cr)), always(lift_state(|s: State<SimpleReconcileState>| s.resource_key_exists(cr.object_ref()))), lift_state(|s: State<SimpleReconcileState>| {!s.reconcile_state_contains(cr.object_ref())}).leads_to(lift_state(reconcile_init_pc_and_no_pending_req(cr))));
+
+    strengthen_spec::<State<SimpleReconcileState>>(sm_partial_spec(simple_reconciler()).and(always(cr_exists(cr))), always(lift_state(reconcile_create_cm_done_implies_pending_create_cm_req_in_flight_or_cm_exists(cr))).and(tla_forall(|msg| always(lift_state(controller_runtime_safety::resp_matches_at_most_one_pending_req(msg, cr.object_ref()))))).and(always(lift_state(reconcile_get_cr_done_implies_pending_req_in_flight_or_resp_in_flight(cr)))).and(always(lift_state(reconciler_at_init_pc(cr)).implies(lift_state(reconcile_init_pc_and_no_pending_req(cr))))), lift_state(|s: State<SimpleReconcileState>| {!s.reconcile_state_contains(cr.object_ref())}).leads_to(lift_state(reconcile_init_pc_and_no_pending_req(cr))));
+
+    temp_pred_equality::<State<SimpleReconcileState>>(partial_spec_with_invariants_and_cr_always_exists(cr), sm_partial_spec(simple_reconciler()).and(always(cr_exists(cr))).and(always(lift_state(reconcile_create_cm_done_implies_pending_create_cm_req_in_flight_or_cm_exists(cr))).and(tla_forall(|msg| always(lift_state(controller_runtime_safety::resp_matches_at_most_one_pending_req(msg, cr.object_ref()))))).and(always(lift_state(reconcile_get_cr_done_implies_pending_req_in_flight_or_resp_in_flight(cr)))).and(always(lift_state(reconciler_at_init_pc(cr)).implies(lift_state(reconcile_init_pc_and_no_pending_req(cr)))))));
+
+    lemma_init_pc_and_no_pending_req_leads_to_cm_exists_with_invariant(cr);
+    leads_to_trans::<State<SimpleReconcileState>>(partial_spec_with_invariants_and_cr_always_exists(cr), |s: State<SimpleReconcileState>| {!s.reconcile_state_contains(cr.object_ref())}, reconcile_init_pc_and_no_pending_req(cr), cm_exists(cr));
 }
 
-#[verifier(external_body)]
-proof fn lemma_reconcile_ongoing_leads_to_cm_always_exists(cr: CustomResourceView)
+proof fn lemma_reconcile_ongoing_leads_to_cm_exists_with_invariant(cr: CustomResourceView)
     ensures
-        sm_spec(simple_reconciler()).entails(
-            lift_state(|s: State<SimpleReconcileState>| s.reconcile_state_contains(cr.object_ref()))
-                .leads_to(always(lift_state(cm_exists(cr))))
+        partial_spec_with_invariants_and_cr_always_exists(cr).entails(
+        lift_state(|s: State<SimpleReconcileState>| s.reconcile_state_contains(cr.object_ref()))
+            .leads_to(lift_state(cm_exists(cr)))
         ),
 {
-    lemma_init_pc_leads_to_cm_always_exists(cr);
-    lemma_after_get_cr_pc_leads_to_cm_always_exists(cr);
-    lemma_after_create_cm_pc_leads_to_cm_always_exists(cr);
+    temp_pred_equality::<State<SimpleReconcileState>>(lift_state(|s: State<SimpleReconcileState>| s.reconcile_state_contains(cr.object_ref())), lift_state(reconciler_reconcile_error(cr)).or(lift_state(reconciler_at_init_pc(cr))).or(lift_state(reconciler_at_after_get_cr_pc(cr))).or(lift_state(reconciler_at_after_create_cm_pc(cr))));
+    lemma_error_pc_leads_to_cm_exists_with_invariant(cr);
+    lemma_init_pc_leads_to_cm_exists_with_invariant(cr);
+    lemma_after_get_cr_pc_leads_to_cm_exists_with_invariant(cr);
+    lemma_after_create_cm_pc_leads_to_cm_exists_with_invariant(cr);
+    or_leads_to_combine_temp::<State<SimpleReconcileState>>(partial_spec_with_invariants_and_cr_always_exists(cr), lift_state(reconciler_reconcile_error(cr)), lift_state(reconciler_at_init_pc(cr)), lift_state(cm_exists(cr)));
+    or_leads_to_combine_temp::<State<SimpleReconcileState>>(partial_spec_with_invariants_and_cr_always_exists(cr), lift_state(reconciler_reconcile_error(cr)).or(lift_state(reconciler_at_init_pc(cr))), lift_state(reconciler_at_after_get_cr_pc(cr)), lift_state(cm_exists(cr)));
+    or_leads_to_combine_temp::<State<SimpleReconcileState>>(partial_spec_with_invariants_and_cr_always_exists(cr), lift_state(reconciler_reconcile_error(cr)).or(lift_state(reconciler_at_init_pc(cr))).or(lift_state(reconciler_at_after_get_cr_pc(cr))), lift_state(reconciler_at_after_create_cm_pc(cr)), lift_state(cm_exists(cr)));
 }
 
-proof fn lemma_init_pc_leads_to_cm_always_exists(cr: CustomResourceView)
+proof fn lemma_error_pc_leads_to_cm_exists_with_invariant(cr: CustomResourceView)
     ensures
-        sm_spec(simple_reconciler()).entails(
+        partial_spec_with_invariants_and_cr_always_exists(cr).entails(
+        lift_state(reconciler_reconcile_error(cr))
+            .leads_to(lift_state(cm_exists(cr)))
+        ),
+{
+    controller_runtime_liveness::lemma_cr_always_exists_entails_reconcile_error_leads_to_reconcile_init_and_no_pending_req::<SimpleReconcileState>(simple_reconciler(), cr.object_ref());
+
+    temp_pred_equality::<State<SimpleReconcileState>>(lift_state(reconcile_init_pc_and_no_pending_req(cr)), lift_state(|s: State<SimpleReconcileState>| {
+        &&& s.reconcile_state_contains(cr.object_ref())
+        &&& s.reconcile_state_of(cr.object_ref()).local_state == (simple_reconciler().reconcile_init_state)()
+        &&& s.reconcile_state_of(cr.object_ref()).pending_req_msg.is_None()
+    }));
+    
+    assert(sm_partial_spec(simple_reconciler()).and(always(lift_state(|s: State<SimpleReconcileState>| s.resource_key_exists(cr.object_ref())))).entails(lift_state(reconciler_reconcile_error(cr)).leads_to(lift_state(reconcile_init_pc_and_no_pending_req(cr)))));
+
+    implies_preserved_by_always_temp::<State<SimpleReconcileState>>(cr_exists(cr), lift_state(|s: State<SimpleReconcileState>| s.resource_key_exists(cr.object_ref())));
+    assert(valid(always(cr_exists(cr)).implies(always(lift_state(|s: State<SimpleReconcileState>| s.resource_key_exists(cr.object_ref()))))));
+
+    partially_strengthen_spec::<State<SimpleReconcileState>>(sm_partial_spec(simple_reconciler()), always(cr_exists(cr)), always(lift_state(|s: State<SimpleReconcileState>| s.resource_key_exists(cr.object_ref()))), lift_state(reconciler_reconcile_error(cr)).leads_to(lift_state(reconcile_init_pc_and_no_pending_req(cr))));
+
+    strengthen_spec::<State<SimpleReconcileState>>(sm_partial_spec(simple_reconciler()).and(always(cr_exists(cr))), always(lift_state(reconcile_create_cm_done_implies_pending_create_cm_req_in_flight_or_cm_exists(cr))).and(tla_forall(|msg| always(lift_state(controller_runtime_safety::resp_matches_at_most_one_pending_req(msg, cr.object_ref()))))).and(always(lift_state(reconcile_get_cr_done_implies_pending_req_in_flight_or_resp_in_flight(cr)))).and(always(lift_state(reconciler_at_init_pc(cr)).implies(lift_state(reconcile_init_pc_and_no_pending_req(cr))))), lift_state(reconciler_reconcile_error(cr)).leads_to(lift_state(reconcile_init_pc_and_no_pending_req(cr))));
+
+    temp_pred_equality::<State<SimpleReconcileState>>(partial_spec_with_invariants_and_cr_always_exists(cr), sm_partial_spec(simple_reconciler()).and(always(cr_exists(cr))).and(always(lift_state(reconcile_create_cm_done_implies_pending_create_cm_req_in_flight_or_cm_exists(cr))).and(tla_forall(|msg| always(lift_state(controller_runtime_safety::resp_matches_at_most_one_pending_req(msg, cr.object_ref()))))).and(always(lift_state(reconcile_get_cr_done_implies_pending_req_in_flight_or_resp_in_flight(cr)))).and(always(lift_state(reconciler_at_init_pc(cr)).implies(lift_state(reconcile_init_pc_and_no_pending_req(cr)))))));
+
+    lemma_init_pc_and_no_pending_req_leads_to_cm_exists_with_invariant(cr);
+    leads_to_trans::<State<SimpleReconcileState>>(partial_spec_with_invariants_and_cr_always_exists(cr), reconciler_reconcile_error(cr), reconcile_init_pc_and_no_pending_req(cr), cm_exists(cr));
+}
+
+proof fn lemma_init_pc_leads_to_cm_exists_with_invariant(cr: CustomResourceView)
+    ensures
+        partial_spec_with_invariants_and_cr_always_exists(cr).entails(
             lift_state(reconciler_at_init_pc(cr))
-            .leads_to(always(lift_state(cm_exists(cr))))
+                .leads_to(lift_state(cm_exists(cr)))
         ),
 {
-    safety::lemma_always_reconcile_init_implies_no_pending_req(cr);
-    lemma_init_pc_leads_to_after_get_cr_pc(cr);
-    lemma_after_get_cr_pc_leads_to_cm_always_exists(cr);
-    leads_to_trans_auto::<State<SimpleReconcileState>>(sm_spec(simple_reconciler()));
-    leads_to_weaken_auto::<State<SimpleReconcileState>>(sm_spec(simple_reconciler()));
+    implies_to_leads_to::<State<SimpleReconcileState>>(partial_spec_with_invariants_and_cr_always_exists(cr), lift_state(reconciler_at_init_pc(cr)), lift_state(reconcile_init_pc_and_no_pending_req(cr)));
+    
+    lemma_init_pc_and_no_pending_req_leads_to_cm_exists_with_invariant(cr);
+    leads_to_trans::<State<SimpleReconcileState>>(partial_spec_with_invariants_and_cr_always_exists(cr), reconciler_at_init_pc(cr), reconcile_init_pc_and_no_pending_req(cr), cm_exists(cr));
 }
 
-proof fn lemma_after_get_cr_pc_leads_to_cm_always_exists(cr: CustomResourceView)
+proof fn lemma_init_pc_and_no_pending_req_leads_to_cm_exists_with_invariant(cr: CustomResourceView)
     ensures
-        sm_spec(simple_reconciler()).entails(
-            lift_state(reconciler_at_after_get_cr_pc(cr))
-                .leads_to(always(lift_state(cm_exists(cr))))
+        partial_spec_with_invariants_and_cr_always_exists(cr).entails(
+            lift_state(reconciler_at_init_pc_and_no_pending_req(cr))
+                .leads_to(lift_state(cm_exists(cr)))
         ),
 {
-    assert forall |ex| #[trigger] sm_spec(simple_reconciler()).satisfied_by(ex) implies lift_state(reconciler_at_after_get_cr_pc(cr)).leads_to(lift_state(reconciler_at_after_create_cm_pc(cr))).satisfied_by(ex) by {
-        safety::lemma_always_reconcile_get_cr_done_implies_pending_req_in_flight_or_resp_in_flight(cr);
+    lemma_init_pc_leads_to_after_get_cr_pc(cr);
+
+    temp_pred_equality::<State<SimpleReconcileState>>(partial_spec_with_invariants_and_cr_always_exists(cr), sm_partial_spec(simple_reconciler()).and(always(lift_state(reconcile_create_cm_done_implies_pending_create_cm_req_in_flight_or_cm_exists(cr))).and(tla_forall(|msg| always(lift_state(controller_runtime_safety::resp_matches_at_most_one_pending_req(msg, cr.object_ref()))))).and(always(lift_state(reconcile_get_cr_done_implies_pending_req_in_flight_or_resp_in_flight(cr)))).and(always(lift_state(reconciler_at_init_pc(cr)).implies(lift_state(reconcile_init_pc_and_no_pending_req(cr))))).and(always(cr_exists(cr)))));
+
+    strengthen_spec(sm_partial_spec(simple_reconciler()), always(lift_state(reconcile_create_cm_done_implies_pending_create_cm_req_in_flight_or_cm_exists(cr))).and(tla_forall(|msg| always(lift_state(controller_runtime_safety::resp_matches_at_most_one_pending_req(msg, cr.object_ref()))))).and(always(lift_state(reconcile_get_cr_done_implies_pending_req_in_flight_or_resp_in_flight(cr)))).and(always(lift_state(reconciler_at_init_pc(cr)).implies(lift_state(reconcile_init_pc_and_no_pending_req(cr))))).and(always(cr_exists(cr))), lift_state(reconciler_at_init_pc_and_no_pending_req(cr)).leads_to(lift_state(reconciler_at_after_get_cr_pc(cr))));
+
+    lemma_after_get_cr_pc_leads_to_cm_exists_with_invariant(cr);
+    leads_to_trans::<State<SimpleReconcileState>>(partial_spec_with_invariants_and_cr_always_exists(cr), reconciler_at_init_pc_and_no_pending_req(cr), reconciler_at_after_get_cr_pc(cr), cm_exists(cr));
+}
+
+proof fn lemma_after_get_cr_pc_leads_to_cm_exists_with_invariant(cr: CustomResourceView)
+    ensures
+        partial_spec_with_invariants_and_cr_always_exists(cr).entails(
+            lift_state(reconciler_at_after_get_cr_pc(cr))
+                .leads_to(lift_state(cm_exists(cr)))
+        ),
+{
+    assert forall |ex| sm_partial_spec(simple_reconciler()).and(tla_forall(|msg| always(lift_state(controller_runtime_safety::resp_matches_at_most_one_pending_req(msg, cr.object_ref()))))).and(always(lift_state(reconcile_get_cr_done_implies_pending_req_in_flight_or_resp_in_flight(cr)))).satisfied_by(ex) implies #[trigger] lift_state(reconciler_at_after_get_cr_pc(cr)).leads_to(lift_state(reconciler_at_after_create_cm_pc(cr))).satisfied_by(ex) by {
         assert forall |i| #[trigger] lift_state(reconciler_at_after_get_cr_pc(cr)).satisfied_by(ex.suffix(i)) implies eventually(lift_state(reconciler_at_after_create_cm_pc(cr))).satisfied_by(ex.suffix(i)) by {
-            instantiate_entailed_always::<State<SimpleReconcileState>>(ex, i, sm_spec(simple_reconciler()), lift_state(safety::reconcile_get_cr_done_implies_pending_req_in_flight_or_resp_in_flight(cr)));
+            assert(lift_state(reconcile_get_cr_done_implies_pending_req_in_flight_or_resp_in_flight(cr)).satisfied_by(ex.suffix(i)));
             let s = ex.suffix(i).head();
             let req_msg = choose |req_msg: Message| {
                 #[trigger] is_controller_get_cr_request_msg(req_msg, cr)
@@ -149,11 +268,11 @@ proof fn lemma_after_get_cr_pc_leads_to_cm_always_exists(cr: CustomResourceView)
                     })
             };
             if (s.message_in_flight(req_msg)) {
-                lemma_req_msg_sent_and_after_get_cr_pc_leads_to_after_create_cm_pc(req_msg, cr);
-                instantiate_entailed_leads_to::<State<SimpleReconcileState>>(ex, i, sm_spec(simple_reconciler()), lift_state(reconciler_at_after_get_cr_pc_and_pending_req_and_req_in_flight(req_msg, cr)), lift_state(reconciler_at_after_create_cm_pc(cr)));
+                lemma_req_msg_sent_and_after_get_cr_pc_leads_to_after_create_cm_pc_with_invariant(req_msg, cr);
+                instantiate_entailed_leads_to::<State<SimpleReconcileState>>(ex, i, sm_partial_spec(simple_reconciler()).and(tla_forall(|msg| always(lift_state(controller_runtime_safety::resp_matches_at_most_one_pending_req(msg, cr.object_ref()))))), lift_state(reconciler_at_after_get_cr_pc_and_pending_req_and_req_in_flight(req_msg, cr)), lift_state(reconciler_at_after_create_cm_pc(cr)));
             } else {
-                lemma_exists_resp_msg_sent_and_after_get_cr_pc_leads_to_after_create_cm_pc(req_msg, cr);
-                instantiate_entailed_leads_to::<State<SimpleReconcileState>>(ex, i, sm_spec(simple_reconciler()), lift_state(|s: State<SimpleReconcileState>| {
+                lemma_exists_resp_msg_sent_and_after_get_cr_pc_leads_to_after_create_cm_pc_with_invariant(req_msg, cr);
+                instantiate_entailed_leads_to::<State<SimpleReconcileState>>(ex, i, sm_partial_spec(simple_reconciler()).and(tla_forall(|msg| always(lift_state(controller_runtime_safety::resp_matches_at_most_one_pending_req(msg, cr.object_ref()))))), lift_state(|s: State<SimpleReconcileState>| {
                     exists |m: Message| {
                         &&& #[trigger] s.message_in_flight(m)
                         &&& resp_msg_matches_req_msg(m, req_msg)
@@ -162,23 +281,24 @@ proof fn lemma_after_get_cr_pc_leads_to_cm_always_exists(cr: CustomResourceView)
             }
         }
     }
-    lemma_after_create_cm_pc_leads_to_cm_always_exists(cr);
-    leads_to_trans_temp::<State<SimpleReconcileState>>(sm_spec(simple_reconciler()), lift_state(reconciler_at_after_get_cr_pc(cr)), lift_state(reconciler_at_after_create_cm_pc(cr)), always(lift_state(cm_exists(cr))));
+    lemma_after_create_cm_pc_leads_to_cm_exists_with_invariant(cr);
+    leads_to_trans::<State<SimpleReconcileState>>(sm_partial_spec(simple_reconciler()).and(always(lift_state(reconcile_create_cm_done_implies_pending_create_cm_req_in_flight_or_cm_exists(cr)))).and(tla_forall(|msg| always(lift_state(controller_runtime_safety::resp_matches_at_most_one_pending_req(msg, cr.object_ref()))))).and(always(lift_state(reconcile_get_cr_done_implies_pending_req_in_flight_or_resp_in_flight(cr)))).and(always(lift_state(reconciler_at_init_pc(cr)).implies(lift_state(reconcile_init_pc_and_no_pending_req(cr))))).and(always(cr_exists(cr))), reconciler_at_after_get_cr_pc(cr), reconciler_at_after_create_cm_pc(cr), cm_exists(cr));
 }
 
-proof fn lemma_after_create_cm_pc_leads_to_cm_always_exists(cr: CustomResourceView)
+proof fn lemma_after_create_cm_pc_leads_to_cm_exists_with_invariant(cr: CustomResourceView)
     ensures
-        sm_spec(simple_reconciler()).entails(
+    partial_spec_with_invariants_and_cr_always_exists(cr).entails(
             lift_state(reconciler_at_after_create_cm_pc(cr))
-                .leads_to(always(lift_state(cm_exists(cr))))
+                .leads_to(lift_state(cm_exists(cr)))
         ),
 {
-    assert forall |ex| #[trigger] sm_spec(simple_reconciler()).satisfied_by(ex) implies
+    assert forall |ex| #[trigger] sm_partial_spec(simple_reconciler()).and(always(lift_state(reconcile_create_cm_done_implies_pending_create_cm_req_in_flight_or_cm_exists(cr)))).satisfied_by(ex) implies
     lift_state(reconciler_at_after_create_cm_pc(cr)).leads_to(lift_state(cm_exists(cr))).satisfied_by(ex) by {
-        safety::lemma_always_reconcile_create_cm_done_implies_pending_create_cm_req_in_flight_or_cm_exists(cr);
+
         assert forall |i| #[trigger] lift_state(reconciler_at_after_create_cm_pc(cr)).satisfied_by(ex.suffix(i))
         implies eventually(lift_state(cm_exists(cr))).satisfied_by(ex.suffix(i)) by {
-            instantiate_entailed_always::<State<SimpleReconcileState>>(ex, i, sm_spec(simple_reconciler()), lift_state(safety::reconcile_create_cm_done_implies_pending_create_cm_req_in_flight_or_cm_exists(cr)));
+            assert(lift_state(reconcile_create_cm_done_implies_pending_create_cm_req_in_flight_or_cm_exists(cr)).satisfied_by(ex.suffix(i)));
+            // instantiate_entailed_always::<State<SimpleReconcileState>>(ex, i, sm_spec(simple_reconciler()), lift_state(reconcile_create_cm_done_implies_pending_create_cm_req_in_flight_or_cm_exists(cr)));
             let s = ex.suffix(i).head();
             let req_msg = choose |m: Message| {
                 (#[trigger] is_controller_create_cm_request_msg(m, cr)
@@ -194,34 +314,11 @@ proof fn lemma_after_create_cm_pc_leads_to_cm_always_exists(cr: CustomResourceVi
                     &&& s.message_in_flight(req_msg) &&& req_msg.dst == HostId::KubernetesAPI &&& req_msg.content.is_create_request() 
                     &&& req_msg.content.get_create_request().obj == cm
                 };
-                kubernetes_api_liveness::lemma_create_req_leads_to_res_exists::<SimpleReconcileState>(simple_reconciler(), req_msg, cm);
-                instantiate_entailed_leads_to::<State<SimpleReconcileState>>(ex, i, sm_spec(simple_reconciler()), lift_state(pre), lift_state(cm_exists(cr)));
+                kubernetes_api_liveness::lemma_create_req_leads_to_res_exists::<SimpleReconcileState>(sm_partial_spec(simple_reconciler()), simple_reconciler(), req_msg, cm);
+                instantiate_entailed_leads_to::<State<SimpleReconcileState>>(ex, i, sm_partial_spec(simple_reconciler()), lift_state(pre), lift_state(cm_exists(cr)));
             }
         };
     };
-    // finally prove stability: spec |= reconciler_at_after_create_cm_pc ~> []cm_exists
-    lemma_p_leads_to_cm_always_exists(cr, lift_state(reconciler_at_after_create_cm_pc(cr)));
-}
-
-proof fn lemma_reconcile_idle_and_scheduled_leads_to_cm_always_exists(cr: CustomResourceView)
-    ensures
-        sm_spec(simple_reconciler()).entails(
-            lift_state(|s: State<SimpleReconcileState>| {
-                &&& !s.reconcile_state_contains(cr.object_ref())
-                &&& s.reconcile_scheduled_for(cr.object_ref())
-            }).leads_to(always(lift_state(|s: State<SimpleReconcileState>| s.resource_key_exists(simple_reconciler::subresource_configmap(cr.object_ref()).object_ref()))))
-        ),
-{
-    let reconcile_idle_and_scheduled = |s: State<SimpleReconcileState>| {
-        &&& !s.reconcile_state_contains(cr.object_ref())
-        &&& s.reconcile_scheduled_for(cr.object_ref())
-    };
-
-    leads_to_weaken_auto::<State<SimpleReconcileState>>(sm_spec(simple_reconciler()));
-
-    controller_runtime_liveness::lemma_reconcile_idle_and_scheduled_leads_to_reconcile_init::<SimpleReconcileState>(simple_reconciler(), cr.object_ref());
-    lemma_init_pc_leads_to_cm_always_exists(cr);
-    leads_to_trans_temp::<State<SimpleReconcileState>>(sm_spec(simple_reconciler()), lift_state(reconcile_idle_and_scheduled), lift_state(reconciler_at_init_pc(cr)), always(lift_state(cm_exists(cr))));
 }
 
 proof fn lemma_p_leads_to_cm_always_exists(cr: CustomResourceView, p: TempPred<State<SimpleReconcileState>>)
@@ -236,18 +333,18 @@ proof fn lemma_p_leads_to_cm_always_exists(cr: CustomResourceView, p: TempPred<S
 {
     let next_and_invariant = |s: State<SimpleReconcileState>, s_prime: State<SimpleReconcileState>| {
         &&& next(simple_reconciler())(s, s_prime)
-        &&& safety::delete_cm_req_msg_not_in_flight(cr)(s)
+        &&& delete_cm_req_msg_not_in_flight(cr)(s)
     };
 
-    safety::lemma_delete_cm_req_msg_never_in_flight(cr);
+    lemma_delete_cm_req_msg_never_in_flight(cr);
 
-    strengthen_next::<State<SimpleReconcileState>>(sm_spec(simple_reconciler()), next(simple_reconciler()), safety::delete_cm_req_msg_not_in_flight(cr), next_and_invariant);
+    strengthen_next::<State<SimpleReconcileState>>(sm_spec(simple_reconciler()), next(simple_reconciler()), delete_cm_req_msg_not_in_flight(cr), next_and_invariant);
     leads_to_stable_temp::<State<SimpleReconcileState>>(sm_spec(simple_reconciler()), lift_action(next_and_invariant), p, lift_state(cm_exists(cr)));
 }
 
 proof fn lemma_init_pc_leads_to_after_get_cr_pc(cr: CustomResourceView)
     ensures
-        sm_spec(simple_reconciler()).entails(
+        sm_partial_spec(simple_reconciler()).entails(
             lift_state(reconciler_at_init_pc_and_no_pending_req(cr)).leads_to(lift_state(reconciler_at_after_get_cr_pc(cr)))
         ),
 {
@@ -257,7 +354,7 @@ proof fn lemma_init_pc_leads_to_after_get_cr_pc(cr: CustomResourceView)
         recv: Option::None,
         scheduled_cr_key: Option::Some(cr.object_ref()),
     };
-    controller_runtime_liveness::lemma_pre_leads_to_post_by_controller::<SimpleReconcileState>(simple_reconciler(), input, next(simple_reconciler()), continue_reconcile(simple_reconciler()), pre, post);
+    controller_runtime_liveness::lemma_pre_leads_to_post_by_controller::<SimpleReconcileState>(sm_partial_spec(simple_reconciler()), simple_reconciler(), input, next(simple_reconciler()), continue_reconcile(simple_reconciler()), pre, post);
 }
 
 proof fn lemma_req_msg_sent_and_after_get_cr_pc_leads_to_after_create_cm_pc(req_msg: Message, cr: CustomResourceView)
@@ -280,7 +377,7 @@ proof fn lemma_req_msg_sent_and_after_get_cr_pc_leads_to_after_create_cm_pc(req_
 
     leads_to_self::<State<SimpleReconcileState>>(pre);
 
-    kubernetes_api_liveness::lemma_get_req_leads_to_some_resp::<SimpleReconcileState>(simple_reconciler(), req_msg, cr.object_ref());
+    kubernetes_api_liveness::lemma_get_req_leads_to_some_resp::<SimpleReconcileState>(sm_spec(simple_reconciler()), simple_reconciler(), req_msg, cr.object_ref());
 
     // Now we have:
     //  spec |= pre ~> reconciler_at_after_get_cr_pc_and_pending_req /\ get_cr_req_in_flight
@@ -290,6 +387,52 @@ proof fn lemma_req_msg_sent_and_after_get_cr_pc_leads_to_after_create_cm_pc(req_
     // Now we have all the premise to fire the leads-to formula from lemma_exists_resp_msg_sent_and_after_get_cr_pc_leads_to_after_create_cm_pc
     lemma_exists_resp_msg_sent_and_after_get_cr_pc_leads_to_after_create_cm_pc(req_msg, cr);
     leads_to_trans::<State<SimpleReconcileState>>(sm_spec(simple_reconciler()),
+        pre,
+        |s| {
+            &&& reconciler_at_after_get_cr_pc_and_pending_req(req_msg, cr)(s)
+            &&& get_cr_resp_msg_sent(s)
+        },
+        reconciler_at_after_create_cm_pc
+    );
+}
+
+proof fn lemma_req_msg_sent_and_after_get_cr_pc_leads_to_after_create_cm_pc_with_invariant(req_msg: Message, cr: CustomResourceView)
+    ensures
+    sm_partial_spec(simple_reconciler()).and(tla_forall(|msg| always(lift_state(controller_runtime_safety::resp_matches_at_most_one_pending_req(msg, cr.object_ref()))))).entails(
+            lift_state(reconciler_at_after_get_cr_pc_and_pending_req_and_req_in_flight(req_msg, cr))
+                .leads_to(lift_state(reconciler_at_after_create_cm_pc(cr)))
+        ),
+{
+    let pre = reconciler_at_after_get_cr_pc_and_pending_req_and_req_in_flight(req_msg, cr);
+    let get_cr_resp_msg_sent = |s: State<SimpleReconcileState>| {
+        exists |resp_msg: Message| {
+            &&& #[trigger] s.message_in_flight(resp_msg)
+            &&& resp_msg_matches_req_msg(resp_msg, req_msg)
+        }
+    };
+    let reconciler_at_after_create_cm_pc = reconciler_at_after_create_cm_pc(cr);
+
+    leads_to_weaken_auto::<State<SimpleReconcileState>>(sm_partial_spec(simple_reconciler()).and(tla_forall(|msg| always(lift_state(controller_runtime_safety::resp_matches_at_most_one_pending_req(msg, cr.object_ref()))))));
+
+    leads_to_self::<State<SimpleReconcileState>>(pre);
+
+    kubernetes_api_liveness::lemma_get_req_leads_to_some_resp::<SimpleReconcileState>(sm_partial_spec(simple_reconciler()).and(tla_forall(|msg| always(lift_state(controller_runtime_safety::resp_matches_at_most_one_pending_req(msg, cr.object_ref()))))), simple_reconciler(), req_msg, cr.object_ref());
+
+    let get_req = |s: State<SimpleReconcileState>| {
+        &&& s.message_in_flight(req_msg)
+        &&& req_msg.dst == HostId::KubernetesAPI
+        &&& req_msg.content.is_get_request()
+        &&& req_msg.content.get_get_request().key == cr.object_ref()
+    };
+
+    // Now we have:
+    //  spec |= pre ~> reconciler_at_after_get_cr_pc_and_pending_req /\ get_cr_req_in_flight
+    //  spec |= get_cr_req_in_flight ~> get_cr_resp_msg_sent
+    // By applying leads_to_partial_confluence, we will get spec |= pre ~> reconciler_at_after_get_cr_pc_and_pending_req /\ get_cr_resp_msg_sent
+    leads_to_partial_confluence::<State<SimpleReconcileState>>(sm_partial_spec(simple_reconciler()).and(tla_forall(|msg| always(lift_state(controller_runtime_safety::resp_matches_at_most_one_pending_req(msg, cr.object_ref()))))), next(simple_reconciler()), pre, reconciler_at_after_get_cr_pc_and_pending_req(req_msg, cr), get_req, get_cr_resp_msg_sent);
+    // Now we have all the premise to fire the leads-to formula from lemma_exists_resp_msg_sent_and_after_get_cr_pc_leads_to_after_create_cm_pc
+    lemma_exists_resp_msg_sent_and_after_get_cr_pc_leads_to_after_create_cm_pc_with_invariant(req_msg, cr);
+    leads_to_trans::<State<SimpleReconcileState>>(sm_partial_spec(simple_reconciler()).and(tla_forall(|msg| always(lift_state(controller_runtime_safety::resp_matches_at_most_one_pending_req(msg, cr.object_ref()))))),
         pre,
         |s| {
             &&& reconciler_at_after_get_cr_pc_and_pending_req(req_msg, cr)(s)
@@ -328,7 +471,39 @@ proof fn lemma_resp_msg_sent_and_after_get_cr_pc_leads_to_after_create_cm_pc(res
     controller_runtime_safety::lemma_always_resp_matches_at_most_one_pending_req::<SimpleReconcileState>(simple_reconciler(), resp_msg, cr.object_ref());
 
     strengthen_next::<State<SimpleReconcileState>>(sm_spec(simple_reconciler()), next(simple_reconciler()), controller_runtime_safety::resp_matches_at_most_one_pending_req(resp_msg, cr.object_ref()), next_and_invariant);
-    controller_runtime_liveness::lemma_pre_leads_to_post_by_controller::<SimpleReconcileState>(simple_reconciler(), input, next_and_invariant, continue_reconcile(simple_reconciler()), pre, post);
+    controller_runtime_liveness::lemma_pre_leads_to_post_by_controller::<SimpleReconcileState>(sm_spec(simple_reconciler()), simple_reconciler(), input, next_and_invariant, continue_reconcile(simple_reconciler()), pre, post);
+}
+
+proof fn lemma_resp_msg_sent_and_after_get_cr_pc_leads_to_after_create_cm_pc_with_invariant(resp_msg: Message, req_msg: Message, cr: CustomResourceView)
+    ensures
+        sm_partial_spec(simple_reconciler()).and(tla_forall(|msg| always(lift_state(controller_runtime_safety::resp_matches_at_most_one_pending_req(msg, cr.object_ref()))))).entails(
+            lift_state(|s: State<SimpleReconcileState>| {
+                &&& s.message_in_flight(resp_msg)
+                &&& resp_msg_matches_req_msg(resp_msg, req_msg)
+                &&& reconciler_at_after_get_cr_pc_and_pending_req(req_msg, cr)(s)
+            }).leads_to(lift_state(reconciler_at_after_create_cm_pc(cr)))
+        ),
+{
+    let pre = |s: State<SimpleReconcileState>| {
+        &&& s.message_in_flight(resp_msg)
+        &&& resp_msg_matches_req_msg(resp_msg, req_msg)
+        &&& reconciler_at_after_get_cr_pc_and_pending_req(req_msg, cr)(s)
+    };
+    let post = reconciler_at_after_create_cm_pc(cr);
+    let input = ControllerActionInput {
+        recv: Option::Some(resp_msg),
+        scheduled_cr_key: Option::Some(cr.object_ref()),
+    };
+    let next_and_invariant = |s, s_prime: State<SimpleReconcileState>| {
+        &&& next(simple_reconciler())(s, s_prime)
+        &&& controller_runtime_safety::resp_matches_at_most_one_pending_req(resp_msg, cr.object_ref())(s)
+    };
+
+    tla_forall_apply::<State<SimpleReconcileState>, Message>(|msg| always(lift_state(controller_runtime_safety::resp_matches_at_most_one_pending_req::<SimpleReconcileState>(msg, cr.object_ref()))), resp_msg);
+
+    strengthen_next::<State<SimpleReconcileState>>(sm_partial_spec(simple_reconciler()).and(tla_forall(|msg| always(lift_state(controller_runtime_safety::resp_matches_at_most_one_pending_req(msg, cr.object_ref()))))), next(simple_reconciler()), controller_runtime_safety::resp_matches_at_most_one_pending_req(resp_msg, cr.object_ref()), next_and_invariant);
+
+    controller_runtime_liveness::lemma_pre_leads_to_post_by_controller::<SimpleReconcileState>(sm_partial_spec(simple_reconciler()).and(tla_forall(|msg| always(lift_state(controller_runtime_safety::resp_matches_at_most_one_pending_req(msg, cr.object_ref()))))), simple_reconciler(), input, next_and_invariant, continue_reconcile(simple_reconciler()), pre, post);
 }
 
 proof fn lemma_exists_resp_msg_sent_and_after_get_cr_pc_leads_to_after_create_cm_pc(req_msg: Message, cr: CustomResourceView)
@@ -359,6 +534,54 @@ proof fn lemma_exists_resp_msg_sent_and_after_get_cr_pc_leads_to_after_create_cm
         temp_pred_equality::<State<SimpleReconcileState>>(pre, m_to_pre1(msg).and(pre2));
     };
     leads_to_exists_intro::<State<SimpleReconcileState>, Message>(sm_spec(simple_reconciler()), |m| m_to_pre1(m).and(pre2), post);
+    tla_exists_and_equality::<State<SimpleReconcileState>, Message>(m_to_pre1, pre2);
+
+    // This is very tedious proof to show exists_m_to_pre1 == tla_exists(m_to_pre1)
+    // I hope we can encapsulate this as a lemma
+    let exists_m_to_pre1 = lift_state(|s: State<SimpleReconcileState>| {
+        exists |m: Message| {
+            &&& #[trigger] s.message_in_flight(m)
+            &&& resp_msg_matches_req_msg(m, req_msg)
+        }
+    });
+    assert forall |ex| #[trigger] exists_m_to_pre1.satisfied_by(ex) implies tla_exists(m_to_pre1).satisfied_by(ex) by {
+        let m = choose |m: Message| {
+            &&& #[trigger] ex.head().message_in_flight(m)
+            &&& resp_msg_matches_req_msg(m, req_msg)
+        };
+        assert(m_to_pre1(m).satisfied_by(ex));
+    };
+    temp_pred_equality::<State<SimpleReconcileState>>(exists_m_to_pre1, tla_exists(m_to_pre1));
+}
+
+proof fn lemma_exists_resp_msg_sent_and_after_get_cr_pc_leads_to_after_create_cm_pc_with_invariant(req_msg: Message, cr: CustomResourceView)
+    ensures
+    sm_partial_spec(simple_reconciler()).and(tla_forall(|msg| always(lift_state(controller_runtime_safety::resp_matches_at_most_one_pending_req(msg, cr.object_ref()))))).entails(
+            lift_state(|s: State<SimpleReconcileState>| {
+                exists |m: Message| {
+                    &&& #[trigger] s.message_in_flight(m)
+                    &&& resp_msg_matches_req_msg(m, req_msg)
+                }
+            }).and(lift_state(reconciler_at_after_get_cr_pc_and_pending_req(req_msg, cr)))
+            .leads_to(lift_state(reconciler_at_after_create_cm_pc(cr)))
+        ),
+{
+    let m_to_pre1 = |m: Message| lift_state(|s: State<SimpleReconcileState>| {
+        &&& s.message_in_flight(m)
+        &&& resp_msg_matches_req_msg(m, req_msg)
+    });
+    let pre2 = lift_state(reconciler_at_after_get_cr_pc_and_pending_req(req_msg, cr));
+    let post = lift_state(reconciler_at_after_create_cm_pc(cr));
+    assert forall |msg: Message| sm_partial_spec(simple_reconciler()).and(tla_forall(|msg1| always(lift_state(controller_runtime_safety::resp_matches_at_most_one_pending_req(msg1, cr.object_ref()))))).entails(#[trigger] m_to_pre1(msg).and(pre2).leads_to(post)) by {
+        lemma_resp_msg_sent_and_after_get_cr_pc_leads_to_after_create_cm_pc_with_invariant(msg, req_msg, cr);
+        let pre = lift_state(|s: State<SimpleReconcileState>| {
+            &&& s.message_in_flight(msg)
+            &&& resp_msg_matches_req_msg(msg, req_msg)
+            &&& reconciler_at_after_get_cr_pc_and_pending_req(req_msg, cr)(s)
+        });
+        temp_pred_equality::<State<SimpleReconcileState>>(pre, m_to_pre1(msg).and(pre2));
+    };
+    leads_to_exists_intro::<State<SimpleReconcileState>, Message>(sm_partial_spec(simple_reconciler()).and(tla_forall(|msg1| always(lift_state(controller_runtime_safety::resp_matches_at_most_one_pending_req(msg1, cr.object_ref()))))), |m| m_to_pre1(m).and(pre2), post);
     tla_exists_and_equality::<State<SimpleReconcileState>, Message>(m_to_pre1, pre2);
 
     // This is very tedious proof to show exists_m_to_pre1 == tla_exists(m_to_pre1)

--- a/src/simple_controller/proof/liveness.rs
+++ b/src/simple_controller/proof/liveness.rs
@@ -77,7 +77,7 @@ proof fn liveness_proof(cr: CustomResourceView)
     temp_pred_equality::<State<SimpleReconcileState>>(lift_state(init(simple_reconciler())).and(sm_partial_spec(simple_reconciler()).and(all_invariants(cr))), sm_spec(simple_reconciler()).and(all_invariants(cr)));
 
     lemma_sm_spec_entails_all_invariants(cr);
-    minimize_spec::<State<SimpleReconcileState>>(sm_spec(simple_reconciler()), all_invariants(cr), always(cr_exists(cr)).leads_to(lift_state(cm_exists(cr))));
+    simplify_predicate::<State<SimpleReconcileState>>(sm_spec(simple_reconciler()), all_invariants(cr));
 
     lemma_p_leads_to_cm_always_exists(cr, always(cr_exists(cr)));
 }

--- a/src/simple_controller/spec/simple_reconciler.rs
+++ b/src/simple_controller/spec/simple_reconciler.rs
@@ -32,7 +32,7 @@ pub open spec fn simple_reconciler() -> Reconciler<SimpleReconcileState> {
 
 pub open spec fn reconcile_init_state() -> SimpleReconcileState {
     SimpleReconcileState {
-        reconcile_pc: 0,
+        reconcile_pc: init_pc(),
     }
 }
 

--- a/src/temporal_logic/rules.rs
+++ b/src/temporal_logic/rules.rs
@@ -144,7 +144,7 @@ proof fn implies_apply_with_always<T>(ex: Execution<T>, p: TempPred<T>, q: TempP
     always_unfold::<T>(ex, p);
 }
 
-pub proof fn entails_apply<T>(ex: Execution<T>, p: TempPred<T>, q: TempPred<T>)
+proof fn entails_apply<T>(ex: Execution<T>, p: TempPred<T>, q: TempPred<T>)
     requires
         p.entails(q),
         p.satisfied_by(ex),
@@ -161,7 +161,7 @@ proof fn entails_apply_auto<T>()
 {
     assert forall |ex: Execution<T>, p: TempPred<T>, q: TempPred<T>|
     #[trigger] valid(p.implies(q)) && p.satisfied_by(ex) implies #[trigger] q.satisfied_by(ex) by {
-       entails_apply(ex, p, q);
+        entails_apply(ex, p, q);
     };
 }
 

--- a/src/temporal_logic/rules.rs
+++ b/src/temporal_logic/rules.rs
@@ -1301,6 +1301,13 @@ pub proof fn wf1_assume<T>(spec: TempPred<T>, next: ActionPred<T>, forward: Acti
     wf1_variant_assume_temp::<T>(spec, lift_action(next), lift_action(forward), lift_state(asm), lift_state(p), lift_state(q));
 }
 
+/// Leads to p and q if (1) p leads to q and (2) ~q and next preserve p
+/// pre:
+///     spec |= [](p /\ ~q /\ next => p')
+///     spec |= p ~> q
+///     spec |= []next
+/// post:
+///     spec |= p ~> p /\ q
 pub proof fn leads_to_confluence_self_temp<T>(spec: TempPred<T>, next: TempPred<T>, p: TempPred<T>, q: TempPred<T>)
     requires
         spec.entails(always(p.and(not(q)).and(next).implies(later(p)))),
@@ -1326,6 +1333,7 @@ pub proof fn leads_to_confluence_self_temp<T>(spec: TempPred<T>, next: TempPred<
     };
 }
 
+/// StatePred version of leads_to_confluence_self_temp
 pub proof fn leads_to_confluence_self<T>(spec: TempPred<T>, next: ActionPred<T>, p: StatePred<T>, q: StatePred<T>)
     requires
         forall |s, s_prime: T| p(s) && !q(s) && #[trigger] next(s, s_prime) ==> p(s_prime),
@@ -1854,6 +1862,12 @@ pub proof fn implies_preserved_by_eventually_temp<T>(p: TempPred<T>, q: TempPred
     };
 }
 
+/// Strength only part of the spec
+/// pre:
+///     spec /\ q |= r
+///     p |= q
+/// post:
+///     spec /\ p |= r
 pub proof fn partially_strengthen_spec<T>(spec: TempPred<T>, p: TempPred<T>, q: TempPred<T>, r: TempPred<T>)
     requires
         spec.and(q).entails(r),

--- a/src/temporal_logic/rules.rs
+++ b/src/temporal_logic/rules.rs
@@ -2121,6 +2121,58 @@ pub proof fn or_leads_to_combine<T>(spec: TempPred<T>, p: StatePred<T>, q: State
     or_leads_to_combine_temp::<T>(spec, lift_state(p), lift_state(q), lift_state(r));
 }
 
+/// Three-predicate-version of or_leads_to_combine_temp.
+pub proof fn or_leads_to_combine_3_temp<T>(spec: TempPred<T>, p1: TempPred<T>, p2: TempPred<T>, p3: TempPred<T>, q: TempPred<T>)
+    requires
+        spec.entails(p1.leads_to(q)),
+        spec.entails(p2.leads_to(q)),
+        spec.entails(p3.leads_to(q)),
+    ensures
+        spec.entails(p1.or(p2).or(p3).leads_to(q)),
+{
+    or_leads_to_combine_temp(spec, p1, p2, q);
+    or_leads_to_combine_temp(spec, p1.or(p2), p3, q);
+}
+
+/// StatePred version of or_leads_to_combine_3_temp.
+pub proof fn or_leads_to_combine_3<T>(spec: TempPred<T>, p1: StatePred<T>, p2: StatePred<T>, p3: StatePred<T>, q: StatePred<T>)
+    requires
+        spec.entails(lift_state(p1).leads_to(lift_state(q))),
+        spec.entails(lift_state(p2).leads_to(lift_state(q))),
+        spec.entails(lift_state(p3).leads_to(lift_state(q))),
+    ensures
+        spec.entails(lift_state(p1).or(lift_state(p2)).or(lift_state(p3)).leads_to(lift_state(q))),
+{
+    or_leads_to_combine_3_temp::<T>(spec, lift_state(p1), lift_state(p2), lift_state(p3), lift_state(q));
+}
+
+/// Four-predicate-version of or_leads_to_combine_temp.
+pub proof fn or_leads_to_combine_4_temp<T>(spec: TempPred<T>, p1: TempPred<T>, p2: TempPred<T>, p3: TempPred<T>, p4: TempPred<T>, q: TempPred<T>)
+    requires
+        spec.entails(p1.leads_to(q)),
+        spec.entails(p2.leads_to(q)),
+        spec.entails(p3.leads_to(q)),
+        spec.entails(p4.leads_to(q)),
+    ensures
+        spec.entails(p1.or(p2).or(p3).or(p4).leads_to(q)),
+{
+    or_leads_to_combine_temp(spec, p1, p2, q);
+    or_leads_to_combine_3_temp(spec, p1.or(p2), p3, p4, q);
+}
+
+/// StatePred version of or_leads_to_combine_4_temp.
+pub proof fn or_leads_to_combine_4<T>(spec: TempPred<T>, p1: StatePred<T>, p2: StatePred<T>, p3: StatePred<T>, p4: StatePred<T>, q: StatePred<T>)
+    requires
+        spec.entails(lift_state(p1).leads_to(lift_state(q))),
+        spec.entails(lift_state(p2).leads_to(lift_state(q))),
+        spec.entails(lift_state(p3).leads_to(lift_state(q))),
+        spec.entails(lift_state(p4).leads_to(lift_state(q))),
+    ensures
+        spec.entails(lift_state(p1).or(lift_state(p2)).or(lift_state(p3)).or(lift_state(p4)).leads_to(lift_state(q))),
+{
+    or_leads_to_combine_4_temp::<T>(spec, lift_state(p1), lift_state(p2), lift_state(p3), lift_state(p4), lift_state(q));
+}
+
 /// Specialized version of or_leads_to_combine used for eliminating q in premise.
 /// pre:
 ///     spec |= p /\ r ~> q

--- a/src/temporal_logic/rules.rs
+++ b/src/temporal_logic/rules.rs
@@ -916,6 +916,31 @@ pub proof fn entails_and_temp<T>(spec: TempPred<T>, p: TempPred<T>, q: TempPred<
     };
 }
 
+pub proof fn entails_and_3_temp<T>(spec: TempPred<T>, p1: TempPred<T>, p2: TempPred<T>, p3: TempPred<T>)
+    requires
+        spec.entails(p1),
+        spec.entails(p2),
+        spec.entails(p3),
+    ensures
+        spec.entails(p1.and(p2).and(p3)),
+{
+    entails_and_temp::<T>(spec, p1, p2);
+    entails_and_temp::<T>(spec, p1.and(p2), p3);
+}
+
+pub proof fn entails_and_4_temp<T>(spec: TempPred<T>, p1: TempPred<T>, p2: TempPred<T>, p3: TempPred<T>, p4: TempPred<T>)
+    requires
+        spec.entails(p1),
+        spec.entails(p2),
+        spec.entails(p3),
+        spec.entails(p4),
+    ensures
+        spec.entails(p1.and(p2).and(p3).and(p4)),
+{
+    entails_and_3_temp::<T>(spec, p1, p2, p3);
+    entails_and_temp::<T>(spec, p1.and(p2).and(p3), p4);
+}
+
 pub proof fn entails_and_different_temp<T>(spec1: TempPred<T>, spec2: TempPred<T>, p: TempPred<T>, q: TempPred<T>)
     requires
         spec1.entails(p),
@@ -960,6 +985,31 @@ pub proof fn stable_and_temp<T>(p: TempPred<T>, q: TempPred<T>)
         stable_unfold::<T>(ex, p);
         stable_unfold::<T>(ex, q);
     }
+}
+
+pub proof fn stable_and_3_temp<T>(p1: TempPred<T>, p2: TempPred<T>, p3: TempPred<T>)
+    requires
+        valid(stable(p1)),
+        valid(stable(p2)),
+        valid(stable(p3)),
+    ensures
+        valid(stable(p1.and(p2).and(p3))),
+{
+    stable_and_temp::<T>(p1, p2);
+    stable_and_temp::<T>(p1.and(p2), p3);
+}
+
+pub proof fn stable_and_4_temp<T>(p1: TempPred<T>, p2: TempPred<T>, p3: TempPred<T>, p4: TempPred<T>)
+    requires
+        valid(stable(p1)),
+        valid(stable(p2)),
+        valid(stable(p3)),
+        valid(stable(p4)),
+    ensures
+        valid(stable(p1.and(p2).and(p3).and(p4))),
+{
+    stable_and_temp::<T>(p1, p2);
+    stable_and_3_temp::<T>(p1.and(p2), p3, p4);
 }
 
 /// Unpack the assumption from left to the right side of |=


### PR DESCRIPTION
The liveness property of simple controller is verified with all possible cases considered. To achieve this, I also parameterize the `spec` in proof of Kubernetes API so that we can specify whether `sm_spec` or `sm_partial_spec` is required. Plus, some rules are added to `temporal_logic::rules`.

Explanatory comments need to be supplemented.