### PR TITLE
Avoid using unofficial workflow actions

### DIFF
--- a/.github/workflows/regression-testing.yml
+++ b/.github/workflows/regression-testing.yml
@@ -2,10 +2,10 @@ name: Regression Testing
 run-name: ${{ github.actor }} is running regression tests
 on:
   workflow_dispatch:
-  # push:
-  #   branches:
-  #     - main
-  # pull_request:
+  push:
+    branches:
+      - main
+  pull_request:
 jobs:
   regression-testing:
     runs-on: ubuntu-latest

--- a/.github/workflows/regression-testing.yml
+++ b/.github/workflows/regression-testing.yml
@@ -17,11 +17,7 @@ jobs:
           repository: verus-lang/verus
           path: verus
       - name: Install latest nightly Rust toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: nightly
-          override: true
-          components: rustfmt, clippy
+        run: curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs -o sh.rustup.rs && sh sh.rustup.rs -y
       - name: Download Z3
         run: cd verus/source && ./tools/get-z3.sh
       - name: Build Verus


### PR DESCRIPTION
Avoid using actions-rs/toolchain@v1 which is not allowed by the current GitHub workflow setting. And enable actions for push and pull requests as well.