### PR TITLE
Specify Kubernetes API's update operations

### DIFF
--- a/src/kubernetes_api_objects/dynamic.rs
+++ b/src/kubernetes_api_objects/dynamic.rs
@@ -91,6 +91,16 @@ impl DynamicObjectView {
             ..self
         }
     }
+
+    pub open spec fn set_resource_version(self, resource_version: nat) -> DynamicObjectView {
+        DynamicObjectView {
+            metadata: ObjectMetaView {
+                resource_version: Option::Some(resource_version),
+                ..self.metadata
+            },
+            ..self
+        }
+    }
 }
 
 }

--- a/src/kubernetes_api_objects/error.rs
+++ b/src/kubernetes_api_objects/error.rs
@@ -11,8 +11,10 @@ verus! {
 #[is_variant]
 pub enum APIError {
     BadRequest,
+    Conflict,
     ObjectNotFound,
     ObjectAlreadyExists,
+    NotSupported,
     Other
 }
 

--- a/src/kubernetes_api_objects/object_meta.rs
+++ b/src/kubernetes_api_objects/object_meta.rs
@@ -158,6 +158,13 @@ impl ObjectMetaView {
         }
     }
 
+    pub open spec fn set_resource_version(self, resource_version: nat) -> ObjectMetaView {
+        ObjectMetaView {
+            resource_version: Option::Some(resource_version),
+            ..self
+        }
+    }
+
     pub open spec fn name_field() -> nat {0}
 
     pub open spec fn namespace_field() -> nat {1}

--- a/src/kubernetes_cluster/spec/kubernetes_api/common.rs
+++ b/src/kubernetes_cluster/spec/kubernetes_api/common.rs
@@ -15,6 +15,7 @@ verus! {
 pub type EtcdState = Map<ObjectRef, DynamicObjectView>;
 
 pub struct KubernetesAPIState {
+    pub resource_version_counter: nat,
     pub resources: EtcdState,
 }
 

--- a/src/kubernetes_cluster/spec/message.rs
+++ b/src/kubernetes_cluster/spec/message.rs
@@ -298,6 +298,13 @@ pub open spec fn delete_req_msg_content(key: ObjectRef, req_id: nat) -> MessageC
     }), req_id)
 }
 
+pub open spec fn update_req_msg_content(key: ObjectRef, obj: DynamicObjectView, req_id: nat) -> MessageContent {
+    MessageContent::APIRequest(APIRequest::UpdateRequest(UpdateRequest{
+        key: key,
+        obj: obj,
+    }), req_id)
+}
+
 pub open spec fn get_resp_msg_content(res: Result<DynamicObjectView, APIError>, resp_id: nat) -> MessageContent {
     MessageContent::APIResponse(APIResponse::GetResponse(GetResponse{
         res: res,

--- a/src/kubernetes_cluster/spec/message.rs
+++ b/src/kubernetes_cluster/spec/message.rs
@@ -107,6 +107,18 @@ impl MessageContent {
         self.get_APIRequest_0().get_DeleteRequest_0()
     }
 
+    pub open spec fn is_update_request(self) -> bool {
+        &&& self.is_APIRequest()
+        &&& self.get_APIRequest_0().is_UpdateRequest()
+    }
+
+    pub open spec fn get_update_request(self) -> UpdateRequest
+        recommends
+            self.is_update_request()
+    {
+        self.get_APIRequest_0().get_UpdateRequest_0()
+    }
+
     pub open spec fn get_req_id(self) -> nat
         recommends
             self.is_APIRequest()
@@ -236,6 +248,12 @@ pub open spec fn form_delete_resp_msg(req_msg: Message, result: Result<DynamicOb
     form_msg(req_msg.dst, req_msg.src, delete_resp_msg_content(result, req_msg.content.get_req_id()))
 }
 
+pub open spec fn form_update_resp_msg(req_msg: Message, result: Result<DynamicObjectView, APIError>) -> Message
+    recommends req_msg.content.is_update_request(),
+{
+    form_msg(req_msg.dst, req_msg.src, update_resp_msg_content(result, req_msg.content.get_req_id()))
+}
+
 pub open spec fn added_event(obj: DynamicObjectView) -> WatchEvent {
     WatchEvent::AddedEvent(AddedEvent{
         obj: obj
@@ -300,6 +318,12 @@ pub open spec fn create_resp_msg_content(res: Result<DynamicObjectView, APIError
 
 pub open spec fn delete_resp_msg_content(res: Result<DynamicObjectView, APIError>, resp_id: nat) -> MessageContent {
     MessageContent::APIResponse(APIResponse::DeleteResponse(DeleteResponse{
+        res: res,
+    }), resp_id)
+}
+
+pub open spec fn update_resp_msg_content(res: Result<DynamicObjectView, APIError>, resp_id: nat) -> MessageContent {
+    MessageContent::APIResponse(APIResponse::UpdateResponse(UpdateResponse{
         res: res,
     }), resp_id)
 }

--- a/src/kubernetes_cluster/spec/message.rs
+++ b/src/kubernetes_cluster/spec/message.rs
@@ -184,6 +184,7 @@ pub open spec fn is_ok_resp(resp: APIResponse) -> bool {
         APIResponse::ListResponse(list_resp) => list_resp.res.is_Ok(),
         APIResponse::CreateResponse(create_resp) => create_resp.res.is_Ok(),
         APIResponse::DeleteResponse(delete_resp) => delete_resp.res.is_Ok(),
+        APIResponse::UpdateResponse(update_resp) => update_resp.res.is_Ok(),
     }
 }
 
@@ -198,7 +199,8 @@ pub open spec fn resp_msg_matches_req_msg(resp_msg: Message, req_msg: Message) -
         APIResponse::GetResponse(_) => req_msg.content.get_APIRequest_0().is_GetRequest(),
         APIResponse::ListResponse(_) => req_msg.content.get_APIRequest_0().is_ListRequest(),
         APIResponse::CreateResponse(_) => req_msg.content.get_APIRequest_0().is_CreateRequest(),
-        APIResponse::DeleteResponse(_) => req_msg.content.get_APIRequest_0().is_DeleteRequest()
+        APIResponse::DeleteResponse(_) => req_msg.content.get_APIRequest_0().is_DeleteRequest(),
+        APIResponse::UpdateResponse(_) => req_msg.content.get_APIRequest_0().is_UpdateRequest(),
     }
 }
 


### PR DESCRIPTION
Revise the Kubernetes API state machine to support handling update requests.

In short, each update request replaces one existing object stored in etcd. The key of handling update in Kubernetes is to check and update the resource version of each object correctly. The resource version is used for multi-version concurrency control in Kubernetes and etcd. Each object has a resource version number and each update to the object increases the resource version. Only the update request that carries the current resource version of the object can successfully update the object.

This versioning mechanism is very important to prove the object created/updated by the controller remains unchanged: suppose the controller always gets the object and then updates the object with the resource version from the get response, the updated object will have a newer (larger) resource version, and all the pending update requests from the previously crashed controller will fail to update this object because their resource version is lower.

An update operation might result in an error response such as (1) Bad request if the namespace or name on the request does not match the object, (2) ObjectNotFound if the object does not exist in etcd, (3) Conflict if the resource version on the request does not match the current resource version of the stored object.

