### PR TITLE
Specify controller crash behavior

### DIFF
--- a/src/kubernetes_cluster/proof/cluster.rs
+++ b/src/kubernetes_cluster/proof/cluster.rs
@@ -28,6 +28,7 @@ use builtin_macros::*;
 
 verus! {
 
+/// Prove weak_fairness is stable.
 proof fn valid_stable_action_weak_fairness<T, Output>(action: Action<State<T>, (), Output>)
     ensures
         valid(stable(action.weak_fairness(()))),
@@ -36,6 +37,7 @@ proof fn valid_stable_action_weak_fairness<T, Output>(action: Action<State<T>, (
     always_p_stable::<State<T>>(split_always);
 }
 
+/// Prove weak_fairness for all input is stable.
 proof fn valid_stable_tla_forall_action_weak_fairness<T, Input, Output>(action: Action<State<T>, Input, Output>)
     ensures
         valid(stable(tla_forall(|input| action.weak_fairness(input)))),
@@ -45,6 +47,7 @@ proof fn valid_stable_tla_forall_action_weak_fairness<T, Input, Output>(action: 
     always_p_stable::<State<T>>(tla_forall(split_always));
 }
 
+/// Prove partial_spec is stable.
 pub proof fn valid_stable_sm_partial_spec<T>(reconciler: Reconciler<T>)
     ensures
         valid(stable(sm_partial_spec(reconciler))),

--- a/src/kubernetes_cluster/proof/mod.rs
+++ b/src/kubernetes_cluster/proof/mod.rs
@@ -1,8 +1,8 @@
 // Copyright 2022 VMware, Inc.
 // SPDX-License-Identifier: MIT
 pub mod cluster;
-pub mod controller_runtime_liveness;
-pub mod controller_runtime_safety;
+// pub mod controller_runtime_liveness;
+// pub mod controller_runtime_safety;
 pub mod kubernetes_api_liveness;
 pub mod kubernetes_api_safety;
 pub mod wf1_assistant;

--- a/src/kubernetes_cluster/proof/wf1_assistant.rs
+++ b/src/kubernetes_cluster/proof/wf1_assistant.rs
@@ -44,7 +44,7 @@ pub proof fn controller_action_pre_implies_next_pre<T>(reconciler: Reconciler<T>
         valid(lift_state(controller_action_pre(reconciler, action, input)).implies(lift_state(controller_next(reconciler).pre(input)))),
 {
     assert forall |s| #[trigger] controller_action_pre(reconciler, action, input)(s) implies controller_next(reconciler).pre(input)(s) by {
-        exists_next_controller_step(reconciler, action, ControllerActionInput{recv: input.0, scheduled_cr_key: input.1, chan_manager: s.chan_manager}, s.controller_state);
+        exists_next_controller_step(reconciler, action, ControllerActionInput{recv: input.0, scheduled_cr_key: input.1, chan_manager: s.chan_manager}, s.controller_state.get_Some_0());
     };
 }
 

--- a/src/kubernetes_cluster/spec/controller/common.rs
+++ b/src/kubernetes_cluster/spec/controller/common.rs
@@ -54,4 +54,11 @@ pub open spec fn insert_scheduled_reconcile<T>(s: ControllerState<T>, key: Objec
     }
 }
 
+pub open spec fn init_controller_state<T>() -> ControllerState<T> {
+    ControllerState {
+        ongoing_reconciles: Map::empty(),
+        scheduled_reconciles: Set::empty(),
+    }
+}
+
 }

--- a/src/kubernetes_cluster/spec/controller/state_machine.rs
+++ b/src/kubernetes_cluster/spec/controller/state_machine.rs
@@ -16,10 +16,7 @@ verus! {
 pub open spec fn controller<T>(reconciler: Reconciler<T>) -> ControllerStateMachine<T> {
     StateMachine {
         init: |s: ControllerState<T>| {
-            s == ControllerState::<T> {
-                ongoing_reconciles: Map::empty(),
-                scheduled_reconciles: Set::empty(),
-            }
+            s == init_controller_state::<T>()
         },
         actions: set![
             run_scheduled_reconcile(reconciler),

--- a/src/kubernetes_cluster/spec/distributed_system.rs
+++ b/src/kubernetes_cluster/spec/distributed_system.rs
@@ -7,8 +7,8 @@ use crate::kubernetes_cluster::spec::{
     client::{client, ClientActionInput, ClientState},
     controller::{
         common::{
-            insert_scheduled_reconcile, ControllerAction, ControllerActionInput, ControllerState,
-            OngoingReconcile,
+            init_controller_state, insert_scheduled_reconcile, ControllerAction,
+            ControllerActionInput, ControllerState, OngoingReconcile,
         },
         state_machine::controller,
     },
@@ -30,10 +30,11 @@ verus! {
 
 pub struct State<T> {
     pub kubernetes_api_state: KubernetesAPIState,
-    pub controller_state: ControllerState<T>,
+    pub controller_state: Option<ControllerState<T>>,
     pub client_state: ClientState,
     pub network_state: NetworkState,
     pub chan_manager: ChannelManager,
+    pub crash_enabled: bool,
 }
 
 impl<T> State<T> {
@@ -58,28 +59,43 @@ impl<T> State<T> {
     }
 
     #[verifier(inline)]
-    pub open spec fn reconcile_state_contains(self, key: ObjectRef) -> bool {
-        self.controller_state.ongoing_reconciles.dom().contains(key)
+    pub open spec fn controller_alive(self) -> bool {
+        self.controller_state.is_Some()
+    }
+
+    #[verifier(inline)]
+    pub open spec fn reconcile_state_contains(self, key: ObjectRef) -> bool
+        recommends
+            self.controller_alive(),
+    {
+        self.controller_state.get_Some_0().ongoing_reconciles.dom().contains(key)
     }
 
     pub open spec fn reconcile_state_of(self, key: ObjectRef) -> OngoingReconcile<T>
-        recommends self.reconcile_state_contains(key)
+        recommends
+            self.controller_alive(),
+            self.reconcile_state_contains(key),
     {
-        self.controller_state.ongoing_reconciles[key]
+        self.controller_state.get_Some_0().ongoing_reconciles[key]
     }
 
-    pub open spec fn reconcile_scheduled_for(self, key: ObjectRef) -> bool {
-        self.controller_state.scheduled_reconciles.contains(key)
+    pub open spec fn reconcile_scheduled_for(self, key: ObjectRef) -> bool
+        recommends
+            self.controller_alive(),
+    {
+        self.controller_state.get_Some_0().scheduled_reconciles.contains(key)
     }
 }
 
 pub open spec fn init<T>(reconciler: Reconciler<T>) -> StatePred<State<T>> {
     |s: State<T>| {
         &&& (kubernetes_api().init)(s.kubernetes_api_state)
-        &&& (controller(reconciler).init)(s.controller_state)
+        &&& s.controller_alive()
+        &&& (controller(reconciler).init)(s.controller_state.get_Some_0())
         &&& (client().init)(s.client_state)
         &&& (network().init)(s.network_state)
         &&& s.chan_manager == ChannelManager::init()
+        &&& s.crash_enabled
     }
 }
 
@@ -126,7 +142,7 @@ pub open spec fn controller_next<T>(reconciler: Reconciler<T>) -> Action<State<T
     let result = |input: (Option<Message>, Option<ObjectRef>), s: State<T>| {
         let host_result = controller(reconciler).next_result(
             ControllerActionInput{recv: input.0, scheduled_cr_key: input.1, chan_manager: s.chan_manager},
-            s.controller_state
+            s.controller_state.get_Some_0()
         );
         let msg_ops = MessageOps {
             recv: input.0,
@@ -138,13 +154,14 @@ pub open spec fn controller_next<T>(reconciler: Reconciler<T>) -> Action<State<T
     };
     Action {
         precondition: |input: (Option<Message>, Option<ObjectRef>), s: State<T>| {
+            &&& s.controller_alive()
             &&& received_msg_destined_for(input.0, HostId::CustomController)
             &&& result(input, s).0.is_Enabled()
             &&& result(input, s).1.is_Enabled()
         },
         transition: |input: (Option<Message>, Option<ObjectRef>), s: State<T>| {
             (State {
-                controller_state: result(input, s).0.get_Enabled_0(),
+                controller_state: Option::Some(result(input, s).0.get_Enabled_0()),
                 network_state: result(input, s).1.get_Enabled_0(),
                 chan_manager: result(input, s).0.get_Enabled_1().1,
                 ..s
@@ -162,15 +179,58 @@ pub open spec fn controller_next<T>(reconciler: Reconciler<T>) -> Action<State<T
 pub open spec fn schedule_controller_reconcile<T>() -> Action<State<T>, ObjectRef, ()> {
     Action {
         precondition: |input: ObjectRef, s: State<T>| {
+            &&& s.controller_alive()
             &&& s.resource_key_exists(input)
             &&& input.kind.is_CustomResourceKind()
         },
         transition: |input: ObjectRef, s: State<T>| {
             (State {
-                controller_state: insert_scheduled_reconcile(s.controller_state, input),
+                controller_state: Option::Some(insert_scheduled_reconcile(s.controller_state.get_Some_0(), input)),
                 ..s
             }, ())
         }
+    }
+}
+
+pub open spec fn crash_controller<T>() -> Action<State<T>, (), ()> {
+    Action {
+        precondition: |input: (), s: State<T>| {
+            s.crash_enabled
+        },
+        transition: |input: (), s: State<T>| {
+            (State {
+                controller_state: Option::None,
+                ..s
+            }, ())
+        },
+    }
+}
+
+pub open spec fn restart_controller<T>() -> Action<State<T>, (), ()> {
+    Action {
+        precondition: |input: (), s: State<T>| {
+            !s.controller_alive()
+        },
+        transition: |input: (), s: State<T>| {
+            (State {
+                controller_state: Option::Some(init_controller_state()),
+                ..s
+            }, ())
+        },
+    }
+}
+
+pub open spec fn disable_crash<T>() -> Action<State<T>, (), ()> {
+    Action {
+        precondition: |input: (), s: State<T>| {
+            true
+        },
+        transition: |input: (), s: State<T>| {
+            (State {
+                crash_enabled: false,
+                ..s
+            }, ())
+        },
     }
 }
 
@@ -219,8 +279,11 @@ pub open spec fn stutter<T>() -> Action<State<T>, (), ()> {
 pub enum Step {
     KubernetesAPIStep(Option<Message>),
     ControllerStep((Option<Message>, Option<ObjectRef>)),
-    ScheduleControllerReconcileStep(ObjectRef),
     ClientStep((Option<Message>, CustomResourceView)),
+    ScheduleControllerReconcileStep(ObjectRef),
+    CrashController(),
+    RestartController(),
+    DisableCrash(),
     StutterStep(),
 }
 
@@ -228,8 +291,11 @@ pub open spec fn next_step<T>(reconciler: Reconciler<T>, s: State<T>, s_prime: S
     match step {
         Step::KubernetesAPIStep(input) => kubernetes_api_next().forward(input)(s, s_prime),
         Step::ControllerStep(input) => controller_next(reconciler).forward(input)(s, s_prime),
-        Step::ScheduleControllerReconcileStep(input) => schedule_controller_reconcile().forward(input)(s, s_prime),
         Step::ClientStep(input) => client_next().forward(input)(s, s_prime),
+        Step::ScheduleControllerReconcileStep(input) => schedule_controller_reconcile().forward(input)(s, s_prime),
+        Step::CrashController() => crash_controller().forward(())(s, s_prime),
+        Step::RestartController() => restart_controller().forward(())(s, s_prime),
+        Step::DisableCrash() => disable_crash().forward(())(s, s_prime),
         Step::StutterStep() => stutter().forward(())(s, s_prime),
     }
 }
@@ -253,6 +319,8 @@ pub open spec fn sm_partial_spec<T>(reconciler: Reconciler<T>) -> TempPred<State
     .and(tla_forall(|input| kubernetes_api_next().weak_fairness(input)))
     .and(tla_forall(|input| controller_next(reconciler).weak_fairness(input)))
     .and(tla_forall(|input| schedule_controller_reconcile().weak_fairness(input)))
+    .and(restart_controller().weak_fairness(()))
+    .and(disable_crash().weak_fairness(()))
 }
 
 pub open spec fn kubernetes_api_action_pre<T>(action: KubernetesAPIAction, input: Option<Message>) -> StatePred<State<T>> {
@@ -276,20 +344,24 @@ pub open spec fn kubernetes_api_action_pre<T>(action: KubernetesAPIAction, input
 
 pub open spec fn controller_action_pre<T>(reconciler: Reconciler<T>, action: ControllerAction<T>, input: (Option<Message>, Option<ObjectRef>)) -> StatePred<State<T>> {
     |s: State<T>| {
-        let host_result = controller(reconciler).next_action_result(
-            action,
-            ControllerActionInput{recv: input.0, scheduled_cr_key: input.1, chan_manager: s.chan_manager},
-            s.controller_state
-        );
-        let msg_ops = MessageOps {
-            recv: input.0,
-            send: host_result.get_Enabled_1().0,
-        };
-        let network_result = network().next_result(msg_ops, s.network_state);
+        if s.controller_alive() {
+            let host_result = controller(reconciler).next_action_result(
+                action,
+                ControllerActionInput{recv: input.0, scheduled_cr_key: input.1, chan_manager: s.chan_manager},
+                s.controller_state.get_Some_0()
+            );
+            let msg_ops = MessageOps {
+                recv: input.0,
+                send: host_result.get_Enabled_1().0,
+            };
+            let network_result = network().next_result(msg_ops, s.network_state);
 
-        &&& received_msg_destined_for(input.0, HostId::CustomController)
-        &&& host_result.is_Enabled()
-        &&& network_result.is_Enabled()
+            &&& received_msg_destined_for(input.0, HostId::CustomController)
+            &&& host_result.is_Enabled()
+            &&& network_result.is_Enabled()
+        } else {
+            false
+        }
     }
 }
 

--- a/src/kubernetes_cluster/spec/distributed_system.rs
+++ b/src/kubernetes_cluster/spec/distributed_system.rs
@@ -30,6 +30,8 @@ verus! {
 
 pub struct State<T> {
     pub kubernetes_api_state: KubernetesAPIState,
+    /// controller_state is in an Option
+    /// because we use Option::None to represent that the controller is not running.
     pub controller_state: Option<ControllerState<T>>,
     pub client_state: ClientState,
     pub network_state: NetworkState,
@@ -192,6 +194,9 @@ pub open spec fn schedule_controller_reconcile<T>() -> Action<State<T>, ObjectRe
     }
 }
 
+/// This action crashes the controller.
+/// It specifies the faulty scenario when the controller crashes and loses all the internal state.
+/// It is controlled by s.crash_enabled so that we can later stop crashing by setting it to false.
 pub open spec fn crash_controller<T>() -> Action<State<T>, (), ()> {
     Action {
         precondition: |input: (), s: State<T>| {
@@ -206,6 +211,7 @@ pub open spec fn crash_controller<T>() -> Action<State<T>, (), ()> {
     }
 }
 
+/// This action restarts the crashed controller.
 pub open spec fn restart_controller<T>() -> Action<State<T>, (), ()> {
     Action {
         precondition: |input: (), s: State<T>| {
@@ -220,6 +226,8 @@ pub open spec fn restart_controller<T>() -> Action<State<T>, (), ()> {
     }
 }
 
+/// This action sets s.crash_enabled to false.
+/// This is used to constraint the crash behavior: the controller eventually stops crashing.
 pub open spec fn disable_crash<T>() -> Action<State<T>, (), ()> {
     Action {
         precondition: |input: (), s: State<T>| {

--- a/src/simple_controller/mod.rs
+++ b/src/simple_controller/mod.rs
@@ -1,5 +1,5 @@
 // Copyright 2022 VMware, Inc.
 // SPDX-License-Identifier: MIT
 pub mod exec;
-pub mod proof;
+// pub mod proof;
 pub mod spec;

--- a/src/temporal_logic/rules.rs
+++ b/src/temporal_logic/rules.rs
@@ -1006,6 +1006,7 @@ pub proof fn stable_and_temp<T>(p: TempPred<T>, q: TempPred<T>)
 
 /// The three-predicate-version of stable_and_temp
 /// This is created for avoid multiple calls to stable_and_temp.
+// TODO: The following stable_and_x_temp lemmas should be generated using a macro
 pub proof fn stable_and_3_temp<T>(p1: TempPred<T>, p2: TempPred<T>, p3: TempPred<T>)
     requires
         valid(stable(p1)),

--- a/src/temporal_logic/rules.rs
+++ b/src/temporal_logic/rules.rs
@@ -1032,6 +1032,37 @@ pub proof fn stable_and_4_temp<T>(p1: TempPred<T>, p2: TempPred<T>, p3: TempPred
     stable_and_3_temp::<T>(p1.and(p2), p3, p4);
 }
 
+/// The five-predicate-version of stable_and_temp
+pub proof fn stable_and_5_temp<T>(p1: TempPred<T>, p2: TempPred<T>, p3: TempPred<T>, p4: TempPred<T>, p5: TempPred<T>)
+    requires
+        valid(stable(p1)),
+        valid(stable(p2)),
+        valid(stable(p3)),
+        valid(stable(p4)),
+        valid(stable(p5)),
+    ensures
+        valid(stable(p1.and(p2).and(p3).and(p4).and(p5))),
+{
+    stable_and_temp::<T>(p1, p2);
+    stable_and_4_temp::<T>(p1.and(p2), p3, p4, p5);
+}
+
+/// The six-predicate-version of stable_and_temp
+pub proof fn stable_and_6_temp<T>(p1: TempPred<T>, p2: TempPred<T>, p3: TempPred<T>, p4: TempPred<T>, p5: TempPred<T>, p6: TempPred<T>)
+    requires
+        valid(stable(p1)),
+        valid(stable(p2)),
+        valid(stable(p3)),
+        valid(stable(p4)),
+        valid(stable(p5)),
+        valid(stable(p6)),
+    ensures
+        valid(stable(p1.and(p2).and(p3).and(p4).and(p5).and(p6))),
+{
+    stable_and_temp::<T>(p1, p2);
+    stable_and_5_temp::<T>(p1.and(p2), p3, p4, p5, p6);
+}
+
 /// Unpack the assumption from left to the right side of |=
 /// pre:
 ///     |= stable(partial_spec)


### PR DESCRIPTION
Specify controller crash and add weak fairness assumption to express "the controller eventually stops crashing".

To support specifying crash, we place controller_state in an Option and use Option::None to represent the case where the controller is not running, and we add a crash_enabled bit as the precondition to crash the controller. We add three new actions to the top-level state machine:
- crash_controller that sets the controller state to Option::None and if crash_enabled
- restart_controller that restarts the controller with the initial controller state if the controller is not running
- disable_crash that sets crash_enabled to false

We also add weak fairness assumption on restart_controller and disable_crash so that later we can prove eventually the controller stops crashing and is running alive.

Besides, we fix a few lemmas in cluster.rs. There are more broken lemmas to fix. Most of them need to be proved in a context where the controller is always alive and never crashes, which is not in the scope of this PR.