### PR TITLE
Model kube::Error as APIError

### DIFF
--- a/src/kubernetes_api_objects/api_method.rs
+++ b/src/kubernetes_api_objects/api_method.rs
@@ -3,6 +3,7 @@
 use crate::kubernetes_api_objects::common::*;
 use crate::kubernetes_api_objects::config_map::*;
 use crate::kubernetes_api_objects::custom_resource::*;
+use crate::kubernetes_api_objects::error::*;
 use crate::kubernetes_api_objects::object::*;
 use crate::pervasive_ext::string_view::*;
 use vstd::prelude::*;
@@ -178,7 +179,6 @@ pub open spec fn opt_req_to_view(req: &Option<KubeAPIRequest>) -> Option<APIRequ
 
 /// APIResponse represents API responses sent from the Kubernetes API for specifications.
 
-// TODO: implement Update and Patch request.
 #[is_variant]
 pub enum APIResponse {
     GetResponse(GetResponse),
@@ -219,15 +219,6 @@ pub struct DeleteResponse {
 // TODO: implement all the variants after we import kube-rs.
 pub enum KubeAPIResponse {
     WillAddSomething,
-}
-
-/// APIError represents the Error codes sent from the Kubernetes API for specifications.
-
-// TODO: implement the error types for executable code.
-#[is_variant]
-pub enum APIError {
-    ObjectNotFound,
-    ObjectAlreadyExists,
 }
 
 }

--- a/src/kubernetes_api_objects/error.rs
+++ b/src/kubernetes_api_objects/error.rs
@@ -1,0 +1,34 @@
+// Copyright 2022 VMware, Inc.
+// SPDX-License-Identifier: MIT
+use crate::kubernetes_api_objects::common::*;
+use crate::kubernetes_api_objects::object_meta::*;
+use kube;
+use vstd::prelude::*;
+
+verus! {
+
+// TODO: implement other error types
+#[is_variant]
+pub enum APIError {
+    ObjectNotFound,
+    ObjectAlreadyExists,
+    Other
+}
+
+#[verifier(external)]
+pub fn kube_error_to_ghost(error: kube::Error) -> APIError {
+    match error {
+        kube::Error::Api(error_resp) => {
+            if error_resp.code == 404 {
+                APIError::ObjectNotFound
+            } else if error_resp.code == 403 {
+                APIError::ObjectAlreadyExists
+            } else {
+                APIError::Other
+            }
+        },
+        _ => APIError::Other,
+    }
+}
+
+}

--- a/src/kubernetes_api_objects/mod.rs
+++ b/src/kubernetes_api_objects/mod.rs
@@ -4,6 +4,7 @@ pub mod api_method;
 pub mod common;
 pub mod config_map;
 pub mod custom_resource;
+pub mod error;
 pub mod object;
 pub mod object_meta;
 pub mod persistent_volume_claim;

--- a/src/kubernetes_cluster/proof/kubernetes_api_liveness.rs
+++ b/src/kubernetes_cluster/proof/kubernetes_api_liveness.rs
@@ -1,7 +1,7 @@
 // Copyright 2022 VMware, Inc.
 // SPDX-License-Identifier: MIT
 #![allow(unused_imports)]
-use crate::kubernetes_api_objects::{api_method::*, common::*, object::*};
+use crate::kubernetes_api_objects::{api_method::*, common::*, error::*, object::*};
 use crate::kubernetes_cluster::{
     proof::wf1_assistant::kubernetes_api_action_pre_implies_next_pre,
     spec::{
@@ -12,11 +12,11 @@ use crate::kubernetes_cluster::{
         reconciler::Reconciler,
     },
 };
-use vstd::{option::*, result::*};
 use crate::temporal_logic::defs::*;
 use crate::temporal_logic::rules::*;
 use builtin::*;
 use builtin_macros::*;
+use vstd::{option::*, result::*};
 
 verus! {
 

--- a/src/kubernetes_cluster/spec/kubernetes_api/state_machine.rs
+++ b/src/kubernetes_cluster/spec/kubernetes_api/state_machine.rs
@@ -1,18 +1,18 @@
 // Copyright 2022 VMware, Inc.
 // SPDX-License-Identifier: MIT
 #![allow(unused_imports)]
-use crate::kubernetes_api_objects::{api_method::*, common::*, object::*};
+use crate::kubernetes_api_objects::{api_method::*, common::*, error::*, object::*};
 use crate::kubernetes_cluster::spec::{
     channel::*,
     kubernetes_api::{builtin_controllers::statefulset_controller, common::*},
     message::*,
 };
-use vstd::{map::*, multiset::*, option::*, result::*, seq::*, set::*};
 use crate::state_machine::action::*;
 use crate::state_machine::state_machine::*;
 use crate::temporal_logic::defs::*;
 use builtin::*;
 use builtin_macros::*;
+use vstd::{map::*, multiset::*, option::*, result::*, seq::*, set::*};
 
 verus! {
 

--- a/src/kubernetes_cluster/spec/message.rs
+++ b/src/kubernetes_cluster/spec/message.rs
@@ -1,11 +1,11 @@
 // Copyright 2022 VMware, Inc.
 // SPDX-License-Identifier: MIT
 #![allow(unused_imports)]
-use crate::kubernetes_api_objects::{api_method::*, common::*, object::*};
-use vstd::{multiset::*, prelude::*};
+use crate::kubernetes_api_objects::{api_method::*, common::*, error::*, object::*};
 use crate::pervasive_ext::string_view::*;
 use builtin::*;
 use builtin_macros::*;
+use vstd::{multiset::*, prelude::*};
 
 verus! {
 


### PR DESCRIPTION
Bridge APIError, which is used in spec and proof, and kube::Error, which is used in implementation code.