### PR TITLE
Prove simple controller liveness under crash

### DIFF
--- a/src/kubernetes_cluster/proof/cluster.rs
+++ b/src/kubernetes_cluster/proof/cluster.rs
@@ -67,4 +67,28 @@ pub proof fn valid_stable_sm_partial_spec<T>(reconciler: Reconciler<T>)
     );
 }
 
+pub proof fn lemma_true_leads_to_crash_always_disabled<T>(spec: TempPred<State<T>>, reconciler: Reconciler<T>)
+    requires
+        spec.entails(always(lift_action(next(reconciler)))),
+        spec.entails(disable_crash().weak_fairness(())),
+    ensures
+        spec.entails(true_pred().leads_to(always(lift_state(crash_disabled::<T>())))),
+{
+    let true_state = |s: State<T>| true;
+    disable_crash().wf1((), spec, next(reconciler), true_state, crash_disabled::<T>());
+    leads_to_stable_temp::<State<T>>(spec, lift_action(next(reconciler)), true_pred(), lift_state(crash_disabled::<T>()));
+}
+
+pub proof fn lemma_any_pred_leads_to_crash_always_disabled<T>(spec: TempPred<State<T>>, reconciler: Reconciler<T>, any_pred: TempPred<State<T>>)
+    requires
+        spec.entails(always(lift_action(next(reconciler)))),
+        spec.entails(disable_crash().weak_fairness(())),
+    ensures
+        spec.entails(any_pred.leads_to(always(lift_state(crash_disabled::<T>())))),
+{
+    valid_implies_implies_leads_to::<State<T>>(spec, any_pred, true_pred());
+    lemma_true_leads_to_crash_always_disabled::<T>(spec, reconciler);
+    leads_to_trans_temp::<State<T>>(spec, any_pred, true_pred(), always(lift_state(crash_disabled::<T>())));
+}
+
 }

--- a/src/kubernetes_cluster/proof/controller_runtime_liveness.rs
+++ b/src/kubernetes_cluster/proof/controller_runtime_liveness.rs
@@ -23,10 +23,6 @@ use builtin_macros::*;
 
 verus! {
 
-pub open spec fn crash_disabled<T>() -> StatePred<State<T>> {
-    |s: State<T>| !s.crash_enabled
-}
-
 pub open spec fn partial_spec_with_always_cr_key_exists_and_crash_disabled<T>(reconciler: Reconciler<T>, cr_key: ObjectRef) -> TempPred<State<T>> {
     sm_partial_spec(reconciler).and(always(lift_state(|s: State<T>| s.resource_key_exists(cr_key)))).and(always(lift_state(crash_disabled::<T>())))
 }

--- a/src/kubernetes_cluster/proof/controller_runtime_liveness.rs
+++ b/src/kubernetes_cluster/proof/controller_runtime_liveness.rs
@@ -23,6 +23,14 @@ use builtin_macros::*;
 
 verus! {
 
+pub open spec fn crash_disabled<T>() -> StatePred<State<T>> {
+    |s: State<T>| !s.crash_enabled
+}
+
+pub open spec fn partial_spec_with_always_cr_key_exists_and_crash_disabled<T>(reconciler: Reconciler<T>, cr_key: ObjectRef) -> TempPred<State<T>> {
+    sm_partial_spec(reconciler).and(always(lift_state(|s: State<T>| s.resource_key_exists(cr_key)))).and(always(lift_state(crash_disabled::<T>())))
+}
+
 pub proof fn lemma_pre_leads_to_post_by_controller<T>(spec: TempPred<State<T>>, reconciler: Reconciler<T>, input: (Option<Message>, Option<ObjectRef>), next: ActionPred<State<T>>, action: ControllerAction<T>, pre: StatePred<State<T>>, post: StatePred<State<T>>)
     requires
         controller(reconciler).actions.contains(action),
@@ -115,6 +123,7 @@ pub proof fn lemma_reconcile_idle_and_scheduled_leads_to_reconcile_init<T>(spec:
     requires
         cr_key.kind.is_CustomResourceKind(),
         spec.entails(always(lift_action(next(reconciler)))),
+        spec.entails(always(lift_state(crash_disabled::<T>()))),
         spec.entails(tla_forall(|i| controller_next(reconciler).weak_fairness(i))),
     ensures
         spec.entails(
@@ -138,8 +147,13 @@ pub proof fn lemma_reconcile_idle_and_scheduled_leads_to_reconcile_init<T>(spec:
         &&& s.reconcile_state_of(cr_key).local_state == (reconciler.reconcile_init_state)()
         &&& s.reconcile_state_of(cr_key).pending_req_msg.is_None()
     };
+    let stronger_next = |s, s_prime: State<T>| {
+        &&& next(reconciler)(s, s_prime)
+        &&& !s.crash_enabled
+    };
+    strengthen_next::<State<T>>(spec, next(reconciler), crash_disabled::<T>(), stronger_next);
     let input = (Option::None, Option::Some(cr_key));
-    lemma_pre_leads_to_post_by_controller::<T>(spec, reconciler, input, next(reconciler), run_scheduled_reconcile(reconciler), pre, post);
+    lemma_pre_leads_to_post_by_controller::<T>(spec, reconciler, input, stronger_next, run_scheduled_reconcile(reconciler), pre, post);
 }
 
 pub proof fn lemma_true_leads_to_reconcile_scheduled_by_assumption<T>(reconciler: Reconciler<T>, cr_key: ObjectRef)
@@ -192,7 +206,7 @@ pub proof fn lemma_cr_always_exists_entails_reconcile_idle_leads_to_reconcile_in
     requires
         cr_key.kind.is_CustomResourceKind(),
     ensures
-        sm_partial_spec(reconciler).and(always(lift_state(|s: State<T>| s.resource_key_exists(cr_key)))).entails(
+        partial_spec_with_always_cr_key_exists_and_crash_disabled(reconciler, cr_key).entails(
             lift_state(|s: State<T>| {!s.reconcile_state_contains(cr_key)})
             .leads_to(lift_state(|s: State<T>| {
                 &&& s.reconcile_state_contains(cr_key)
@@ -201,20 +215,16 @@ pub proof fn lemma_cr_always_exists_entails_reconcile_idle_leads_to_reconcile_in
             }))
     ),
 {
-    lemma_reconcile_idle_leads_to_reconcile_idle_and_scheduled_by_assumption::<T>(reconciler, cr_key);
-    lemma_reconcile_idle_and_scheduled_leads_to_reconcile_init::<T>(sm_partial_spec(reconciler), reconciler, cr_key);
-    strengthen_spec::<State<T>>(sm_partial_spec(reconciler), always(lift_state(|s: State<T>| s.resource_key_exists(cr_key))),
-        lift_state(|s: State<T>| {
-            &&& !s.reconcile_state_contains(cr_key)
-            &&& s.reconcile_scheduled_for(cr_key)
-        })
-        .leads_to(lift_state(|s: State<T>| {
-            &&& s.reconcile_state_contains(cr_key)
-            &&& s.reconcile_state_of(cr_key).local_state == (reconciler.reconcile_init_state)()
-            &&& s.reconcile_state_of(cr_key).pending_req_msg.is_None()
-        })));
 
-    leads_to_trans_auto::<State<T>>(sm_partial_spec(reconciler).and(always(lift_state(|s: State<T>| s.resource_key_exists(cr_key)))));
+    lemma_reconcile_idle_leads_to_reconcile_idle_and_scheduled_by_assumption::<T>(reconciler, cr_key);
+    entails_trans::<State<T>>(partial_spec_with_always_cr_key_exists_and_crash_disabled(reconciler, cr_key), sm_partial_spec(reconciler).and(always(lift_state(|s: State<T>| s.resource_key_exists(cr_key)))), lift_state(|s: State<T>| !s.reconcile_state_contains(cr_key))
+    .leads_to(lift_state(|s: State<T>| {
+        &&& !s.reconcile_state_contains(cr_key)
+        &&& s.reconcile_scheduled_for(cr_key)})
+    ));
+    lemma_reconcile_idle_and_scheduled_leads_to_reconcile_init::<T>(partial_spec_with_always_cr_key_exists_and_crash_disabled(reconciler, cr_key), reconciler, cr_key);
+
+    leads_to_trans_auto::<State<T>>(partial_spec_with_always_cr_key_exists_and_crash_disabled(reconciler, cr_key));
 }
 
 
@@ -222,7 +232,7 @@ pub proof fn lemma_cr_always_exists_entails_reconcile_error_leads_to_reconcile_i
     requires
         cr_key.kind.is_CustomResourceKind(),
     ensures
-        sm_partial_spec(reconciler).and(always(lift_state(|s: State<T>| s.resource_key_exists(cr_key)))).entails(
+        partial_spec_with_always_cr_key_exists_and_crash_disabled(reconciler, cr_key).entails(
             lift_state(|s: State<T>| {
                 &&& s.reconcile_state_contains(cr_key)
                 &&& (reconciler.reconcile_error)(s.reconcile_state_of(cr_key).local_state)
@@ -235,27 +245,21 @@ pub proof fn lemma_cr_always_exists_entails_reconcile_error_leads_to_reconcile_i
         ),
 {
     lemma_reconcile_error_leads_to_reconcile_idle::<T>(reconciler, cr_key);
-    strengthen_spec::<State<T>>(sm_partial_spec(reconciler), always(lift_state(|s: State<T>| s.resource_key_exists(cr_key))), lift_state(|s: State<T>| {
+    entails_trans::<State<T>>(partial_spec_with_always_cr_key_exists_and_crash_disabled(reconciler, cr_key), sm_partial_spec(reconciler), lift_state(|s: State<T>| {
         &&& s.reconcile_state_contains(cr_key)
         &&& (reconciler.reconcile_error)(s.reconcile_state_of(cr_key).local_state)
-    })
+        })
         .leads_to(lift_state(|s: State<T>| {
             &&& !s.reconcile_state_contains(cr_key)
         })));
     lemma_reconcile_idle_leads_to_reconcile_idle_and_scheduled_by_assumption::<T>(reconciler, cr_key);
-    lemma_reconcile_idle_and_scheduled_leads_to_reconcile_init::<T>(sm_partial_spec(reconciler), reconciler, cr_key);
-    strengthen_spec::<State<T>>(sm_partial_spec(reconciler), always(lift_state(|s: State<T>| s.resource_key_exists(cr_key))),
-    lift_state(|s: State<T>| {
-        &&& !s.reconcile_state_contains(cr_key)
-        &&& s.reconcile_scheduled_for(cr_key)
-        })
-        .leads_to(lift_state(|s: State<T>| {
-            &&& s.reconcile_state_contains(cr_key)
-            &&& s.reconcile_state_of(cr_key).local_state == (reconciler.reconcile_init_state)()
-            &&& s.reconcile_state_of(cr_key).pending_req_msg.is_None()
-        })));
+    entails_trans::<State<T>>(partial_spec_with_always_cr_key_exists_and_crash_disabled(reconciler, cr_key), sm_partial_spec(reconciler).and(always(lift_state(|s: State<T>| s.resource_key_exists(cr_key)))), lift_state(|s: State<T>| !s.reconcile_state_contains(cr_key))
+            .leads_to(lift_state(|s: State<T>| {
+                &&& !s.reconcile_state_contains(cr_key)
+                &&& s.reconcile_scheduled_for(cr_key)})));
+    lemma_reconcile_idle_and_scheduled_leads_to_reconcile_init::<T>(partial_spec_with_always_cr_key_exists_and_crash_disabled(reconciler, cr_key), reconciler, cr_key);
 
-    leads_to_trans_auto::<State<T>>(sm_partial_spec(reconciler).and(always(lift_state(|s: State<T>| s.resource_key_exists(cr_key)))));
+    leads_to_trans_auto::<State<T>>(partial_spec_with_always_cr_key_exists_and_crash_disabled(reconciler, cr_key));
 }
 
 }

--- a/src/kubernetes_cluster/proof/mod.rs
+++ b/src/kubernetes_cluster/proof/mod.rs
@@ -1,8 +1,8 @@
 // Copyright 2022 VMware, Inc.
 // SPDX-License-Identifier: MIT
 pub mod cluster;
-// pub mod controller_runtime_liveness;
-// pub mod controller_runtime_safety;
+pub mod controller_runtime_liveness;
+pub mod controller_runtime_safety;
 pub mod kubernetes_api_liveness;
 pub mod kubernetes_api_safety;
 pub mod wf1_assistant;

--- a/src/kubernetes_cluster/spec/distributed_system.rs
+++ b/src/kubernetes_cluster/spec/distributed_system.rs
@@ -332,4 +332,8 @@ pub open spec fn controller_action_pre<T>(reconciler: Reconciler<T>, action: Con
     }
 }
 
+pub open spec fn crash_disabled<T>() -> StatePred<State<T>> {
+    |s: State<T>| !s.crash_enabled
+}
+
 }

--- a/src/simple_controller/mod.rs
+++ b/src/simple_controller/mod.rs
@@ -1,5 +1,5 @@
 // Copyright 2022 VMware, Inc.
 // SPDX-License-Identifier: MIT
 pub mod exec;
-// pub mod proof;
+pub mod proof;
 pub mod spec;

--- a/src/simple_controller/proof/liveness.rs
+++ b/src/simple_controller/proof/liveness.rs
@@ -38,13 +38,15 @@ spec fn cr_matched(cr: CustomResourceView) -> TempPred<State<SimpleReconcileStat
 }
 
 /// Proof strategy:
-///     (1) For case_1, case_2, ..., case_n, we prove partial_spec /\ all_invariants /\ []cr_exists |= case_i ~> cm_exists. The disjunction of case_1, case_2, ..., case_n should be true.
-///     (2) Now we have partial_spec /\ all_invariants /\ []cr_exists |= true ~> cm_exists. Unpacking []cr_exists to the right side, we have spec /\ all_invariants |= []cr_exists ~> cm_exists.
+///     (1) For case_1, case_2, ..., case_n, we prove partial_spec /\ [] crash_disabled /\ all_invariants /\ []cr_exists |= case_i ~> cm_exists. The disjunction of case_1, case_2, ..., case_n should be true.
+///     (2) Now we have partial_spec /\ [] crash_disabled /\ all_invariants /\ []cr_exists |= true ~> cm_exists. Unpacking [] crash_disabled /\ []cr_exists to the right side, we have spec /\ all_invariants |= []cr_exists ~> cm_exists.
 ///     (3) To unpack []cr_exists, we have to prove the stability of partial_spec /\ all_invariants.
-///     (4) By proving all the invariants can be infer from spec, here comes to spec |= []cr_exists ~> cm_exists.
-///     (5) Finally, with the help of lemma_p_leads_to_cm_always_exists, the liveness property is proved.
+///     (4) By proving all the invariants can be inferred from spec, here comes to spec |= []cr_exists /\ [] crash_disabled ~> cm_exists.
+///     (5) Next, with the help of lemma_p_leads_to_cm_always_exists, we have spec |= []cr_exists /\ [] crash_disabled ~> [] cm_exists.
+///     (6) By the weak fairness of the action disable_crash, we have spec |= []cr_exists ~> [] cr_exists /\ [] crash_disabled.
+///     (7) By the transitivity of leads_to relation, we have spec |= []cr_exists ~> [] cr_matched.
 
-/// To prove the liveness property, we need some invariants (these invariants have already contained always constraint).
+/// To prove the liveness property, we need some invariants (these invariants have already contained "always" constraint).
 spec fn all_invariants(cr: CustomResourceView) -> TempPred<State<SimpleReconcileState>> {
     always(lift_state(reconcile_create_cm_done_implies_pending_create_cm_req_in_flight_or_cm_exists(cr)))
     .and(tla_forall(|msg| always(lift_state(controller_runtime_safety::resp_matches_at_most_one_pending_req(msg, cr.object_ref())))))


### PR DESCRIPTION
When crash is enabled, we can first assume that the system enters a state $S$ when crash will always be disabled and cm always exists will eventually happen. The rest is to prove that under our spec, state $S$ will be reached anyway.

This means to separate the verification into two parts:
    (1) `spec |= []cr_exists ~> []cr_exists /\ [] !crash_enabled`
    (2) `spec |= []cr_exists /\ [] !crash_enabled ~> []cr_matched`
The second is similar to the previous proof.