### PR TITLE
Generate TLA proofs with any number of arguments using macros

### DIFF
--- a/src/controller_examples/simple_controller/proof/liveness.rs
+++ b/src/controller_examples/simple_controller/proof/liveness.rs
@@ -608,10 +608,13 @@ proof fn lemma_init_pc_and_no_pending_req_leads_to_after_get_cr_pc_and_exists_pe
         &&& !s.crash_enabled
         &&& every_in_flight_msg_has_lower_id_than_chan_manager::<SimpleReconcileState>()(s)
     };
-    strengthen_next_2::<State<SimpleReconcileState>>(partial_spec_with_invariants_and_assumptions(cr),
-        next(simple_reconciler()), crash_disabled::<SimpleReconcileState>(),
-        every_in_flight_msg_has_lower_id_than_chan_manager::<SimpleReconcileState>(), stronger_next);
-
+    entails_always_and_n!(partial_spec_with_invariants_and_assumptions(cr),
+        lift_action(next(simple_reconciler())), lift_state(crash_disabled::<SimpleReconcileState>()),
+        lift_state(every_in_flight_msg_has_lower_id_than_chan_manager::<SimpleReconcileState>()));
+    temp_pred_equality(lift_action(stronger_next),
+        lift_action(next(simple_reconciler()))
+        .and(lift_state(crash_disabled::<SimpleReconcileState>()))
+        .and(lift_state(every_in_flight_msg_has_lower_id_than_chan_manager::<SimpleReconcileState>())));
     assert forall |s, s_prime| reconciler_init_and_no_pending_req(simple_reconciler(), cr.object_ref())(s) && #[trigger] stronger_next(s, s_prime) implies
     reconciler_init_and_no_pending_req(simple_reconciler(), cr.object_ref())(s_prime)
     || reconciler_at_after_get_cr_pc_and_exists_pending_req_and_req_in_flight_and_no_resp_in_flight(cr)(s_prime) by {
@@ -636,10 +639,14 @@ proof fn lemma_after_get_cr_pc_and_pending_req_in_flight_and_no_resp_in_flight_l
         && s.resource_obj_exists(cr.to_dynamic_object())
         && every_in_flight_req_has_unique_id::<SimpleReconcileState>()(s)
     };
-    strengthen_next_3::<State<SimpleReconcileState>>(partial_spec_with_invariants_and_assumptions(cr),
-        next(simple_reconciler()), crash_disabled::<SimpleReconcileState>(),
-        |s: State<SimpleReconcileState>| s.resource_obj_exists(cr.to_dynamic_object()),
-        every_in_flight_req_has_unique_id::<SimpleReconcileState>(), stronger_next);
+    entails_always_and_n!(partial_spec_with_invariants_and_assumptions(cr),
+        lift_action(next(simple_reconciler())), lift_state(crash_disabled::<SimpleReconcileState>()),
+        lift_state(|s: State<SimpleReconcileState>| s.resource_obj_exists(cr.to_dynamic_object())),
+        lift_state(every_in_flight_req_has_unique_id::<SimpleReconcileState>()));
+    temp_pred_equality(lift_action(stronger_next),
+        lift_action(next(simple_reconciler())).and(lift_state(crash_disabled::<SimpleReconcileState>()))
+        .and(lift_state(|s: State<SimpleReconcileState>| s.resource_obj_exists(cr.to_dynamic_object())))
+        .and(lift_state(every_in_flight_req_has_unique_id::<SimpleReconcileState>())));
     kubernetes_api_liveness::lemma_pre_leads_to_post_by_kubernetes_api::<SimpleReconcileState>(
         partial_spec_with_invariants_and_assumptions(cr), simple_reconciler(), Option::Some(req_msg), stronger_next,
         handle_request(), pre, post);
@@ -779,10 +786,14 @@ proof fn ideal_spec_entails_strengthen_next_with_rep_resp_injectivity(resp_msg: 
     entails_trans::<State<SimpleReconcileState>>(spec, tla_forall_pred_2,
         always(lift_state(resp_matches_at_most_one_pending_req(resp_msg, cr.object_ref()))));
 
-    strengthen_next_3::<State<SimpleReconcileState>>(spec, next(simple_reconciler()),
-        at_most_one_resp_matches_req(resp_msg, cr.object_ref()),
-        resp_matches_at_most_one_pending_req(resp_msg, cr.object_ref()),
-        crash_disabled::<SimpleReconcileState>(), next_and_invariant);
+    entails_always_and_n!(spec, lift_action(next(simple_reconciler())),
+        lift_state(at_most_one_resp_matches_req(resp_msg, cr.object_ref())),
+        lift_state(resp_matches_at_most_one_pending_req(resp_msg, cr.object_ref())),
+        lift_state(crash_disabled::<SimpleReconcileState>()));
+    temp_pred_equality(lift_action(next_and_invariant),
+        lift_action(next(simple_reconciler())).and(lift_state(at_most_one_resp_matches_req(resp_msg, cr.object_ref())))
+        .and(lift_state(resp_matches_at_most_one_pending_req(resp_msg, cr.object_ref())))
+        .and(lift_state(crash_disabled::<SimpleReconcileState>())));
 }
 
 pub proof fn next_and_not_crash_preserves_init_pc_or_reconciler_at_after_get_cr_pc_and_pending_req_in_flight_and_no_resp_in_flight(cr: CustomResourceView, s: State<SimpleReconcileState>, s_prime: State<SimpleReconcileState>)

--- a/src/controller_examples/simple_controller/proof/liveness.rs
+++ b/src/controller_examples/simple_controller/proof/liveness.rs
@@ -291,11 +291,11 @@ proof fn lemma_reconcile_ongoing_leads_to_cm_exists(cr: CustomResourceView)
     lemma_init_pc_leads_to_cm_exists(cr);
     lemma_after_get_cr_pc_leads_to_cm_exists(cr);
     lemma_after_create_cm_pc_leads_to_cm_exists(cr);
-    or_leads_to_combine_4_temp::<State<SimpleReconcileState>>(partial_spec_with_invariants_and_assumptions(cr),
+    or_leads_to_combine_n!(partial_spec_with_invariants_and_assumptions(cr),
         lift_state(reconciler_reconcile_error(cr)),
         lift_state(reconciler_at_init_pc(cr)),
         lift_state(reconciler_at_after_get_cr_pc(cr)),
-        lift_state(reconciler_at_after_create_cm_pc(cr)),
+        lift_state(reconciler_at_after_create_cm_pc(cr));
         lift_state(cm_exists(cr)));
 }
 

--- a/src/controller_examples/simple_controller/proof/liveness.rs
+++ b/src/controller_examples/simple_controller/proof/liveness.rs
@@ -180,7 +180,7 @@ proof fn lemma_valid_stable_sm_partial_spec_and_invariants(cr: CustomResourceVie
     let a_to_always_1 = |resp_msg: Message| always(lift_state(at_most_one_resp_matches_req(resp_msg, cr.object_ref())));
     tla_forall_always_equality_variant::<State<SimpleReconcileState>, Message>(a_to_always_1, a_to_p_1);
 
-    stable_and_7_temp::<State<SimpleReconcileState>>(
+    stable_and_n!(
         always(lift_state(reconcile_create_cm_done_implies_pending_create_cm_req_in_flight_or_cm_exists(cr))),
         tla_forall(|msg| always(lift_state(resp_matches_at_most_one_pending_req(msg, cr.object_ref())))),
         tla_forall(|msg| always(lift_state(at_most_one_resp_matches_req(msg, cr.object_ref())))),
@@ -207,7 +207,7 @@ proof fn lemma_sm_spec_entails_all_invariants(cr: CustomResourceView)
     lemma_always_every_in_flight_msg_has_lower_id_than_chan_manager::<SimpleReconcileState>(simple_reconciler());
     lemma_always_every_in_flight_req_has_unique_id::<SimpleReconcileState>(simple_reconciler());
 
-    entails_and_7_temp::<State<SimpleReconcileState>>(sm_spec(simple_reconciler()),
+    entails_and_n!(sm_spec(simple_reconciler()),
         always(lift_state(reconcile_create_cm_done_implies_pending_create_cm_req_in_flight_or_cm_exists(cr))),
         tla_forall(|msg| always(lift_state(resp_matches_at_most_one_pending_req(msg, cr.object_ref())))),
         tla_forall(|resp_msg: Message| always(lift_state(at_most_one_resp_matches_req(resp_msg, cr.object_ref())))),
@@ -256,7 +256,7 @@ proof fn lemma_reconcile_idle_leads_to_cm_exists(cr: CustomResourceView)
 
     entails_trans::<State<SimpleReconcileState>>(partial_spec_with_invariants_and_assumptions(cr), always(cr_exists(cr)),
         always(lift_state(|s: State<SimpleReconcileState>| s.resource_key_exists(cr.object_ref()))));
-    entails_and_3_temp::<State<SimpleReconcileState>>(partial_spec_with_invariants_and_assumptions(cr),
+    entails_and_n!(partial_spec_with_invariants_and_assumptions(cr),
         sm_partial_spec(simple_reconciler()),
         always(lift_state(|s: State<SimpleReconcileState>| s.resource_key_exists(cr.object_ref()))),
         always(lift_state(crash_disabled::<SimpleReconcileState>())));
@@ -327,7 +327,7 @@ proof fn lemma_error_pc_leads_to_cm_exists(cr: CustomResourceView)
 
     entails_trans::<State<SimpleReconcileState>>(partial_spec_with_invariants_and_assumptions(cr), always(cr_exists(cr)),
         always(lift_state(|s: State<SimpleReconcileState>| s.resource_key_exists(cr.object_ref()))));
-    entails_and_3_temp::<State<SimpleReconcileState>>(partial_spec_with_invariants_and_assumptions(cr),
+    entails_and_n!(partial_spec_with_invariants_and_assumptions(cr),
         sm_partial_spec(simple_reconciler()),
         always(lift_state(|s: State<SimpleReconcileState>| s.resource_key_exists(cr.object_ref()))),
         always(lift_state(crash_disabled::<SimpleReconcileState>())));

--- a/src/kubernetes_cluster/proof/cluster.rs
+++ b/src/kubernetes_cluster/proof/cluster.rs
@@ -58,7 +58,7 @@ pub proof fn valid_stable_sm_partial_spec<T>(reconciler: Reconciler<T>)
     valid_stable_tla_forall_action_weak_fairness::<T, ObjectRef, ()>(schedule_controller_reconcile());
     valid_stable_action_weak_fairness::<T, ()>(disable_crash());
 
-    stable_and_5_temp::<State<T>>(
+    stable_and_n!(
         always(lift_action(next(reconciler))),
         tla_forall(|input| kubernetes_api_next().weak_fairness(input)),
         tla_forall(|input| controller_next(reconciler).weak_fairness(input)),

--- a/src/kubernetes_cluster/proof/controller_runtime_liveness.rs
+++ b/src/kubernetes_cluster/proof/controller_runtime_liveness.rs
@@ -264,7 +264,7 @@ pub proof fn lemma_cr_always_exists_entails_reconcile_error_leads_to_reconcile_i
 
     leads_to_trans_auto::<State<T>>(partial_spec_with_always_cr_key_exists_and_crash_disabled(reconciler, cr_key));
 
-    entails_and_3_temp::<State<T>>(spec, sm_partial_spec(reconciler), always(lift_state(|s: State<T>| s.resource_key_exists(cr_key))), always(lift_state(crash_disabled::<T>())));
+    entails_and_n!(spec, sm_partial_spec(reconciler), always(lift_state(|s: State<T>| s.resource_key_exists(cr_key))), always(lift_state(crash_disabled::<T>())));
     entails_trans::<State<T>>(spec, partial_spec_with_always_cr_key_exists_and_crash_disabled(reconciler, cr_key),
     lift_state(|s: State<T>| {
         &&& s.reconcile_state_contains(cr_key)

--- a/src/kubernetes_cluster/proof/controller_runtime_safety.rs
+++ b/src/kubernetes_cluster/proof/controller_runtime_safety.rs
@@ -120,8 +120,13 @@ pub proof fn lemma_always_every_in_flight_msg_has_unique_id<T>(reconciler: Recon
     };
     lemma_always_every_in_flight_msg_has_lower_id_than_chan_manager::<T>(reconciler);
     lemma_always_every_in_flight_req_is_unique::<T>(reconciler);
-    strengthen_next_2::<State<T>>(sm_spec(reconciler), next(reconciler),
-        every_in_flight_msg_has_lower_id_than_chan_manager::<T>(), every_in_flight_req_is_unique::<T>(), stronger_next);
+    entails_always_and_n!(sm_spec(reconciler), lift_action(next(reconciler)),
+        lift_state(every_in_flight_msg_has_lower_id_than_chan_manager::<T>()),
+        lift_state(every_in_flight_req_is_unique::<T>()));
+    temp_pred_equality(lift_action(stronger_next),
+        lift_action(next(reconciler))
+        .and(lift_state(every_in_flight_msg_has_lower_id_than_chan_manager::<T>()))
+        .and(lift_state(every_in_flight_req_is_unique::<T>())));
     assert forall |s, s_prime: State<T>| invariant(s) && #[trigger] stronger_next(s, s_prime) implies
     invariant(s_prime) by {
         next_and_unique_lower_msg_id_preserves_in_flight_msg_has_unique_id::<T>(reconciler, s, s_prime);

--- a/src/simple_controller.rs
+++ b/src/simple_controller.rs
@@ -1,6 +1,5 @@
 // Copyright 2022 VMware, Inc.
 // SPDX-License-Identifier: MIT
-#![feature(macro_metavar_expr)]
 #![allow(unused_imports)]
 
 pub mod controller_examples;

--- a/src/simple_controller.rs
+++ b/src/simple_controller.rs
@@ -1,6 +1,6 @@
 // Copyright 2022 VMware, Inc.
 // SPDX-License-Identifier: MIT
-
+#![feature(macro_metavar_expr)]
 #![allow(unused_imports)]
 
 pub mod controller_examples;

--- a/src/temporal_logic/rules.rs
+++ b/src/temporal_logic/rules.rs
@@ -926,6 +926,16 @@ pub proof fn entails_and_temp<T>(spec: TempPred<T>, p: TempPred<T>, q: TempPred<
     };
 }
 
+/// Entails the conjunction of all the p if entails each of them.
+/// pre:
+///     spec |= p1
+///     spec |= p2
+///        ...
+///     spec |= pn
+/// post:
+///     spec |= p1 /\ p2 /\ ... /\ pn
+///
+/// Usage: entails_and_n!(spec, p1, p2, p3, p4)
 #[macro_export]
 macro_rules! entails_and_n {
     [$($tail:tt)*] => {
@@ -947,6 +957,16 @@ macro_rules! entails_and_n_internal {
 pub use entails_and_n;
 pub use entails_and_n_internal;
 
+/// Entails always the conjunction of all the p if entails each always p.
+/// pre:
+///     spec |= []p1
+///     spec |= []p2
+///        ...
+///     spec |= []pn
+/// post:
+///     spec |= [](p1 /\ p2 /\ ... /\ pn)
+///
+/// Usage: entails_always_and_n!(spec, p1, p2, p3, p4)
 #[macro_export]
 macro_rules! entails_always_and_n {
     [$($tail:tt)*] => {
@@ -1022,6 +1042,16 @@ pub proof fn stable_and_temp<T>(p: TempPred<T>, q: TempPred<T>)
     }
 }
 
+/// The conjunction of all the p is stable if each p is stable.
+/// pre:
+///     |= stable(p1)
+///     |= stable(p2)
+///      ...
+///     |= stable(pn)
+/// post:
+///     |= stable(p1 /\ p2 /\ ... /\ pn)
+///
+/// Usage: stable_and_n!(p1, p2, p3, p4)
 #[macro_export]
 macro_rules! stable_and_n {
     [$($tail:tt)*] => {
@@ -2085,6 +2115,16 @@ pub proof fn or_leads_to_combine<T>(spec: TempPred<T>, p: StatePred<T>, q: State
     or_leads_to_combine_temp::<T>(spec, lift_state(p), lift_state(q), lift_state(r));
 }
 
+/// Combine the premises of all the leads_to using or.
+/// pre:
+///     spec |= p1 ~> q
+///     spec |= p2 ~> q
+///         ...
+///     spec |= pn ~> q
+/// post:
+///     spec |= (p1 \/ p2 \/ ... \/ pn) ~> q
+///
+/// Usage: or_leads_to_combine_n!(spec, p1, p2, p3, p4; q)
 #[macro_export]
 macro_rules! or_leads_to_combine_n {
     [$($tail:tt)*] => {

--- a/src/temporal_logic/rules.rs
+++ b/src/temporal_logic/rules.rs
@@ -934,93 +934,26 @@ pub proof fn entails_and_temp<T>(spec: TempPred<T>, p: TempPred<T>, q: TempPred<
     };
 }
 
-#[allow(unused_macros)]
+#[macro_export]
 macro_rules! entails_and_n {
-    ($t:ty, $spec:expr, $p1:expr, $p2:expr) => {
-        entails_and_temp::<$t>($spec, $p1, $p2);
-    };
-    ($t:ty, $spec:expr, $p1:expr, $p2:expr, $($tail:tt)*) => {
-        entails_and_temp::<$t>($spec, $p1, $p2);
-        entails_and_n!($t, $spec, $p1.and($p2), $($tail)*);
+    [$($tail:tt)*] => {
+        ::builtin_macros::verus_proof_macro_exprs!($crate::temporal_logic::rules::entails_and_n_internal!($($tail)*));
     };
 }
 
-/// The three-predicate-version for entails_and_temp
-pub proof fn entails_and_3_temp<T>(spec: TempPred<T>, p1: TempPred<T>, p2: TempPred<T>, p3: TempPred<T>)
-    requires
-        spec.entails(p1),
-        spec.entails(p2),
-        spec.entails(p3),
-    ensures
-        spec.entails(p1.and(p2).and(p3)),
-{
-    // entails_and_temp::<T>(spec, p1, p2);
-    // entails_and_temp::<T>(spec, p1.and(p2), p3);
-    entails_and_n!(T, spec, p1, p2, p3);
+#[macro_export]
+macro_rules! entails_and_n_internal {
+    ($spec:expr, $p1:expr, $p2:expr) => {
+        entails_and_temp($spec, $p1, $p2);
+    };
+    ($spec:expr, $p1:expr, $p2:expr, $($tail:tt)*) => {
+        entails_and_temp($spec, $p1, $p2);
+        entails_and_n_internal!($spec, $p1.and($p2), $($tail)*);
+    };
 }
 
-/// The four-predicate-version for entails_and_temp
-pub proof fn entails_and_4_temp<T>(spec: TempPred<T>, p1: TempPred<T>, p2: TempPred<T>, p3: TempPred<T>, p4: TempPred<T>)
-    requires
-        spec.entails(p1),
-        spec.entails(p2),
-        spec.entails(p3),
-        spec.entails(p4),
-    ensures
-        spec.entails(p1.and(p2).and(p3).and(p4)),
-{
-    // entails_and_3_temp::<T>(spec, p1, p2, p3);
-    // entails_and_temp::<T>(spec, p1.and(p2).and(p3), p4);
-    entails_and_n!(T, spec, p1, p2, p3, p4);
-}
-
-/// The five-predicate-version for entails_and_temp
-pub proof fn entails_and_5_temp<T>(spec: TempPred<T>, p1: TempPred<T>, p2: TempPred<T>, p3: TempPred<T>, p4: TempPred<T>, p5: TempPred<T>)
-    requires
-        spec.entails(p1),
-        spec.entails(p2),
-        spec.entails(p3),
-        spec.entails(p4),
-        spec.entails(p5),
-    ensures
-        spec.entails(p1.and(p2).and(p3).and(p4).and(p5)),
-{
-    entails_and_4_temp::<T>(spec, p1, p2, p3, p4);
-    entails_and_temp::<T>(spec, p1.and(p2).and(p3).and(p4), p5);
-}
-
-/// The six-predicate-version for entails_and_temp
-pub proof fn entails_and_6_temp<T>(spec: TempPred<T>, p1: TempPred<T>, p2: TempPred<T>, p3: TempPred<T>, p4: TempPred<T>, p5: TempPred<T>, p6: TempPred<T>)
-    requires
-        spec.entails(p1),
-        spec.entails(p2),
-        spec.entails(p3),
-        spec.entails(p4),
-        spec.entails(p5),
-        spec.entails(p6),
-    ensures
-        spec.entails(p1.and(p2).and(p3).and(p4).and(p5).and(p6)),
-{
-    entails_and_5_temp::<T>(spec, p1, p2, p3, p4, p5);
-    entails_and_temp::<T>(spec, p1.and(p2).and(p3).and(p4).and(p5), p6);
-}
-
-/// The six-predicate-version for entails_and_temp
-pub proof fn entails_and_7_temp<T>(spec: TempPred<T>, p1: TempPred<T>, p2: TempPred<T>, p3: TempPred<T>, p4: TempPred<T>, p5: TempPred<T>, p6: TempPred<T>, p7: TempPred<T>)
-    requires
-        spec.entails(p1),
-        spec.entails(p2),
-        spec.entails(p3),
-        spec.entails(p4),
-        spec.entails(p5),
-        spec.entails(p6),
-        spec.entails(p7),
-    ensures
-        spec.entails(p1.and(p2).and(p3).and(p4).and(p5).and(p6).and(p7)),
-{
-    entails_and_temp::<T>(spec, p1, p2);
-    entails_and_6_temp::<T>(spec, p1.and(p2), p3, p4, p5, p6, p7);
-}
+pub use entails_and_n;
+pub use entails_and_n_internal;
 
 /// Combining two specs together entails p and q if each of them entails p, q respectively.
 /// pre:
@@ -1074,82 +1007,26 @@ pub proof fn stable_and_temp<T>(p: TempPred<T>, q: TempPred<T>)
     }
 }
 
-/// The three-predicate-version of stable_and_temp
-/// This is created for avoid multiple calls to stable_and_temp.
-// TODO: The following stable_and_x_temp lemmas should be generated using a macro
-pub proof fn stable_and_3_temp<T>(p1: TempPred<T>, p2: TempPred<T>, p3: TempPred<T>)
-    requires
-        valid(stable(p1)),
-        valid(stable(p2)),
-        valid(stable(p3)),
-    ensures
-        valid(stable(p1.and(p2).and(p3))),
-{
-    stable_and_temp::<T>(p1, p2);
-    stable_and_temp::<T>(p1.and(p2), p3);
+#[macro_export]
+macro_rules! stable_and_n {
+    [$($tail:tt)*] => {
+        ::builtin_macros::verus_proof_macro_exprs!($crate::temporal_logic::rules::stable_and_n_internal!($($tail)*));
+    };
 }
 
-/// The four-predicate-version of stable_and_temp
-pub proof fn stable_and_4_temp<T>(p1: TempPred<T>, p2: TempPred<T>, p3: TempPred<T>, p4: TempPred<T>)
-    requires
-        valid(stable(p1)),
-        valid(stable(p2)),
-        valid(stable(p3)),
-        valid(stable(p4)),
-    ensures
-        valid(stable(p1.and(p2).and(p3).and(p4))),
-{
-    stable_and_temp::<T>(p1, p2);
-    stable_and_3_temp::<T>(p1.and(p2), p3, p4);
+#[macro_export]
+macro_rules! stable_and_n_internal {
+    ($p1:expr, $p2:expr) => {
+        stable_and_temp($p1, $p2);
+    };
+    ($p1:expr, $p2:expr, $($tail:tt)*) => {
+        stable_and_temp($p1, $p2);
+        stable_and_n_internal!($p1.and($p2), $($tail)*);
+    };
 }
 
-/// The five-predicate-version of stable_and_temp
-pub proof fn stable_and_5_temp<T>(p1: TempPred<T>, p2: TempPred<T>, p3: TempPred<T>, p4: TempPred<T>, p5: TempPred<T>)
-    requires
-        valid(stable(p1)),
-        valid(stable(p2)),
-        valid(stable(p3)),
-        valid(stable(p4)),
-        valid(stable(p5)),
-    ensures
-        valid(stable(p1.and(p2).and(p3).and(p4).and(p5))),
-{
-    stable_and_temp::<T>(p1, p2);
-    stable_and_4_temp::<T>(p1.and(p2), p3, p4, p5);
-}
-
-/// The six-predicate-version of stable_and_temp
-pub proof fn stable_and_6_temp<T>(p1: TempPred<T>, p2: TempPred<T>, p3: TempPred<T>, p4: TempPred<T>, p5: TempPred<T>, p6: TempPred<T>)
-    requires
-        valid(stable(p1)),
-        valid(stable(p2)),
-        valid(stable(p3)),
-        valid(stable(p4)),
-        valid(stable(p5)),
-        valid(stable(p6)),
-    ensures
-        valid(stable(p1.and(p2).and(p3).and(p4).and(p5).and(p6))),
-{
-    stable_and_temp::<T>(p1, p2);
-    stable_and_5_temp::<T>(p1.and(p2), p3, p4, p5, p6);
-}
-
-/// The seven-predicate-version of stable_and_temp
-pub proof fn stable_and_7_temp<T>(p1: TempPred<T>, p2: TempPred<T>, p3: TempPred<T>, p4: TempPred<T>, p5: TempPred<T>, p6: TempPred<T>, p7: TempPred<T>)
-    requires
-        valid(stable(p1)),
-        valid(stable(p2)),
-        valid(stable(p3)),
-        valid(stable(p4)),
-        valid(stable(p5)),
-        valid(stable(p6)),
-        valid(stable(p7)),
-    ensures
-        valid(stable(p1.and(p2).and(p3).and(p4).and(p5).and(p6).and(p7))),
-{
-    stable_and_temp::<T>(p1, p2);
-    stable_and_6_temp::<T>(p1.and(p2), p3, p4, p5, p6, p7);
-}
+pub use stable_and_n;
+pub use stable_and_n_internal;
 
 /// Unpack the assumption from left to the right side of |=
 /// pre:
@@ -1250,7 +1127,7 @@ pub proof fn strengthen_next_2<T>(spec: TempPred<T>, next: ActionPred<T>, inv1: 
     ensures
         spec.entails(always(lift_action(next_and_inv))),
 {
-    entails_and_3_temp::<T>(spec, always(lift_action(next)), always(lift_state(inv1)), always(lift_state(inv2)));
+    entails_and_n!(spec, always(lift_action(next)), always(lift_state(inv1)), always(lift_state(inv2)));
     always_and_3_equality::<T>(lift_action(next), lift_state(inv1), lift_state(inv2));
     temp_pred_equality::<T>(lift_action(next_and_inv), lift_action(next).and(lift_state(inv1)).and(lift_state(inv2)));
 }
@@ -1266,7 +1143,7 @@ pub proof fn strengthen_next_3<T>(spec: TempPred<T>, next: ActionPred<T>, inv1: 
     ensures
         spec.entails(always(lift_action(next_and_inv))),
 {
-    entails_and_4_temp::<T>(spec, always(lift_action(next)), always(lift_state(inv1)), always(lift_state(inv2)), always(lift_state(inv3)));
+    entails_and_n!(spec, always(lift_action(next)), always(lift_state(inv1)), always(lift_state(inv2)), always(lift_state(inv3)));
     always_and_3_equality::<T>(lift_action(next), lift_state(inv1), lift_state(inv2));
 
     always_and_equality::<T>(lift_action(next).and(lift_state(inv1)).and(lift_state(inv2)), lift_state(inv3));

--- a/src/temporal_logic/rules.rs
+++ b/src/temporal_logic/rules.rs
@@ -934,6 +934,17 @@ pub proof fn entails_and_temp<T>(spec: TempPred<T>, p: TempPred<T>, q: TempPred<
     };
 }
 
+#[allow(unused_macros)]
+macro_rules! entails_and_n {
+    ($t:ty, $spec:expr, $p1:expr, $p2:expr) => {
+        entails_and_temp::<$t>($spec, $p1, $p2);
+    };
+    ($t:ty, $spec:expr, $p1:expr, $p2:expr, $($tail:tt)*) => {
+        entails_and_temp::<$t>($spec, $p1, $p2);
+        entails_and_n!($t, $spec, $p1.and($p2), $($tail)*);
+    };
+}
+
 /// The three-predicate-version for entails_and_temp
 pub proof fn entails_and_3_temp<T>(spec: TempPred<T>, p1: TempPred<T>, p2: TempPred<T>, p3: TempPred<T>)
     requires
@@ -943,8 +954,9 @@ pub proof fn entails_and_3_temp<T>(spec: TempPred<T>, p1: TempPred<T>, p2: TempP
     ensures
         spec.entails(p1.and(p2).and(p3)),
 {
-    entails_and_temp::<T>(spec, p1, p2);
-    entails_and_temp::<T>(spec, p1.and(p2), p3);
+    // entails_and_temp::<T>(spec, p1, p2);
+    // entails_and_temp::<T>(spec, p1.and(p2), p3);
+    entails_and_n!(T, spec, p1, p2, p3);
 }
 
 /// The four-predicate-version for entails_and_temp
@@ -957,8 +969,9 @@ pub proof fn entails_and_4_temp<T>(spec: TempPred<T>, p1: TempPred<T>, p2: TempP
     ensures
         spec.entails(p1.and(p2).and(p3).and(p4)),
 {
-    entails_and_3_temp::<T>(spec, p1, p2, p3);
-    entails_and_temp::<T>(spec, p1.and(p2).and(p3), p4);
+    // entails_and_3_temp::<T>(spec, p1, p2, p3);
+    // entails_and_temp::<T>(spec, p1.and(p2).and(p3), p4);
+    entails_and_n!(T, spec, p1, p2, p3, p4);
 }
 
 /// The five-predicate-version for entails_and_temp

--- a/src/temporal_logic/rules.rs
+++ b/src/temporal_logic/rules.rs
@@ -601,35 +601,6 @@ pub proof fn always_and_equality<T>(p: TempPred<T>, q: TempPred<T>)
     temp_pred_equality::<T>(always(p.and(q)), always(p).and(always(q)));
 }
 
-#[macro_export]
-macro_rules! always_and_n {
-    [$($tail:tt)*] => {
-        ::builtin_macros::verus_proof_macro_exprs!($crate::temporal_logic::rules::always_and_n_internal!($($tail)*));
-    };
-}
-
-#[macro_export]
-macro_rules! always_and_n_internal {
-    ($p1:expr, $p2:expr) => {
-        always_and_equality($p1, $p2);
-    };
-    ($p1:expr, $p2:expr, $($tail:tt)*) => {
-        always_and_equality($p1, $p2);
-        always_and_n_internal!($p1.and($p2), $($tail)*);
-    };
-}
-
-pub use always_and_n;
-pub use always_and_n_internal;
-
-pub proof fn always_and_3_equality<T>(p1: TempPred<T>, p2: TempPred<T>, p3: TempPred<T>)
-    ensures
-        always(p1.and(p2).and(p3)) == always(p1).and(always(p2)).and(always(p3)),
-{
-    always_and_equality::<T>(p1, p2);
-    always_and_equality::<T>(p1.and(p2), p3);
-}
-
 pub proof fn p_and_always_p_equals_always_p<T>(p: TempPred<T>)
     ensures
         p.and(always(p)) == always(p),
@@ -2114,57 +2085,26 @@ pub proof fn or_leads_to_combine<T>(spec: TempPred<T>, p: StatePred<T>, q: State
     or_leads_to_combine_temp::<T>(spec, lift_state(p), lift_state(q), lift_state(r));
 }
 
-/// Three-predicate-version of or_leads_to_combine_temp.
-pub proof fn or_leads_to_combine_3_temp<T>(spec: TempPred<T>, p1: TempPred<T>, p2: TempPred<T>, p3: TempPred<T>, q: TempPred<T>)
-    requires
-        spec.entails(p1.leads_to(q)),
-        spec.entails(p2.leads_to(q)),
-        spec.entails(p3.leads_to(q)),
-    ensures
-        spec.entails(p1.or(p2).or(p3).leads_to(q)),
-{
-    or_leads_to_combine_temp(spec, p1, p2, q);
-    or_leads_to_combine_temp(spec, p1.or(p2), p3, q);
+#[macro_export]
+macro_rules! or_leads_to_combine_n {
+    [$($tail:tt)*] => {
+        ::builtin_macros::verus_proof_macro_exprs!($crate::temporal_logic::rules::or_leads_to_combine_n_internal!($($tail)*));
+    };
 }
 
-/// StatePred version of or_leads_to_combine_3_temp.
-pub proof fn or_leads_to_combine_3<T>(spec: TempPred<T>, p1: StatePred<T>, p2: StatePred<T>, p3: StatePred<T>, q: StatePred<T>)
-    requires
-        spec.entails(lift_state(p1).leads_to(lift_state(q))),
-        spec.entails(lift_state(p2).leads_to(lift_state(q))),
-        spec.entails(lift_state(p3).leads_to(lift_state(q))),
-    ensures
-        spec.entails(lift_state(p1).or(lift_state(p2)).or(lift_state(p3)).leads_to(lift_state(q))),
-{
-    or_leads_to_combine_3_temp::<T>(spec, lift_state(p1), lift_state(p2), lift_state(p3), lift_state(q));
+#[macro_export]
+macro_rules! or_leads_to_combine_n_internal {
+    ($spec:expr, $p1:expr, $p2:expr; $q:expr) => {
+        or_leads_to_combine_temp($spec, $p1, $p2, $q);
+    };
+    ($spec:expr, $p1:expr, $p2:expr, $($rest:expr),+; $q:expr) => {
+        or_leads_to_combine_temp($spec, $p1, $p2, $q);
+        or_leads_to_combine_n_internal!($spec, $p1.or($p2), $($rest),+; $q);
+    };
 }
 
-/// Four-predicate-version of or_leads_to_combine_temp.
-pub proof fn or_leads_to_combine_4_temp<T>(spec: TempPred<T>, p1: TempPred<T>, p2: TempPred<T>, p3: TempPred<T>, p4: TempPred<T>, q: TempPred<T>)
-    requires
-        spec.entails(p1.leads_to(q)),
-        spec.entails(p2.leads_to(q)),
-        spec.entails(p3.leads_to(q)),
-        spec.entails(p4.leads_to(q)),
-    ensures
-        spec.entails(p1.or(p2).or(p3).or(p4).leads_to(q)),
-{
-    or_leads_to_combine_temp(spec, p1, p2, q);
-    or_leads_to_combine_3_temp(spec, p1.or(p2), p3, p4, q);
-}
-
-/// StatePred version of or_leads_to_combine_4_temp.
-pub proof fn or_leads_to_combine_4<T>(spec: TempPred<T>, p1: StatePred<T>, p2: StatePred<T>, p3: StatePred<T>, p4: StatePred<T>, q: StatePred<T>)
-    requires
-        spec.entails(lift_state(p1).leads_to(lift_state(q))),
-        spec.entails(lift_state(p2).leads_to(lift_state(q))),
-        spec.entails(lift_state(p3).leads_to(lift_state(q))),
-        spec.entails(lift_state(p4).leads_to(lift_state(q))),
-    ensures
-        spec.entails(lift_state(p1).or(lift_state(p2)).or(lift_state(p3)).or(lift_state(p4)).leads_to(lift_state(q))),
-{
-    or_leads_to_combine_4_temp::<T>(spec, lift_state(p1), lift_state(p2), lift_state(p3), lift_state(p4), lift_state(q));
-}
+pub use or_leads_to_combine_n;
+pub use or_leads_to_combine_n_internal;
 
 /// Specialized version of or_leads_to_combine used for eliminating q in premise.
 /// pre:


### PR DESCRIPTION
This is to address the issue that we have to keep adding proof functions that take different numbers of arguments for different use cases. This PR adds macros for certain TLA rules that take an arbitrary number of arguments.