### PR TITLE
Invoke `reconcile_core` with the custom resource object, rather than its reference

### DIFF
--- a/src/controller_examples/simple_controller/mod.rs
+++ b/src/controller_examples/simple_controller/mod.rs
@@ -1,5 +1,5 @@
 // Copyright 2022 VMware, Inc.
 // SPDX-License-Identifier: MIT
 pub mod exec;
-pub mod proof;
+// pub mod proof;
 pub mod spec;

--- a/src/controller_examples/simple_controller/proof/liveness.rs
+++ b/src/controller_examples/simple_controller/proof/liveness.rs
@@ -39,7 +39,7 @@ spec fn cr_exists(cr: CustomResourceView) -> TempPred<State<SimpleReconcileState
 
 spec fn cr_matched(cr: CustomResourceView) -> TempPred<State<SimpleReconcileState>> {
     lift_state(|s: State<SimpleReconcileState>|
-        s.resource_key_exists(reconciler::subresource_configmap(cr).object_ref()))
+        s.resource_key_exists(reconciler::make_config_map(cr).object_ref()))
 }
 
 /// Proof strategy:
@@ -608,13 +608,13 @@ proof fn lemma_after_get_cr_pc_and_ok_resp_in_flight_leads_to_cm_exists(req_msg:
                 s.message_in_flight(msg)
                 && msg.dst == HostId::KubernetesAPI
                 && #[trigger] msg.content.is_create_request()
-                && msg.content.get_create_request().obj == reconciler::subresource_configmap(cr).to_dynamic_object()
+                && msg.content.get_create_request().obj == reconciler::make_config_map(cr).to_dynamic_object()
             };
             let kube_pre = |s: State<SimpleReconcileState>| {
                 &&& s.message_in_flight(req_msg)
                 &&& req_msg.dst == HostId::KubernetesAPI
                 &&& req_msg.content.is_create_request()
-                &&& req_msg.content.get_create_request().obj == reconciler::subresource_configmap(cr).to_dynamic_object()
+                &&& req_msg.content.get_create_request().obj == reconciler::make_config_map(cr).to_dynamic_object()
             };
             kubernetes_api_liveness::lemma_pre_leads_to_post_by_kubernetes_api(spec, simple_reconciler(), Option::Some(req_msg), next(simple_reconciler()), handle_request(), kube_pre, cm_exists(cr));
             instantiate_entailed_leads_to(ex, i, spec, lift_state(kube_pre), lift_state(cm_exists(cr)));

--- a/src/controller_examples/simple_controller/proof/safety.rs
+++ b/src/controller_examples/simple_controller/proof/safety.rs
@@ -144,7 +144,7 @@ pub open spec fn delete_cm_req_msg_not_in_flight(cr: CustomResourceView) -> Stat
             &&& #[trigger] s.message_in_flight(m)
             &&& m.dst == HostId::KubernetesAPI
             &&& m.content.is_delete_request()
-            &&& m.content.get_delete_request().key == reconciler::subresource_configmap(cr).object_ref()
+            &&& m.content.get_delete_request().key == reconciler::make_config_map(cr).object_ref()
         }
     }
 }
@@ -158,7 +158,7 @@ pub proof fn lemma_delete_cm_req_msg_never_in_flight(cr: CustomResourceView)
         assert(!exists |m: Message| s.message_in_flight(m)
             && m.dst == HostId::KubernetesAPI
             && #[trigger] m.content.is_delete_request()
-            && m.content.get_delete_request().key == reconciler::subresource_configmap(cr).object_ref()
+            && m.content.get_delete_request().key == reconciler::make_config_map(cr).object_ref()
         );
     };
     init_invariant::<State<SimpleReconcileState>>(sm_spec(simple_reconciler()), init(simple_reconciler()), next(simple_reconciler()), invariant);

--- a/src/controller_examples/simple_controller/proof/shared.rs
+++ b/src/controller_examples/simple_controller/proof/shared.rs
@@ -138,7 +138,7 @@ pub open spec fn reconciler_at_after_create_cm_pc_and_req_in_flight_and_cm_creat
             s.message_in_flight(req_msg)
             && req_msg.dst == HostId::KubernetesAPI
             && req_msg.content.is_create_request()
-            && req_msg.content.get_create_request().obj == reconciler::subresource_configmap(cr).to_dynamic_object()
+            && req_msg.content.get_create_request().obj == reconciler::make_config_map(cr).to_dynamic_object()
     }
 }
 
@@ -172,7 +172,7 @@ pub open spec fn reconciler_reconcile_done_or_error(cr: CustomResourceView) -> S
 }
 
 pub open spec fn cm_exists(cr: CustomResourceView) -> StatePred<State<SimpleReconcileState>> {
-    |s: State<SimpleReconcileState>| s.resource_key_exists(reconciler::subresource_configmap(cr).object_ref())
+    |s: State<SimpleReconcileState>| s.resource_key_exists(reconciler::make_config_map(cr).object_ref())
 }
 
 pub open spec fn is_controller_get_cr_request_msg(msg: Message, cr: CustomResourceView) -> bool {
@@ -186,7 +186,7 @@ pub open spec fn is_controller_create_cm_request_msg(msg: Message, cr: CustomRes
     &&& msg.src == HostId::CustomController
     &&& msg.dst == HostId::KubernetesAPI
     &&& msg.content.is_create_request()
-    &&& msg.content.get_create_request().obj == reconciler::subresource_configmap(cr).to_dynamic_object()
+    &&& msg.content.get_create_request().obj == reconciler::make_config_map(cr).to_dynamic_object()
 }
 
 }

--- a/src/controller_examples/simple_controller/spec/custom_resource.rs
+++ b/src/controller_examples/simple_controller/spec/custom_resource.rs
@@ -10,17 +10,12 @@ use crate::pervasive_ext::string_view::*;
 use vstd::prelude::*;
 use vstd::string::*;
 
-use deps_hack::SimpleCR;
-use deps_hack::SimpleCRSpec;
-
-use deps_hack::k8s_openapi::apimachinery::pkg::apis::meta::v1::ObjectMeta as K8SObjectMeta;
-
 verus! {
 
 // TODO: CustomResource should be defined by the controller developer
 #[verifier(external_body)]
 pub struct CustomResource {
-    inner: SimpleCR
+    inner: deps_hack::SimpleCR
 }
 
 pub struct CustomResourceView {
@@ -37,7 +32,7 @@ impl CustomResource {
         ensures
             res@.kind == Kind::CustomResourceKind,
     {
-        ApiResource::from_kube(deps_hack::kube::api::ApiResource::erase::<SimpleCR>(&()))
+        ApiResource::from_kube(deps_hack::kube::api::ApiResource::erase::<deps_hack::SimpleCR>(&()))
     }
 
     #[verifier(external_body)]
@@ -74,7 +69,21 @@ impl CustomResource {
         ensures
             cr@ == CustomResourceView::from_dynamic_object(obj@),
     {
-        CustomResource {inner: obj.into_kube().try_parse::<SimpleCR>().unwrap()}
+        CustomResource {inner: obj.into_kube().try_parse::<deps_hack::SimpleCR>().unwrap()}
+    }
+}
+
+impl ResourceWrapper<deps_hack::SimpleCR> for CustomResource {
+    #[verifier(external)]
+    fn from_kube(inner: deps_hack::SimpleCR) -> CustomResource {
+        CustomResource {
+            inner: inner
+        }
+    }
+
+    #[verifier(external)]
+    fn into_kube(self) -> deps_hack::SimpleCR {
+        self.inner
     }
 }
 
@@ -128,7 +137,7 @@ impl ResourceView for CustomResourceView {
 
 #[verifier(external_body)]
 pub struct CustomResourceSpec {
-    inner: SimpleCRSpec
+    inner: deps_hack::SimpleCRSpec
 }
 
 pub struct CustomResourceSpecView {

--- a/src/controller_examples/zookeeper_controller/common/mod.rs
+++ b/src/controller_examples/zookeeper_controller/common/mod.rs
@@ -9,7 +9,6 @@ verus! {
 #[is_variant]
 pub enum ZookeeperReconcileStep {
     Init,
-    AfterGetZK,
     AfterCreateHeadlessService,
     AfterCreateClientService,
     AfterCreateAdminServerService,

--- a/src/controller_examples/zookeeper_controller/exec/reconciler.rs
+++ b/src/controller_examples/zookeeper_controller/exec/reconciler.rs
@@ -44,7 +44,9 @@ impl Reconciler<ZookeeperCluster, ZookeeperReconcileState> for ZookeeperReconcil
         reconcile_init_state()
     }
 
-    fn reconcile_core(&self, zk: &ZookeeperCluster, resp_o: Option<KubeAPIResponse>, state: ZookeeperReconcileState) -> (ZookeeperReconcileState, Option<KubeAPIRequest>) {
+    fn reconcile_core(
+        &self, zk: &ZookeeperCluster, resp_o: Option<KubeAPIResponse>, state: ZookeeperReconcileState
+    ) -> (ZookeeperReconcileState, Option<KubeAPIRequest>) {
         reconcile_core(zk, resp_o, state)
     }
 
@@ -92,7 +94,9 @@ pub fn reconcile_error(state: &ZookeeperReconcileState) -> (res: bool)
 
 // TODO: make the shim layer pass zk, instead of zk_ref, to reconcile_core
 
-pub fn reconcile_core(zk: &ZookeeperCluster, resp_o: Option<KubeAPIResponse>, state: ZookeeperReconcileState) -> (res: (ZookeeperReconcileState, Option<KubeAPIRequest>))
+pub fn reconcile_core(
+    zk: &ZookeeperCluster, resp_o: Option<KubeAPIResponse>, state: ZookeeperReconcileState
+) -> (res: (ZookeeperReconcileState, Option<KubeAPIRequest>))
     requires
         zk@.metadata.name.is_Some(),
         zk@.metadata.namespace.is_Some(),
@@ -485,7 +489,9 @@ fn make_stateful_set(zk: &ZookeeperCluster) -> (stateful_set: StatefulSet)
                         proof {
                             assert_seqs_equal!(
                                 access_modes@.map_values(|mode: String| mode@),
-                                zk_spec::make_stateful_set(zk@).spec.get_Some_0().volume_claim_templates.get_Some_0()[0].spec.get_Some_0().access_modes.get_Some_0()
+                                zk_spec::make_stateful_set(zk@)
+                                    .spec.get_Some_0().volume_claim_templates.get_Some_0()[0]
+                                    .spec.get_Some_0().access_modes.get_Some_0()
                             );
                         }
 

--- a/src/controller_examples/zookeeper_controller/spec/reconciler.rs
+++ b/src/controller_examples/zookeeper_controller/spec/reconciler.rs
@@ -44,7 +44,9 @@ pub open spec fn reconcile_error(state: ZookeeperReconcileState) -> bool {
     }
 }
 
-pub open spec fn reconcile_core(zk: ZookeeperClusterView, resp_o: Option<APIResponse>, state: ZookeeperReconcileState) -> (ZookeeperReconcileState, Option<APIRequest>)
+pub open spec fn reconcile_core(
+    zk: ZookeeperClusterView, resp_o: Option<APIResponse>, state: ZookeeperReconcileState
+) -> (ZookeeperReconcileState, Option<APIRequest>)
     recommends
         zk.metadata.name.is_Some(),
         zk.metadata.namespace.is_Some(),

--- a/src/controller_examples/zookeeper_controller/spec/zookeepercluster.rs
+++ b/src/controller_examples/zookeeper_controller/spec/zookeepercluster.rs
@@ -53,11 +53,6 @@ impl ZookeeperCluster {
         self.inner.spec.replica
     }
 
-    #[verifier(external)]
-    pub fn into_kube(self) -> deps_hack::ZookeeperCluster {
-        self.inner
-    }
-
     #[verifier(external_body)]
     pub fn api_resource() -> (res: ApiResource)
         ensures
@@ -86,6 +81,20 @@ impl ZookeeperCluster {
             zk@ == ZookeeperClusterView::from_dynamic_object(obj@),
     {
         ZookeeperCluster { inner: obj.into_kube().try_parse::<deps_hack::ZookeeperCluster>().unwrap() }
+    }
+}
+
+impl ResourceWrapper<deps_hack::ZookeeperCluster> for ZookeeperCluster {
+    #[verifier(external)]
+    fn from_kube(inner: deps_hack::ZookeeperCluster) -> ZookeeperCluster {
+        ZookeeperCluster {
+            inner: inner
+        }
+    }
+
+    #[verifier(external)]
+    fn into_kube(self) -> deps_hack::ZookeeperCluster {
+        self.inner
     }
 }
 

--- a/src/deps_hack/Cargo.lock
+++ b/src/deps_hack/Cargo.lock
@@ -255,6 +255,7 @@ dependencies = [
  "k8s-openapi",
  "kube",
  "kube-client",
+ "kube-core",
  "kube-derive",
  "schemars",
  "serde",

--- a/src/deps_hack/Cargo.toml
+++ b/src/deps_hack/Cargo.toml
@@ -17,6 +17,7 @@ ws = ["kube/ws"]
 kube = { version = "0.78.0", default-features = false, features = ["admission"] }
 kube-derive = { version = "0.78.0", default-features = false } # only needed to opt out of schema
 kube-client = { version = "0.78.0", default-features = false }
+kube-core = { version = "0.78.0", default-features = false }
 k8s-openapi = { version = "0.17.0", default-features = false }
 tokio = { version = "1.14.0", features = ["full"] }
 serde = { version = "1.0.130", features = ["derive"] }

--- a/src/deps_hack/src/lib.rs
+++ b/src/deps_hack/src/lib.rs
@@ -3,6 +3,7 @@ pub use futures;
 pub use k8s_openapi;
 pub use kube;
 pub use kube_client;
+pub use kube_core;
 pub use kube_derive;
 pub use schemars;
 pub use serde;

--- a/src/kubernetes_api_objects/resource.rs
+++ b/src/kubernetes_api_objects/resource.rs
@@ -12,6 +12,13 @@ use deps_hack::kube::api::DynamicObject as K8SDynamicObject;
 verus! {
 
 /// This trait defines the methods that each ghost type of Kubernetes resource object should implement
+pub trait ResourceWrapper<T>: Sized {
+    fn from_kube(inner: T) -> Self;
+
+    fn into_kube(self) -> T;
+}
+
+/// This trait defines the methods that each ghost type of Kubernetes resource object should implement
 pub trait ResourceView: Sized {
     /// Get the metadata of the object
 

--- a/src/kubernetes_cluster/mod.rs
+++ b/src/kubernetes_cluster/mod.rs
@@ -1,4 +1,4 @@
 // Copyright 2022 VMware, Inc.
 // SPDX-License-Identifier: MIT
-// pub mod proof;
+pub mod proof;
 pub mod spec;

--- a/src/kubernetes_cluster/mod.rs
+++ b/src/kubernetes_cluster/mod.rs
@@ -1,4 +1,4 @@
 // Copyright 2022 VMware, Inc.
 // SPDX-License-Identifier: MIT
-pub mod proof;
+// pub mod proof;
 pub mod spec;

--- a/src/kubernetes_cluster/proof/cluster.rs
+++ b/src/kubernetes_cluster/proof/cluster.rs
@@ -37,7 +37,9 @@ proof fn valid_stable_action_weak_fairness<K: ResourceView, T, Output>(action: A
 }
 
 /// Prove weak_fairness for all input is stable.
-proof fn valid_stable_tla_forall_action_weak_fairness<K: ResourceView, T, Input, Output>(action: Action<State<K, T>, Input, Output>)
+proof fn valid_stable_tla_forall_action_weak_fairness<K: ResourceView, T, Input, Output>(
+    action: Action<State<K, T>, Input, Output>
+)
     ensures
         valid(stable(tla_forall(|input| action.weak_fairness(input)))),
 {
@@ -66,7 +68,9 @@ pub proof fn valid_stable_sm_partial_spec<K: ResourceView, T>(reconciler: Reconc
     );
 }
 
-pub proof fn lemma_true_leads_to_crash_always_disabled<K: ResourceView, T>(spec: TempPred<State<K, T>>, reconciler: Reconciler<K, T>)
+pub proof fn lemma_true_leads_to_crash_always_disabled<K: ResourceView, T>(
+    spec: TempPred<State<K, T>>, reconciler: Reconciler<K, T>
+)
     requires
         spec.entails(always(lift_action(next(reconciler)))),
         spec.entails(disable_crash().weak_fairness(())),
@@ -78,7 +82,9 @@ pub proof fn lemma_true_leads_to_crash_always_disabled<K: ResourceView, T>(spec:
     leads_to_stable_temp::<State<K, T>>(spec, lift_action(next(reconciler)), true_pred(), lift_state(crash_disabled::<K, T>()));
 }
 
-pub proof fn lemma_any_pred_leads_to_crash_always_disabled<K: ResourceView, T>(spec: TempPred<State<K, T>>, reconciler: Reconciler<K, T>, any_pred: TempPred<State<K, T>>)
+pub proof fn lemma_any_pred_leads_to_crash_always_disabled<K: ResourceView, T>(
+    spec: TempPred<State<K, T>>, reconciler: Reconciler<K, T>, any_pred: TempPred<State<K, T>>
+)
     requires
         spec.entails(always(lift_action(next(reconciler)))),
         spec.entails(disable_crash().weak_fairness(())),

--- a/src/kubernetes_cluster/proof/cluster.rs
+++ b/src/kubernetes_cluster/proof/cluster.rs
@@ -6,8 +6,7 @@ use crate::kubernetes_cluster::spec::{
     client,
     client::{client, ClientActionInput, ClientState},
     controller::common::{
-        insert_scheduled_reconcile, ControllerAction, ControllerActionInput, ControllerState,
-        OngoingReconcile,
+        ControllerAction, ControllerActionInput, ControllerState, OngoingReconcile,
     },
     controller::state_machine::controller,
     distributed_system::*,

--- a/src/kubernetes_cluster/proof/cluster.rs
+++ b/src/kubernetes_cluster/proof/cluster.rs
@@ -55,7 +55,7 @@ pub proof fn valid_stable_sm_partial_spec<K: ResourceView, T>(reconciler: Reconc
     always_p_stable::<State<K, T>>(lift_action(next(reconciler)));
     valid_stable_tla_forall_action_weak_fairness::<K, T, Option<Message>, ()>(kubernetes_api_next());
     valid_stable_tla_forall_action_weak_fairness::<K, T, (Option<Message>, Option<ObjectRef>), ()>(controller_next(reconciler));
-    valid_stable_tla_forall_action_weak_fairness::<K, T, K, ()>(schedule_controller_reconcile());
+    valid_stable_tla_forall_action_weak_fairness::<K, T, ObjectRef, ()>(schedule_controller_reconcile());
     valid_stable_action_weak_fairness::<K, T, ()>(disable_crash());
 
     stable_and_n!(

--- a/src/kubernetes_cluster/proof/controller_runtime_liveness.rs
+++ b/src/kubernetes_cluster/proof/controller_runtime_liveness.rs
@@ -23,52 +23,52 @@ use vstd::{option::*, result::*};
 
 verus! {
 
-pub open spec fn partial_spec_with_always_cr_key_exists_and_crash_disabled<K: ResourceView, T>(reconciler: Reconciler<K, T>, cr_key: ObjectRef) -> TempPred<State<T>> {
-    sm_partial_spec(reconciler).and(always(lift_state(|s: State<T>| s.resource_key_exists(cr_key)))).and(always(lift_state(crash_disabled::<T>())))
+pub open spec fn partial_spec_with_always_cr_key_exists_and_crash_disabled<K: ResourceView, T>(reconciler: Reconciler<K, T>, cr_key: ObjectRef) -> TempPred<State<K, T>> {
+    sm_partial_spec(reconciler).and(always(lift_state(|s: State<K, T>| s.resource_key_exists(cr_key)))).and(always(lift_state(crash_disabled::<K, T>())))
 }
 
-pub open spec fn reconciler_init_and_no_pending_req<K: ResourceView, T>(reconciler: Reconciler<K, T>, cr_key: ObjectRef) -> StatePred<State<T>> {
-    |s: State<T>| {
+pub open spec fn reconciler_init_and_no_pending_req<K: ResourceView, T>(reconciler: Reconciler<K, T>, cr_key: ObjectRef) -> StatePred<State<K, T>> {
+    |s: State<K, T>| {
         &&& s.reconcile_state_contains(cr_key)
         &&& s.reconcile_state_of(cr_key).local_state == (reconciler.reconcile_init_state)()
         &&& s.reconcile_state_of(cr_key).pending_req_msg.is_None()
     }
 }
 
-pub proof fn lemma_pre_leads_to_post_by_controller<K: ResourceView, T>(spec: TempPred<State<T>>, reconciler: Reconciler<K, T>, input: (Option<Message>, Option<ObjectRef>), next: ActionPred<State<T>>, action: ControllerAction<T>, pre: StatePred<State<T>>, post: StatePred<State<T>>)
+pub proof fn lemma_pre_leads_to_post_by_controller<K: ResourceView, T>(spec: TempPred<State<K, T>>, reconciler: Reconciler<K, T>, input: (Option<Message>, Option<ObjectRef>), next: ActionPred<State<K, T>>, action: ControllerAction<K, T>, pre: StatePred<State<K, T>>, post: StatePred<State<K, T>>)
     requires
         controller(reconciler).actions.contains(action),
-        forall |s, s_prime: State<T>| pre(s) && #[trigger] next(s, s_prime) ==> pre(s_prime) || post(s_prime),
-        forall |s, s_prime: State<T>| pre(s) && #[trigger] next(s, s_prime) && controller_next(reconciler).forward(input)(s, s_prime) ==> post(s_prime),
-        forall |s: State<T>| #[trigger] pre(s) ==> controller_action_pre(reconciler, action, input)(s),
+        forall |s, s_prime: State<K, T>| pre(s) && #[trigger] next(s, s_prime) ==> pre(s_prime) || post(s_prime),
+        forall |s, s_prime: State<K, T>| pre(s) && #[trigger] next(s, s_prime) && controller_next(reconciler).forward(input)(s, s_prime) ==> post(s_prime),
+        forall |s: State<K, T>| #[trigger] pre(s) ==> controller_action_pre(reconciler, action, input)(s),
         spec.entails(always(lift_action(next))),
         spec.entails(tla_forall(|i| controller_next(reconciler).weak_fairness(i))),
     ensures
         spec.entails(lift_state(pre).leads_to(lift_state(post))),
 {
-    use_tla_forall::<State<T>, (Option<Message>, Option<ObjectRef>)>(spec, |i| controller_next(reconciler).weak_fairness(i), input);
+    use_tla_forall::<State<K, T>, (Option<Message>, Option<ObjectRef>)>(spec, |i| controller_next(reconciler).weak_fairness(i), input);
 
     controller_action_pre_implies_next_pre(reconciler, action, input);
-    valid_implies_trans::<State<T>>(lift_state(pre), lift_state(controller_action_pre(reconciler, action, input)), lift_state(controller_next(reconciler).pre(input)));
+    valid_implies_trans::<State<K, T>>(lift_state(pre), lift_state(controller_action_pre(reconciler, action, input)), lift_state(controller_next(reconciler).pre(input)));
 
     controller_next(reconciler).wf1(input, spec, next, pre, post);
 }
 
-pub proof fn lemma_pre_leads_to_post_with_assumption_by_controller<K: ResourceView, T>(spec: TempPred<State<T>>, reconciler: Reconciler<K, T>, input: (Option<Message>, Option<ObjectRef>), next: ActionPred<State<T>>, action: ControllerAction<T>, assumption: StatePred<State<T>>, pre: StatePred<State<T>>, post: StatePred<State<T>>)
+pub proof fn lemma_pre_leads_to_post_with_assumption_by_controller<K: ResourceView, T>(spec: TempPred<State<K, T>>, reconciler: Reconciler<K, T>, input: (Option<Message>, Option<ObjectRef>), next: ActionPred<State<K, T>>, action: ControllerAction<K, T>, assumption: StatePred<State<K, T>>, pre: StatePred<State<K, T>>, post: StatePred<State<K, T>>)
     requires
         controller(reconciler).actions.contains(action),
-        forall |s, s_prime: State<T>| pre(s) && #[trigger] next(s, s_prime) && assumption(s) ==> pre(s_prime) || post(s_prime),
-        forall |s, s_prime: State<T>| pre(s) && #[trigger] next(s, s_prime) && controller_next(reconciler).forward(input)(s, s_prime) ==> post(s_prime),
-        forall |s: State<T>| #[trigger] pre(s) ==> controller_action_pre(reconciler, action, input)(s),
+        forall |s, s_prime: State<K, T>| pre(s) && #[trigger] next(s, s_prime) && assumption(s) ==> pre(s_prime) || post(s_prime),
+        forall |s, s_prime: State<K, T>| pre(s) && #[trigger] next(s, s_prime) && controller_next(reconciler).forward(input)(s, s_prime) ==> post(s_prime),
+        forall |s: State<K, T>| #[trigger] pre(s) ==> controller_action_pre(reconciler, action, input)(s),
         spec.entails(always(lift_action(next))),
         spec.entails(tla_forall(|i| controller_next(reconciler).weak_fairness(i))),
     ensures
         spec.entails(lift_state(pre).and(always(lift_state(assumption))).leads_to(lift_state(post))),
 {
-    use_tla_forall::<State<T>, (Option<Message>, Option<ObjectRef>)>(spec, |i| controller_next(reconciler).weak_fairness(i), input);
+    use_tla_forall::<State<K, T>, (Option<Message>, Option<ObjectRef>)>(spec, |i| controller_next(reconciler).weak_fairness(i), input);
 
     controller_action_pre_implies_next_pre(reconciler, action, input);
-    valid_implies_trans::<State<T>>(lift_state(pre), lift_state(controller_action_pre(reconciler, action, input)), lift_state(controller_next(reconciler).pre(input)));
+    valid_implies_trans::<State<K, T>>(lift_state(pre), lift_state(controller_action_pre(reconciler, action, input)), lift_state(controller_next(reconciler).pre(input)));
 
     controller_next(reconciler).wf1_assume(input, spec, next, assumption, pre, post);
 }
@@ -78,20 +78,20 @@ pub proof fn lemma_reconcile_done_leads_to_reconcile_idle<K: ResourceView, T>(re
         cr_key.kind.is_CustomResourceKind(),
     ensures
         sm_spec(reconciler).entails(
-            lift_state(|s: State<T>| {
+            lift_state(|s: State<K, T>| {
                 &&& s.reconcile_state_contains(cr_key)
                 &&& (reconciler.reconcile_done)(s.reconcile_state_of(cr_key).local_state)
             })
-                .leads_to(lift_state(|s: State<T>| {
+                .leads_to(lift_state(|s: State<K, T>| {
                     &&& !s.reconcile_state_contains(cr_key)
                 }))
         ),
 {
-    let pre = |s: State<T>| {
+    let pre = |s: State<K, T>| {
         &&& s.reconcile_state_contains(cr_key)
         &&& (reconciler.reconcile_done)(s.reconcile_state_of(cr_key).local_state)
     };
-    let post = |s: State<T>| {
+    let post = |s: State<K, T>| {
         &&& !s.reconcile_state_contains(cr_key)
     };
     let input = (Option::None, Option::Some(cr_key));
@@ -103,59 +103,59 @@ pub proof fn lemma_reconcile_error_leads_to_reconcile_idle<K: ResourceView, T>(r
         cr_key.kind.is_CustomResourceKind(),
     ensures
         sm_partial_spec(reconciler).entails(
-            lift_state(|s: State<T>| {
+            lift_state(|s: State<K, T>| {
                 &&& s.reconcile_state_contains(cr_key)
                 &&& (reconciler.reconcile_error)(s.reconcile_state_of(cr_key).local_state)
             })
-                .leads_to(lift_state(|s: State<T>| {
+                .leads_to(lift_state(|s: State<K, T>| {
                     &&& !s.reconcile_state_contains(cr_key)
                 }))
         ),
 {
-    let pre = |s: State<T>| {
+    let pre = |s: State<K, T>| {
         &&& s.reconcile_state_contains(cr_key)
         &&& (reconciler.reconcile_error)(s.reconcile_state_of(cr_key).local_state)
     };
-    let post = |s: State<T>| {
+    let post = |s: State<K, T>| {
         &&& !s.reconcile_state_contains(cr_key)
     };
     let input = (Option::None, Option::Some(cr_key));
     lemma_pre_leads_to_post_by_controller(sm_partial_spec(reconciler), reconciler, input, next(reconciler), end_reconcile(reconciler), pre, post);
 }
 
-pub proof fn lemma_reconcile_idle_and_scheduled_leads_to_reconcile_init<K: ResourceView, T>(spec: TempPred<State<T>>, reconciler: Reconciler<K, T>, cr_key: ObjectRef)
+pub proof fn lemma_reconcile_idle_and_scheduled_leads_to_reconcile_init<K: ResourceView, T>(spec: TempPred<State<K, T>>, reconciler: Reconciler<K, T>, cr_key: ObjectRef)
     requires
         cr_key.kind.is_CustomResourceKind(),
         spec.entails(always(lift_action(next(reconciler)))),
-        spec.entails(always(lift_state(crash_disabled::<T>()))),
+        spec.entails(always(lift_state(crash_disabled::<K, T>()))),
         spec.entails(tla_forall(|i| controller_next(reconciler).weak_fairness(i))),
     ensures
         spec.entails(
-            lift_state(|s: State<T>| {
+            lift_state(|s: State<K, T>| {
                 &&& !s.reconcile_state_contains(cr_key)
                 &&& s.reconcile_scheduled_for(cr_key)
             })
-                .leads_to(lift_state(|s: State<T>| {
+                .leads_to(lift_state(|s: State<K, T>| {
                     &&& s.reconcile_state_contains(cr_key)
                     &&& s.reconcile_state_of(cr_key).local_state == (reconciler.reconcile_init_state)()
                     &&& s.reconcile_state_of(cr_key).pending_req_msg.is_None()
                 }))
         ),
 {
-    let pre = |s: State<T>| {
+    let pre = |s: State<K, T>| {
         &&& !s.reconcile_state_contains(cr_key)
         &&& s.reconcile_scheduled_for(cr_key)
     };
-    let post = |s: State<T>| {
+    let post = |s: State<K, T>| {
         &&& s.reconcile_state_contains(cr_key)
         &&& s.reconcile_state_of(cr_key).local_state == (reconciler.reconcile_init_state)()
         &&& s.reconcile_state_of(cr_key).pending_req_msg.is_None()
     };
-    let stronger_next = |s, s_prime: State<T>| {
+    let stronger_next = |s, s_prime: State<K, T>| {
         &&& next(reconciler)(s, s_prime)
         &&& !s.crash_enabled
     };
-    strengthen_next::<State<T>>(spec, next(reconciler), crash_disabled::<T>(), stronger_next);
+    strengthen_next::<State<K, T>>(spec, next(reconciler), crash_disabled::<K, T>(), stronger_next);
     let input = (Option::None, Option::Some(cr_key));
     lemma_pre_leads_to_post_by_controller(spec, reconciler, input, stronger_next, run_scheduled_reconcile(reconciler), pre, post);
 }
@@ -164,21 +164,21 @@ pub proof fn lemma_true_leads_to_reconcile_scheduled_by_assumption<K: ResourceVi
     requires
         cr_key.kind.is_CustomResourceKind(),
     ensures
-        sm_partial_spec(reconciler).and(always(lift_state(|s: State<T>| s.resource_key_exists(cr_key)))).entails(
-            true_pred().leads_to(lift_state(|s: State<T>| s.reconcile_scheduled_for(cr_key)))
+        sm_partial_spec(reconciler).and(always(lift_state(|s: State<K, T>| s.resource_key_exists(cr_key)))).entails(
+            true_pred().leads_to(lift_state(|s: State<K, T>| s.reconcile_scheduled_for(cr_key)))
         ),
 {
-    let cr_key_exists = |s: State<T>| s.resource_key_exists(cr_key);
+    let cr_key_exists = |s: State<K, T>| s.resource_key_exists(cr_key);
     let spec = sm_partial_spec(reconciler).and(always(lift_state(cr_key_exists)));
-    let pre = |s: State<T>| true;
-    let post = |s: State<T>| s.reconcile_scheduled_for(cr_key);
-    let next_and_cr_exists = |s, s_prime: State<T>| {
+    let pre = |s: State<K, T>| true;
+    let post = |s: State<K, T>| s.reconcile_scheduled_for(cr_key);
+    let next_and_cr_exists = |s, s_prime: State<K, T>| {
         &&& next(reconciler)(s, s_prime)
         &&& cr_key_exists(s)
     };
-    strengthen_next::<State<T>>(spec, next(reconciler), cr_key_exists, next_and_cr_exists);
-    temp_pred_equality::<State<T>>(lift_state(cr_key_exists), lift_state(schedule_controller_reconcile().pre(cr_key)));
-    use_tla_forall::<State<T>, ObjectRef>(spec, |key| schedule_controller_reconcile().weak_fairness(key), cr_key);
+    strengthen_next::<State<K, T>>(spec, next(reconciler), cr_key_exists, next_and_cr_exists);
+    temp_pred_equality::<State<K, T>>(lift_state(cr_key_exists), lift_state(schedule_controller_reconcile().pre(cr_key)));
+    use_tla_forall::<State<K, T>, ObjectRef>(spec, |key| schedule_controller_reconcile().weak_fairness(key), cr_key);
     schedule_controller_reconcile().wf1(cr_key, spec, next_and_cr_exists, pre, post);
 }
 
@@ -186,22 +186,22 @@ pub proof fn lemma_reconcile_idle_leads_to_reconcile_idle_and_scheduled_by_assum
     requires
         cr_key.kind.is_CustomResourceKind(),
     ensures
-        sm_partial_spec(reconciler).and(always(lift_state(|s: State<T>| s.resource_key_exists(cr_key)))).entails(
-            lift_state(|s: State<T>| !s.reconcile_state_contains(cr_key))
-                .leads_to(lift_state(|s: State<T>| {
+        sm_partial_spec(reconciler).and(always(lift_state(|s: State<K, T>| s.resource_key_exists(cr_key)))).entails(
+            lift_state(|s: State<K, T>| !s.reconcile_state_contains(cr_key))
+                .leads_to(lift_state(|s: State<K, T>| {
                     &&& !s.reconcile_state_contains(cr_key)
                     &&& s.reconcile_scheduled_for(cr_key)})
             ),
         )
 {
-    let spec = sm_partial_spec(reconciler).and(always(lift_state(|s: State<T>| s.resource_key_exists(cr_key))));
-    let reconcile_idle = lift_state(|s: State<T>| { !s.reconcile_state_contains(cr_key) });
-    let reconcile_scheduled = lift_state(|s: State<T>| { s.reconcile_scheduled_for(cr_key) });
+    let spec = sm_partial_spec(reconciler).and(always(lift_state(|s: State<K, T>| s.resource_key_exists(cr_key))));
+    let reconcile_idle = lift_state(|s: State<K, T>| { !s.reconcile_state_contains(cr_key) });
+    let reconcile_scheduled = lift_state(|s: State<K, T>| { s.reconcile_scheduled_for(cr_key) });
     valid_implies_implies_leads_to(spec, reconcile_idle, true_pred());
     lemma_true_leads_to_reconcile_scheduled_by_assumption(reconciler, cr_key);
     leads_to_trans_temp(spec, reconcile_idle, true_pred(), reconcile_scheduled);
-    leads_to_confluence_self_temp::<State<T>>(spec, lift_action(next(reconciler)), reconcile_idle, reconcile_scheduled);
-    temp_pred_equality::<State<T>>(reconcile_idle.and(reconcile_scheduled), lift_state(|s: State<T>| {
+    leads_to_confluence_self_temp::<State<K, T>>(spec, lift_action(next(reconciler)), reconcile_idle, reconcile_scheduled);
+    temp_pred_equality::<State<K, T>>(reconcile_idle.and(reconcile_scheduled), lift_state(|s: State<K, T>| {
         &&& !s.reconcile_state_contains(cr_key)
         &&& s.reconcile_scheduled_for(cr_key)}));
 }
@@ -211,8 +211,8 @@ pub proof fn lemma_cr_always_exists_entails_reconcile_idle_leads_to_reconcile_in
         cr_key.kind.is_CustomResourceKind(),
     ensures
         partial_spec_with_always_cr_key_exists_and_crash_disabled(reconciler, cr_key).entails(
-            lift_state(|s: State<T>| {!s.reconcile_state_contains(cr_key)})
-            .leads_to(lift_state(|s: State<T>| {
+            lift_state(|s: State<K, T>| {!s.reconcile_state_contains(cr_key)})
+            .leads_to(lift_state(|s: State<K, T>| {
                 &&& s.reconcile_state_contains(cr_key)
                 &&& s.reconcile_state_of(cr_key).local_state == (reconciler.reconcile_init_state)()
                 &&& s.reconcile_state_of(cr_key).pending_req_msg.is_None()
@@ -221,26 +221,26 @@ pub proof fn lemma_cr_always_exists_entails_reconcile_idle_leads_to_reconcile_in
 {
 
     lemma_reconcile_idle_leads_to_reconcile_idle_and_scheduled_by_assumption(reconciler, cr_key);
-    entails_trans::<State<T>>(partial_spec_with_always_cr_key_exists_and_crash_disabled(reconciler, cr_key), sm_partial_spec(reconciler).and(always(lift_state(|s: State<T>| s.resource_key_exists(cr_key)))), lift_state(|s: State<T>| !s.reconcile_state_contains(cr_key))
-    .leads_to(lift_state(|s: State<T>| {
+    entails_trans::<State<K, T>>(partial_spec_with_always_cr_key_exists_and_crash_disabled(reconciler, cr_key), sm_partial_spec(reconciler).and(always(lift_state(|s: State<K, T>| s.resource_key_exists(cr_key)))), lift_state(|s: State<K, T>| !s.reconcile_state_contains(cr_key))
+    .leads_to(lift_state(|s: State<K, T>| {
         &&& !s.reconcile_state_contains(cr_key)
         &&& s.reconcile_scheduled_for(cr_key)})
     ));
     lemma_reconcile_idle_and_scheduled_leads_to_reconcile_init(partial_spec_with_always_cr_key_exists_and_crash_disabled(reconciler, cr_key), reconciler, cr_key);
 
-    leads_to_trans_auto::<State<T>>(partial_spec_with_always_cr_key_exists_and_crash_disabled(reconciler, cr_key));
+    leads_to_trans_auto::<State<K, T>>(partial_spec_with_always_cr_key_exists_and_crash_disabled(reconciler, cr_key));
 }
 
 
-pub proof fn lemma_cr_always_exists_entails_reconcile_error_leads_to_reconcile_init_and_no_pending_req<K: ResourceView, T>(spec: TempPred<State<T>>, reconciler: Reconciler<K, T>, cr_key: ObjectRef)
+pub proof fn lemma_cr_always_exists_entails_reconcile_error_leads_to_reconcile_init_and_no_pending_req<K: ResourceView, T>(spec: TempPred<State<K, T>>, reconciler: Reconciler<K, T>, cr_key: ObjectRef)
     requires
         cr_key.kind.is_CustomResourceKind(),
         spec.entails(sm_partial_spec(reconciler)),
-        spec.entails(always(lift_state(|s: State<T>| s.resource_key_exists(cr_key)))),
-        spec.entails(always(lift_state(crash_disabled::<T>()))),
+        spec.entails(always(lift_state(|s: State<K, T>| s.resource_key_exists(cr_key)))),
+        spec.entails(always(lift_state(crash_disabled::<K, T>()))),
     ensures
         spec.entails(
-            lift_state(|s: State<T>| {
+            lift_state(|s: State<K, T>| {
                 &&& s.reconcile_state_contains(cr_key)
                 &&& (reconciler.reconcile_error)(s.reconcile_state_of(cr_key).local_state)
             })
@@ -248,29 +248,29 @@ pub proof fn lemma_cr_always_exists_entails_reconcile_error_leads_to_reconcile_i
         ),
 {
     lemma_reconcile_error_leads_to_reconcile_idle(reconciler, cr_key);
-    entails_trans::<State<T>>(partial_spec_with_always_cr_key_exists_and_crash_disabled(reconciler, cr_key), sm_partial_spec(reconciler), lift_state(|s: State<T>| {
+    entails_trans::<State<K, T>>(partial_spec_with_always_cr_key_exists_and_crash_disabled(reconciler, cr_key), sm_partial_spec(reconciler), lift_state(|s: State<K, T>| {
         &&& s.reconcile_state_contains(cr_key)
         &&& (reconciler.reconcile_error)(s.reconcile_state_of(cr_key).local_state)
         })
-        .leads_to(lift_state(|s: State<T>| {
+        .leads_to(lift_state(|s: State<K, T>| {
             &&& !s.reconcile_state_contains(cr_key)
         })));
     lemma_reconcile_idle_leads_to_reconcile_idle_and_scheduled_by_assumption(reconciler, cr_key);
-    entails_trans::<State<T>>(partial_spec_with_always_cr_key_exists_and_crash_disabled(reconciler, cr_key), sm_partial_spec(reconciler).and(always(lift_state(|s: State<T>| s.resource_key_exists(cr_key)))), lift_state(|s: State<T>| !s.reconcile_state_contains(cr_key))
-            .leads_to(lift_state(|s: State<T>| {
+    entails_trans::<State<K, T>>(partial_spec_with_always_cr_key_exists_and_crash_disabled(reconciler, cr_key), sm_partial_spec(reconciler).and(always(lift_state(|s: State<K, T>| s.resource_key_exists(cr_key)))), lift_state(|s: State<K, T>| !s.reconcile_state_contains(cr_key))
+            .leads_to(lift_state(|s: State<K, T>| {
                 &&& !s.reconcile_state_contains(cr_key)
                 &&& s.reconcile_scheduled_for(cr_key)})));
     lemma_reconcile_idle_and_scheduled_leads_to_reconcile_init(partial_spec_with_always_cr_key_exists_and_crash_disabled(reconciler, cr_key), reconciler, cr_key);
 
-    leads_to_trans_auto::<State<T>>(partial_spec_with_always_cr_key_exists_and_crash_disabled(reconciler, cr_key));
+    leads_to_trans_auto::<State<K, T>>(partial_spec_with_always_cr_key_exists_and_crash_disabled(reconciler, cr_key));
 
-    entails_and_n!(spec, sm_partial_spec(reconciler), always(lift_state(|s: State<T>| s.resource_key_exists(cr_key))), always(lift_state(crash_disabled::<T>())));
-    entails_trans::<State<T>>(spec, partial_spec_with_always_cr_key_exists_and_crash_disabled(reconciler, cr_key),
-    lift_state(|s: State<T>| {
+    entails_and_n!(spec, sm_partial_spec(reconciler), always(lift_state(|s: State<K, T>| s.resource_key_exists(cr_key))), always(lift_state(crash_disabled::<K, T>())));
+    entails_trans::<State<K, T>>(spec, partial_spec_with_always_cr_key_exists_and_crash_disabled(reconciler, cr_key),
+    lift_state(|s: State<K, T>| {
         &&& s.reconcile_state_contains(cr_key)
         &&& (reconciler.reconcile_error)(s.reconcile_state_of(cr_key).local_state)
     })
-        .leads_to(lift_state(|s: State<T>| {
+        .leads_to(lift_state(|s: State<K, T>| {
             &&& s.reconcile_state_contains(cr_key)
             &&& s.reconcile_state_of(cr_key).local_state == (reconciler.reconcile_init_state)()
             &&& s.reconcile_state_of(cr_key).pending_req_msg.is_None()

--- a/src/kubernetes_cluster/proof/controller_runtime_safety.rs
+++ b/src/kubernetes_cluster/proof/controller_runtime_safety.rs
@@ -28,7 +28,9 @@ pub open spec fn every_in_flight_msg_has_lower_id_than_chan_manager<K: ResourceV
     }
 }
 
-pub proof fn lemma_always_every_in_flight_msg_has_lower_id_than_chan_manager<K: ResourceView, T>(reconciler: Reconciler<K, T>)
+pub proof fn lemma_always_every_in_flight_msg_has_lower_id_than_chan_manager<K: ResourceView, T>(
+    reconciler: Reconciler<K, T>
+)
     ensures
         sm_spec(reconciler).entails(always(lift_state(every_in_flight_msg_has_lower_id_than_chan_manager()))),
 {
@@ -40,8 +42,9 @@ pub proof fn lemma_always_every_in_flight_msg_has_lower_id_than_chan_manager<K: 
     init_invariant::<State<K, T>>(sm_spec(reconciler), init(reconciler), next(reconciler), invariant);
 }
 
-proof fn next_preserves_every_in_flight_msg_has_lower_id_than_chan_manager<K: ResourceView, T>(reconciler: Reconciler<K, T>,
-s: State<K, T>, s_prime: State<K, T>)
+proof fn next_preserves_every_in_flight_msg_has_lower_id_than_chan_manager<K: ResourceView, T>(
+    reconciler: Reconciler<K, T>, s: State<K, T>, s_prime: State<K, T>
+)
     requires
         every_in_flight_msg_has_lower_id_than_chan_manager::<K, T>()(s), next(reconciler)(s, s_prime),
     ensures
@@ -86,8 +89,9 @@ pub proof fn lemma_always_every_in_flight_req_is_unique<K: ResourceView, T>(reco
         &&& every_in_flight_msg_has_lower_id_than_chan_manager()(s)
     };
     lemma_always_every_in_flight_msg_has_lower_id_than_chan_manager(reconciler);
-    strengthen_next::<State<K, T>>(sm_spec(reconciler), next(reconciler),
-        every_in_flight_msg_has_lower_id_than_chan_manager(), stronger_next);
+    strengthen_next::<State<K, T>>(
+        sm_spec(reconciler), next(reconciler), every_in_flight_msg_has_lower_id_than_chan_manager(), stronger_next
+    );
     assert forall |s, s_prime: State<K, T>| invariant(s) && #[trigger] stronger_next(s, s_prime) implies
     invariant(s_prime) by {
         assert forall |msg: Message| msg.content.is_APIRequest() && #[trigger] s_prime.message_in_flight(msg) implies
@@ -127,13 +131,18 @@ pub proof fn lemma_always_every_in_flight_msg_has_unique_id<K: ResourceView, T>(
     };
     lemma_always_every_in_flight_msg_has_lower_id_than_chan_manager(reconciler);
     lemma_always_every_in_flight_req_is_unique(reconciler);
-    entails_always_and_n!(sm_spec(reconciler), lift_action(next(reconciler)),
+    entails_always_and_n!(
+        sm_spec(reconciler),
+        lift_action(next(reconciler)),
         lift_state(every_in_flight_msg_has_lower_id_than_chan_manager::<K, T>()),
-        lift_state(every_in_flight_req_is_unique::<K, T>()));
-    temp_pred_equality(lift_action(stronger_next),
+        lift_state(every_in_flight_req_is_unique::<K, T>())
+    );
+    temp_pred_equality(
+        lift_action(stronger_next),
         lift_action(next(reconciler))
-        .and(lift_state(every_in_flight_msg_has_lower_id_than_chan_manager::<K, T>()))
-        .and(lift_state(every_in_flight_req_is_unique::<K, T>())));
+            .and(lift_state(every_in_flight_msg_has_lower_id_than_chan_manager::<K, T>()))
+            .and(lift_state(every_in_flight_req_is_unique::<K, T>()))
+    );
     assert forall |s, s_prime: State<K, T>| invariant(s) && #[trigger] stronger_next(s, s_prime) implies
     invariant(s_prime) by {
         next_and_unique_lower_msg_id_preserves_in_flight_msg_has_unique_id(reconciler, s, s_prime);
@@ -141,11 +150,14 @@ pub proof fn lemma_always_every_in_flight_msg_has_unique_id<K: ResourceView, T>(
     init_invariant::<State<K, T>>(sm_spec(reconciler), init(reconciler), stronger_next, invariant);
 }
 
-proof fn next_and_unique_lower_msg_id_preserves_in_flight_msg_has_unique_id<K: ResourceView, T>(reconciler: Reconciler<K, T>,
-s: State<K, T>, s_prime: State<K, T>)
+proof fn next_and_unique_lower_msg_id_preserves_in_flight_msg_has_unique_id<K: ResourceView, T>(
+    reconciler: Reconciler<K, T>, s: State<K, T>, s_prime: State<K, T>
+)
     requires
         next(reconciler)(s, s_prime),
-        every_in_flight_msg_has_lower_id_than_chan_manager::<K, T>()(s), every_in_flight_req_is_unique::<K, T>()(s), every_in_flight_msg_has_unique_id::<K, T>()(s), // the invariant
+        every_in_flight_msg_has_lower_id_than_chan_manager::<K, T>()(s),
+        every_in_flight_req_is_unique::<K, T>()(s),
+        every_in_flight_msg_has_unique_id::<K, T>()(s), // the invariant
     ensures
         every_in_flight_msg_has_unique_id::<K, T>()(s_prime),
 {
@@ -169,13 +181,17 @@ s: State<K, T>, s_prime: State<K, T>)
     };
 }
 
-proof fn newly_added_msg_have_different_id_from_existing_ones<K: ResourceView, T>(reconciler: Reconciler<K, T>, s: State<K, T>,
-s_prime: State<K, T>, msg_1: Message, msg_2: Message)
+proof fn newly_added_msg_have_different_id_from_existing_ones<K: ResourceView, T>(
+    reconciler: Reconciler<K, T>, s: State<K, T>, s_prime: State<K, T>, msg_1: Message, msg_2: Message
+)
     requires
         next(reconciler)(s, s_prime),
-        every_in_flight_msg_has_lower_id_than_chan_manager::<K, T>()(s), every_in_flight_req_is_unique::<K, T>()(s),
-        s.message_in_flight(msg_1), !s.message_in_flight(msg_2),
-        s_prime.message_in_flight(msg_1), s_prime.message_in_flight(msg_2),
+        every_in_flight_msg_has_lower_id_than_chan_manager::<K, T>()(s),
+        every_in_flight_req_is_unique::<K, T>()(s),
+        s.message_in_flight(msg_1),
+        !s.message_in_flight(msg_2),
+        s_prime.message_in_flight(msg_1),
+        s_prime.message_in_flight(msg_2),
         every_in_flight_msg_has_unique_id::<K, T>()(s), // the invariant
     ensures
         msg_1.content.get_msg_id() != msg_2.content.get_msg_id(),
@@ -189,8 +205,7 @@ s_prime: State<K, T>, msg_1: Message, msg_2: Message)
 }
 
 pub open spec fn req_in_flight_or_pending_at_controller<K: ResourceView, T>(req_msg: Message, s: State<K, T>) -> bool {
-    req_msg.content.is_APIRequest()
-    && (s.message_in_flight(req_msg)
+    req_msg.content.is_APIRequest() && (s.message_in_flight(req_msg)
     || exists |cr_key: ObjectRef| (
         #[trigger] s.reconcile_state_contains(cr_key)
         && s.reconcile_state_of(cr_key).pending_req_msg == Option::Some(req_msg)
@@ -222,21 +237,25 @@ pub proof fn lemma_always_every_in_flight_or_pending_req_has_unique_id<K: Resour
     };
     lemma_always_every_in_flight_msg_has_lower_id_than_chan_manager(reconciler);
     lemma_always_pending_req_has_lower_req_id_than_chan_manager(reconciler);
-    entails_always_and_n!(sm_spec(reconciler), lift_action(next(reconciler)),
+    entails_always_and_n!(
+        sm_spec(reconciler),
+        lift_action(next(reconciler)),
         lift_state(every_in_flight_msg_has_lower_id_than_chan_manager::<K, T>()),
-        lift_state(pending_req_has_lower_req_id_than_chan_manager::<K, T>()));
-    temp_pred_equality(lift_action(stronger_next),
+        lift_state(pending_req_has_lower_req_id_than_chan_manager::<K, T>())
+    );
+    temp_pred_equality(
+        lift_action(stronger_next),
         lift_action(next(reconciler))
-        .and(lift_state(every_in_flight_msg_has_lower_id_than_chan_manager::<K, T>()))
-        .and(lift_state(pending_req_has_lower_req_id_than_chan_manager::<K, T>())));
+            .and(lift_state(every_in_flight_msg_has_lower_id_than_chan_manager::<K, T>()))
+            .and(lift_state(pending_req_has_lower_req_id_than_chan_manager::<K, T>()))
+    );
     assert forall |s, s_prime: State<K, T>| invariant(s) && #[trigger] stronger_next(s, s_prime)
     implies invariant(s_prime) by {
         assert forall |req_msg, other_msg: Message| #[trigger] req_in_flight_or_pending_at_controller(req_msg, s_prime)
         && #[trigger] req_in_flight_or_pending_at_controller(other_msg, s_prime) && req_msg != other_msg
         implies req_msg.content.get_req_id() != other_msg.content.get_req_id() by {
-            if req_in_flight_or_pending_at_controller(req_msg, s)
-                && req_in_flight_or_pending_at_controller(other_msg, s) {
-                    assert(req_msg.content.get_req_id() != other_msg.content.get_req_id());
+            if req_in_flight_or_pending_at_controller(req_msg, s) && req_in_flight_or_pending_at_controller(other_msg, s) {
+                assert(req_msg.content.get_req_id() != other_msg.content.get_req_id());
             } else if req_in_flight_or_pending_at_controller(req_msg, s) {
                 assert(req_msg.content.get_req_id() != other_msg.content.get_req_id());
             } else if req_in_flight_or_pending_at_controller(other_msg, s) {
@@ -247,7 +266,6 @@ pub proof fn lemma_always_every_in_flight_or_pending_req_has_unique_id<K: Resour
     init_invariant::<State<K, T>>(sm_spec(reconciler), init(reconciler), stronger_next, invariant);
 }
 
-
 pub open spec fn pending_req_has_lower_req_id_than_chan_manager<K: ResourceView, T>() -> StatePred<State<K, T>> {
     |s: State<K, T>| {
         forall |cr_key: ObjectRef|
@@ -257,7 +275,9 @@ pub open spec fn pending_req_has_lower_req_id_than_chan_manager<K: ResourceView,
     }
 }
 
-pub proof fn lemma_always_pending_req_has_lower_req_id_than_chan_manager<K: ResourceView, T>(reconciler: Reconciler<K, T>)
+pub proof fn lemma_always_pending_req_has_lower_req_id_than_chan_manager<K: ResourceView, T>(
+    reconciler: Reconciler<K, T>
+)
     ensures
         sm_spec(reconciler).entails(always(lift_state(pending_req_has_lower_req_id_than_chan_manager()))),
 {
@@ -265,8 +285,9 @@ pub proof fn lemma_always_pending_req_has_lower_req_id_than_chan_manager<K: Reso
     init_invariant::<State<K, T>>(sm_spec(reconciler), init(reconciler), next(reconciler), invariant);
 }
 
-pub open spec fn resp_matches_at_most_one_pending_req<K: ResourceView, T>(resp_msg: Message, cr_key: ObjectRef) -> StatePred<State<K, T>>
-{
+pub open spec fn resp_matches_at_most_one_pending_req<K: ResourceView, T>(
+    resp_msg: Message, cr_key: ObjectRef
+) -> StatePred<State<K, T>> {
     |s: State<K, T>| {
         s.reconcile_state_contains(cr_key)
         && s.reconcile_state_of(cr_key).pending_req_msg.is_Some()
@@ -281,8 +302,9 @@ pub open spec fn resp_matches_at_most_one_pending_req<K: ResourceView, T>(resp_m
     }
 }
 
-pub open spec fn at_most_one_resp_matches_req<K: ResourceView, T>(resp_msg: Message, cr_key: ObjectRef) -> StatePred<State<K, T>>
-{
+pub open spec fn at_most_one_resp_matches_req<K: ResourceView, T>(
+    resp_msg: Message, cr_key: ObjectRef
+) -> StatePred<State<K, T>> {
     |s: State<K, T>| {
         s.reconcile_state_contains(cr_key)
         && s.message_in_flight(resp_msg)
@@ -295,23 +317,30 @@ pub open spec fn at_most_one_resp_matches_req<K: ResourceView, T>(resp_msg: Mess
     }
 }
 
-pub proof fn lemma_always_at_most_one_resp_matches_req<K: ResourceView, T>(reconciler: Reconciler<K, T>, resp_msg: Message,
-cr_key: ObjectRef)
+pub proof fn lemma_always_at_most_one_resp_matches_req<K: ResourceView, T>(
+    reconciler: Reconciler<K, T>, resp_msg: Message, cr_key: ObjectRef
+)
     ensures
         sm_spec(reconciler).entails(always(lift_state(at_most_one_resp_matches_req(resp_msg, cr_key)))),
 {
-    implies_preserved_by_always::<State<K, T>>(every_in_flight_msg_has_unique_id::<K, T>(), at_most_one_resp_matches_req::<K, T>
-    (resp_msg, cr_key));
+    implies_preserved_by_always::<State<K, T>>(
+        every_in_flight_msg_has_unique_id::<K, T>(), at_most_one_resp_matches_req::<K, T>(resp_msg, cr_key)
+    );
     lemma_always_every_in_flight_msg_has_unique_id(reconciler);
-    entails_trans::<State<K, T>>(sm_spec(reconciler), always(lift_state(every_in_flight_msg_has_unique_id::<K, T>())),
-        always(lift_state(at_most_one_resp_matches_req::<K, T>(resp_msg, cr_key))));
+    entails_trans::<State<K, T>>(
+        sm_spec(reconciler),
+        always(lift_state(every_in_flight_msg_has_unique_id::<K, T>())),
+        always(lift_state(at_most_one_resp_matches_req::<K, T>(resp_msg, cr_key)))
+    );
 }
 
-pub proof fn lemma_forall_always_at_most_one_resp_matches_req<K: ResourceView, T>(reconciler: Reconciler<K, T>,
-cr_key: ObjectRef)
+pub proof fn lemma_forall_always_at_most_one_resp_matches_req<K: ResourceView, T>(
+    reconciler: Reconciler<K, T>, cr_key: ObjectRef
+)
     ensures
-        sm_spec(reconciler).entails(tla_forall(|resp_msg: Message| always(lift_state(at_most_one_resp_matches_req
-            (resp_msg, cr_key))))),
+        sm_spec(reconciler).entails(
+            tla_forall(|resp_msg: Message| always(lift_state(at_most_one_resp_matches_req(resp_msg, cr_key))))
+        ),
 {
     let m_to_p = |msg| always(lift_state(at_most_one_resp_matches_req(msg, cr_key)));
     assert forall |msg| #[trigger] sm_spec(reconciler).entails(m_to_p(msg)) by {
@@ -320,8 +349,9 @@ cr_key: ObjectRef)
     spec_entails_tla_forall(sm_spec(reconciler), m_to_p);
 }
 
-pub proof fn lemma_always_resp_matches_at_most_one_pending_req<K: ResourceView, T>(reconciler: Reconciler<K, T>,
-resp_msg: Message, cr_key: ObjectRef)
+pub proof fn lemma_always_resp_matches_at_most_one_pending_req<K: ResourceView, T>(
+    reconciler: Reconciler<K, T>, resp_msg: Message, cr_key: ObjectRef
+)
     requires
         cr_key.kind.is_CustomResourceKind(),
     ensures
@@ -335,16 +365,21 @@ resp_msg: Message, cr_key: ObjectRef)
 
     lemma_always_pending_req_has_lower_req_id_than_chan_manager(reconciler);
 
-    strengthen_next::<State<K, T>>(sm_spec(reconciler), next(reconciler), pending_req_has_lower_req_id_than_chan_manager(), stronger_next);
+    strengthen_next::<State<K, T>>(
+        sm_spec(reconciler), next(reconciler), pending_req_has_lower_req_id_than_chan_manager(), stronger_next
+    );
     init_invariant::<State<K, T>>(sm_spec(reconciler), init(reconciler), stronger_next, invariant);
 }
 
-pub proof fn lemma_forall_resp_always_matches_at_most_one_pending_req<K: ResourceView, T>(reconciler: Reconciler<K, T>,
-cr_key: ObjectRef)
+pub proof fn lemma_forall_resp_always_matches_at_most_one_pending_req<K: ResourceView, T>(
+    reconciler: Reconciler<K, T>, cr_key: ObjectRef
+)
     requires
         cr_key.kind.is_CustomResourceKind(),
     ensures
-        sm_spec(reconciler).entails(tla_forall(|msg| always(lift_state(resp_matches_at_most_one_pending_req(msg, cr_key))))),
+        sm_spec(reconciler).entails(
+            tla_forall(|msg| always(lift_state(resp_matches_at_most_one_pending_req(msg, cr_key))))
+        ),
 {
     let m_to_p = |msg| always(lift_state(resp_matches_at_most_one_pending_req(msg, cr_key)));
     assert forall |msg| #[trigger] sm_spec(reconciler).entails(m_to_p(msg)) by {
@@ -353,7 +388,9 @@ cr_key: ObjectRef)
     spec_entails_tla_forall(sm_spec(reconciler), m_to_p);
 }
 
-pub open spec fn each_resp_matches_at_most_one_pending_req<K: ResourceView, T>(cr_key: ObjectRef) -> StatePred<State<K, T>>
+pub open spec fn each_resp_matches_at_most_one_pending_req<K: ResourceView, T>(
+    cr_key: ObjectRef
+) -> StatePred<State<K, T>>
     recommends
         cr_key.kind.is_CustomResourceKind(),
 {
@@ -372,8 +409,9 @@ pub open spec fn each_resp_matches_at_most_one_pending_req<K: ResourceView, T>(c
     }
 }
 
-pub proof fn lemma_always_each_resp_matches_at_most_one_pending_req<K: ResourceView, T>(reconciler: Reconciler<K, T>,
-cr_key: ObjectRef)
+pub proof fn lemma_always_each_resp_matches_at_most_one_pending_req<K: ResourceView, T>(
+    reconciler: Reconciler<K, T>, cr_key: ObjectRef
+)
     requires
         cr_key.kind.is_CustomResourceKind(),
     ensures
@@ -387,7 +425,9 @@ cr_key: ObjectRef)
 
     lemma_always_pending_req_has_lower_req_id_than_chan_manager(reconciler);
 
-    strengthen_next::<State<K, T>>(sm_spec(reconciler), next(reconciler), pending_req_has_lower_req_id_than_chan_manager(), stronger_next);
+    strengthen_next::<State<K, T>>(
+        sm_spec(reconciler), next(reconciler), pending_req_has_lower_req_id_than_chan_manager(), stronger_next
+    );
     init_invariant::<State<K, T>>(sm_spec(reconciler), init(reconciler), stronger_next, invariant);
 }
 

--- a/src/kubernetes_cluster/proof/controller_runtime_safety.rs
+++ b/src/kubernetes_cluster/proof/controller_runtime_safety.rs
@@ -20,8 +20,8 @@ use vstd::{option::*, result::*};
 
 verus! {
 
-pub open spec fn every_in_flight_msg_has_lower_id_than_chan_manager<T>() -> StatePred<State<T>> {
-    |s: State<T>| {
+pub open spec fn every_in_flight_msg_has_lower_id_than_chan_manager<K: ResourceView, T>() -> StatePred<State<K, T>> {
+    |s: State<K, T>| {
         forall |msg: Message|
             #[trigger] s.message_in_flight(msg)
             ==> msg.content.get_msg_id() < s.chan_manager.cur_chan_id
@@ -32,20 +32,20 @@ pub proof fn lemma_always_every_in_flight_msg_has_lower_id_than_chan_manager<K: 
     ensures
         sm_spec(reconciler).entails(always(lift_state(every_in_flight_msg_has_lower_id_than_chan_manager()))),
 {
-    let invariant = every_in_flight_msg_has_lower_id_than_chan_manager::<T>();
-    assert forall |s, s_prime: State<T>| invariant(s) && #[trigger] next(reconciler)(s, s_prime) implies
+    let invariant = every_in_flight_msg_has_lower_id_than_chan_manager::<K, T>();
+    assert forall |s, s_prime: State<K, T>| invariant(s) && #[trigger] next(reconciler)(s, s_prime) implies
     invariant(s_prime) by {
         next_preserves_every_in_flight_msg_has_lower_id_than_chan_manager::<K, T>(reconciler, s, s_prime);
     };
-    init_invariant::<State<T>>(sm_spec(reconciler), init(reconciler), next(reconciler), invariant);
+    init_invariant::<State<K, T>>(sm_spec(reconciler), init(reconciler), next(reconciler), invariant);
 }
 
 proof fn next_preserves_every_in_flight_msg_has_lower_id_than_chan_manager<K: ResourceView, T>(reconciler: Reconciler<K, T>,
-s: State<T>, s_prime: State<T>)
+s: State<K, T>, s_prime: State<K, T>)
     requires
-        every_in_flight_msg_has_lower_id_than_chan_manager::<T>()(s), next(reconciler)(s, s_prime),
+        every_in_flight_msg_has_lower_id_than_chan_manager::<K, T>()(s), next(reconciler)(s, s_prime),
     ensures
-        every_in_flight_msg_has_lower_id_than_chan_manager::<T>()(s_prime),
+        every_in_flight_msg_has_lower_id_than_chan_manager::<K, T>()(s_prime),
 {
     assert forall |msg: Message| #[trigger] s_prime.message_in_flight(msg) implies
     msg.content.get_msg_id() < s_prime.chan_manager.cur_chan_id by {
@@ -66,8 +66,8 @@ s: State<T>, s_prime: State<T>)
     };
 }
 
-pub open spec fn every_in_flight_req_is_unique<T>() -> StatePred<State<T>> {
-    |s: State<T>| {
+pub open spec fn every_in_flight_req_is_unique<K: ResourceView, T>() -> StatePred<State<K, T>> {
+    |s: State<K, T>| {
         forall |msg: Message|
             msg.content.is_APIRequest() && #[trigger] s.message_in_flight(msg)
             ==> s.network_state.in_flight.count(msg) == 1
@@ -77,18 +77,18 @@ pub open spec fn every_in_flight_req_is_unique<T>() -> StatePred<State<T>> {
 pub proof fn lemma_always_every_in_flight_req_is_unique<K: ResourceView, T>(reconciler: Reconciler<K, T>)
     ensures
         sm_spec(reconciler).entails(
-            always(lift_state(every_in_flight_req_is_unique::<T>()))
+            always(lift_state(every_in_flight_req_is_unique::<K, T>()))
         ),
 {
-    let invariant = every_in_flight_req_is_unique::<T>();
-    let stronger_next = |s, s_prime: State<T>| {
+    let invariant = every_in_flight_req_is_unique::<K, T>();
+    let stronger_next = |s, s_prime: State<K, T>| {
         &&& next(reconciler)(s, s_prime)
         &&& every_in_flight_msg_has_lower_id_than_chan_manager()(s)
     };
     lemma_always_every_in_flight_msg_has_lower_id_than_chan_manager(reconciler);
-    strengthen_next::<State<T>>(sm_spec(reconciler), next(reconciler),
+    strengthen_next::<State<K, T>>(sm_spec(reconciler), next(reconciler),
         every_in_flight_msg_has_lower_id_than_chan_manager(), stronger_next);
-    assert forall |s, s_prime: State<T>| invariant(s) && #[trigger] stronger_next(s, s_prime) implies
+    assert forall |s, s_prime: State<K, T>| invariant(s) && #[trigger] stronger_next(s, s_prime) implies
     invariant(s_prime) by {
         assert forall |msg: Message| msg.content.is_APIRequest() && #[trigger] s_prime.message_in_flight(msg) implies
         s_prime.network_state.in_flight.count(msg) == 1 by {
@@ -97,11 +97,11 @@ pub proof fn lemma_always_every_in_flight_req_is_unique<K: ResourceView, T>(reco
             }
         };
     };
-    init_invariant::<State<T>>(sm_spec(reconciler), init(reconciler), stronger_next, invariant);
+    init_invariant::<State<K, T>>(sm_spec(reconciler), init(reconciler), stronger_next, invariant);
 }
 
-pub open spec fn every_in_flight_msg_has_unique_id<T>() -> StatePred<State<T>> {
-    |s: State<T>| {
+pub open spec fn every_in_flight_msg_has_unique_id<K: ResourceView, T>() -> StatePred<State<K, T>> {
+    |s: State<K, T>| {
         forall |msg: Message|
             #[trigger] s.message_in_flight(msg)
             ==> (
@@ -116,38 +116,38 @@ pub open spec fn every_in_flight_msg_has_unique_id<T>() -> StatePred<State<T>> {
 pub proof fn lemma_always_every_in_flight_msg_has_unique_id<K: ResourceView, T>(reconciler: Reconciler<K, T>)
     ensures
         sm_spec(reconciler).entails(
-            always(lift_state(every_in_flight_msg_has_unique_id::<T>()))
+            always(lift_state(every_in_flight_msg_has_unique_id::<K, T>()))
         ),
 {
-    let invariant = every_in_flight_msg_has_unique_id::<T>();
-    let stronger_next = |s, s_prime: State<T>| {
+    let invariant = every_in_flight_msg_has_unique_id::<K, T>();
+    let stronger_next = |s, s_prime: State<K, T>| {
         next(reconciler)(s, s_prime)
-        && every_in_flight_msg_has_lower_id_than_chan_manager::<T>()(s)
-        && every_in_flight_req_is_unique::<T>()(s)
+        && every_in_flight_msg_has_lower_id_than_chan_manager::<K, T>()(s)
+        && every_in_flight_req_is_unique::<K, T>()(s)
     };
     lemma_always_every_in_flight_msg_has_lower_id_than_chan_manager(reconciler);
     lemma_always_every_in_flight_req_is_unique(reconciler);
     entails_always_and_n!(sm_spec(reconciler), lift_action(next(reconciler)),
-        lift_state(every_in_flight_msg_has_lower_id_than_chan_manager::<T>()),
-        lift_state(every_in_flight_req_is_unique::<T>()));
+        lift_state(every_in_flight_msg_has_lower_id_than_chan_manager::<K, T>()),
+        lift_state(every_in_flight_req_is_unique::<K, T>()));
     temp_pred_equality(lift_action(stronger_next),
         lift_action(next(reconciler))
-        .and(lift_state(every_in_flight_msg_has_lower_id_than_chan_manager::<T>()))
-        .and(lift_state(every_in_flight_req_is_unique::<T>())));
-    assert forall |s, s_prime: State<T>| invariant(s) && #[trigger] stronger_next(s, s_prime) implies
+        .and(lift_state(every_in_flight_msg_has_lower_id_than_chan_manager::<K, T>()))
+        .and(lift_state(every_in_flight_req_is_unique::<K, T>())));
+    assert forall |s, s_prime: State<K, T>| invariant(s) && #[trigger] stronger_next(s, s_prime) implies
     invariant(s_prime) by {
         next_and_unique_lower_msg_id_preserves_in_flight_msg_has_unique_id(reconciler, s, s_prime);
     };
-    init_invariant::<State<T>>(sm_spec(reconciler), init(reconciler), stronger_next, invariant);
+    init_invariant::<State<K, T>>(sm_spec(reconciler), init(reconciler), stronger_next, invariant);
 }
 
 proof fn next_and_unique_lower_msg_id_preserves_in_flight_msg_has_unique_id<K: ResourceView, T>(reconciler: Reconciler<K, T>,
-s: State<T>, s_prime: State<T>)
+s: State<K, T>, s_prime: State<K, T>)
     requires
         next(reconciler)(s, s_prime),
-        every_in_flight_msg_has_lower_id_than_chan_manager::<T>()(s), every_in_flight_req_is_unique::<T>()(s), every_in_flight_msg_has_unique_id::<T>()(s), // the invariant
+        every_in_flight_msg_has_lower_id_than_chan_manager::<K, T>()(s), every_in_flight_req_is_unique::<K, T>()(s), every_in_flight_msg_has_unique_id::<K, T>()(s), // the invariant
     ensures
-        every_in_flight_msg_has_unique_id::<T>()(s_prime),
+        every_in_flight_msg_has_unique_id::<K, T>()(s_prime),
 {
     assert forall |msg: Message| #[trigger] s_prime.message_in_flight(msg) implies
     (forall |other_msg: Message| #[trigger] s_prime.message_in_flight(other_msg) && msg != other_msg
@@ -169,14 +169,14 @@ s: State<T>, s_prime: State<T>)
     };
 }
 
-proof fn newly_added_msg_have_different_id_from_existing_ones<K: ResourceView, T>(reconciler: Reconciler<K, T>, s: State<T>,
-s_prime: State<T>, msg_1: Message, msg_2: Message)
+proof fn newly_added_msg_have_different_id_from_existing_ones<K: ResourceView, T>(reconciler: Reconciler<K, T>, s: State<K, T>,
+s_prime: State<K, T>, msg_1: Message, msg_2: Message)
     requires
         next(reconciler)(s, s_prime),
-        every_in_flight_msg_has_lower_id_than_chan_manager::<T>()(s), every_in_flight_req_is_unique::<T>()(s),
+        every_in_flight_msg_has_lower_id_than_chan_manager::<K, T>()(s), every_in_flight_req_is_unique::<K, T>()(s),
         s.message_in_flight(msg_1), !s.message_in_flight(msg_2),
         s_prime.message_in_flight(msg_1), s_prime.message_in_flight(msg_2),
-        every_in_flight_msg_has_unique_id::<T>()(s), // the invariant
+        every_in_flight_msg_has_unique_id::<K, T>()(s), // the invariant
     ensures
         msg_1.content.get_msg_id() != msg_2.content.get_msg_id(),
 {
@@ -188,7 +188,7 @@ s_prime: State<T>, msg_1: Message, msg_2: Message)
     }
 }
 
-pub open spec fn req_in_flight_or_pending_at_controller<T>(req_msg: Message, s: State<T>) -> bool {
+pub open spec fn req_in_flight_or_pending_at_controller<K: ResourceView, T>(req_msg: Message, s: State<K, T>) -> bool {
     req_msg.content.is_APIRequest()
     && (s.message_in_flight(req_msg)
     || exists |cr_key: ObjectRef| (
@@ -197,8 +197,8 @@ pub open spec fn req_in_flight_or_pending_at_controller<T>(req_msg: Message, s: 
     ))
 }
 
-pub open spec fn every_in_flight_or_pending_req_has_unique_id<T>() -> StatePred<State<T>> {
-    |s: State<T>| {
+pub open spec fn every_in_flight_or_pending_req_has_unique_id<K: ResourceView, T>() -> StatePred<State<K, T>> {
+    |s: State<K, T>| {
         forall |msg1, msg2: Message|
             #![trigger req_in_flight_or_pending_at_controller(msg1, s), req_in_flight_or_pending_at_controller(msg2, s)]
             req_in_flight_or_pending_at_controller(msg1, s)
@@ -211,25 +211,25 @@ pub open spec fn every_in_flight_or_pending_req_has_unique_id<T>() -> StatePred<
 pub proof fn lemma_always_every_in_flight_or_pending_req_has_unique_id<K: ResourceView, T>(reconciler: Reconciler<K, T>)
     ensures
         sm_spec(reconciler).entails(
-            always(lift_state(every_in_flight_or_pending_req_has_unique_id::<T>()))
+            always(lift_state(every_in_flight_or_pending_req_has_unique_id::<K, T>()))
         ),
 {
-    let invariant = every_in_flight_or_pending_req_has_unique_id::<T>();
-    let stronger_next = |s, s_prime: State<T>| {
+    let invariant = every_in_flight_or_pending_req_has_unique_id::<K, T>();
+    let stronger_next = |s, s_prime: State<K, T>| {
         next(reconciler)(s, s_prime)
-        && every_in_flight_msg_has_lower_id_than_chan_manager::<T>()(s)
-        && pending_req_has_lower_req_id_than_chan_manager::<T>()(s)
+        && every_in_flight_msg_has_lower_id_than_chan_manager::<K, T>()(s)
+        && pending_req_has_lower_req_id_than_chan_manager::<K, T>()(s)
     };
     lemma_always_every_in_flight_msg_has_lower_id_than_chan_manager(reconciler);
     lemma_always_pending_req_has_lower_req_id_than_chan_manager(reconciler);
     entails_always_and_n!(sm_spec(reconciler), lift_action(next(reconciler)),
-        lift_state(every_in_flight_msg_has_lower_id_than_chan_manager::<T>()),
-        lift_state(pending_req_has_lower_req_id_than_chan_manager::<T>()));
+        lift_state(every_in_flight_msg_has_lower_id_than_chan_manager::<K, T>()),
+        lift_state(pending_req_has_lower_req_id_than_chan_manager::<K, T>()));
     temp_pred_equality(lift_action(stronger_next),
         lift_action(next(reconciler))
-        .and(lift_state(every_in_flight_msg_has_lower_id_than_chan_manager::<T>()))
-        .and(lift_state(pending_req_has_lower_req_id_than_chan_manager::<T>())));
-    assert forall |s, s_prime: State<T>| invariant(s) && #[trigger] stronger_next(s, s_prime)
+        .and(lift_state(every_in_flight_msg_has_lower_id_than_chan_manager::<K, T>()))
+        .and(lift_state(pending_req_has_lower_req_id_than_chan_manager::<K, T>())));
+    assert forall |s, s_prime: State<K, T>| invariant(s) && #[trigger] stronger_next(s, s_prime)
     implies invariant(s_prime) by {
         assert forall |req_msg, other_msg: Message| #[trigger] req_in_flight_or_pending_at_controller(req_msg, s_prime)
         && #[trigger] req_in_flight_or_pending_at_controller(other_msg, s_prime) && req_msg != other_msg
@@ -244,12 +244,12 @@ pub proof fn lemma_always_every_in_flight_or_pending_req_has_unique_id<K: Resour
             }
         };
     };
-    init_invariant::<State<T>>(sm_spec(reconciler), init(reconciler), stronger_next, invariant);
+    init_invariant::<State<K, T>>(sm_spec(reconciler), init(reconciler), stronger_next, invariant);
 }
 
 
-pub open spec fn pending_req_has_lower_req_id_than_chan_manager<T>() -> StatePred<State<T>> {
-    |s: State<T>| {
+pub open spec fn pending_req_has_lower_req_id_than_chan_manager<K: ResourceView, T>() -> StatePred<State<K, T>> {
+    |s: State<K, T>| {
         forall |cr_key: ObjectRef|
             #[trigger] s.reconcile_state_contains(cr_key)
             && s.reconcile_state_of(cr_key).pending_req_msg.is_Some()
@@ -261,13 +261,13 @@ pub proof fn lemma_always_pending_req_has_lower_req_id_than_chan_manager<K: Reso
     ensures
         sm_spec(reconciler).entails(always(lift_state(pending_req_has_lower_req_id_than_chan_manager()))),
 {
-    let invariant = pending_req_has_lower_req_id_than_chan_manager::<T>();
-    init_invariant::<State<T>>(sm_spec(reconciler), init(reconciler), next(reconciler), invariant);
+    let invariant = pending_req_has_lower_req_id_than_chan_manager::<K, T>();
+    init_invariant::<State<K, T>>(sm_spec(reconciler), init(reconciler), next(reconciler), invariant);
 }
 
-pub open spec fn resp_matches_at_most_one_pending_req<T>(resp_msg: Message, cr_key: ObjectRef) -> StatePred<State<T>>
+pub open spec fn resp_matches_at_most_one_pending_req<K: ResourceView, T>(resp_msg: Message, cr_key: ObjectRef) -> StatePred<State<K, T>>
 {
-    |s: State<T>| {
+    |s: State<K, T>| {
         s.reconcile_state_contains(cr_key)
         && s.reconcile_state_of(cr_key).pending_req_msg.is_Some()
         && resp_msg_matches_req_msg(resp_msg, s.reconcile_state_of(cr_key).pending_req_msg.get_Some_0())
@@ -281,9 +281,9 @@ pub open spec fn resp_matches_at_most_one_pending_req<T>(resp_msg: Message, cr_k
     }
 }
 
-pub open spec fn at_most_one_resp_matches_req<T>(resp_msg: Message, cr_key: ObjectRef) -> StatePred<State<T>>
+pub open spec fn at_most_one_resp_matches_req<K: ResourceView, T>(resp_msg: Message, cr_key: ObjectRef) -> StatePred<State<K, T>>
 {
-    |s: State<T>| {
+    |s: State<K, T>| {
         s.reconcile_state_contains(cr_key)
         && s.message_in_flight(resp_msg)
         && s.reconcile_state_of(cr_key).pending_req_msg.is_Some()
@@ -300,11 +300,11 @@ cr_key: ObjectRef)
     ensures
         sm_spec(reconciler).entails(always(lift_state(at_most_one_resp_matches_req(resp_msg, cr_key)))),
 {
-    implies_preserved_by_always::<State<T>>(every_in_flight_msg_has_unique_id::<T>(), at_most_one_resp_matches_req::<T>
+    implies_preserved_by_always::<State<K, T>>(every_in_flight_msg_has_unique_id::<K, T>(), at_most_one_resp_matches_req::<K, T>
     (resp_msg, cr_key));
     lemma_always_every_in_flight_msg_has_unique_id(reconciler);
-    entails_trans::<State<T>>(sm_spec(reconciler), always(lift_state(every_in_flight_msg_has_unique_id::<T>())),
-        always(lift_state(at_most_one_resp_matches_req::<T>(resp_msg, cr_key))));
+    entails_trans::<State<K, T>>(sm_spec(reconciler), always(lift_state(every_in_flight_msg_has_unique_id::<K, T>())),
+        always(lift_state(at_most_one_resp_matches_req::<K, T>(resp_msg, cr_key))));
 }
 
 pub proof fn lemma_forall_always_at_most_one_resp_matches_req<K: ResourceView, T>(reconciler: Reconciler<K, T>,
@@ -327,16 +327,16 @@ resp_msg: Message, cr_key: ObjectRef)
     ensures
         sm_spec(reconciler).entails(always(lift_state(resp_matches_at_most_one_pending_req(resp_msg, cr_key)))),
 {
-    let invariant = resp_matches_at_most_one_pending_req::<T>(resp_msg, cr_key);
-    let stronger_next = |s, s_prime: State<T>| {
+    let invariant = resp_matches_at_most_one_pending_req::<K, T>(resp_msg, cr_key);
+    let stronger_next = |s, s_prime: State<K, T>| {
         &&& next(reconciler)(s, s_prime)
         &&& pending_req_has_lower_req_id_than_chan_manager()(s)
     };
 
     lemma_always_pending_req_has_lower_req_id_than_chan_manager(reconciler);
 
-    strengthen_next::<State<T>>(sm_spec(reconciler), next(reconciler), pending_req_has_lower_req_id_than_chan_manager(), stronger_next);
-    init_invariant::<State<T>>(sm_spec(reconciler), init(reconciler), stronger_next, invariant);
+    strengthen_next::<State<K, T>>(sm_spec(reconciler), next(reconciler), pending_req_has_lower_req_id_than_chan_manager(), stronger_next);
+    init_invariant::<State<K, T>>(sm_spec(reconciler), init(reconciler), stronger_next, invariant);
 }
 
 pub proof fn lemma_forall_resp_always_matches_at_most_one_pending_req<K: ResourceView, T>(reconciler: Reconciler<K, T>,
@@ -353,11 +353,11 @@ cr_key: ObjectRef)
     spec_entails_tla_forall(sm_spec(reconciler), m_to_p);
 }
 
-pub open spec fn each_resp_matches_at_most_one_pending_req<T>(cr_key: ObjectRef) -> StatePred<State<T>>
+pub open spec fn each_resp_matches_at_most_one_pending_req<K: ResourceView, T>(cr_key: ObjectRef) -> StatePred<State<K, T>>
     recommends
         cr_key.kind.is_CustomResourceKind(),
 {
-    |s: State<T>| {
+    |s: State<K, T>| {
         forall |resp_msg: Message|
             s.reconcile_state_contains(cr_key)
             && s.reconcile_state_of(cr_key).pending_req_msg.is_Some()
@@ -379,16 +379,16 @@ cr_key: ObjectRef)
     ensures
         sm_spec(reconciler).entails(always(lift_state(each_resp_matches_at_most_one_pending_req(cr_key)))),
 {
-    let invariant = each_resp_matches_at_most_one_pending_req::<T>(cr_key);
-    let stronger_next = |s, s_prime: State<T>| {
+    let invariant = each_resp_matches_at_most_one_pending_req::<K, T>(cr_key);
+    let stronger_next = |s, s_prime: State<K, T>| {
         &&& next(reconciler)(s, s_prime)
         &&& pending_req_has_lower_req_id_than_chan_manager()(s)
     };
 
     lemma_always_pending_req_has_lower_req_id_than_chan_manager(reconciler);
 
-    strengthen_next::<State<T>>(sm_spec(reconciler), next(reconciler), pending_req_has_lower_req_id_than_chan_manager(), stronger_next);
-    init_invariant::<State<T>>(sm_spec(reconciler), init(reconciler), stronger_next, invariant);
+    strengthen_next::<State<K, T>>(sm_spec(reconciler), next(reconciler), pending_req_has_lower_req_id_than_chan_manager(), stronger_next);
+    init_invariant::<State<K, T>>(sm_spec(reconciler), init(reconciler), stronger_next, invariant);
 }
 
 }

--- a/src/kubernetes_cluster/proof/kubernetes_api_liveness.rs
+++ b/src/kubernetes_cluster/proof/kubernetes_api_liveness.rs
@@ -20,58 +20,58 @@ use vstd::{option::*, result::*};
 
 verus! {
 
-pub proof fn lemma_pre_leads_to_post_by_kubernetes_api<K: ResourceView, T>(spec: TempPred<State<T>>, reconciler: Reconciler<K, T>, input: Option<Message>, next: ActionPred<State<T>>, action: KubernetesAPIAction, pre: StatePred<State<T>>, post: StatePred<State<T>>)
+pub proof fn lemma_pre_leads_to_post_by_kubernetes_api<K: ResourceView, T>(spec: TempPred<State<K, T>>, reconciler: Reconciler<K, T>, input: Option<Message>, next: ActionPred<State<K, T>>, action: KubernetesAPIAction, pre: StatePred<State<K, T>>, post: StatePred<State<K, T>>)
     requires
         kubernetes_api().actions.contains(action),
-        forall |s, s_prime: State<T>| pre(s) && #[trigger] next(s, s_prime) ==> pre(s_prime) || post(s_prime),
-        forall |s, s_prime: State<T>| pre(s) && #[trigger] next(s, s_prime) && kubernetes_api_next().forward(input)(s, s_prime) ==> post(s_prime),
-        forall |s: State<T>| #[trigger] pre(s) ==> kubernetes_api_action_pre(action, input)(s),
+        forall |s, s_prime: State<K, T>| pre(s) && #[trigger] next(s, s_prime) ==> pre(s_prime) || post(s_prime),
+        forall |s, s_prime: State<K, T>| pre(s) && #[trigger] next(s, s_prime) && kubernetes_api_next().forward(input)(s, s_prime) ==> post(s_prime),
+        forall |s: State<K, T>| #[trigger] pre(s) ==> kubernetes_api_action_pre(action, input)(s),
         spec.entails(always(lift_action(next))),
         spec.entails(tla_forall(|i| kubernetes_api_next().weak_fairness(i))),
     ensures
         spec.entails(lift_state(pre).leads_to(lift_state(post))),
 {
-    use_tla_forall::<State<T>, Option<Message>>(spec, |i| kubernetes_api_next().weak_fairness(i), input);
+    use_tla_forall::<State<K, T>, Option<Message>>(spec, |i| kubernetes_api_next().weak_fairness(i), input);
 
-    kubernetes_api_action_pre_implies_next_pre::<T>(action, input);
-    valid_implies_trans::<State<T>>(lift_state(pre), lift_state(kubernetes_api_action_pre(action, input)), lift_state(kubernetes_api_next().pre(input)));
+    kubernetes_api_action_pre_implies_next_pre::<K, T>(action, input);
+    valid_implies_trans::<State<K, T>>(lift_state(pre), lift_state(kubernetes_api_action_pre(action, input)), lift_state(kubernetes_api_next().pre(input)));
 
     kubernetes_api_next().wf1(input, spec, next, pre, post);
 }
 
-pub proof fn lemma_pre_leads_to_post_with_assumption_by_kubernetes_api<K: ResourceView, T>(spec: TempPred<State<T>>, reconciler: Reconciler<K, T>, input: Option<Message>, next: ActionPred<State<T>>, action: KubernetesAPIAction, assumption: StatePred<State<T>>, pre: StatePred<State<T>>, post: StatePred<State<T>>)
+pub proof fn lemma_pre_leads_to_post_with_assumption_by_kubernetes_api<K: ResourceView, T>(spec: TempPred<State<K, T>>, reconciler: Reconciler<K, T>, input: Option<Message>, next: ActionPred<State<K, T>>, action: KubernetesAPIAction, assumption: StatePred<State<K, T>>, pre: StatePred<State<K, T>>, post: StatePred<State<K, T>>)
     requires
         kubernetes_api().actions.contains(action),
-        forall |s, s_prime: State<T>| pre(s) && #[trigger] next(s, s_prime) && assumption(s) ==> pre(s_prime) || post(s_prime),
-        forall |s, s_prime: State<T>| pre(s) && #[trigger] next(s, s_prime) && kubernetes_api_next().forward(input)(s, s_prime) ==> post(s_prime),
-        forall |s: State<T>| #[trigger] pre(s) ==> kubernetes_api_action_pre(action, input)(s),
+        forall |s, s_prime: State<K, T>| pre(s) && #[trigger] next(s, s_prime) && assumption(s) ==> pre(s_prime) || post(s_prime),
+        forall |s, s_prime: State<K, T>| pre(s) && #[trigger] next(s, s_prime) && kubernetes_api_next().forward(input)(s, s_prime) ==> post(s_prime),
+        forall |s: State<K, T>| #[trigger] pre(s) ==> kubernetes_api_action_pre(action, input)(s),
         spec.entails(always(lift_action(next))),
         spec.entails(tla_forall(|i| kubernetes_api_next().weak_fairness(i))),
     ensures
         spec.entails(lift_state(pre).and(always(lift_state(assumption))).leads_to(lift_state(post))),
 {
-    use_tla_forall::<State<T>, Option<Message>>(spec, |i| kubernetes_api_next().weak_fairness(i), input);
+    use_tla_forall::<State<K, T>, Option<Message>>(spec, |i| kubernetes_api_next().weak_fairness(i), input);
 
-    kubernetes_api_action_pre_implies_next_pre::<T>(action, input);
-    valid_implies_trans::<State<T>>(lift_state(pre), lift_state(kubernetes_api_action_pre(action, input)), lift_state(kubernetes_api_next().pre(input)));
+    kubernetes_api_action_pre_implies_next_pre::<K, T>(action, input);
+    valid_implies_trans::<State<K, T>>(lift_state(pre), lift_state(kubernetes_api_action_pre(action, input)), lift_state(kubernetes_api_next().pre(input)));
 
     kubernetes_api_next().wf1_assume(input, spec, next, assumption, pre, post);
 }
 
-pub proof fn lemma_get_req_leads_to_some_resp<K: ResourceView, T>(spec: TempPred<State<T>>, reconciler: Reconciler<K, T>, msg: Message, key: ObjectRef)
+pub proof fn lemma_get_req_leads_to_some_resp<K: ResourceView, T>(spec: TempPred<State<K, T>>, reconciler: Reconciler<K, T>, msg: Message, key: ObjectRef)
     requires
         spec.entails(always(lift_action(next(reconciler)))),
         spec.entails(tla_forall(|i| kubernetes_api_next().weak_fairness(i))),
     ensures
         spec.entails(
-            lift_state(|s: State<T>| {
+            lift_state(|s: State<K, T>| {
                     &&& s.message_in_flight(msg)
                     &&& msg.dst == HostId::KubernetesAPI
                     &&& msg.content.is_get_request()
                     &&& msg.content.get_get_request().key == key
                 })
                 .leads_to(
-                    lift_state(|s: State<T>|
+                    lift_state(|s: State<K, T>|
                         exists |resp_msg: Message| {
                             &&& #[trigger] s.message_in_flight(resp_msg)
                             &&& resp_msg_matches_req_msg(resp_msg, msg)
@@ -81,17 +81,17 @@ pub proof fn lemma_get_req_leads_to_some_resp<K: ResourceView, T>(spec: TempPred
         ),
 {
     let input = Option::Some(msg);
-    let pre = |s: State<T>| {
+    let pre = |s: State<K, T>| {
         &&& s.message_in_flight(msg)
         &&& msg.dst == HostId::KubernetesAPI
         &&& msg.content.is_get_request()
         &&& msg.content.get_get_request().key == key
     };
-    let post = |s: State<T>| exists |resp_msg: Message| {
+    let post = |s: State<K, T>| exists |resp_msg: Message| {
         &&& #[trigger] s.message_in_flight(resp_msg)
         &&& resp_msg_matches_req_msg(resp_msg, msg)
     };
-    assert forall |s, s_prime: State<T>| pre(s) && #[trigger] next(reconciler)(s, s_prime) && kubernetes_api_next().forward(input)(s, s_prime)
+    assert forall |s, s_prime: State<K, T>| pre(s) && #[trigger] next(reconciler)(s, s_prime) && kubernetes_api_next().forward(input)(s, s_prime)
     implies post(s_prime) by {
         if s.resource_key_exists(key) {
             let ok_resp_msg = form_get_resp_msg(msg, Result::Ok(s.resource_obj_of(key)));
@@ -106,56 +106,56 @@ pub proof fn lemma_get_req_leads_to_some_resp<K: ResourceView, T>(spec: TempPred
     lemma_pre_leads_to_post_by_kubernetes_api(spec, reconciler, input, next(reconciler), handle_request(), pre, post);
 }
 
-pub proof fn lemma_get_req_leads_to_ok_or_err_resp<K: ResourceView, T>(spec: TempPred<State<T>>, reconciler: Reconciler<K, T>, msg: Message, key: ObjectRef)
+pub proof fn lemma_get_req_leads_to_ok_or_err_resp<K: ResourceView, T>(spec: TempPred<State<K, T>>, reconciler: Reconciler<K, T>, msg: Message, key: ObjectRef)
     requires
         spec.entails(always(lift_action(next(reconciler)))),
         spec.entails(tla_forall(|i| kubernetes_api_next().weak_fairness(i))),
     ensures
         spec.entails(
-            lift_state(|s: State<T>| {
+            lift_state(|s: State<K, T>| {
                 &&& s.message_in_flight(msg)
                 &&& msg.dst == HostId::KubernetesAPI
                 &&& msg.content.is_get_request()
                 &&& msg.content.get_get_request().key == key
             })
                 .leads_to(
-                    lift_state(|s: State<T>| s.message_in_flight(form_get_resp_msg(msg, Result::Ok(s.resource_obj_of(key)))))
-                    .or(lift_state(|s: State<T>| s.message_in_flight(form_get_resp_msg(msg, Result::Err(APIError::ObjectNotFound)))))
+                    lift_state(|s: State<K, T>| s.message_in_flight(form_get_resp_msg(msg, Result::Ok(s.resource_obj_of(key)))))
+                    .or(lift_state(|s: State<K, T>| s.message_in_flight(form_get_resp_msg(msg, Result::Err(APIError::ObjectNotFound)))))
                 )
         ),
 {
-    let pre = |s: State<T>| {
+    let pre = |s: State<K, T>| {
         &&& s.message_in_flight(msg)
         &&& msg.dst == HostId::KubernetesAPI
         &&& msg.content.is_get_request()
         &&& msg.content.get_get_request().key == key
     };
-    let post = |s: State<T>| {
+    let post = |s: State<K, T>| {
         ||| s.message_in_flight(form_get_resp_msg(msg, Result::Ok(s.resource_obj_of(key))))
         ||| s.message_in_flight(form_get_resp_msg(msg, Result::Err(APIError::ObjectNotFound)))
     };
     lemma_pre_leads_to_post_by_kubernetes_api(spec, reconciler, Option::Some(msg), next(reconciler), handle_request(), pre, post);
-    temp_pred_equality::<State<T>>(
+    temp_pred_equality::<State<K, T>>(
         lift_state(post),
-        lift_state(|s: State<T>| s.message_in_flight(form_get_resp_msg(msg, Result::Ok(s.resource_obj_of(key)))))
-        .or(lift_state(|s: State<T>| s.message_in_flight(form_get_resp_msg(msg, Result::Err(APIError::ObjectNotFound)))))
+        lift_state(|s: State<K, T>| s.message_in_flight(form_get_resp_msg(msg, Result::Ok(s.resource_obj_of(key)))))
+        .or(lift_state(|s: State<K, T>| s.message_in_flight(form_get_resp_msg(msg, Result::Err(APIError::ObjectNotFound)))))
     );
 }
 
-pub proof fn lemma_get_req_leads_to_ok_resp_if_never_delete<K: ResourceView, T>(spec: TempPred<State<T>>, reconciler: Reconciler<K, T>, msg: Message, res: DynamicObjectView)
+pub proof fn lemma_get_req_leads_to_ok_resp_if_never_delete<K: ResourceView, T>(spec: TempPred<State<K, T>>, reconciler: Reconciler<K, T>, msg: Message, res: DynamicObjectView)
     requires
         spec.entails(always(lift_action(next(reconciler)))),
         spec.entails(tla_forall(|i| kubernetes_api_next().weak_fairness(i))),
     ensures
         spec.entails(
-            lift_state(|s: State<T>| {
+            lift_state(|s: State<K, T>| {
                 &&& s.message_in_flight(msg)
                 &&& msg.dst == HostId::KubernetesAPI
                 &&& msg.content.is_get_request()
                 &&& msg.content.get_get_request().key == res.object_ref()
                 &&& s.resource_obj_exists(res)
             })
-            .and(always(lift_state(|s: State<T>| {
+            .and(always(lift_state(|s: State<K, T>| {
                 forall |other: Message|
                 !{
                     &&& #[trigger] s.message_in_flight(other)
@@ -164,17 +164,17 @@ pub proof fn lemma_get_req_leads_to_ok_resp_if_never_delete<K: ResourceView, T>(
                     &&& other.content.get_delete_request().key == res.object_ref()
                 }
             })))
-                .leads_to(lift_state(|s: State<T>| s.message_in_flight(form_get_resp_msg(msg, Result::Ok(res)))))
+                .leads_to(lift_state(|s: State<K, T>| s.message_in_flight(form_get_resp_msg(msg, Result::Ok(res)))))
         ),
 {
-    let pre = |s: State<T>| {
+    let pre = |s: State<K, T>| {
         &&& s.message_in_flight(msg)
         &&& msg.dst == HostId::KubernetesAPI
         &&& msg.content.is_get_request()
         &&& msg.content.get_get_request().key == res.object_ref()
         &&& s.resource_obj_exists(res)
     };
-    let assumption = |s: State<T>| {
+    let assumption = |s: State<K, T>| {
         forall |other: Message|
             !{
                 &&& #[trigger] s.message_in_flight(other)
@@ -183,72 +183,72 @@ pub proof fn lemma_get_req_leads_to_ok_resp_if_never_delete<K: ResourceView, T>(
                 &&& other.content.get_delete_request().key == res.object_ref()
             }
     };
-    let post = |s: State<T>| s.message_in_flight(form_get_resp_msg(msg, Result::Ok(res)));
+    let post = |s: State<K, T>| s.message_in_flight(form_get_resp_msg(msg, Result::Ok(res)));
     lemma_pre_leads_to_post_with_assumption_by_kubernetes_api(spec, reconciler, Option::Some(msg), next(reconciler), handle_request(), assumption, pre, post);
 }
 
-pub proof fn lemma_create_req_leads_to_res_exists<K: ResourceView, T>(spec: TempPred<State<T>>, reconciler: Reconciler<K, T>, msg: Message, res: DynamicObjectView)
+pub proof fn lemma_create_req_leads_to_res_exists<K: ResourceView, T>(spec: TempPred<State<K, T>>, reconciler: Reconciler<K, T>, msg: Message, res: DynamicObjectView)
     requires
         spec.entails(always(lift_action(next(reconciler)))),
         spec.entails(tla_forall(|i| kubernetes_api_next().weak_fairness(i))),
     ensures
         spec.entails(
-            lift_state(|s: State<T>| {
+            lift_state(|s: State<K, T>| {
                 &&& s.message_in_flight(msg)
                 &&& msg.dst == HostId::KubernetesAPI
                 &&& msg.content.is_create_request()
                 &&& msg.content.get_create_request().obj == res
             })
-                .leads_to(lift_state(|s: State<T>| s.resource_key_exists(res.object_ref())))
+                .leads_to(lift_state(|s: State<K, T>| s.resource_key_exists(res.object_ref())))
         ),
 {
-    let pre = |s: State<T>| {
+    let pre = |s: State<K, T>| {
         &&& s.message_in_flight(msg)
         &&& msg.dst == HostId::KubernetesAPI
         &&& msg.content.is_create_request()
         &&& msg.content.get_create_request().obj == res
     };
-    let post = |s: State<T>| {
+    let post = |s: State<K, T>| {
         s.resource_key_exists(res.object_ref())
     };
     lemma_pre_leads_to_post_by_kubernetes_api(spec, reconciler, Option::Some(msg), next(reconciler), handle_request(), pre, post);
 }
 
-pub proof fn lemma_delete_req_leads_to_res_not_exists<K: ResourceView, T>(spec: TempPred<State<T>>, reconciler: Reconciler<K, T>, msg: Message, res: DynamicObjectView)
+pub proof fn lemma_delete_req_leads_to_res_not_exists<K: ResourceView, T>(spec: TempPred<State<K, T>>, reconciler: Reconciler<K, T>, msg: Message, res: DynamicObjectView)
     requires
         spec.entails(always(lift_action(next(reconciler)))),
         spec.entails(tla_forall(|i| kubernetes_api_next().weak_fairness(i))),
     ensures
         spec.entails(
-            lift_state(|s: State<T>| {
+            lift_state(|s: State<K, T>| {
                 &&& s.message_in_flight(msg)
                 &&& msg.dst == HostId::KubernetesAPI
                 &&& msg.content.is_delete_request()
                 &&& msg.content.get_delete_request().key == res.object_ref()
             })
-                .leads_to(lift_state(|s: State<T>| !s.resource_obj_exists(res)))
+                .leads_to(lift_state(|s: State<K, T>| !s.resource_obj_exists(res)))
         ),
 {
-    let pre = |s: State<T>| {
+    let pre = |s: State<K, T>| {
         &&& s.message_in_flight(msg)
         &&& msg.dst == HostId::KubernetesAPI
         &&& msg.content.is_delete_request()
         &&& msg.content.get_delete_request().key == res.object_ref()
     };
-    let post = |s: State<T>| {
+    let post = |s: State<K, T>| {
         !s.resource_obj_exists(res)
     };
     lemma_pre_leads_to_post_by_kubernetes_api(spec, reconciler, Option::Some(msg), next(reconciler), handle_request(), pre, post);
 }
 
-pub proof fn lemma_always_res_always_exists_implies_delete_never_sent<K: ResourceView, T>(spec: TempPred<State<T>>, reconciler: Reconciler<K, T>, msg: Message, res: DynamicObjectView)
+pub proof fn lemma_always_res_always_exists_implies_delete_never_sent<K: ResourceView, T>(spec: TempPred<State<K, T>>, reconciler: Reconciler<K, T>, msg: Message, res: DynamicObjectView)
     requires
         spec.entails(always(lift_action(next(reconciler)))),
         spec.entails(tla_forall(|i| kubernetes_api_next().weak_fairness(i))),
     ensures
         spec.entails(always(
-            always(lift_state(|s: State<T>| s.resource_obj_exists(res)))
-                .implies(always(lift_state(|s: State<T>| {
+            always(lift_state(|s: State<K, T>| s.resource_obj_exists(res)))
+                .implies(always(lift_state(|s: State<K, T>| {
                     !{
                         &&& s.message_in_flight(msg)
                         &&& msg.dst == HostId::KubernetesAPI
@@ -259,27 +259,27 @@ pub proof fn lemma_always_res_always_exists_implies_delete_never_sent<K: Resourc
         )),
 {
     lemma_delete_req_leads_to_res_not_exists(spec, reconciler, msg, res);
-    leads_to_contraposition::<State<T>>(spec,
-        |s: State<T>| {
+    leads_to_contraposition::<State<K, T>>(spec,
+        |s: State<K, T>| {
             &&& s.message_in_flight(msg)
             &&& msg.dst == HostId::KubernetesAPI
             &&& msg.content.is_delete_request()
             &&& msg.content.get_delete_request().key == res.object_ref()
         },
-        |s: State<T>| !s.resource_obj_exists(res)
+        |s: State<K, T>| !s.resource_obj_exists(res)
     );
-    temp_pred_equality::<State<T>>(
-        not(lift_state(|s: State<T>| !s.resource_obj_exists(res))),
-        lift_state(|s: State<T>| s.resource_obj_exists(res))
+    temp_pred_equality::<State<K, T>>(
+        not(lift_state(|s: State<K, T>| !s.resource_obj_exists(res))),
+        lift_state(|s: State<K, T>| s.resource_obj_exists(res))
     );
-    temp_pred_equality::<State<T>>(
-        not(lift_state(|s: State<T>| {
+    temp_pred_equality::<State<K, T>>(
+        not(lift_state(|s: State<K, T>| {
             &&& s.message_in_flight(msg)
             &&& msg.dst == HostId::KubernetesAPI
             &&& msg.content.is_delete_request()
             &&& msg.content.get_delete_request().key == res.object_ref()
         })),
-        lift_state(|s: State<T>| {
+        lift_state(|s: State<K, T>| {
             !{
                 &&& s.message_in_flight(msg)
                 &&& msg.dst == HostId::KubernetesAPI

--- a/src/kubernetes_cluster/proof/mod.rs
+++ b/src/kubernetes_cluster/proof/mod.rs
@@ -1,7 +1,7 @@
 // Copyright 2022 VMware, Inc.
 // SPDX-License-Identifier: MIT
 pub mod cluster;
-// pub mod controller_runtime_liveness;
+pub mod controller_runtime_liveness;
 pub mod controller_runtime_safety;
 pub mod kubernetes_api_liveness;
 pub mod kubernetes_api_safety;

--- a/src/kubernetes_cluster/proof/mod.rs
+++ b/src/kubernetes_cluster/proof/mod.rs
@@ -1,7 +1,7 @@
 // Copyright 2022 VMware, Inc.
 // SPDX-License-Identifier: MIT
 pub mod cluster;
-pub mod controller_runtime_liveness;
+// pub mod controller_runtime_liveness;
 pub mod controller_runtime_safety;
 pub mod kubernetes_api_liveness;
 pub mod kubernetes_api_safety;

--- a/src/kubernetes_cluster/proof/wf1_assistant.rs
+++ b/src/kubernetes_cluster/proof/wf1_assistant.rs
@@ -26,18 +26,18 @@ use vstd::{option::*, seq::*, set::*};
 
 verus! {
 
-pub proof fn kubernetes_api_action_pre_implies_next_pre<T>(action: KubernetesAPIAction, input: Option<Message>)
+pub proof fn kubernetes_api_action_pre_implies_next_pre<K: ResourceView, T>(action: KubernetesAPIAction, input: Option<Message>)
     requires
         kubernetes_api().actions.contains(action),
     ensures
-        valid(lift_state(kubernetes_api_action_pre::<T>(action, input)).implies(lift_state(kubernetes_api_next().pre(input)))),
+        valid(lift_state(kubernetes_api_action_pre::<K, T>(action, input)).implies(lift_state(kubernetes_api_next().pre(input)))),
 {
-    assert forall |s: State<T>| #[trigger] kubernetes_api_action_pre(action, input)(s) implies kubernetes_api_next().pre(input)(s) by {
+    assert forall |s: State<K, T>| #[trigger] kubernetes_api_action_pre(action, input)(s) implies kubernetes_api_next().pre(input)(s) by {
         exists_next_kubernetes_api_step(action, KubernetesAPIActionInput{recv: input, chan_manager: s.chan_manager}, s.kubernetes_api_state);
     };
 }
 
-pub proof fn controller_action_pre_implies_next_pre<K: ResourceView, T>(reconciler: Reconciler<K, T>, action: ControllerAction<T>, input: (Option<Message>, Option<ObjectRef>))
+pub proof fn controller_action_pre_implies_next_pre<K: ResourceView, T>(reconciler: Reconciler<K, T>, action: ControllerAction<K, T>, input: (Option<Message>, Option<ObjectRef>))
     requires
         controller(reconciler).actions.contains(action),
     ensures
@@ -58,7 +58,7 @@ pub proof fn exists_next_kubernetes_api_step(action: KubernetesAPIAction, input:
     assert(((kubernetes_api().step_to_action)(KubernetesAPIStep::HandleRequest).precondition)(input, s));
 }
 
-pub proof fn exists_next_controller_step<K: ResourceView, T>(reconciler: Reconciler<K, T>, action: ControllerAction<T>, input: ControllerActionInput, s: ControllerState<T>)
+pub proof fn exists_next_controller_step<K: ResourceView, T>(reconciler: Reconciler<K, T>, action: ControllerAction<K, T>, input: ControllerActionInput, s: ControllerState<K, T>)
     requires
         controller(reconciler).actions.contains(action),
         (action.precondition)(input, s),

--- a/src/kubernetes_cluster/spec/controller/common.rs
+++ b/src/kubernetes_cluster/spec/controller/common.rs
@@ -46,13 +46,6 @@ pub open spec fn controller_req_msg(req: APIRequest, req_id: nat) -> Message {
     form_msg(HostId::CustomController, HostId::KubernetesAPI, MessageContent::APIRequest(req, req_id))
 }
 
-pub open spec fn insert_scheduled_reconcile<K: ResourceView, T>(s: ControllerState<K, T>, obj: K) -> ControllerState<K, T> {
-    ControllerState {
-        scheduled_reconciles: s.scheduled_reconciles.insert(obj.object_ref(), obj),
-        ..s
-    }
-}
-
 pub open spec fn init_controller_state<K: ResourceView, T>() -> ControllerState<K, T> {
     ControllerState {
         ongoing_reconciles: Map::empty(),

--- a/src/kubernetes_cluster/spec/controller/common.rs
+++ b/src/kubernetes_cluster/spec/controller/common.rs
@@ -1,7 +1,7 @@
 // Copyright 2022 VMware, Inc.
 // SPDX-License-Identifier: MIT
 #![allow(unused_imports)]
-use crate::kubernetes_api_objects::{api_method::*, common::*};
+use crate::kubernetes_api_objects::{api_method::*, common::*, resource::*};
 use crate::kubernetes_cluster::spec::{channel::*, message::*};
 use crate::reconciler::spec::*;
 use crate::state_machine::action::*;
@@ -12,12 +12,13 @@ use vstd::{map::*, multiset::*, option::*, seq::*, set::*};
 
 verus! {
 
-pub struct ControllerState<T> {
-    pub ongoing_reconciles: Map<ObjectRef, OngoingReconcile<T>>,
-    pub scheduled_reconciles: Set<ObjectRef>,
+pub struct ControllerState<K: ResourceView, T> {
+    pub ongoing_reconciles: Map<ObjectRef, OngoingReconcile<K, T>>,
+    pub scheduled_reconciles: Map<ObjectRef, K>,
 }
 
-pub struct OngoingReconcile<T> {
+pub struct OngoingReconcile<K: ResourceView, T> {
+    pub triggering_cr: K,
     pub pending_req_msg: Option<Message>,
     pub local_state: T,
 }
@@ -37,28 +38,25 @@ pub struct ControllerActionInput {
 
 pub type ControllerActionOutput = (Multiset<Message>, ChannelManager);
 
-pub type ControllerStateMachine<T> = StateMachine<ControllerState<T>, ControllerActionInput, ControllerActionInput, ControllerActionOutput, ControllerStep>;
+pub type ControllerStateMachine<K, T> = StateMachine<ControllerState<K, T>, ControllerActionInput, ControllerActionInput, ControllerActionOutput, ControllerStep>;
 
-pub type ControllerAction<T> = Action<ControllerState<T>, ControllerActionInput, ControllerActionOutput>;
+pub type ControllerAction<K, T> = Action<ControllerState<K, T>, ControllerActionInput, ControllerActionOutput>;
 
 pub open spec fn controller_req_msg(req: APIRequest, req_id: nat) -> Message {
     form_msg(HostId::CustomController, HostId::KubernetesAPI, MessageContent::APIRequest(req, req_id))
 }
 
-pub open spec fn insert_scheduled_reconcile<T>(s: ControllerState<T>, key: ObjectRef) -> ControllerState<T>
-    recommends
-        key.kind.is_CustomResourceKind(),
-{
+pub open spec fn insert_scheduled_reconcile<K: ResourceView, T>(s: ControllerState<K, T>, obj: K) -> ControllerState<K, T> {
     ControllerState {
-        scheduled_reconciles: s.scheduled_reconciles.insert(key),
+        scheduled_reconciles: s.scheduled_reconciles.insert(obj.object_ref(), obj),
         ..s
     }
 }
 
-pub open spec fn init_controller_state<T>() -> ControllerState<T> {
+pub open spec fn init_controller_state<K: ResourceView, T>() -> ControllerState<K, T> {
     ControllerState {
         ongoing_reconciles: Map::empty(),
-        scheduled_reconciles: Set::empty(),
+        scheduled_reconciles: Map::empty(),
     }
 }
 

--- a/src/kubernetes_cluster/spec/controller/state_machine.rs
+++ b/src/kubernetes_cluster/spec/controller/state_machine.rs
@@ -15,10 +15,10 @@ use vstd::{map::*, option::*, seq::*, set::*, string::*};
 
 verus! {
 
-pub open spec fn controller<K: ResourceView, T>(reconciler: Reconciler<K, T>) -> ControllerStateMachine<T> {
+pub open spec fn controller<K: ResourceView, T>(reconciler: Reconciler<K, T>) -> ControllerStateMachine<K, T> {
     StateMachine {
-        init: |s: ControllerState<T>| {
-            s == init_controller_state::<T>()
+        init: |s: ControllerState<K, T>| {
+            s == init_controller_state::<K, T>()
         },
         actions: set![
             run_scheduled_reconcile(reconciler),

--- a/src/kubernetes_cluster/spec/distributed_system.rs
+++ b/src/kubernetes_cluster/spec/distributed_system.rs
@@ -161,8 +161,8 @@ pub open spec fn controller_next<K: ResourceView, T>(reconciler: Reconciler<K, T
 /// infinitely frequently invoked for it. The assumption that cr always exists and the weak fairness assumption on this
 /// action allow us to prove reconcile is always eventually scheduled.
 ///
-/// This action abstracts away a lot of implementation details in the Kubernetes API and controller runtime
-/// framework, such as the list-then-watch pattern.
+/// This action abstracts away a lot of implementation details in the Kubernetes API and kube framework,
+/// such as the list-then-watch pattern.
 ///
 /// In general, this action assumes the following key behavior:
 /// (1) The kube library always invokes `reconcile_with` (defined in the shim layer) whenever a cr object gets created

--- a/src/reconciler/exec/mod.rs
+++ b/src/reconciler/exec/mod.rs
@@ -8,9 +8,9 @@ use vstd::option::*;
 
 verus! {
 
-pub trait Reconciler<T> {
+pub trait Reconciler<R, T> {
     fn reconcile_init_state(&self) -> T;
-    fn reconcile_core(&self, cr_key: &KubeObjectRef, resp_o: Option<KubeAPIResponse>, state: T) -> (T, Option<KubeAPIRequest>);
+    fn reconcile_core(&self, cr: &R, resp_o: Option<KubeAPIResponse>, state: T) -> (T, Option<KubeAPIRequest>);
     fn reconcile_done(&self, state: &T) -> bool;
     fn reconcile_error(&self, state: &T) -> bool;
 }

--- a/src/reconciler/spec/mod.rs
+++ b/src/reconciler/spec/mod.rs
@@ -22,7 +22,7 @@ pub struct Reconciler<#[verifier(maybe_negative)] K: ResourceView, #[verifier(ma
     // reconcile_core describes the logic of reconcile function and is the key logic we want to verify.
     // Each reconcile_core should take the local state and a response of the previous request (if any) as input
     // and outputs the next local state and the request to send to Kubernetes API (if any).
-    pub reconcile_core: ReconcileCore<T>,
+    pub reconcile_core: ReconcileCore<K, T>,
 
     // reconcile_done is used to tell the controller_runtime whether this reconcile round is done.
     // If it is true, controller_runtime will probably requeue the reconcile.
@@ -31,16 +31,11 @@ pub struct Reconciler<#[verifier(maybe_negative)] K: ResourceView, #[verifier(ma
     // reconcile_error is used to tell the controller_runtime whether this reconcile round returns with error.
     // If it is true, controller_runtime will requeue the reconcile.
     pub reconcile_error: ReconcileError<T>,
-
-    // use K so that Rust no longer complains about "parameter `K` is never used"
-    pub consume_kubernetes_resource_type: FnSpec(K) -> K,
 }
 
 pub type ReconcileInitState<T> = FnSpec() -> T;
 
-pub type ReconcileTrigger = FnSpec(Message) -> Option<ObjectRef>;
-
-pub type ReconcileCore<T> = FnSpec(ObjectRef, Option<APIResponse>, T) -> (T, Option<APIRequest>);
+pub type ReconcileCore<K, T> = FnSpec(K, Option<APIResponse>, T) -> (T, Option<APIRequest>);
 
 pub type ReconcileDone<T> = FnSpec(T) -> bool;
 

--- a/src/simple_controller.rs
+++ b/src/simple_controller.rs
@@ -16,11 +16,11 @@ use builtin::*;
 use builtin_macros::*;
 
 use crate::simple_controller::exec::reconciler::{SimpleReconcileState, SimpleReconciler};
+use crate::simple_controller::spec::custom_resource::CustomResource;
 use deps_hack::anyhow::Result;
 use deps_hack::kube::CustomResourceExt;
 use deps_hack::serde_yaml;
 use deps_hack::tokio;
-use deps_hack::SimpleCR;
 use shim_layer::run_controller;
 use std::env;
 
@@ -34,10 +34,10 @@ async fn main() -> Result<()> {
 
     if cmd == String::from("export") {
         println!("exporting custom resource definition");
-        println!("{}", serde_yaml::to_string(&SimpleCR::crd())?);
+        println!("{}", serde_yaml::to_string(&deps_hack::SimpleCR::crd())?);
     } else if cmd == String::from("run") {
         println!("running simple-controller");
-        run_controller::<SimpleCR, SimpleReconciler, SimpleReconcileState>().await?;
+        run_controller::<deps_hack::SimpleCR, CustomResource, SimpleReconciler, SimpleReconcileState>().await?;
         println!("controller terminated");
     } else {
         println!("wrong command; please use \"export\" or \"run\"");

--- a/src/zookeeper_controller.rs
+++ b/src/zookeeper_controller.rs
@@ -16,6 +16,7 @@ use builtin::*;
 use builtin_macros::*;
 
 use crate::zookeeper_controller::exec::reconciler::{ZookeeperReconcileState, ZookeeperReconciler};
+use crate::zookeeper_controller::spec::zookeepercluster::ZookeeperCluster;
 use deps_hack::anyhow::Result;
 use deps_hack::kube::CustomResourceExt;
 use deps_hack::serde_yaml;
@@ -36,7 +37,7 @@ async fn main() -> Result<()> {
         println!("{}", serde_yaml::to_string(&deps_hack::ZookeeperCluster::crd())?);
     } else if cmd == String::from("run") {
         println!("running zookeeper-controller");
-        run_controller::<deps_hack::ZookeeperCluster, ZookeeperReconciler, ZookeeperReconcileState>().await?;
+        run_controller::<deps_hack::ZookeeperCluster, ZookeeperCluster, ZookeeperReconciler, ZookeeperReconcileState>().await?;
         println!("controller terminated");
     } else {
         println!("wrong command; please use \"export\" or \"run\"");


### PR DESCRIPTION
Changes the signature of `reconcile_core` from `reconcile_core(&KubeObjectRef, ...) -> ...` to `reconcile_core(&CustomResource, ...) -> ...` and updates the related spec and proof code accordingly.

The purpose is to simplify the controller implementation. More concretely, the first thing that almost every controller does is to get the triggering custom resource (cr) object. Instead of letting each controller send a request to get the custom resource object and store it in its local reconcile state, our shim layer can directly get the object (by a quorum read at etcd) and pass it to `reconcile_core`.

### Changes in the spec state machine and impacts on the proof

To make the spec state machine match the change in the exec code, this PR also revises the `schedule_controller_reconcile` action to make it pass the cr object to the controller when scheduling reconcile. The new `schedule_controller_reconcile` action matches (and trusts) the behavior that:
(1) `reconcile_with` (in the shim layer) will be triggered when a cr object gets created,
(2) inside `reconcile_with`, the shim layer only calls `reconcile_core` if the cr object exists,
(3) the shim layer passes the cr object to `reconcile_core`, and
(4) the `reconcile_with` gets re-queued unless the cr object no longer exists.

This change also simplifies the liveness proof. Previously one needed to reason about the process of "under the assumption that the cr object always exists, the controller sending a get cr request leads to the controller receiving an OK response containing exactly the same cr object" when proving liveness, but it is no longer needed because now `reconcile_core` gets the cr object "for free".

### What if you get a stale object?

One might wonder how we avoid passing a stale cr object to `reconcile_core`. It depends:
(1) The shim layer does NOT get the cr object from the local cache of API server or the controller, but from a quorum read to etcd (of course we need to trust etcd and Kubernetes here). So we don't worry about stale cache problems.
(2) The "time-of-check to time-of-use" (TOCTOU) issue still exists, and there is no way to prevent that unless we add locks on the cr objects. However, our goal is never to prevent TOCTOU issue but to ensure the controller can survive it and eventually reaches the desired state as long as the cr object gets stable. So what we really care about is whether the spec state machine can capture all the possible TOCTOU issues that could happen in reality. Unfortunately, we don't have a rigorous proof of this yet. An informal way to reason about this is that we have a client host state machine that can create or delete any cr object at any point (later we will also make it able to update the cr object), so for any real-world executions where the cr object gets changed after the shim layer reads it and passes it to `reconcile_core`, our state machine has a corresponding execution that right after `schedule_controller_reconcile` schedules a reconcile with the cr object, the client host changes the cr object.

### New problems introduced

This is actually not a _new_ problem. As we have more and more generic types to carry in our proof, the proof functions read quite verbose. Associated types, once supported, can help solve the problem.

