### PR TITLE
Change the verified crate to only depend on deps-hack, which simplifies the build

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -14,33 +14,7 @@ rv=$VERUS_DIR/source/target-verus/release/verus
 cd deps_hack
 cargo build
 cd ..
-k8s_openapi_rlib="$(find deps_hack/target/debug/deps -name 'libk8s_openapi-*.rlib' | head -n 1)"
-kube_rlib="$(find deps_hack/target/debug/deps -name 'libkube-*.rlib' | head -n 1)"
-kube_client_rlib="$(find deps_hack/target/debug/deps -name 'libkube_client-*.rlib' | head -n 1)"
-kube_core_rlib="$(find deps_hack/target/debug/deps -name 'libkube_core-*.rlib' | head -n 1)"
-kube_runtime_rlib="$(find deps_hack/target/debug/deps -name 'libkube_runtime-*.rlib' | head -n 1)"
-serde_rlib="$(find deps_hack/target/debug/deps -name 'libserde-*.rlib' | head -n 1)"
-serde_json_rlib="$(find deps_hack/target/debug/deps -name 'libserde_json-*.rlib' | head -n 1)"
-serde_yaml_rlib="$(find deps_hack/target/debug/deps -name 'libserde_yaml-*.rlib' | head -n 1)"
-schemars_rlib="$(find deps_hack/target/debug/deps -name 'libschemars-*.rlib' | head -n 1)"
-tokio_rlib="$(find deps_hack/target/debug/deps -name 'libtokio-*.rlib' | head -n 1)"
-tracing_rlib="$(find deps_hack/target/debug/deps -name 'libtracing-*.rlib' | head -n 1)"
-anyhow_rlib="$(find deps_hack/target/debug/deps -name 'libanyhow-*.rlib' | head -n 1)"
-futures_rlib="$(find deps_hack/target/debug/deps -name 'libfutures-*.rlib' | head -n 1)"
 "$rv" -L dependency=deps_hack/target/debug/deps \
-  --extern=k8s_openapi="$k8s_openapi_rlib" \
-  --extern=kube="$kube_rlib" \
-  --extern=kube_client="$kube_client_rlib" \
-  --extern=kube_core="$kube_core_rlib" \
-  --extern=kube_runtime="$kube_runtime_rlib" \
-  --extern=serde="$serde_rlib" \
-  --extern=serde_json="$serde_json_rlib" \
-  --extern=serde_yaml="$serde_yaml_rlib" \
-  --extern=schemars="$schemars_rlib" \
-  --extern=tokio="$tokio_rlib" \
-  --extern=tracing="$tracing_rlib" \
-  --extern=anyhow="$anyhow_rlib" \
-  --extern=futures="$futures_rlib" \
   --extern=deps_hack="deps_hack/target/debug/libdeps_hack.rlib" \
   --expand-errors \
   --compile \

--- a/src/controller_examples/simple_controller/spec/custom_resource.rs
+++ b/src/controller_examples/simple_controller/spec/custom_resource.rs
@@ -13,7 +13,7 @@ use vstd::string::*;
 use deps_hack::SimpleCR;
 use deps_hack::SimpleCRSpec;
 
-use k8s_openapi::apimachinery::pkg::apis::meta::v1::ObjectMeta as K8SObjectMeta;
+use deps_hack::k8s_openapi::apimachinery::pkg::apis::meta::v1::ObjectMeta as K8SObjectMeta;
 
 verus! {
 

--- a/src/controller_examples/simple_controller/spec/custom_resource.rs
+++ b/src/controller_examples/simple_controller/spec/custom_resource.rs
@@ -37,7 +37,7 @@ impl CustomResource {
         ensures
             res@.kind == Kind::CustomResourceKind,
     {
-        ApiResource::from_kube(kube::api::ApiResource::erase::<SimpleCR>(&()))
+        ApiResource::from_kube(deps_hack::kube::api::ApiResource::erase::<SimpleCR>(&()))
     }
 
     #[verifier(external_body)]

--- a/src/controller_examples/zookeeper_controller/exec/reconciler.rs
+++ b/src/controller_examples/zookeeper_controller/exec/reconciler.rs
@@ -678,8 +678,8 @@ fn make_zk_pod_spec(zk: &ZookeeperCluster) -> (pod_spec: PodSpec)
 fn make_readiness_probe() -> Probe
 {
     Probe::from_kube(
-        k8s_openapi::api::core::v1::Probe {
-            exec: std::option::Option::Some(k8s_openapi::api::core::v1::ExecAction {
+        deps_hack::k8s_openapi::api::core::v1::Probe {
+            exec: std::option::Option::Some(deps_hack::k8s_openapi::api::core::v1::ExecAction {
                 command: std::option::Option::Some(vec!["zookeeperReady.sh".to_string()]),
             }),
             failure_threshold: std::option::Option::Some(3),
@@ -687,7 +687,7 @@ fn make_readiness_probe() -> Probe
             period_seconds: std::option::Option::Some(10),
             success_threshold: std::option::Option::Some(1),
             timeout_seconds: std::option::Option::Some(10),
-            ..k8s_openapi::api::core::v1::Probe::default()
+            ..deps_hack::k8s_openapi::api::core::v1::Probe::default()
         }
     )
 }
@@ -696,8 +696,8 @@ fn make_readiness_probe() -> Probe
 fn make_liveness_probe() -> Probe
 {
     Probe::from_kube(
-        k8s_openapi::api::core::v1::Probe {
-            exec: std::option::Option::Some(k8s_openapi::api::core::v1::ExecAction {
+        deps_hack::k8s_openapi::api::core::v1::Probe {
+            exec: std::option::Option::Some(deps_hack::k8s_openapi::api::core::v1::ExecAction {
                 command: std::option::Option::Some(vec!["zookeeperLive.sh".to_string()]),
             }),
             failure_threshold: std::option::Option::Some(3),
@@ -705,7 +705,7 @@ fn make_liveness_probe() -> Probe
             period_seconds: std::option::Option::Some(10),
             success_threshold: std::option::Option::Some(1),
             timeout_seconds: std::option::Option::Some(10),
-            ..k8s_openapi::api::core::v1::Probe::default()
+            ..deps_hack::k8s_openapi::api::core::v1::Probe::default()
         }
     )
 }
@@ -714,12 +714,12 @@ fn make_liveness_probe() -> Probe
 fn make_resource_requirements() -> ResourceRequirements
 {
     ResourceRequirements::from_kube(
-        k8s_openapi::api::core::v1::ResourceRequirements {
+        deps_hack::k8s_openapi::api::core::v1::ResourceRequirements {
             requests: std::option::Option::Some(std::collections::BTreeMap::from([(
                 "storage".to_string(),
-                k8s_openapi::apimachinery::pkg::api::resource::Quantity("20Gi".to_string()),
+                deps_hack::k8s_openapi::apimachinery::pkg::api::resource::Quantity("20Gi".to_string()),
             )])),
-            ..k8s_openapi::api::core::v1::ResourceRequirements::default()
+            ..deps_hack::k8s_openapi::api::core::v1::ResourceRequirements::default()
         }
     )
 }

--- a/src/controller_examples/zookeeper_controller/spec/zookeepercluster.rs
+++ b/src/controller_examples/zookeeper_controller/spec/zookeepercluster.rs
@@ -63,7 +63,7 @@ impl ZookeeperCluster {
         ensures
             res@.kind == Kind::CustomResourceKind,
     {
-        ApiResource::from_kube(kube::api::ApiResource::erase::<deps_hack::ZookeeperCluster>(&()))
+        ApiResource::from_kube(deps_hack::kube::api::ApiResource::erase::<deps_hack::ZookeeperCluster>(&()))
     }
 
     // NOTE: This function assumes serde_json::to_string won't fail!
@@ -74,17 +74,8 @@ impl ZookeeperCluster {
     {
         // TODO: this might be unnecessarily slow
         DynamicObject::from_kube(
-            k8s_openapi::serde_json::from_str(&k8s_openapi::serde_json::to_string(&self.inner).unwrap()).unwrap()
+            deps_hack::k8s_openapi::serde_json::from_str(&deps_hack::k8s_openapi::serde_json::to_string(&self.inner).unwrap()).unwrap()
         )
-
-        // DynamicObject::from_kube(kube::api::DynamicObject {
-        //     types: std::option::Option::Some(kube::api::TypeMeta {
-        //         api_version: Self::api_resource().into_kube().api_version,
-        //         kind: Self::api_resource().into_kube().kind,
-        //     }),
-        //     metadata: self.inner.metadata,
-        //     data: k8s_openapi::serde_json::to_value(self.inner.spec).unwrap(),
-        // })
     }
 
     /// Convert a DynamicObject to a ConfigMap

--- a/src/deps_hack/src/lib.rs
+++ b/src/deps_hack/src/lib.rs
@@ -2,6 +2,8 @@ pub use anyhow;
 pub use futures;
 pub use k8s_openapi;
 pub use kube;
+pub use kube_client;
+pub use kube_derive;
 pub use schemars;
 pub use serde;
 pub use serde_json;

--- a/src/kubernetes_api_objects/api_resource.rs
+++ b/src/kubernetes_api_objects/api_resource.rs
@@ -4,8 +4,8 @@ use crate::kubernetes_api_objects::common::*;
 use crate::kubernetes_api_objects::object_meta::*;
 use vstd::prelude::*;
 
-use k8s_openapi::apimachinery::pkg::apis::meta::v1::ObjectMeta as K8SObjectMeta;
-use kube::api::ApiResource as K8SApiResource;
+use deps_hack::k8s_openapi::apimachinery::pkg::apis::meta::v1::ObjectMeta as K8SObjectMeta;
+use deps_hack::kube::api::ApiResource as K8SApiResource;
 
 verus! {
 

--- a/src/kubernetes_api_objects/config_map.rs
+++ b/src/kubernetes_api_objects/config_map.rs
@@ -24,7 +24,7 @@ verus! {
 
 #[verifier(external_body)]
 pub struct ConfigMap {
-    inner: k8s_openapi::api::core::v1::ConfigMap,
+    inner: deps_hack::k8s_openapi::api::core::v1::ConfigMap,
 }
 
 impl ConfigMap {
@@ -36,7 +36,7 @@ impl ConfigMap {
             config_map@ == ConfigMapView::default(),
     {
         ConfigMap {
-            inner: k8s_openapi::api::core::v1::ConfigMap::default(),
+            inner: deps_hack::k8s_openapi::api::core::v1::ConfigMap::default(),
         }
     }
 
@@ -74,14 +74,14 @@ impl ConfigMap {
     }
 
     #[verifier(external)]
-    pub fn from_kube(inner: k8s_openapi::api::core::v1::ConfigMap) -> ConfigMap {
+    pub fn from_kube(inner: deps_hack::k8s_openapi::api::core::v1::ConfigMap) -> ConfigMap {
         ConfigMap {
             inner: inner
         }
     }
 
     #[verifier(external)]
-    pub fn into_kube(self) -> k8s_openapi::api::core::v1::ConfigMap {
+    pub fn into_kube(self) -> deps_hack::k8s_openapi::api::core::v1::ConfigMap {
         self.inner
     }
 
@@ -90,7 +90,7 @@ impl ConfigMap {
         ensures
             res@.kind == Kind::ConfigMapKind,
     {
-        ApiResource::from_kube(kube::api::ApiResource::erase::<k8s_openapi::api::core::v1::ConfigMap>(&()))
+        ApiResource::from_kube(deps_hack::kube::api::ApiResource::erase::<deps_hack::k8s_openapi::api::core::v1::ConfigMap>(&()))
     }
 
     #[verifier(external_body)]
@@ -99,7 +99,7 @@ impl ConfigMap {
             obj@ == self@.to_dynamic_object(),
     {
         DynamicObject::from_kube(
-            k8s_openapi::serde_json::from_str(&k8s_openapi::serde_json::to_string(&self.inner).unwrap()).unwrap()
+            deps_hack::k8s_openapi::serde_json::from_str(&deps_hack::k8s_openapi::serde_json::to_string(&self.inner).unwrap()).unwrap()
         )
     }
 
@@ -108,7 +108,7 @@ impl ConfigMap {
         ensures
             cm@ == ConfigMapView::from_dynamic_object(obj@),
     {
-        ConfigMap {inner: obj.into_kube().try_parse::<k8s_openapi::api::core::v1::ConfigMap>().unwrap()}
+        ConfigMap {inner: obj.into_kube().try_parse::<deps_hack::k8s_openapi::api::core::v1::ConfigMap>().unwrap()}
     }
 }
 

--- a/src/kubernetes_api_objects/dynamic.rs
+++ b/src/kubernetes_api_objects/dynamic.rs
@@ -6,8 +6,8 @@ use crate::kubernetes_api_objects::object_meta::*;
 use crate::pervasive_ext::string_view::*;
 use vstd::prelude::*;
 
-use k8s_openapi::apimachinery::pkg::apis::meta::v1::ObjectMeta as K8SObjectMeta;
-use kube::api::DynamicObject as K8SDynamicObject;
+use deps_hack::k8s_openapi::apimachinery::pkg::apis::meta::v1::ObjectMeta as K8SObjectMeta;
+use deps_hack::kube::api::DynamicObject as K8SDynamicObject;
 
 verus! {
 

--- a/src/kubernetes_api_objects/error.rs
+++ b/src/kubernetes_api_objects/error.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MIT
 use crate::kubernetes_api_objects::common::*;
 use crate::kubernetes_api_objects::object_meta::*;
-use kube;
+use deps_hack::kube;
 use vstd::prelude::*;
 
 verus! {

--- a/src/kubernetes_api_objects/label_selector.rs
+++ b/src/kubernetes_api_objects/label_selector.rs
@@ -20,7 +20,7 @@ verus! {
 
 #[verifier(external_body)]
 pub struct LabelSelector {
-    inner: k8s_openapi::apimachinery::pkg::apis::meta::v1::LabelSelector,
+    inner: deps_hack::k8s_openapi::apimachinery::pkg::apis::meta::v1::LabelSelector,
 }
 
 impl LabelSelector {
@@ -32,7 +32,7 @@ impl LabelSelector {
             object_meta@ == LabelSelectorView::default(),
     {
         LabelSelector {
-            inner: k8s_openapi::apimachinery::pkg::apis::meta::v1::LabelSelector::default(),
+            inner: deps_hack::k8s_openapi::apimachinery::pkg::apis::meta::v1::LabelSelector::default(),
         }
     }
 
@@ -45,7 +45,7 @@ impl LabelSelector {
     }
 
     #[verifier(external)]
-    pub fn into_kube(self) -> k8s_openapi::apimachinery::pkg::apis::meta::v1::LabelSelector {
+    pub fn into_kube(self) -> deps_hack::k8s_openapi::apimachinery::pkg::apis::meta::v1::LabelSelector {
         self.inner
     }
 }

--- a/src/kubernetes_api_objects/object_meta.rs
+++ b/src/kubernetes_api_objects/object_meta.rs
@@ -20,7 +20,7 @@ verus! {
 
 #[verifier(external_body)]
 pub struct ObjectMeta {
-    inner: k8s_openapi::apimachinery::pkg::apis::meta::v1::ObjectMeta,
+    inner: deps_hack::k8s_openapi::apimachinery::pkg::apis::meta::v1::ObjectMeta,
 }
 
 impl ObjectMeta {
@@ -32,7 +32,7 @@ impl ObjectMeta {
             object_meta@ == ObjectMetaView::default(),
     {
         ObjectMeta {
-            inner: k8s_openapi::apimachinery::pkg::apis::meta::v1::ObjectMeta::default(),
+            inner: deps_hack::k8s_openapi::apimachinery::pkg::apis::meta::v1::ObjectMeta::default(),
         }
     }
 
@@ -93,12 +93,12 @@ impl ObjectMeta {
     }
 
     #[verifier(external)]
-    pub fn from_kube(inner: k8s_openapi::apimachinery::pkg::apis::meta::v1::ObjectMeta) -> ObjectMeta {
+    pub fn from_kube(inner: deps_hack::k8s_openapi::apimachinery::pkg::apis::meta::v1::ObjectMeta) -> ObjectMeta {
         ObjectMeta { inner: inner }
     }
 
     #[verifier(external)]
-    pub fn into_kube(self) -> k8s_openapi::apimachinery::pkg::apis::meta::v1::ObjectMeta {
+    pub fn into_kube(self) -> deps_hack::k8s_openapi::apimachinery::pkg::apis::meta::v1::ObjectMeta {
         self.inner
     }
 }

--- a/src/kubernetes_api_objects/persistent_volume_claim.rs
+++ b/src/kubernetes_api_objects/persistent_volume_claim.rs
@@ -25,7 +25,7 @@ verus! {
 
 #[verifier(external_body)]
 pub struct PersistentVolumeClaim {
-    inner: k8s_openapi::api::core::v1::PersistentVolumeClaim,
+    inner: deps_hack::k8s_openapi::api::core::v1::PersistentVolumeClaim,
 }
 
 impl PersistentVolumeClaim {
@@ -37,7 +37,7 @@ impl PersistentVolumeClaim {
             pvc@ == PersistentVolumeClaimView::default(),
     {
         PersistentVolumeClaim {
-            inner: k8s_openapi::api::core::v1::PersistentVolumeClaim::default(),
+            inner: deps_hack::k8s_openapi::api::core::v1::PersistentVolumeClaim::default(),
         }
     }
 
@@ -75,7 +75,7 @@ impl PersistentVolumeClaim {
     }
 
     #[verifier(external)]
-    pub fn into_kube(self) -> k8s_openapi::api::core::v1::PersistentVolumeClaim {
+    pub fn into_kube(self) -> deps_hack::k8s_openapi::api::core::v1::PersistentVolumeClaim {
         self.inner
     }
 
@@ -84,7 +84,7 @@ impl PersistentVolumeClaim {
         ensures
             res@.kind == Kind::CustomResourceKind,
     {
-        ApiResource::from_kube(kube::api::ApiResource::erase::<k8s_openapi::api::core::v1::PersistentVolumeClaim>(&()))
+        ApiResource::from_kube(deps_hack::kube::api::ApiResource::erase::<deps_hack::k8s_openapi::api::core::v1::PersistentVolumeClaim>(&()))
     }
 
     #[verifier(external_body)]
@@ -93,7 +93,7 @@ impl PersistentVolumeClaim {
             obj@ == self@.to_dynamic_object(),
     {
         DynamicObject::from_kube(
-            k8s_openapi::serde_json::from_str(&k8s_openapi::serde_json::to_string(&self.inner).unwrap()).unwrap()
+            deps_hack::k8s_openapi::serde_json::from_str(&deps_hack::k8s_openapi::serde_json::to_string(&self.inner).unwrap()).unwrap()
         )
     }
 
@@ -102,13 +102,13 @@ impl PersistentVolumeClaim {
         ensures
             pvc@ == PersistentVolumeClaimView::from_dynamic_object(obj@),
     {
-        PersistentVolumeClaim { inner: obj.into_kube().try_parse::<k8s_openapi::api::core::v1::PersistentVolumeClaim>().unwrap() }
+        PersistentVolumeClaim { inner: obj.into_kube().try_parse::<deps_hack::k8s_openapi::api::core::v1::PersistentVolumeClaim>().unwrap() }
     }
 }
 
 #[verifier(external_body)]
 pub struct PersistentVolumeClaimSpec {
-    inner: k8s_openapi::api::core::v1::PersistentVolumeClaimSpec,
+    inner: deps_hack::k8s_openapi::api::core::v1::PersistentVolumeClaimSpec,
 }
 
 impl PersistentVolumeClaimSpec {
@@ -120,7 +120,7 @@ impl PersistentVolumeClaimSpec {
             pvc_spec@ == PersistentVolumeClaimSpecView::default(),
     {
         PersistentVolumeClaimSpec {
-            inner: k8s_openapi::api::core::v1::PersistentVolumeClaimSpec::default(),
+            inner: deps_hack::k8s_openapi::api::core::v1::PersistentVolumeClaimSpec::default(),
         }
     }
 
@@ -143,7 +143,7 @@ impl PersistentVolumeClaimSpec {
     }
 
     #[verifier(external)]
-    pub fn into_kube(self) -> k8s_openapi::api::core::v1::PersistentVolumeClaimSpec {
+    pub fn into_kube(self) -> deps_hack::k8s_openapi::api::core::v1::PersistentVolumeClaimSpec {
         self.inner
     }
 }

--- a/src/kubernetes_api_objects/pod.rs
+++ b/src/kubernetes_api_objects/pod.rs
@@ -28,7 +28,7 @@ verus! {
 
 #[verifier(external_body)]
 pub struct Pod {
-    inner: k8s_openapi::api::core::v1::Pod,
+    inner: deps_hack::k8s_openapi::api::core::v1::Pod,
 }
 
 impl Pod {
@@ -40,7 +40,7 @@ impl Pod {
             pod@ == PodView::default(),
     {
         Pod {
-            inner: k8s_openapi::api::core::v1::Pod::default(),
+            inner: deps_hack::k8s_openapi::api::core::v1::Pod::default(),
         }
     }
 
@@ -78,7 +78,7 @@ impl Pod {
     }
 
     #[verifier(external)]
-    pub fn into_kube(self) -> k8s_openapi::api::core::v1::Pod {
+    pub fn into_kube(self) -> deps_hack::k8s_openapi::api::core::v1::Pod {
         self.inner
     }
 
@@ -87,7 +87,7 @@ impl Pod {
         ensures
             res@.kind == Kind::CustomResourceKind,
     {
-        ApiResource::from_kube(kube::api::ApiResource::erase::<k8s_openapi::api::core::v1::Pod>(&()))
+        ApiResource::from_kube(deps_hack::kube::api::ApiResource::erase::<deps_hack::k8s_openapi::api::core::v1::Pod>(&()))
     }
 
     // NOTE: This function assumes serde_json::to_string won't fail!
@@ -97,7 +97,7 @@ impl Pod {
             obj@ == self@.to_dynamic_object(),
     {
         DynamicObject::from_kube(
-            k8s_openapi::serde_json::from_str(&k8s_openapi::serde_json::to_string(&self.inner).unwrap()).unwrap()
+            deps_hack::k8s_openapi::serde_json::from_str(&deps_hack::k8s_openapi::serde_json::to_string(&self.inner).unwrap()).unwrap()
         )
     }
 
@@ -107,13 +107,13 @@ impl Pod {
         ensures
             pod@ == PodView::from_dynamic_object(obj@),
     {
-        Pod { inner: obj.into_kube().try_parse::<k8s_openapi::api::core::v1::Pod>().unwrap() }
+        Pod { inner: obj.into_kube().try_parse::<deps_hack::k8s_openapi::api::core::v1::Pod>().unwrap() }
     }
 }
 
 #[verifier(external_body)]
 pub struct PodSpec {
-    inner: k8s_openapi::api::core::v1::PodSpec,
+    inner: deps_hack::k8s_openapi::api::core::v1::PodSpec,
 }
 
 impl PodSpec {
@@ -125,7 +125,7 @@ impl PodSpec {
             pod_spec@ == PodSpecView::default(),
     {
         PodSpec {
-            inner: k8s_openapi::api::core::v1::PodSpec::default(),
+            inner: deps_hack::k8s_openapi::api::core::v1::PodSpec::default(),
         }
     }
 
@@ -146,14 +146,14 @@ impl PodSpec {
     }
 
     #[verifier(external)]
-    pub fn into_kube(self) -> k8s_openapi::api::core::v1::PodSpec {
+    pub fn into_kube(self) -> deps_hack::k8s_openapi::api::core::v1::PodSpec {
         self.inner
     }
 }
 
 #[verifier(external_body)]
 pub struct Container {
-    inner: k8s_openapi::api::core::v1::Container,
+    inner: deps_hack::k8s_openapi::api::core::v1::Container,
 }
 
 impl Container {
@@ -165,7 +165,7 @@ impl Container {
             container@ == ContainerView::default(),
     {
         Container {
-            inner: k8s_openapi::api::core::v1::Container::default(),
+            inner: deps_hack::k8s_openapi::api::core::v1::Container::default(),
         }
     }
 
@@ -242,14 +242,14 @@ impl Container {
     }
 
     #[verifier(external)]
-    pub fn into_kube(self) -> k8s_openapi::api::core::v1::Container {
+    pub fn into_kube(self) -> deps_hack::k8s_openapi::api::core::v1::Container {
         self.inner
     }
 }
 
 #[verifier(external_body)]
 pub struct ContainerPort {
-    inner: k8s_openapi::api::core::v1::ContainerPort,
+    inner: deps_hack::k8s_openapi::api::core::v1::ContainerPort,
 }
 
 impl ContainerPort {
@@ -261,7 +261,7 @@ impl ContainerPort {
             container_port@ == ContainerPortView::default(),
     {
         ContainerPort {
-            inner: k8s_openapi::api::core::v1::ContainerPort::default(),
+            inner: deps_hack::k8s_openapi::api::core::v1::ContainerPort::default(),
         }
     }
 
@@ -293,31 +293,31 @@ impl ContainerPort {
     }
 
     #[verifier(external)]
-    pub fn into_kube(self) -> k8s_openapi::api::core::v1::ContainerPort {
+    pub fn into_kube(self) -> deps_hack::k8s_openapi::api::core::v1::ContainerPort {
         self.inner
     }
 }
 
 #[verifier(external_body)]
 pub struct Probe {
-    inner: k8s_openapi::api::core::v1::Probe,
+    inner: deps_hack::k8s_openapi::api::core::v1::Probe,
 }
 
 impl Probe {
     #[verifier(external)]
-    pub fn from_kube(inner: k8s_openapi::api::core::v1::Probe) -> Probe {
+    pub fn from_kube(inner: deps_hack::k8s_openapi::api::core::v1::Probe) -> Probe {
         Probe { inner: inner }
     }
 
     #[verifier(external)]
-    pub fn into_kube(self) -> k8s_openapi::api::core::v1::Probe {
+    pub fn into_kube(self) -> deps_hack::k8s_openapi::api::core::v1::Probe {
         self.inner
     }
 }
 
 #[verifier(external_body)]
 pub struct VolumeMount {
-    inner: k8s_openapi::api::core::v1::VolumeMount,
+    inner: deps_hack::k8s_openapi::api::core::v1::VolumeMount,
 }
 
 impl VolumeMount {
@@ -329,7 +329,7 @@ impl VolumeMount {
             volume_mount@ == VolumeMountView::default(),
     {
         VolumeMount {
-            inner: k8s_openapi::api::core::v1::VolumeMount::default(),
+            inner: deps_hack::k8s_openapi::api::core::v1::VolumeMount::default(),
         }
     }
 
@@ -361,14 +361,14 @@ impl VolumeMount {
     }
 
     #[verifier(external)]
-    pub fn into_kube(self) -> k8s_openapi::api::core::v1::VolumeMount {
+    pub fn into_kube(self) -> deps_hack::k8s_openapi::api::core::v1::VolumeMount {
         self.inner
     }
 }
 
 #[verifier(external_body)]
 pub struct Volume {
-    inner: k8s_openapi::api::core::v1::Volume,
+    inner: deps_hack::k8s_openapi::api::core::v1::Volume,
 }
 
 impl Volume {
@@ -380,7 +380,7 @@ impl Volume {
             volume@ == VolumeView::default(),
     {
         Volume {
-            inner: k8s_openapi::api::core::v1::Volume::default(),
+            inner: deps_hack::k8s_openapi::api::core::v1::Volume::default(),
         }
     }
 
@@ -401,14 +401,14 @@ impl Volume {
     }
 
     #[verifier(external)]
-    pub fn into_kube(self) -> k8s_openapi::api::core::v1::Volume {
+    pub fn into_kube(self) -> deps_hack::k8s_openapi::api::core::v1::Volume {
         self.inner
     }
 }
 
 #[verifier(external_body)]
 pub struct ConfigMapVolumeSource {
-    inner: k8s_openapi::api::core::v1::ConfigMapVolumeSource,
+    inner: deps_hack::k8s_openapi::api::core::v1::ConfigMapVolumeSource,
 }
 
 impl ConfigMapVolumeSource {
@@ -420,7 +420,7 @@ impl ConfigMapVolumeSource {
             config_map_volume_source@ == ConfigMapVolumeSourceView::default(),
     {
         ConfigMapVolumeSource {
-            inner: k8s_openapi::api::core::v1::ConfigMapVolumeSource::default(),
+            inner: deps_hack::k8s_openapi::api::core::v1::ConfigMapVolumeSource::default(),
         }
     }
 
@@ -433,7 +433,7 @@ impl ConfigMapVolumeSource {
     }
 
     #[verifier(external)]
-    pub fn into_kube(self) -> k8s_openapi::api::core::v1::ConfigMapVolumeSource {
+    pub fn into_kube(self) -> deps_hack::k8s_openapi::api::core::v1::ConfigMapVolumeSource {
         self.inner
     }
 }

--- a/src/kubernetes_api_objects/pod_template_spec.rs
+++ b/src/kubernetes_api_objects/pod_template_spec.rs
@@ -17,7 +17,7 @@ verus! {
 
 #[verifier(external_body)]
 pub struct PodTemplateSpec {
-    inner: k8s_openapi::api::core::v1::PodTemplateSpec,
+    inner: deps_hack::k8s_openapi::api::core::v1::PodTemplateSpec,
 }
 
 impl PodTemplateSpec {
@@ -29,7 +29,7 @@ impl PodTemplateSpec {
             pod_template_spec@ == PodTemplateSpecView::default(),
     {
         PodTemplateSpec {
-            inner: k8s_openapi::api::core::v1::PodTemplateSpec::default(),
+            inner: deps_hack::k8s_openapi::api::core::v1::PodTemplateSpec::default(),
         }
     }
 
@@ -50,7 +50,7 @@ impl PodTemplateSpec {
     }
 
     #[verifier(external)]
-    pub fn into_kube(self) -> k8s_openapi::api::core::v1::PodTemplateSpec {
+    pub fn into_kube(self) -> deps_hack::k8s_openapi::api::core::v1::PodTemplateSpec {
         self.inner
     }
 }

--- a/src/kubernetes_api_objects/resource.rs
+++ b/src/kubernetes_api_objects/resource.rs
@@ -6,8 +6,8 @@ use crate::kubernetes_api_objects::object_meta::*;
 use crate::pervasive_ext::string_view::*;
 use vstd::prelude::*;
 
-use k8s_openapi::apimachinery::pkg::apis::meta::v1::ObjectMeta as K8SObjectMeta;
-use kube::api::DynamicObject as K8SDynamicObject;
+use deps_hack::k8s_openapi::apimachinery::pkg::apis::meta::v1::ObjectMeta as K8SObjectMeta;
+use deps_hack::kube::api::DynamicObject as K8SDynamicObject;
 
 verus! {
 

--- a/src/kubernetes_api_objects/resource_requirements.rs
+++ b/src/kubernetes_api_objects/resource_requirements.rs
@@ -6,17 +6,17 @@ verus! {
 
 #[verifier(external_body)]
 pub struct ResourceRequirements {
-    inner: k8s_openapi::api::core::v1::ResourceRequirements
+    inner: deps_hack::k8s_openapi::api::core::v1::ResourceRequirements
 }
 
 impl ResourceRequirements {
     #[verifier(external)]
-    pub fn from_kube(inner: k8s_openapi::api::core::v1::ResourceRequirements) -> ResourceRequirements {
+    pub fn from_kube(inner: deps_hack::k8s_openapi::api::core::v1::ResourceRequirements) -> ResourceRequirements {
         ResourceRequirements { inner: inner }
     }
 
     #[verifier(external)]
-    pub fn into_kube(self) -> k8s_openapi::api::core::v1::ResourceRequirements {
+    pub fn into_kube(self) -> deps_hack::k8s_openapi::api::core::v1::ResourceRequirements {
         self.inner
     }
 }

--- a/src/kubernetes_api_objects/service.rs
+++ b/src/kubernetes_api_objects/service.rs
@@ -9,8 +9,15 @@ use crate::kubernetes_api_objects::resource::*;
 use crate::pervasive_ext::string_map::StringMap;
 use crate::pervasive_ext::string_view::StringView;
 use vstd::prelude::*;
+<<<<<<< HEAD
 use vstd::seq_lib::*;
 use vstd::vec::*;
+=======
+
+use deps_hack::k8s_openapi::api::core::v1::Service as K8SService;
+use deps_hack::k8s_openapi::api::core::v1::ServiceSpec as K8SServiceSpec;
+use deps_hack::k8s_openapi::api::core::v1::ServiceStatus as K8SServiceStatus;
+>>>>>>> change the verified crate to only depend on deps-hack, which simplifies the build
 
 verus! {
 

--- a/src/kubernetes_api_objects/service.rs
+++ b/src/kubernetes_api_objects/service.rs
@@ -9,15 +9,8 @@ use crate::kubernetes_api_objects::resource::*;
 use crate::pervasive_ext::string_map::StringMap;
 use crate::pervasive_ext::string_view::StringView;
 use vstd::prelude::*;
-<<<<<<< HEAD
 use vstd::seq_lib::*;
 use vstd::vec::*;
-=======
-
-use deps_hack::k8s_openapi::api::core::v1::Service as K8SService;
-use deps_hack::k8s_openapi::api::core::v1::ServiceSpec as K8SServiceSpec;
-use deps_hack::k8s_openapi::api::core::v1::ServiceStatus as K8SServiceStatus;
->>>>>>> change the verified crate to only depend on deps-hack, which simplifies the build
 
 verus! {
 
@@ -33,7 +26,7 @@ verus! {
 
 #[verifier(external_body)]
 pub struct Service {
-    inner: k8s_openapi::api::core::v1::Service,
+    inner: deps_hack::k8s_openapi::api::core::v1::Service,
 }
 
 impl Service {
@@ -45,7 +38,7 @@ impl Service {
             service@ == ServiceView::default(),
     {
         Service {
-            inner: k8s_openapi::api::core::v1::Service::default(),
+            inner: deps_hack::k8s_openapi::api::core::v1::Service::default(),
         }
     }
 
@@ -83,7 +76,7 @@ impl Service {
     }
 
     #[verifier(external)]
-    pub fn into_kube(self) -> k8s_openapi::api::core::v1::Service {
+    pub fn into_kube(self) -> deps_hack::k8s_openapi::api::core::v1::Service {
         self.inner
     }
 
@@ -92,7 +85,7 @@ impl Service {
         ensures
             res@.kind == Kind::CustomResourceKind,
     {
-        ApiResource::from_kube(kube::api::ApiResource::erase::<k8s_openapi::api::core::v1::Service>(&()))
+        ApiResource::from_kube(deps_hack::kube::api::ApiResource::erase::<deps_hack::k8s_openapi::api::core::v1::Service>(&()))
     }
 
     #[verifier(external_body)]
@@ -101,7 +94,7 @@ impl Service {
             obj@ == self@.to_dynamic_object(),
     {
         DynamicObject::from_kube(
-            k8s_openapi::serde_json::from_str(&k8s_openapi::serde_json::to_string(&self.inner).unwrap()).unwrap()
+            deps_hack::k8s_openapi::serde_json::from_str(&deps_hack::k8s_openapi::serde_json::to_string(&self.inner).unwrap()).unwrap()
         )
     }
 
@@ -110,13 +103,13 @@ impl Service {
         ensures
             svc@ == ServiceView::from_dynamic_object(obj@),
     {
-        Service { inner: obj.into_kube().try_parse::<k8s_openapi::api::core::v1::Service>().unwrap() }
+        Service { inner: obj.into_kube().try_parse::<deps_hack::k8s_openapi::api::core::v1::Service>().unwrap() }
     }
 }
 
 #[verifier(external_body)]
 pub struct ServiceSpec {
-    inner: k8s_openapi::api::core::v1::ServiceSpec,
+    inner: deps_hack::k8s_openapi::api::core::v1::ServiceSpec,
 }
 
 impl ServiceSpec {
@@ -128,7 +121,7 @@ impl ServiceSpec {
             service_spec@ == ServiceSpecView::default(),
     {
         ServiceSpec {
-            inner: k8s_openapi::api::core::v1::ServiceSpec::default(),
+            inner: deps_hack::k8s_openapi::api::core::v1::ServiceSpec::default(),
         }
     }
 
@@ -159,14 +152,14 @@ impl ServiceSpec {
     }
 
     #[verifier(external)]
-    pub fn into_kube(self) -> k8s_openapi::api::core::v1::ServiceSpec {
+    pub fn into_kube(self) -> deps_hack::k8s_openapi::api::core::v1::ServiceSpec {
         self.inner
     }
 }
 
 #[verifier(external_body)]
 pub struct ServicePort {
-    inner: k8s_openapi::api::core::v1::ServicePort,
+    inner: deps_hack::k8s_openapi::api::core::v1::ServicePort,
 }
 
 impl ServicePort {
@@ -178,7 +171,7 @@ impl ServicePort {
             service_port@ == ServicePortView::default(),
     {
         ServicePort {
-            inner: k8s_openapi::api::core::v1::ServicePort::default(),
+            inner: deps_hack::k8s_openapi::api::core::v1::ServicePort::default(),
         }
     }
 
@@ -210,7 +203,7 @@ impl ServicePort {
     }
 
     #[verifier(external)]
-    pub fn into_kube(self) -> k8s_openapi::api::core::v1::ServicePort {
+    pub fn into_kube(self) -> deps_hack::k8s_openapi::api::core::v1::ServicePort {
         self.inner
     }
 }

--- a/src/kubernetes_api_objects/stateful_set.rs
+++ b/src/kubernetes_api_objects/stateful_set.rs
@@ -32,7 +32,7 @@ verus! {
 
 #[verifier(external_body)]
 pub struct StatefulSet {
-    inner: k8s_openapi::api::apps::v1::StatefulSet,
+    inner: deps_hack::k8s_openapi::api::apps::v1::StatefulSet,
 }
 
 impl StatefulSet {
@@ -44,7 +44,7 @@ impl StatefulSet {
             stateful_set@ == StatefulSetView::default(),
     {
         StatefulSet {
-            inner: k8s_openapi::api::apps::v1::StatefulSet::default(),
+            inner: deps_hack::k8s_openapi::api::apps::v1::StatefulSet::default(),
         }
     }
 
@@ -82,7 +82,7 @@ impl StatefulSet {
     }
 
     #[verifier(external)]
-    pub fn into_kube(self) -> k8s_openapi::api::apps::v1::StatefulSet {
+    pub fn into_kube(self) -> deps_hack::k8s_openapi::api::apps::v1::StatefulSet {
         self.inner
     }
 
@@ -91,7 +91,7 @@ impl StatefulSet {
         ensures
             res@.kind == Kind::CustomResourceKind,
     {
-        ApiResource::from_kube(kube::api::ApiResource::erase::<k8s_openapi::api::apps::v1::StatefulSet>(&()))
+        ApiResource::from_kube(deps_hack::kube::api::ApiResource::erase::<deps_hack::k8s_openapi::api::apps::v1::StatefulSet>(&()))
     }
 
     // NOTE: This function assumes serde_json::to_string won't fail!
@@ -101,7 +101,7 @@ impl StatefulSet {
             obj@ == self@.to_dynamic_object(),
     {
         DynamicObject::from_kube(
-            k8s_openapi::serde_json::from_str(&k8s_openapi::serde_json::to_string(&self.inner).unwrap()).unwrap()
+            deps_hack::k8s_openapi::serde_json::from_str(&deps_hack::k8s_openapi::serde_json::to_string(&self.inner).unwrap()).unwrap()
         )
     }
 
@@ -111,13 +111,13 @@ impl StatefulSet {
         ensures
             sts@ == StatefulSetView::from_dynamic_object(obj@),
     {
-        StatefulSet { inner: obj.into_kube().try_parse::<k8s_openapi::api::apps::v1::StatefulSet>().unwrap() }
+        StatefulSet { inner: obj.into_kube().try_parse::<deps_hack::k8s_openapi::api::apps::v1::StatefulSet>().unwrap() }
     }
 }
 
 #[verifier(external_body)]
 pub struct StatefulSetSpec {
-    inner: k8s_openapi::api::apps::v1::StatefulSetSpec,
+    inner: deps_hack::k8s_openapi::api::apps::v1::StatefulSetSpec,
 }
 
 impl StatefulSetSpec {
@@ -129,7 +129,7 @@ impl StatefulSetSpec {
             stateful_set_spec@ == StatefulSetSpecView::default(),
     {
         StatefulSetSpec {
-            inner: k8s_openapi::api::apps::v1::StatefulSetSpec::default(),
+            inner: deps_hack::k8s_openapi::api::apps::v1::StatefulSetSpec::default(),
         }
     }
 
@@ -176,7 +176,7 @@ impl StatefulSetSpec {
     }
 
     #[verifier(external)]
-    pub fn into_kube(self) -> k8s_openapi::api::apps::v1::StatefulSetSpec {
+    pub fn into_kube(self) -> deps_hack::k8s_openapi::api::apps::v1::StatefulSetSpec {
         self.inner
     }
 }

--- a/src/shim_layer/mod.rs
+++ b/src/shim_layer/mod.rs
@@ -3,20 +3,20 @@
 #![allow(unused_imports)]
 use crate::kubernetes_api_objects::{api_method::*, common::*, dynamic::*, error::*};
 use crate::reconciler::exec::*;
-use anyhow::Result;
 use builtin::*;
 use builtin_macros::*;
 use core::fmt::Debug;
 use core::hash::Hash;
-use deps_hack::Error;
-use futures::StreamExt;
-use futures::TryFuture;
-use kube::{
+use deps_hack::anyhow::Result;
+use deps_hack::futures::StreamExt;
+use deps_hack::futures::TryFuture;
+use deps_hack::kube::{
     api::{Api, ListParams, ObjectMeta, PostParams, Resource},
     runtime::controller::{Action, Controller},
     Client, CustomResource, CustomResourceExt,
 };
-use serde::de::DeserializeOwned;
+use deps_hack::serde::de::DeserializeOwned;
+use deps_hack::Error;
 use std::sync::Arc;
 use std::time::Duration;
 use vstd::{option::*, string::*};
@@ -199,9 +199,9 @@ pub struct Data {
 
 // TODO: revisit the translation; the current implementation is too coarse grained.
 #[verifier(external)]
-pub fn kube_error_to_ghost(error: &kube::Error) -> APIError {
+pub fn kube_error_to_ghost(error: &deps_hack::kube::Error) -> APIError {
     match error {
-        kube::Error::Api(error_resp) => {
+        deps_hack::kube::Error::Api(error_resp) => {
             if error_resp.code == 404 {
                 APIError::ObjectNotFound
             } else if error_resp.code == 403 {

--- a/src/shim_layer/mod.rs
+++ b/src/shim_layer/mod.rs
@@ -117,7 +117,7 @@ where
         match req_option {
             Option::Some(req) => match req {
                 KubeAPIRequest::GetRequest(get_req) => {
-                    let api = Api::<kube::api::DynamicObject>::namespaced_with(
+                    let api = Api::<deps_hack::kube::api::DynamicObject>::namespaced_with(
                         client.clone(), get_req.namespace.as_rust_string_ref(), get_req.api_resource.as_kube_ref()
                     );
                     match api.get(get_req.name.as_rust_string_ref()).await {
@@ -140,7 +140,7 @@ where
                     }
                 },
                 KubeAPIRequest::CreateRequest(create_req) => {
-                    let api = Api::<kube::api::DynamicObject>::namespaced_with(
+                    let api = Api::<deps_hack::kube::api::DynamicObject>::namespaced_with(
                         client.clone(), &create_req.obj.kube_metadata_ref().namespace.as_ref().unwrap(), &create_req.api_resource.into_kube()
                     );
                     let pp = PostParams::default();

--- a/src/simple_controller.rs
+++ b/src/simple_controller.rs
@@ -17,10 +17,13 @@ use builtin_macros::*;
 
 use crate::simple_controller::exec::reconciler::{SimpleReconcileState, SimpleReconciler};
 use anyhow::Result;
+use deps_hack::kube::CustomResourceExt;
 use deps_hack::SimpleCR;
-use kube::CustomResourceExt;
 use shim_layer::run_controller;
 use std::env;
+
+use deps_hack::serde_yaml;
+use deps_hack::tokio;
 
 verus! {
 

--- a/src/simple_controller.rs
+++ b/src/simple_controller.rs
@@ -16,14 +16,13 @@ use builtin::*;
 use builtin_macros::*;
 
 use crate::simple_controller::exec::reconciler::{SimpleReconcileState, SimpleReconciler};
-use anyhow::Result;
+use deps_hack::anyhow::Result;
 use deps_hack::kube::CustomResourceExt;
+use deps_hack::serde_yaml;
+use deps_hack::tokio;
 use deps_hack::SimpleCR;
 use shim_layer::run_controller;
 use std::env;
-
-use deps_hack::serde_yaml;
-use deps_hack::tokio;
 
 verus! {
 

--- a/src/zookeeper_controller.rs
+++ b/src/zookeeper_controller.rs
@@ -16,8 +16,10 @@ use builtin::*;
 use builtin_macros::*;
 
 use crate::zookeeper_controller::exec::reconciler::{ZookeeperReconcileState, ZookeeperReconciler};
-use anyhow::Result;
-use kube::CustomResourceExt;
+use deps_hack::anyhow::Result;
+use deps_hack::kube::CustomResourceExt;
+use deps_hack::serde_yaml;
+use deps_hack::tokio;
 use shim_layer::run_controller;
 use std::env;
 


### PR DESCRIPTION
this is still due to verus' missing support for cargo, so we resulting need build dependencies separately

this solution is still clearly imperfect, but should be more robust because it does not directly depend on the rlibs deps in cargo's target/deps