### PR TITLE
Make crash and restart atomic

### DIFF
--- a/src/kubernetes_cluster/proof/cluster.rs
+++ b/src/kubernetes_cluster/proof/cluster.rs
@@ -56,15 +56,13 @@ pub proof fn valid_stable_sm_partial_spec<T>(reconciler: Reconciler<T>)
     valid_stable_tla_forall_action_weak_fairness::<T, Option<Message>, ()>(kubernetes_api_next());
     valid_stable_tla_forall_action_weak_fairness::<T, (Option<Message>, Option<ObjectRef>), ()>(controller_next(reconciler));
     valid_stable_tla_forall_action_weak_fairness::<T, ObjectRef, ()>(schedule_controller_reconcile());
-    valid_stable_action_weak_fairness::<T, ()>(restart_controller());
     valid_stable_action_weak_fairness::<T, ()>(disable_crash());
 
-    stable_and_6_temp::<State<T>>(
+    stable_and_5_temp::<State<T>>(
         always(lift_action(next(reconciler))),
         tla_forall(|input| kubernetes_api_next().weak_fairness(input)),
         tla_forall(|input| controller_next(reconciler).weak_fairness(input)),
         tla_forall(|input| schedule_controller_reconcile().weak_fairness(input)),
-        restart_controller().weak_fairness(()),
         disable_crash().weak_fairness(())
     );
 }

--- a/src/kubernetes_cluster/proof/wf1_assistant.rs
+++ b/src/kubernetes_cluster/proof/wf1_assistant.rs
@@ -44,7 +44,7 @@ pub proof fn controller_action_pre_implies_next_pre<T>(reconciler: Reconciler<T>
         valid(lift_state(controller_action_pre(reconciler, action, input)).implies(lift_state(controller_next(reconciler).pre(input)))),
 {
     assert forall |s| #[trigger] controller_action_pre(reconciler, action, input)(s) implies controller_next(reconciler).pre(input)(s) by {
-        exists_next_controller_step(reconciler, action, ControllerActionInput{recv: input.0, scheduled_cr_key: input.1, chan_manager: s.chan_manager}, s.controller_state.get_Some_0());
+        exists_next_controller_step(reconciler, action, ControllerActionInput{recv: input.0, scheduled_cr_key: input.1, chan_manager: s.chan_manager}, s.controller_state);
     };
 }
 


### PR DESCRIPTION
Collapse the previous `crash_controller` and `restart_controller` into one action. This would simplify the proof because we no longer need to carry the Option. Note that the new specification on crash still allows the execution that the controller restart does not immediately happen after the crash: not scheduling any controller action before `restart_controller` is the same as the controller is crashed and then restarted by `restart_controller`.