### PR TITLE
Revise the k8s API spec to check namespace when creating objects

### DIFF
--- a/src/controller_examples/simple_controller/exec/reconciler.rs
+++ b/src/controller_examples/simple_controller/exec/reconciler.rs
@@ -127,7 +127,6 @@ pub fn make_configmap(cr: &CustomResource) -> (cm: ConfigMap)
     config_map.set_metadata({
         let mut metadata = ObjectMeta::default();
         metadata.set_name(cr.metadata().name().unwrap().clone().concat(new_strlit("-cm")));
-        metadata.set_namespace(cr.metadata().namespace().unwrap().clone());
         metadata
     });
     config_map.set_data({

--- a/src/controller_examples/simple_controller/exec/reconciler.rs
+++ b/src/controller_examples/simple_controller/exec/reconciler.rs
@@ -106,6 +106,7 @@ pub fn reconcile_core(cr: &CustomResource, resp_o: Option<KubeAPIResponse>, stat
         let req_o = Option::Some(KubeAPIRequest::CreateRequest(
             KubeCreateRequest {
                 api_resource: ConfigMap::api_resource(),
+                namespace: cr.metadata().namespace().unwrap(),
                 obj: config_map.to_dynamic_object(),
             }
         ));

--- a/src/controller_examples/simple_controller/spec/reconciler.rs
+++ b/src/controller_examples/simple_controller/spec/reconciler.rs
@@ -82,7 +82,6 @@ pub open spec fn make_config_map(cr: CustomResourceView) -> ConfigMapView
     let config_map = ConfigMapView::default()
         .set_metadata(ObjectMetaView::default()
             .set_name(cr.metadata.name.get_Some_0() + new_strlit("-cm")@)
-            .set_namespace(cr.metadata.namespace.get_Some_0())
         )
         .set_data(Map::empty().insert(new_strlit("content")@, cr.spec.content));
     config_map
@@ -91,6 +90,7 @@ pub open spec fn make_config_map(cr: CustomResourceView) -> ConfigMapView
 pub open spec fn create_cm_req(cr: CustomResourceView) -> APIRequest
 {
     APIRequest::CreateRequest(CreateRequest{
+        namespace: cr.metadata.namespace.get_Some_0(),
         obj: make_config_map(cr).to_dynamic_object(),
     })
 }

--- a/src/controller_examples/zookeeper_controller/exec/reconciler.rs
+++ b/src/controller_examples/zookeeper_controller/exec/reconciler.rs
@@ -110,6 +110,7 @@ pub fn reconcile_core(
             let req_o = Option::Some(KubeAPIRequest::CreateRequest(
                 KubeCreateRequest {
                     api_resource: Service::api_resource(),
+                    namespace: zk.namespace().unwrap(),
                     obj: headless_service.to_dynamic_object(),
                 }
             ));
@@ -124,6 +125,7 @@ pub fn reconcile_core(
             let req_o = Option::Some(KubeAPIRequest::CreateRequest(
                 KubeCreateRequest {
                     api_resource: Service::api_resource(),
+                    namespace: zk.namespace().unwrap(),
                     obj: client_service.to_dynamic_object(),
                 }
             ));
@@ -138,6 +140,7 @@ pub fn reconcile_core(
             let req_o = Option::Some(KubeAPIRequest::CreateRequest(
                 KubeCreateRequest {
                     api_resource: Service::api_resource(),
+                    namespace: zk.namespace().unwrap(),
                     obj: admin_server_service.to_dynamic_object(),
                 }
             ));
@@ -152,6 +155,7 @@ pub fn reconcile_core(
             let req_o = Option::Some(KubeAPIRequest::CreateRequest(
                 KubeCreateRequest {
                     api_resource: ConfigMap::api_resource(),
+                    namespace: zk.namespace().unwrap(),
                     obj: config_map.to_dynamic_object(),
                 }
             ));
@@ -166,6 +170,7 @@ pub fn reconcile_core(
             let req_o = Option::Some(KubeAPIRequest::CreateRequest(
                 KubeCreateRequest {
                     api_resource: StatefulSet::api_resource(),
+                    namespace: zk.namespace().unwrap(),
                     obj: stateful_set.to_dynamic_object(),
                 }
             ));
@@ -268,7 +273,6 @@ fn make_service(zk: &ZookeeperCluster, name: String, ports: Vec<ServicePort>, cl
     service.set_metadata({
         let mut metadata = ObjectMeta::default();
         metadata.set_name(name);
-        metadata.set_namespace(zk.namespace().unwrap());
         metadata.set_labels({
             let mut labels = StringMap::empty();
             labels.insert(new_strlit("app").to_string(), zk.name().unwrap());
@@ -306,7 +310,6 @@ fn make_config_map(zk: &ZookeeperCluster) -> (config_map: ConfigMap)
     config_map.set_metadata({
         let mut metadata = ObjectMeta::default();
         metadata.set_name(zk.name().unwrap().concat(new_strlit("-configmap")));
-        metadata.set_namespace(zk.namespace().unwrap());
         metadata.set_labels({
             let mut labels = StringMap::empty();
             labels.insert(new_strlit("app").to_string(), zk.name().unwrap());
@@ -424,7 +427,6 @@ fn make_stateful_set(zk: &ZookeeperCluster) -> (stateful_set: StatefulSet)
     stateful_set.set_metadata({
         let mut metadata = ObjectMeta::default();
         metadata.set_name(zk.name().unwrap());
-        metadata.set_namespace(zk.namespace().unwrap());
         metadata.set_labels({
             let mut labels = StringMap::empty();
             labels.insert(new_strlit("app").to_string(), zk.name().unwrap());

--- a/src/controller_examples/zookeeper_controller/spec/reconciler.rs
+++ b/src/controller_examples/zookeeper_controller/spec/reconciler.rs
@@ -56,6 +56,7 @@ pub open spec fn reconcile_core(
         ZookeeperReconcileStep::Init => {
             let headless_service = make_headless_service(zk);
             let req_o = Option::Some(APIRequest::CreateRequest(CreateRequest{
+                namespace: zk.metadata.namespace.get_Some_0(),
                 obj: headless_service.to_dynamic_object(),
             }));
             let state_prime = ZookeeperReconcileState {
@@ -67,6 +68,7 @@ pub open spec fn reconcile_core(
         ZookeeperReconcileStep::AfterCreateHeadlessService => {
             let client_service = make_client_service(zk);
             let req_o = Option::Some(APIRequest::CreateRequest(CreateRequest{
+                namespace: zk.metadata.namespace.get_Some_0(),
                 obj: client_service.to_dynamic_object(),
             }));
             let state_prime = ZookeeperReconcileState {
@@ -78,6 +80,7 @@ pub open spec fn reconcile_core(
         ZookeeperReconcileStep::AfterCreateClientService => {
             let admin_server_service = make_admin_server_service(zk);
             let req_o = Option::Some(APIRequest::CreateRequest(CreateRequest{
+                namespace: zk.metadata.namespace.get_Some_0(),
                 obj: admin_server_service.to_dynamic_object(),
             }));
             let state_prime = ZookeeperReconcileState {
@@ -89,6 +92,7 @@ pub open spec fn reconcile_core(
         ZookeeperReconcileStep::AfterCreateAdminServerService => {
             let config_map = make_config_map(zk);
             let req_o = Option::Some(APIRequest::CreateRequest(CreateRequest{
+                namespace: zk.metadata.namespace.get_Some_0(),
                 obj: config_map.to_dynamic_object(),
             }));
             let state_prime = ZookeeperReconcileState {
@@ -100,6 +104,7 @@ pub open spec fn reconcile_core(
         ZookeeperReconcileStep::AfterCreateConfigMap => {
             let stateful_set = make_stateful_set(zk);
             let req_o = Option::Some(APIRequest::CreateRequest(CreateRequest{
+                namespace: zk.metadata.namespace.get_Some_0(),
                 obj: stateful_set.to_dynamic_object(),
             }));
             let state_prime = ZookeeperReconcileState {
@@ -174,7 +179,6 @@ pub open spec fn make_service(
     ServiceView::default()
         .set_metadata(ObjectMetaView::default()
             .set_name(name)
-            .set_namespace(zk.metadata.namespace.get_Some_0())
             .set_labels(Map::empty().insert(new_strlit("app")@, zk.metadata.name.get_Some_0()))
         ).set_spec({
             let spec = ServiceSpecView::default()
@@ -198,7 +202,6 @@ pub open spec fn make_config_map(zk: ZookeeperClusterView) -> ConfigMapView
     ConfigMapView::default()
         .set_metadata(ObjectMetaView::default()
             .set_name(zk.metadata.name.get_Some_0() + new_strlit("-configmap")@)
-            .set_namespace(zk.metadata.namespace.get_Some_0())
             .set_labels(Map::empty().insert(new_strlit("app")@, zk.metadata.name.get_Some_0()))
         )
         .set_data(Map::empty()
@@ -293,7 +296,6 @@ pub open spec fn make_stateful_set(zk: ZookeeperClusterView) -> StatefulSetView
     let labels = Map::empty().insert(new_strlit("app")@, zk.metadata.name.get_Some_0());
     let metadata = ObjectMetaView::default()
         .set_name(name)
-        .set_namespace(zk.metadata.namespace.get_Some_0())
         .set_labels(labels);
 
     let spec = StatefulSetSpecView::default()

--- a/src/kubernetes_api_objects/api_method.rs
+++ b/src/kubernetes_api_objects/api_method.rs
@@ -42,6 +42,7 @@ pub struct ListRequest {
 /// CreateRequest creates the obj.
 
 pub struct CreateRequest {
+    pub namespace: StringView,
     pub obj: DynamicObjectView,
 }
 
@@ -90,6 +91,7 @@ pub struct KubeListRequest {
 
 pub struct KubeCreateRequest {
     pub api_resource: ApiResource,
+    pub namespace: String,
     pub obj: DynamicObject,
 }
 
@@ -116,6 +118,7 @@ impl KubeAPIRequest {
                 namespace: list_req.namespace@,
             }),
             KubeAPIRequest::CreateRequest(create_req) => APIRequest::CreateRequest(CreateRequest {
+                namespace: create_req.namespace@,
                 obj: create_req.obj@,
             }),
             KubeAPIRequest::DeleteRequest(delete_req) => APIRequest::DeleteRequest(DeleteRequest {

--- a/src/kubernetes_api_objects/dynamic.rs
+++ b/src/kubernetes_api_objects/dynamic.rs
@@ -78,6 +78,16 @@ impl DynamicObjectView {
             namespace: self.metadata.namespace.get_Some_0(),
         }
     }
+
+    pub open spec fn set_namespace(self, namespace: StringView) -> DynamicObjectView {
+        DynamicObjectView {
+            metadata: ObjectMetaView {
+                namespace: Option::Some(namespace),
+                ..self.metadata
+            },
+            ..self
+        }
+    }
 }
 
 }

--- a/src/kubernetes_api_objects/error.rs
+++ b/src/kubernetes_api_objects/error.rs
@@ -10,11 +10,10 @@ verus! {
 // TODO: implement other error types
 #[is_variant]
 pub enum APIError {
+    BadRequest,
     ObjectNotFound,
     ObjectAlreadyExists,
     Other
 }
-
-pub struct ParseDynamicObjectError {}
 
 }

--- a/src/kubernetes_cluster/proof/kubernetes_api_liveness.rs
+++ b/src/kubernetes_cluster/proof/kubernetes_api_liveness.rs
@@ -198,6 +198,7 @@ pub proof fn lemma_create_req_leads_to_res_exists<K: ResourceView, T>(spec: Temp
                 &&& msg.dst == HostId::KubernetesAPI
                 &&& msg.content.is_create_request()
                 &&& msg.content.get_create_request().obj == res
+                &&& msg.content.get_create_request().obj.metadata.namespace.is_None()
             })
                 .leads_to(lift_state(|s: State<K, T>| s.resource_key_exists(res.object_ref())))
         ),
@@ -207,6 +208,7 @@ pub proof fn lemma_create_req_leads_to_res_exists<K: ResourceView, T>(spec: Temp
         &&& msg.dst == HostId::KubernetesAPI
         &&& msg.content.is_create_request()
         &&& msg.content.get_create_request().obj == res
+        &&& msg.content.get_create_request().obj.metadata.namespace.is_None()
     };
     let post = |s: State<K, T>| {
         s.resource_key_exists(res.object_ref())

--- a/src/kubernetes_cluster/spec/client.rs
+++ b/src/kubernetes_cluster/spec/client.rs
@@ -41,7 +41,7 @@ pub open spec fn send_create_cr<K: ResourceView>() -> ClientAction<K> {
             &&& input.recv.is_None()
         },
         transition: |input: ClientActionInput<K>, s: ClientState| {
-            (ClientState{}, (Multiset::singleton(client_req_msg(create_req_msg_content(input.cr.to_dynamic_object(), input.chan_manager.allocate().1))), input.chan_manager.allocate().0))
+            (ClientState{}, (Multiset::singleton(client_req_msg(create_req_msg_content(input.cr.metadata().namespace.get_Some_0(), input.cr.to_dynamic_object(), input.chan_manager.allocate().1))), input.chan_manager.allocate().0))
         },
     }
 }

--- a/src/kubernetes_cluster/spec/message.rs
+++ b/src/kubernetes_cluster/spec/message.rs
@@ -265,8 +265,9 @@ pub open spec fn list_req_msg_content(kind: Kind, namespace: StringView, req_id:
     }), req_id)
 }
 
-pub open spec fn create_req_msg_content(obj: DynamicObjectView, req_id: nat) -> MessageContent {
+pub open spec fn create_req_msg_content(namespace: StringView, obj: DynamicObjectView, req_id: nat) -> MessageContent {
     MessageContent::APIRequest(APIRequest::CreateRequest(CreateRequest{
+        namespace: namespace,
         obj: obj,
     }), req_id)
 }

--- a/src/shim_layer/mod.rs
+++ b/src/shim_layer/mod.rs
@@ -155,9 +155,7 @@ where
                 },
                 KubeAPIRequest::CreateRequest(create_req) => {
                     let api = Api::<deps_hack::kube::api::DynamicObject>::namespaced_with(
-                        client.clone(),
-                        &create_req.obj.kube_metadata_ref().namespace.as_ref().unwrap(),
-                        create_req.api_resource.as_kube_ref()
+                        client.clone(), create_req.namespace.as_rust_string_ref(), create_req.api_resource.as_kube_ref()
                     );
                     let pp = PostParams::default();
                     let obj_to_create = create_req.obj.into_kube();


### PR DESCRIPTION
To get closer to how Kubernetes handles creation requests in reality, this PR makes two major changes: (1) the creation request will carry a namespace field, and (2) the k8s API will check whether the namespace of the provided object matches the namespace sent on the creation request; if not, the k8s API will reject the request with the error BadRequest.

Currently the k8s API state machine handles creation requests as follows:
(1) if the namespace set in the provided object does not match the namespace sent on the creation request, then return BadRequest error, else go to (2)
(2) if the object already exists, then return AlreadyExists error, else go to (3)
(3) creates the object

The current specification for how to handle creation requests is still not perfect yet because there are other error cases (e.g., setting an invalid name). We will cover more cases in the spec when we need to reason about them in the proof.
