### PR TITLE
Make from_dynamic_object and unmarshal return Result

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 src/main
 src/tla_examples/main
 src/*-controller
+src/*_controller
 src/*.long-type-*.txt
 src/.verus-log/
 reference-controllers/*-controller/target/

--- a/src/controller_examples/simple_controller/spec/custom_resource.rs
+++ b/src/controller_examples/simple_controller/spec/custom_resource.rs
@@ -78,7 +78,7 @@ impl CustomResource {
             let res = CustomResource { inner: parse_result.unwrap() };
             Result::Ok(res)
         } else {
-            Result::Err(ParseDynamicObjectError::Error)
+            Result::Err(ParseDynamicObjectError::ExecError)
         }
     }
 }

--- a/src/controller_examples/simple_controller/spec/custom_resource.rs
+++ b/src/controller_examples/simple_controller/spec/custom_resource.rs
@@ -125,11 +125,11 @@ impl ResourceView for CustomResourceView {
     }
 
     open spec fn from_dynamic_object(obj: DynamicObjectView) -> Result<CustomResourceView, ParseDynamicObjectError> {
-        let data_object = obj.data.get_Some_0();
+        let data_object = obj.data.get_Object_0();
         let data_spec_unmarshal = CustomResourceSpecView::unmarshal(data_object[spec_field()]);
         if !obj.data.is_Object() {
             Result::Err(ParseDynamicObjectError::UnexpectedType)
-        } else if !obj.data.get_Some_0().dom().contains(spec_field()) {
+        } else if !data_object.dom().contains(spec_field()) {
             Result::Err(ParseDynamicObjectError::MissingField)
         } else if data_spec_unmarshal.is_Err() {
             Result::Err(ParseDynamicObjectError::UnmarshalError)
@@ -142,7 +142,10 @@ impl ResourceView for CustomResourceView {
         }
     }
 
-    proof fn to_dynamic_preserves_integrity() {}
+    proof fn to_dynamic_preserves_integrity() {
+        CustomResourceSpecView::marshal_preserves_integrity();
+        CustomResourceSpecView::marshal_returns_non_null();
+    }
 }
 
 #[verifier(external_body)]

--- a/src/controller_examples/zookeeper_controller/exec/reconciler.rs
+++ b/src/controller_examples/zookeeper_controller/exec/reconciler.rs
@@ -3,8 +3,8 @@
 #![allow(unused_imports)]
 use crate::kubernetes_api_objects::{
     api_method::*, common::*, config_map::*, label_selector::*, object_meta::*,
-    persistent_volume_claim::*, pod::*, pod_template_spec::*, resource_requirements::*, service::*,
-    stateful_set::*,
+    persistent_volume_claim::*, pod::*, pod_template_spec::*, resource::*,
+    resource_requirements::*, service::*, stateful_set::*,
 };
 use crate::pervasive_ext::string_map::StringMap;
 use crate::pervasive_ext::string_view::*;

--- a/src/controller_examples/zookeeper_controller/spec/zookeepercluster.rs
+++ b/src/controller_examples/zookeeper_controller/spec/zookeepercluster.rs
@@ -85,7 +85,7 @@ impl ZookeeperCluster {
             let res = ZookeeperCluster { inner: parse_result.unwrap() };
             Result::Ok(res)
         } else {
-            Result::Err(ParseDynamicObjectError::Error)
+            Result::Err(ParseDynamicObjectError::ExecError)
         }
     }
 }

--- a/src/controller_examples/zookeeper_controller/spec/zookeepercluster.rs
+++ b/src/controller_examples/zookeeper_controller/spec/zookeepercluster.rs
@@ -146,7 +146,7 @@ impl ResourceView for ZookeeperClusterView {
 
     open spec fn from_dynamic_object(obj: DynamicObjectView) -> Result<ZookeeperClusterView, ParseDynamicObjectError> {
         if obj.data.is_Object() {
-            let obj_data = obj.get_Object_0();
+            let obj_data = obj.data.get_Object_0();
             if obj_data.dom().contains(spec_field()) {
                 let data_spec = obj_data[spec_field()];
                 if (data_spec.is_Object()) {
@@ -161,6 +161,8 @@ impl ResourceView for ZookeeperClusterView {
                                 },
                             };
                             Result::Ok(res)
+                        } else {
+                            Result::Err(ParseDynamicObjectError::UnexpectedType)
                         }
                     } else {
                         Result::Err(ParseDynamicObjectError::MissingField)

--- a/src/kubernetes_api_objects/config_map.rs
+++ b/src/kubernetes_api_objects/config_map.rs
@@ -103,7 +103,7 @@ impl ConfigMap {
             let res = ConfigMap { inner: parse_result.unwrap() };
             Result::Ok(res)
         } else {
-            Result::Err(ParseDynamicObjectError::Error)
+            Result::Err(ParseDynamicObjectError::ExecError)
         }
     }
 }

--- a/src/kubernetes_api_objects/config_map.rs
+++ b/src/kubernetes_api_objects/config_map.rs
@@ -188,30 +188,26 @@ impl ResourceView for ConfigMapView {
     }
 
     open spec fn from_dynamic_object(obj: DynamicObjectView) -> Result<ConfigMapView, ParseDynamicObjectError> {
-        if obj.data.is_Object() {
-            let obj_data = obj.data.get_Object_0();
-            if obj_data.dom().contains(Self::data_field()) {
-                let data_data = obj_data[Self::data_field()];
-                if data_data.is_Null() {
-                    let res = ConfigMapView {
-                        metadata: obj.metadata,
-                        data: Option::None,
-                    };
-                    Result::Ok(res)
-                } else if data_data.is_StringStringMap() {
-                    let res = ConfigMapView {
-                        metadata: obj.metadata,
-                        data: Option::Some(data_data.get_StringStringMap_0()),
-                    };
-                    Result::Ok(res)
-                } else {
-                    Result::Err(ParseDynamicObjectError::UnexpectedType)
-                }
-            } else {
-                Result::Err(ParseDynamicObjectError::MissingField)
-            }
-        } else {
+        let data_object = obj.data.get_Object_0();
+        let data_data = data_object[Self::data_field()];
+        if !obj.data.is_Object() {
             Result::Err(ParseDynamicObjectError::UnexpectedType)
+        } else if !data_object.dom().contains(Self::data_field()) {
+            Result::Err(ParseDynamicObjectError::MissingField)
+        } else if !data_data.is_Null() && !data_data.is_StringStringMap() {
+            Result::Err(ParseDynamicObjectError::UnexpectedType)
+        } else if data_data.is_Null() {
+            let res = ConfigMapView {
+                metadata: obj.metadata,
+                data: Option::None,
+            };
+            Result::Ok(res)
+        } else {
+            let res = ConfigMapView {
+                metadata: obj.metadata,
+                data: Option::Some(data_data.get_StringStringMap_0()),
+            };
+            Result::Ok(res)
         }
     }
 

--- a/src/kubernetes_api_objects/error.rs
+++ b/src/kubernetes_api_objects/error.rs
@@ -20,6 +20,7 @@ pub enum ParseDynamicObjectError {
     MissingField,
     UnexpectedType,
     Error,
+    UnmarshalError,
 }
 
 }

--- a/src/kubernetes_api_objects/error.rs
+++ b/src/kubernetes_api_objects/error.rs
@@ -19,8 +19,8 @@ pub enum APIError {
 pub enum ParseDynamicObjectError {
     MissingField,
     UnexpectedType,
-    Error,
     UnmarshalError,
+    ExecError,
 }
 
 }

--- a/src/kubernetes_api_objects/error.rs
+++ b/src/kubernetes_api_objects/error.rs
@@ -16,4 +16,10 @@ pub enum APIError {
     Other
 }
 
+pub enum ParseDynamicObjectError {
+    MissingField,
+    UnexpectedType,
+    Error,
+}
+
 }

--- a/src/kubernetes_api_objects/label_selector.rs
+++ b/src/kubernetes_api_objects/label_selector.rs
@@ -1,6 +1,7 @@
 // Copyright 2022 VMware, Inc.
 // SPDX-License-Identifier: MIT
 use crate::kubernetes_api_objects::dynamic::*;
+use crate::kubernetes_api_objects::error::ParseDynamicObjectError;
 use crate::kubernetes_api_objects::marshal::*;
 use crate::kubernetes_api_objects::resource::*;
 use crate::pervasive_ext::string_map::*;
@@ -85,23 +86,12 @@ impl LabelSelectorView {
 }
 
 impl Marshalable for LabelSelectorView {
-    open spec fn marshal(self) -> Value {
-        Value::Object(
-            Map::empty()
-                .insert(Self::match_labels_field(), if self.match_labels.is_None() { Value::Null } else {
-                    Value::StringStringMap(self.match_labels.get_Some_0())
-                })
-        )
-    }
 
-    open spec fn unmarshal(value: Value) -> Self {
-        LabelSelectorView {
-            match_labels: if value.get_Object_0()[Self::match_labels_field()].is_Null() { Option::None } else {
-                Option::Some(value.get_Object_0()[Self::match_labels_field()].get_StringStringMap_0())
-            },
-        }
-    }
+    spec fn marshal(self) -> Value;
 
+    spec fn unmarshal(value: Value) -> Result<Self, ParseDynamicObjectError>;
+
+    #[verifier(external_body)]
     proof fn marshal_preserves_integrity() {}
 }
 

--- a/src/kubernetes_api_objects/label_selector.rs
+++ b/src/kubernetes_api_objects/label_selector.rs
@@ -92,7 +92,7 @@ impl Marshalable for LabelSelectorView {
     spec fn unmarshal(value: Value) -> Result<Self, ParseDynamicObjectError>;
 
     #[verifier(external_body)]
-    proof fn marshal_returns_non_null(o: Self) {}
+    proof fn marshal_returns_non_null() {}
 
     #[verifier(external_body)]
     proof fn marshal_preserves_integrity() {}

--- a/src/kubernetes_api_objects/label_selector.rs
+++ b/src/kubernetes_api_objects/label_selector.rs
@@ -92,6 +92,9 @@ impl Marshalable for LabelSelectorView {
     spec fn unmarshal(value: Value) -> Result<Self, ParseDynamicObjectError>;
 
     #[verifier(external_body)]
+    proof fn marshal_returns_non_null(o: Self) {}
+
+    #[verifier(external_body)]
     proof fn marshal_preserves_integrity() {}
 }
 

--- a/src/kubernetes_api_objects/marshal.rs
+++ b/src/kubernetes_api_objects/marshal.rs
@@ -39,6 +39,9 @@ pub trait Marshalable: Sized {
 
     spec fn unmarshal(value: Value) -> Result<Self, ParseDynamicObjectError>;
 
+    proof fn marshal_returns_non_null(o: Self)
+        ensures !o.marshal().is_Null();
+
     /// Check if the data integrity is preserved after marshaling and unmarshaling
     proof fn marshal_preserves_integrity()
         ensures

--- a/src/kubernetes_api_objects/marshal.rs
+++ b/src/kubernetes_api_objects/marshal.rs
@@ -39,8 +39,9 @@ pub trait Marshalable: Sized {
 
     spec fn unmarshal(value: Value) -> Result<Self, ParseDynamicObjectError>;
 
-    proof fn marshal_returns_non_null(o: Self)
-        ensures !o.marshal().is_Null();
+    proof fn marshal_returns_non_null()
+        ensures
+            forall |o: Self| !(#[trigger] o.marshal()).is_Null();
 
     /// Check if the data integrity is preserved after marshaling and unmarshaling
     proof fn marshal_preserves_integrity()

--- a/src/kubernetes_api_objects/marshal.rs
+++ b/src/kubernetes_api_objects/marshal.rs
@@ -1,5 +1,6 @@
 // Copyright 2022 VMware, Inc.
 // SPDX-License-Identifier: MIT
+use crate::kubernetes_api_objects::error::ParseDynamicObjectError;
 use crate::pervasive_ext::string_view::*;
 use vstd::prelude::*;
 
@@ -32,16 +33,16 @@ pub enum Value {
 pub trait Marshalable: Sized {
     /// Marshal the object to a Value
 
-    open spec fn marshal(self) -> Value;
+    spec fn marshal(self) -> Value;
 
     /// Unmarshal the object back from a Value
 
-    open spec fn unmarshal(value: Value) -> Self;
+    spec fn unmarshal(value: Value) -> Result<Self, ParseDynamicObjectError>;
 
     /// Check if the data integrity is preserved after marshaling and unmarshaling
-
     proof fn marshal_preserves_integrity()
-        ensures forall |o: Self| o == Self::unmarshal(#[trigger] o.marshal());
+        ensures
+            forall |o: Self| Self::unmarshal(#[trigger] o.marshal()).is_Ok() && o == Self::unmarshal(o.marshal()).get_Ok_0();
 }
 
 }

--- a/src/kubernetes_api_objects/object_meta.rs
+++ b/src/kubernetes_api_objects/object_meta.rs
@@ -178,7 +178,7 @@ impl Marshalable for ObjectMetaView {
     closed spec fn unmarshal(value: Value) -> Result<Self, ParseDynamicObjectError>;
 
     #[verifier(external_body)]
-    proof fn marshal_returns_non_null(o: Self) {}
+    proof fn marshal_returns_non_null() {}
 
     #[verifier(external_body)]
     proof fn marshal_preserves_integrity() {}

--- a/src/kubernetes_api_objects/object_meta.rs
+++ b/src/kubernetes_api_objects/object_meta.rs
@@ -1,5 +1,6 @@
 // Copyright 2022 VMware, Inc.
 // SPDX-License-Identifier: MIT
+use crate::kubernetes_api_objects::error::ParseDynamicObjectError;
 use crate::kubernetes_api_objects::marshal::*;
 use crate::kubernetes_api_objects::resource::*;
 use crate::pervasive_ext::string_map::*;
@@ -172,53 +173,11 @@ impl ObjectMetaView {
 }
 
 impl Marshalable for ObjectMetaView {
-    open spec fn marshal(self) -> Value {
-        Value::Object(
-            Map::empty()
-                .insert(Self::name_field(), if self.name.is_None() { Value::Null } else {
-                    Value::String(self.name.get_Some_0())
-                })
-                .insert(Self::namespace_field(), if self.namespace.is_None() { Value::Null } else {
-                    Value::String(self.namespace.get_Some_0())
-                })
-                .insert(Self::generate_name_field(), if self.generate_name.is_None() { Value::Null } else {
-                    Value::String(self.generate_name.get_Some_0())
-                })
-                .insert(Self::resource_version_field(), if self.resource_version.is_None() { Value::Null } else {
-                    Value::Nat(self.resource_version.get_Some_0())
-                })
-                .insert(Self::uid_field(), if self.uid.is_None() { Value::Null } else {
-                    Value::String(self.uid.get_Some_0())
-                })
-                .insert(Self::labels_field(), if self.labels.is_None() { Value::Null } else {
-                    Value::StringStringMap(self.labels.get_Some_0())
-                })
-        )
-    }
+    closed spec fn marshal(self) -> Value;
 
-    open spec fn unmarshal(value: Value) -> Self {
-        ObjectMetaView {
-            name: if value.get_Object_0()[Self::name_field()].is_Null() { Option::None } else {
-                Option::Some(value.get_Object_0()[Self::name_field()].get_String_0())
-            },
-            namespace: if value.get_Object_0()[Self::namespace_field()].is_Null() { Option::None } else {
-                Option::Some(value.get_Object_0()[Self::namespace_field()].get_String_0())
-            },
-            generate_name: if value.get_Object_0()[Self::generate_name_field()].is_Null() { Option::None } else {
-                Option::Some(value.get_Object_0()[Self::generate_name_field()].get_String_0())
-            },
-            resource_version: if value.get_Object_0()[Self::resource_version_field()].is_Null() { Option::None } else {
-                Option::Some(value.get_Object_0()[Self::resource_version_field()].get_Nat_0())
-            },
-            uid: if value.get_Object_0()[Self::uid_field()].is_Null() { Option::None } else {
-                Option::Some(value.get_Object_0()[Self::uid_field()].get_String_0())
-            },
-            labels: if value.get_Object_0()[Self::labels_field()].is_Null() { Option::None } else {
-                Option::Some(value.get_Object_0()[Self::labels_field()].get_StringStringMap_0())
-            },
-        }
-    }
+    closed spec fn unmarshal(value: Value) -> Result<Self, ParseDynamicObjectError>;
 
+    #[verifier(external_body)]
     proof fn marshal_preserves_integrity() {}
 }
 

--- a/src/kubernetes_api_objects/object_meta.rs
+++ b/src/kubernetes_api_objects/object_meta.rs
@@ -178,6 +178,9 @@ impl Marshalable for ObjectMetaView {
     closed spec fn unmarshal(value: Value) -> Result<Self, ParseDynamicObjectError>;
 
     #[verifier(external_body)]
+    proof fn marshal_returns_non_null(o: Self) {}
+
+    #[verifier(external_body)]
     proof fn marshal_preserves_integrity() {}
 }
 

--- a/src/kubernetes_api_objects/persistent_volume_claim.rs
+++ b/src/kubernetes_api_objects/persistent_volume_claim.rs
@@ -104,7 +104,7 @@ impl PersistentVolumeClaim {
             let res = PersistentVolumeClaim { inner: parse_result.unwrap() };
             Result::Ok(res)
         } else {
-            Result::Err(ParseDynamicObjectError::Error)
+            Result::Err(ParseDynamicObjectError::ExecError)
         }
     }
 }

--- a/src/kubernetes_api_objects/persistent_volume_claim.rs
+++ b/src/kubernetes_api_objects/persistent_volume_claim.rs
@@ -270,23 +270,8 @@ impl ResourceView for PersistentVolumeClaimView {
     }
 
     proof fn to_dynamic_preserves_integrity() {
-        assert forall |o: Self| Self::from_dynamic_object(#[trigger] o.to_dynamic_object()).is_Ok()
-        && o == Self::from_dynamic_object(o.to_dynamic_object()).get_Ok_0() by {
-            let dyn_obj = o.to_dynamic_object();
-            assert(dyn_obj.data.is_Object());
-            PersistentVolumeClaimSpecView::marshal_preserves_integrity();
-            assert(Self::from_dynamic_object(dyn_obj).is_Ok());
-            let res = Self::from_dynamic_object(dyn_obj).get_Ok_0();
-            assert(res.metadata == o.metadata);
-            if o.spec.is_None() {
-                assert(o == Self::from_dynamic_object(dyn_obj).get_Ok_0());
-            } else {
-                assert(PersistentVolumeClaimSpecView::unmarshal(o.spec.get_Some_0().marshal()).is_Ok());
-                assert(o.spec.get_Some_0() == PersistentVolumeClaimSpecView::unmarshal(o.spec.get_Some_0().marshal()).get_Ok_0());
-                assert(res.spec.is_Some());
-                assert(res.spec.get_Some_0() == o.spec.get_Some_0());
-            }
-        }
+        PersistentVolumeClaimSpecView::marshal_preserves_integrity();
+        PersistentVolumeClaimSpecView::marshal_returns_non_null();
     }
 }
 
@@ -296,7 +281,7 @@ impl Marshalable for PersistentVolumeClaimView {
     spec fn unmarshal(value: Value) -> Result<PersistentVolumeClaimView, ParseDynamicObjectError>;
 
     #[verifier(external_body)]
-    proof fn marshal_returns_non_null(o: Self) {}
+    proof fn marshal_returns_non_null() {}
 
     #[verifier(external_body)]
     proof fn marshal_preserves_integrity() {}
@@ -329,7 +314,7 @@ impl Marshalable for PersistentVolumeClaimSpecView {
     closed spec fn unmarshal(value: Value) -> Result<Self, ParseDynamicObjectError>;
 
     #[verifier(external_body)]
-    proof fn marshal_returns_non_null(o: Self) {}
+    proof fn marshal_returns_non_null() {}
 
     #[verifier(external_body)]
     proof fn marshal_preserves_integrity() {}

--- a/src/kubernetes_api_objects/persistent_volume_claim.rs
+++ b/src/kubernetes_api_objects/persistent_volume_claim.rs
@@ -231,41 +231,34 @@ impl ResourceView for PersistentVolumeClaimView {
             kind: self.kind(),
             metadata: self.metadata,
             data: Value::Object(Map::empty()
-                                    .insert(Self::spec_field(), if self.spec.is_None() {Value::Null} else {
-                                        self.spec.get_Some_0().marshal()
-                                    })),
+                                    .insert(Self::spec_field(),
+                                        if self.spec.is_None() {Value::Null} else {self.spec.get_Some_0().marshal()})),
         }
     }
 
     open spec fn from_dynamic_object(obj: DynamicObjectView) -> Result<PersistentVolumeClaimView, ParseDynamicObjectError> {
         // if obj.kind != Self::kind()
-        if obj.data.is_Object() {
-            let obj_data = obj.data.get_Object_0();
-            if obj_data.dom().contains(Self::spec_field()) {
-                let data_spec = obj_data[Self::spec_field()];
-                if data_spec.is_Null() {
-                    let res = PersistentVolumeClaimView {
-                        metadata: obj.metadata,
-                        spec: Option::None,
-                    };
-                    Result::Ok(res)
-                } else {
-                    let data_spec_1 = PersistentVolumeClaimSpecView::unmarshal(data_spec);
-                    if data_spec_1.is_Ok() {
-                        let res = PersistentVolumeClaimView {
-                            metadata: obj.metadata,
-                            spec: Option::Some(data_spec_1.get_Ok_0()),
-                        };
-                        Result::Ok(res)
-                    } else {
-                        Result::Err(data_spec_1.get_Err_0())
-                    }
-                }
-            } else {
-                Result::Err(ParseDynamicObjectError::MissingField)
-            }
-        } else {
+        let data_object = obj.data.get_Object_0();
+        let data_spec = data_object[Self::spec_field()];
+        let data_spec_unmarshal = PersistentVolumeClaimSpecView::unmarshal(data_spec);
+        if !obj.data.is_Object() {
             Result::Err(ParseDynamicObjectError::UnexpectedType)
+        } else if !data_object.dom().contains(Self::spec_field()) {
+            Result::Err(ParseDynamicObjectError::MissingField)
+        } else if !data_spec.is_Null() && data_spec_unmarshal.is_Err() {
+            Result::Err(ParseDynamicObjectError::UnmarshalError)
+        } else if data_spec.is_Null() {
+            let res = PersistentVolumeClaimView {
+                metadata: obj.metadata,
+                spec: Option::None,
+            };
+            Result::Ok(res)
+        } else {
+            let res = PersistentVolumeClaimView {
+                metadata: obj.metadata,
+                spec: Option::Some(data_spec_unmarshal.get_Ok_0()),
+            };
+            Result::Ok(res)
         }
     }
 

--- a/src/kubernetes_api_objects/pod.rs
+++ b/src/kubernetes_api_objects/pod.rs
@@ -581,6 +581,9 @@ impl Marshalable for PodSpecView {
     spec fn unmarshal(value: Value) -> Result<Self, ParseDynamicObjectError>;
 
     #[verifier(external_body)]
+    proof fn marshal_returns_non_null(o: Self) {}
+
+    #[verifier(external_body)]
     proof fn marshal_preserves_integrity() {}
 }
 
@@ -644,6 +647,9 @@ impl Marshalable for ContainerView {
     spec fn unmarshal(value: Value) -> Result<Self, ParseDynamicObjectError>;
 
     #[verifier(external_body)]
+    proof fn marshal_returns_non_null(o: Self) {}
+
+    #[verifier(external_body)]
     proof fn marshal_preserves_integrity() {}
 }
 
@@ -683,6 +689,9 @@ impl Marshalable for ContainerPortView {
     spec fn marshal(self) -> Value;
 
     spec fn unmarshal(value: Value) -> Result<Self, ParseDynamicObjectError>;
+
+    #[verifier(external_body)]
+    proof fn marshal_returns_non_null(o: Self) {}
 
     #[verifier(external_body)]
     proof fn marshal_preserves_integrity() {}
@@ -726,6 +735,9 @@ impl Marshalable for VolumeMountView {
     spec fn unmarshal(value: Value) -> Result<Self, ParseDynamicObjectError>;
 
     #[verifier(external_body)]
+    proof fn marshal_returns_non_null(o: Self) {}
+
+    #[verifier(external_body)]
     proof fn marshal_preserves_integrity() {}
 }
 
@@ -767,6 +779,9 @@ impl Marshalable for VolumeView {
     spec fn unmarshal(value: Value) -> Result<Self, ParseDynamicObjectError>;
 
     #[verifier(external_body)]
+    proof fn marshal_returns_non_null(o: Self) {}
+
+    #[verifier(external_body)]
     proof fn marshal_preserves_integrity() {}
 }
 
@@ -795,6 +810,9 @@ impl Marshalable for ConfigMapVolumeSourceView {
     spec fn marshal(self) -> Value;
 
     spec fn unmarshal(value: Value) -> Result<Self, ParseDynamicObjectError>;
+
+    #[verifier(external_body)]
+    proof fn marshal_returns_non_null(o: Self) {}
 
     #[verifier(external_body)]
     proof fn marshal_preserves_integrity() {}

--- a/src/kubernetes_api_objects/pod.rs
+++ b/src/kubernetes_api_objects/pod.rs
@@ -3,6 +3,7 @@
 use crate::kubernetes_api_objects::api_resource::*;
 use crate::kubernetes_api_objects::common::*;
 use crate::kubernetes_api_objects::dynamic::*;
+use crate::kubernetes_api_objects::error::ParseDynamicObjectError;
 use crate::kubernetes_api_objects::marshal::*;
 use crate::kubernetes_api_objects::object_meta::*;
 use crate::kubernetes_api_objects::resource::*;
@@ -103,11 +104,18 @@ impl Pod {
 
     /// Convert a DynamicObject to a Pod
     #[verifier(external_body)]
-    pub fn from_dynamic_object(obj: DynamicObject) -> (pod: Pod)
+    pub fn from_dynamic_object(obj: DynamicObject) -> (res: Result<Pod, ParseDynamicObjectError>)
         ensures
-            pod@ == PodView::from_dynamic_object(obj@),
+            res.is_Ok() == PodView::from_dynamic_object(obj@).is_Ok(),
+            res.is_Ok() ==> res.get_Ok_0()@ == PodView::from_dynamic_object(obj@).get_Ok_0(),
     {
-        Pod { inner: obj.into_kube().try_parse::<deps_hack::k8s_openapi::api::core::v1::Pod>().unwrap() }
+        let parse_result = obj.into_kube().try_parse::<deps_hack::k8s_openapi::api::core::v1::Pod>();
+        if parse_result.is_ok() {
+            let res = Pod { inner: parse_result.unwrap() };
+            Result::Ok(res)
+        } else {
+            Result::Err(ParseDynamicObjectError::Error)
+        }
     }
 }
 
@@ -499,12 +507,34 @@ impl ResourceView for PodView {
         }
     }
 
-    open spec fn from_dynamic_object(obj: DynamicObjectView) -> PodView {
-        PodView {
-            metadata: obj.metadata,
-            spec: if obj.data.get_Object_0()[Self::spec_field()].is_Null() { Option::None } else {
-                Option::Some(PodSpecView::unmarshal(obj.data.get_Object_0()[Self::spec_field()]))
-            },
+    open spec fn from_dynamic_object(obj: DynamicObjectView) -> Result<PodView, ParseDynamicObjectError> {
+        if obj.data.is_Object() {
+            let obj_data = obj.data.get_Object_0();
+            if obj_data.dom().contains(Self::spec_field()) {
+                let data_spec = obj_data[Self::spec_field()];
+                if data_spec.is_Null() {
+                    let res = PodView {
+                        metadata: obj.metadata,
+                        spec: Option::None,
+                    };
+                    Result::Ok(res)
+                } else {
+                    let data_spec_1 = PodSpecView::unmarshal(data_spec);
+                    if data_spec_1.is_Ok() {
+                        let res = PodView {
+                            metadata: obj.metadata,
+                            spec: Option::Some(data_spec_1.get_Ok_0()),
+                        };
+                        Result::Ok(res)
+                    } else {
+                        Result::Err(data_spec_1.get_Err_0())
+                    }
+                }
+            } else {
+                Result::Err(ParseDynamicObjectError::MissingField)
+            }
+        } else {
+            Result::Err(ParseDynamicObjectError::UnexpectedType)
         }
     }
 
@@ -546,34 +576,12 @@ impl PodSpecView {
 }
 
 impl Marshalable for PodSpecView {
-    open spec fn marshal(self) -> Value {
-        Value::Object(
-            Map::empty()
-                .insert(Self::containers_field(), Value::Array(self.containers.map_values(|container: ContainerView| container.marshal())))
-                .insert(Self::volumes_field(), if self.volumes.is_None() { Value::Null } else {
-                    Value::Array(self.volumes.get_Some_0().map_values(|volume: VolumeView| volume.marshal()))
-                })
-        )
-    }
+    spec fn marshal(self) -> Value;
 
-    open spec fn unmarshal(value: Value) -> Self {
-        PodSpecView {
-            containers: value.get_Object_0()[Self::containers_field()].get_Array_0().map_values(|v| ContainerView::unmarshal(v)),
-            volumes: if value.get_Object_0()[Self::volumes_field()].is_Null() { Option::None } else {
-                Option::Some(value.get_Object_0()[Self::volumes_field()].get_Array_0().map_values(|v| VolumeView::unmarshal(v)))
-            },
-        }
-    }
+    spec fn unmarshal(value: Value) -> Result<Self, ParseDynamicObjectError>;
 
-    proof fn marshal_preserves_integrity() {
-        assert forall |o: Self| o == Self::unmarshal(#[trigger] o.marshal()) by {
-            ContainerView::marshal_preserves_integrity();
-            assert_seqs_equal!(o.containers, Self::unmarshal(o.marshal()).containers);
-            if o.volumes.is_Some() {
-                assert_seqs_equal!(o.volumes.get_Some_0(), Self::unmarshal(o.marshal()).volumes.get_Some_0());
-            }
-        }
-    }
+    #[verifier(external_body)]
+    proof fn marshal_preserves_integrity() {}
 }
 
 pub struct ContainerView {
@@ -631,47 +639,12 @@ impl ContainerView {
 }
 
 impl Marshalable for ContainerView {
-    open spec fn marshal(self) -> Value {
-        Value::Object(
-            Map::empty()
-                .insert(Self::image_field(), if self.image.is_None() { Value::Null } else {
-                    Value::String(self.image.get_Some_0())
-                })
-                .insert(Self::name_field(), Value::String(self.name))
-                .insert(Self::ports_field(), if self.ports.is_None() { Value::Null } else {
-                    Value::Array(self.ports.get_Some_0().map_values(|port: ContainerPortView| port.marshal()))
-                })
-                .insert(Self::volume_mounts_field(), if self.volume_mounts.is_None() { Value::Null } else {
-                    Value::Array(self.volume_mounts.get_Some_0().map_values(|volume_mount: VolumeMountView| volume_mount.marshal()))
-                })
-        )
-    }
+    spec fn marshal(self) -> Value;
 
-    open spec fn unmarshal(value: Value) -> Self {
-        ContainerView {
-            image: if value.get_Object_0()[Self::image_field()].is_Null() { Option::None } else {
-                Option::Some(value.get_Object_0()[Self::image_field()].get_String_0())
-            },
-            name: value.get_Object_0()[Self::name_field()].get_String_0(),
-            ports: if value.get_Object_0()[Self::ports_field()].is_Null() { Option::None } else {
-                Option::Some(value.get_Object_0()[Self::ports_field()].get_Array_0().map_values(|v| ContainerPortView::unmarshal(v)))
-            },
-            volume_mounts: if value.get_Object_0()[Self::volume_mounts_field()].is_Null() { Option::None } else {
-                Option::Some(value.get_Object_0()[Self::volume_mounts_field()].get_Array_0().map_values(|v| VolumeMountView::unmarshal(v)))
-            },
-        }
-    }
+    spec fn unmarshal(value: Value) -> Result<Self, ParseDynamicObjectError>;
 
-    proof fn marshal_preserves_integrity() {
-        assert forall |o: Self| o == Self::unmarshal(#[trigger] o.marshal()) by {
-            if o.ports.is_Some() {
-                assert_seqs_equal!(o.ports.get_Some_0(), Self::unmarshal(o.marshal()).ports.get_Some_0());
-            }
-            if o.volume_mounts.is_Some() {
-                assert_seqs_equal!(o.volume_mounts.get_Some_0(), Self::unmarshal(o.marshal()).volume_mounts.get_Some_0());
-            }
-        }
-    }
+    #[verifier(external_body)]
+    proof fn marshal_preserves_integrity() {}
 }
 
 pub struct ContainerPortView {
@@ -707,25 +680,11 @@ impl ContainerPortView {
 }
 
 impl Marshalable for ContainerPortView {
-    open spec fn marshal(self) -> Value {
-        Value::Object(
-            Map::empty()
-                .insert(Self::container_port_field(), Value::Int(self.container_port))
-                .insert(Self::name_field(), if self.name.is_None() { Value::Null } else {
-                    Value::String(self.name.get_Some_0())
-                })
-        )
-    }
+    spec fn marshal(self) -> Value;
 
-    open spec fn unmarshal(value: Value) -> Self {
-        ContainerPortView {
-            container_port: value.get_Object_0()[Self::container_port_field()].get_Int_0(),
-            name: if value.get_Object_0()[Self::name_field()].is_Null() { Option::None } else {
-                Option::Some(value.get_Object_0()[Self::name_field()].get_String_0())
-            },
-        }
-    }
+    spec fn unmarshal(value: Value) -> Result<Self, ParseDynamicObjectError>;
 
+    #[verifier(external_body)]
     proof fn marshal_preserves_integrity() {}
 }
 
@@ -762,21 +721,11 @@ impl VolumeMountView {
 }
 
 impl Marshalable for VolumeMountView {
-    open spec fn marshal(self) -> Value {
-        Value::Object(
-            Map::empty()
-                .insert(Self::mount_path_field(), Value::String(self.mount_path))
-                .insert(Self::name_field(), Value::String(self.name))
-        )
-    }
+    spec fn marshal(self) -> Value;
 
-    open spec fn unmarshal(value: Value) -> Self {
-        VolumeMountView {
-            mount_path: value.get_Object_0()[Self::mount_path_field()].get_String_0(),
-            name: value.get_Object_0()[Self::name_field()].get_String_0(),
-        }
-    }
+    spec fn unmarshal(value: Value) -> Result<Self, ParseDynamicObjectError>;
 
+    #[verifier(external_body)]
     proof fn marshal_preserves_integrity() {}
 }
 
@@ -813,25 +762,11 @@ impl VolumeView {
 }
 
 impl Marshalable for VolumeView {
-    open spec fn marshal(self) -> Value {
-        Value::Object(
-            Map::empty()
-                .insert(Self::config_map_field(), if self.config_map.is_None() { Value::Null } else {
-                    self.config_map.get_Some_0().marshal()
-                })
-                .insert(Self::name_field(), Value::String(self.name))
-        )
-    }
+    spec fn marshal(self) -> Value;
 
-    open spec fn unmarshal(value: Value) -> Self {
-        VolumeView {
-            config_map: if value.get_Object_0()[Self::config_map_field()].is_Null() { Option::None } else {
-                Option::Some(ConfigMapVolumeSourceView::unmarshal(value.get_Object_0()[Self::config_map_field()]))
-            },
-            name: value.get_Object_0()[Self::name_field()].get_String_0(),
-        }
-    }
+    spec fn unmarshal(value: Value) -> Result<Self, ParseDynamicObjectError>;
 
+    #[verifier(external_body)]
     proof fn marshal_preserves_integrity() {}
 }
 
@@ -857,23 +792,11 @@ impl ConfigMapVolumeSourceView {
 }
 
 impl Marshalable for ConfigMapVolumeSourceView {
-    open spec fn marshal(self) -> Value {
-        Value::Object(
-            Map::empty()
-                .insert(Self::name_field(), if self.name.is_None() { Value::Null } else {
-                    Value::String(self.name.get_Some_0())
-                })
-        )
-    }
+    spec fn marshal(self) -> Value;
 
-    open spec fn unmarshal(value: Value) -> Self {
-        ConfigMapVolumeSourceView {
-            name: if value.get_Object_0()[Self::name_field()].is_Null() { Option::None } else {
-                Option::Some(value.get_Object_0()[Self::name_field()].get_String_0())
-            },
-        }
-    }
+    spec fn unmarshal(value: Value) -> Result<Self, ParseDynamicObjectError>;
 
+    #[verifier(external_body)]
     proof fn marshal_preserves_integrity() {}
 }
 

--- a/src/kubernetes_api_objects/pod.rs
+++ b/src/kubernetes_api_objects/pod.rs
@@ -540,6 +540,7 @@ impl ResourceView for PodView {
 
     proof fn to_dynamic_preserves_integrity() {
         PodSpecView::marshal_preserves_integrity();
+        PodSpecView::marshal_returns_non_null();
     }
 }
 
@@ -581,7 +582,7 @@ impl Marshalable for PodSpecView {
     spec fn unmarshal(value: Value) -> Result<Self, ParseDynamicObjectError>;
 
     #[verifier(external_body)]
-    proof fn marshal_returns_non_null(o: Self) {}
+    proof fn marshal_returns_non_null() {}
 
     #[verifier(external_body)]
     proof fn marshal_preserves_integrity() {}
@@ -647,7 +648,7 @@ impl Marshalable for ContainerView {
     spec fn unmarshal(value: Value) -> Result<Self, ParseDynamicObjectError>;
 
     #[verifier(external_body)]
-    proof fn marshal_returns_non_null(o: Self) {}
+    proof fn marshal_returns_non_null() {}
 
     #[verifier(external_body)]
     proof fn marshal_preserves_integrity() {}
@@ -691,7 +692,7 @@ impl Marshalable for ContainerPortView {
     spec fn unmarshal(value: Value) -> Result<Self, ParseDynamicObjectError>;
 
     #[verifier(external_body)]
-    proof fn marshal_returns_non_null(o: Self) {}
+    proof fn marshal_returns_non_null() {}
 
     #[verifier(external_body)]
     proof fn marshal_preserves_integrity() {}
@@ -735,7 +736,7 @@ impl Marshalable for VolumeMountView {
     spec fn unmarshal(value: Value) -> Result<Self, ParseDynamicObjectError>;
 
     #[verifier(external_body)]
-    proof fn marshal_returns_non_null(o: Self) {}
+    proof fn marshal_returns_non_null() {}
 
     #[verifier(external_body)]
     proof fn marshal_preserves_integrity() {}
@@ -779,7 +780,7 @@ impl Marshalable for VolumeView {
     spec fn unmarshal(value: Value) -> Result<Self, ParseDynamicObjectError>;
 
     #[verifier(external_body)]
-    proof fn marshal_returns_non_null(o: Self) {}
+    proof fn marshal_returns_non_null() {}
 
     #[verifier(external_body)]
     proof fn marshal_preserves_integrity() {}
@@ -812,7 +813,7 @@ impl Marshalable for ConfigMapVolumeSourceView {
     spec fn unmarshal(value: Value) -> Result<Self, ParseDynamicObjectError>;
 
     #[verifier(external_body)]
-    proof fn marshal_returns_non_null(o: Self) {}
+    proof fn marshal_returns_non_null() {}
 
     #[verifier(external_body)]
     proof fn marshal_preserves_integrity() {}

--- a/src/kubernetes_api_objects/pod.rs
+++ b/src/kubernetes_api_objects/pod.rs
@@ -114,7 +114,7 @@ impl Pod {
             let res = Pod { inner: parse_result.unwrap() };
             Result::Ok(res)
         } else {
-            Result::Err(ParseDynamicObjectError::Error)
+            Result::Err(ParseDynamicObjectError::ExecError)
         }
     }
 }

--- a/src/kubernetes_api_objects/pod_template_spec.rs
+++ b/src/kubernetes_api_objects/pod_template_spec.rs
@@ -94,7 +94,7 @@ impl Marshalable for PodTemplateSpecView {
     spec fn unmarshal(value: Value) -> Result<Self, ParseDynamicObjectError>;
 
     #[verifier(external_body)]
-    proof fn marshal_returns_non_null(o: Self) {}
+    proof fn marshal_returns_non_null() {}
 
     #[verifier(external_body)]
     proof fn marshal_preserves_integrity() {}

--- a/src/kubernetes_api_objects/pod_template_spec.rs
+++ b/src/kubernetes_api_objects/pod_template_spec.rs
@@ -3,6 +3,7 @@
 use crate::kubernetes_api_objects::api_resource::*;
 use crate::kubernetes_api_objects::common::*;
 use crate::kubernetes_api_objects::dynamic::*;
+use crate::kubernetes_api_objects::error::ParseDynamicObjectError;
 use crate::kubernetes_api_objects::marshal::*;
 use crate::kubernetes_api_objects::object_meta::*;
 use crate::kubernetes_api_objects::pod::*;
@@ -88,32 +89,12 @@ impl PodTemplateSpecView {
 }
 
 impl Marshalable for PodTemplateSpecView {
-    open spec fn marshal(self) -> Value {
-        Value::Object(
-            Map::empty()
-                .insert(Self::metadata_field(), if self.metadata.is_None() { Value::Null } else {
-                    self.metadata.get_Some_0().marshal()
-                })
-                .insert(Self::spec_field(), if self.spec.is_None() { Value::Null } else {
-                    self.spec.get_Some_0().marshal()
-                })
-        )
-    }
+    spec fn marshal(self) -> Value;
 
-    open spec fn unmarshal(value: Value) -> Self {
-        PodTemplateSpecView {
-            metadata: if value.get_Object_0()[Self::metadata_field()].is_Null() { Option::None } else {
-                Option::Some(ObjectMetaView::unmarshal(value.get_Object_0()[Self::metadata_field()]))
-            },
-            spec: if value.get_Object_0()[Self::spec_field()].is_Null() { Option::None } else {
-                Option::Some(PodSpecView::unmarshal(value.get_Object_0()[Self::spec_field()]))
-            },
-        }
-    }
+    spec fn unmarshal(value: Value) -> Result<Self, ParseDynamicObjectError>;
 
-    proof fn marshal_preserves_integrity() {
-        PodSpecView::marshal_preserves_integrity();
-    }
+    #[verifier(external_body)]
+    proof fn marshal_preserves_integrity() {}
 }
 
 }

--- a/src/kubernetes_api_objects/pod_template_spec.rs
+++ b/src/kubernetes_api_objects/pod_template_spec.rs
@@ -94,6 +94,9 @@ impl Marshalable for PodTemplateSpecView {
     spec fn unmarshal(value: Value) -> Result<Self, ParseDynamicObjectError>;
 
     #[verifier(external_body)]
+    proof fn marshal_returns_non_null(o: Self) {}
+
+    #[verifier(external_body)]
     proof fn marshal_preserves_integrity() {}
 }
 

--- a/src/kubernetes_api_objects/resource.rs
+++ b/src/kubernetes_api_objects/resource.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: MIT
 use crate::kubernetes_api_objects::common::*;
 use crate::kubernetes_api_objects::dynamic::*;
+use crate::kubernetes_api_objects::error::ParseDynamicObjectError;
 use crate::kubernetes_api_objects::object_meta::*;
 use crate::pervasive_ext::string_view::*;
 use vstd::prelude::*;
@@ -40,12 +41,14 @@ pub trait ResourceView: Sized {
 
     /// Convert back from a dynamic object
 
-    open spec fn from_dynamic_object(obj: DynamicObjectView) -> Self;
+    open spec fn from_dynamic_object(obj: DynamicObjectView) -> Result<Self, ParseDynamicObjectError>;
 
     /// Check if the data integrity is preserved after converting to and back from dynamic object
 
     proof fn to_dynamic_preserves_integrity()
-        ensures forall |o: Self| o == Self::from_dynamic_object(#[trigger] o.to_dynamic_object());
+        ensures
+            forall |o: Self| Self::from_dynamic_object(#[trigger] o.to_dynamic_object()).is_Ok()
+                            && o == Self::from_dynamic_object(o.to_dynamic_object()).get_Ok_0();
 }
 
 }

--- a/src/kubernetes_api_objects/resource_requirements.rs
+++ b/src/kubernetes_api_objects/resource_requirements.rs
@@ -1,5 +1,6 @@
 // Copyright 2022 VMware, Inc.
 // SPDX-License-Identifier: MIT
+use crate::kubernetes_api_objects::resource::*;
 use vstd::prelude::*;
 
 verus! {
@@ -9,16 +10,18 @@ pub struct ResourceRequirements {
     inner: deps_hack::k8s_openapi::api::core::v1::ResourceRequirements
 }
 
-impl ResourceRequirements {
+impl ResourceWrapper<deps_hack::k8s_openapi::api::core::v1::ResourceRequirements> for ResourceRequirements {
     #[verifier(external)]
-    pub fn from_kube(inner: deps_hack::k8s_openapi::api::core::v1::ResourceRequirements) -> ResourceRequirements {
+    fn from_kube(inner: deps_hack::k8s_openapi::api::core::v1::ResourceRequirements) -> ResourceRequirements {
         ResourceRequirements { inner: inner }
     }
 
     #[verifier(external)]
-    pub fn into_kube(self) -> deps_hack::k8s_openapi::api::core::v1::ResourceRequirements {
+    fn into_kube(self) -> deps_hack::k8s_openapi::api::core::v1::ResourceRequirements {
         self.inner
     }
 }
+
+impl ResourceRequirements {}
 
 }

--- a/src/kubernetes_api_objects/service.rs
+++ b/src/kubernetes_api_objects/service.rs
@@ -311,15 +311,6 @@ impl ResourceView for ServiceView {
     proof fn to_dynamic_preserves_integrity() {
         ServiceSpecView::marshal_preserves_integrity();
         ServiceSpecView::marshal_returns_non_null();
-        // assert forall |o: Self| Self::from_dynamic_object(#[trigger] o.to_dynamic_object()).is_Ok()
-        // && o == Self::from_dynamic_object(o.to_dynamic_object()).get_Ok_0() by {
-        //     if o.spec.is_Some() && o.spec.get_Some_0().ports.is_Some() {
-        //         assert_seqs_equal!(
-        //             o.spec.get_Some_0().ports.get_Some_0(),
-        //             Self::from_dynamic_object(o.to_dynamic_object()).get_Ok_0().spec.get_Some_0().ports.get_Some_0()
-        //         );
-        //     }
-        // }
     }
 }
 

--- a/src/kubernetes_api_objects/service.rs
+++ b/src/kubernetes_api_objects/service.rs
@@ -110,7 +110,7 @@ impl Service {
             let res = Service { inner: parse_result.unwrap() };
             Result::Ok(res)
         } else {
-            Result::Err(ParseDynamicObjectError::Error)
+            Result::Err(ParseDynamicObjectError::ExecError)
         }
     }
 }

--- a/src/kubernetes_api_objects/service.rs
+++ b/src/kubernetes_api_objects/service.rs
@@ -309,15 +309,17 @@ impl ResourceView for ServiceView {
     }
 
     proof fn to_dynamic_preserves_integrity() {
-        assert forall |o: Self| Self::from_dynamic_object(#[trigger] o.to_dynamic_object()).is_Ok()
-        && o == Self::from_dynamic_object(o.to_dynamic_object()).get_Ok_0() by {
-            if o.spec.is_Some() && o.spec.get_Some_0().ports.is_Some() {
-                assert_seqs_equal!(
-                    o.spec.get_Some_0().ports.get_Some_0(),
-                    Self::from_dynamic_object(o.to_dynamic_object()).get_Ok_0().spec.get_Some_0().ports.get_Some_0()
-                );
-            }
-        }
+        ServiceSpecView::marshal_preserves_integrity();
+        ServiceSpecView::marshal_returns_non_null();
+        // assert forall |o: Self| Self::from_dynamic_object(#[trigger] o.to_dynamic_object()).is_Ok()
+        // && o == Self::from_dynamic_object(o.to_dynamic_object()).get_Ok_0() by {
+        //     if o.spec.is_Some() && o.spec.get_Some_0().ports.is_Some() {
+        //         assert_seqs_equal!(
+        //             o.spec.get_Some_0().ports.get_Some_0(),
+        //             Self::from_dynamic_object(o.to_dynamic_object()).get_Ok_0().spec.get_Some_0().ports.get_Some_0()
+        //         );
+        //     }
+        // }
     }
 }
 
@@ -370,7 +372,7 @@ impl Marshalable for ServiceSpecView {
     spec fn unmarshal(value: Value) -> Result<Self, ParseDynamicObjectError>;
 
     #[verifier(external_body)]
-    proof fn marshal_returns_non_null(o: Self) {}
+    proof fn marshal_returns_non_null() {}
 
     #[verifier(external_body)]
     proof fn marshal_preserves_integrity() {}
@@ -414,7 +416,7 @@ impl Marshalable for ServicePortView {
     spec fn unmarshal(value: Value) -> Result<Self, ParseDynamicObjectError>;
 
     #[verifier(external_body)]
-    proof fn marshal_returns_non_null(o: Self) {}
+    proof fn marshal_returns_non_null() {}
 
     #[verifier(external_body)]
     proof fn marshal_preserves_integrity() {}

--- a/src/kubernetes_api_objects/service.rs
+++ b/src/kubernetes_api_objects/service.rs
@@ -278,33 +278,27 @@ impl ResourceView for ServiceView {
     }
 
     open spec fn from_dynamic_object(obj: DynamicObjectView) -> Result<ServiceView, ParseDynamicObjectError> {
-        if obj.data.is_Object() {
-            let obj_data = obj.data.get_Object_0();
-            if obj_data.dom().contains(Self::spec_field()) {
-                let data_spec = obj_data[Self::spec_field()];
-                if data_spec.is_Null() {
-                    let res = ServiceView {
-                        metadata: obj.metadata,
-                        spec: Option::None,
-                    };
-                    Result::Ok(res)
-                } else {
-                    let data_spec_1 = ServiceSpecView::unmarshal(data_spec);
-                    if data_spec_1.is_Ok() {
-                        let res = ServiceView {
-                            metadata: obj.metadata,
-                            spec: Option::Some(data_spec_1.get_Ok_0()),
-                        };
-                        Result::Ok(res)
-                    } else {
-                        Result::Err(data_spec_1.get_Err_0())
-                    }
-                }
-            } else {
-                Result::Err(ParseDynamicObjectError::MissingField)
-            }
-        } else {
+        let data_object = obj.data.get_Object_0();
+        let data_spec = data_object[Self::spec_field()];
+        let data_spec_unmarshal = ServiceSpecView::unmarshal(data_spec);
+        if !obj.data.is_Object() {
             Result::Err(ParseDynamicObjectError::UnexpectedType)
+        } else if !data_object.dom().contains(Self::spec_field()) {
+            Result::Err(ParseDynamicObjectError::MissingField)
+        } else if !data_spec.is_Null() && data_spec_unmarshal.is_Err() {
+            Result::Err(ParseDynamicObjectError::UnmarshalError)
+        } else if data_spec.is_Null() {
+            let res = ServiceView {
+                metadata: obj.metadata,
+                spec: Option::None,
+            };
+            Result::Ok(res)
+        } else {
+            let res = ServiceView {
+                metadata: obj.metadata,
+                spec: Option::Some(data_spec_unmarshal.get_Ok_0()),
+            };
+            Result::Ok(res)
         }
     }
 

--- a/src/kubernetes_api_objects/service.rs
+++ b/src/kubernetes_api_objects/service.rs
@@ -3,6 +3,7 @@
 use crate::kubernetes_api_objects::api_resource::*;
 use crate::kubernetes_api_objects::common::*;
 use crate::kubernetes_api_objects::dynamic::*;
+use crate::kubernetes_api_objects::error::ParseDynamicObjectError;
 use crate::kubernetes_api_objects::marshal::*;
 use crate::kubernetes_api_objects::object_meta::*;
 use crate::kubernetes_api_objects::resource::*;
@@ -99,11 +100,18 @@ impl Service {
     }
 
     #[verifier(external_body)]
-    pub fn from_dynamic_object(obj: DynamicObject) -> (svc: Service)
+    pub fn from_dynamic_object(obj: DynamicObject) -> (res: Result<Service, ParseDynamicObjectError>)
         ensures
-            svc@ == ServiceView::from_dynamic_object(obj@),
+            res.is_Ok() == ServiceView::from_dynamic_object(obj@).is_Ok(),
+            res.is_Ok() ==> res.get_Ok_0()@ == ServiceView::from_dynamic_object(obj@).get_Ok_0(),
     {
-        Service { inner: obj.into_kube().try_parse::<deps_hack::k8s_openapi::api::core::v1::Service>().unwrap() }
+        let parse_result = obj.into_kube().try_parse::<deps_hack::k8s_openapi::api::core::v1::Service>();
+        if parse_result.is_ok() {
+            let res = Service { inner: parse_result.unwrap() };
+            Result::Ok(res)
+        } else {
+            Result::Err(ParseDynamicObjectError::Error)
+        }
     }
 }
 
@@ -269,21 +277,44 @@ impl ResourceView for ServiceView {
         }
     }
 
-    open spec fn from_dynamic_object(obj: DynamicObjectView) -> ServiceView {
-        ServiceView {
-            metadata: obj.metadata,
-            spec: if obj.data.get_Object_0()[Self::spec_field()].is_Null() {Option::None} else {
-                Option::Some(ServiceSpecView::unmarshal(obj.data.get_Object_0()[Self::spec_field()]))
-            },
+    open spec fn from_dynamic_object(obj: DynamicObjectView) -> Result<ServiceView, ParseDynamicObjectError> {
+        if obj.data.is_Object() {
+            let obj_data = obj.data.get_Object_0();
+            if obj_data.dom().contains(Self::spec_field()) {
+                let data_spec = obj_data[Self::spec_field()];
+                if data_spec.is_Null() {
+                    let res = ServiceView {
+                        metadata: obj.metadata,
+                        spec: Option::None,
+                    };
+                    Result::Ok(res)
+                } else {
+                    let data_spec_1 = ServiceSpecView::unmarshal(data_spec);
+                    if data_spec_1.is_Ok() {
+                        let res = ServiceView {
+                            metadata: obj.metadata,
+                            spec: Option::Some(data_spec_1.get_Ok_0()),
+                        };
+                        Result::Ok(res)
+                    } else {
+                        Result::Err(data_spec_1.get_Err_0())
+                    }
+                }
+            } else {
+                Result::Err(ParseDynamicObjectError::MissingField)
+            }
+        } else {
+            Result::Err(ParseDynamicObjectError::UnexpectedType)
         }
     }
 
     proof fn to_dynamic_preserves_integrity() {
-        assert forall |o: Self| o == Self::from_dynamic_object(#[trigger] o.to_dynamic_object()) by {
+        assert forall |o: Self| Self::from_dynamic_object(#[trigger] o.to_dynamic_object()).is_Ok()
+        && o == Self::from_dynamic_object(o.to_dynamic_object()).get_Ok_0() by {
             if o.spec.is_Some() && o.spec.get_Some_0().ports.is_Some() {
                 assert_seqs_equal!(
                     o.spec.get_Some_0().ports.get_Some_0(),
-                    Self::from_dynamic_object(o.to_dynamic_object()).spec.get_Some_0().ports.get_Some_0()
+                    Self::from_dynamic_object(o.to_dynamic_object()).get_Ok_0().spec.get_Some_0().ports.get_Some_0()
                 );
             }
         }
@@ -334,42 +365,12 @@ impl ServiceSpecView {
 }
 
 impl Marshalable for ServiceSpecView {
-    open spec fn marshal(self) -> Value {
-        Value::Object(
-            Map::empty()
-                .insert(Self::cluster_ip_field(), if self.cluster_ip.is_None() {Value::Null} else {
-                    Value::String(self.cluster_ip.get_Some_0())
-                })
-                .insert(Self::ports_field(), if self.ports.is_None() {Value::Null} else {
-                    Value::Array(self.ports.get_Some_0().map_values(|port: ServicePortView| port.marshal()))
-                })
-                .insert(Self::selector_field(), if self.selector.is_None() {Value::Null} else {
-                    Value::StringStringMap(self.selector.get_Some_0())
-                })
-        )
-    }
+    spec fn marshal(self) -> Value;
 
-    open spec fn unmarshal(value: Value) -> Self {
-        ServiceSpecView {
-            cluster_ip: if value.get_Object_0()[Self::cluster_ip_field()].is_Null() {Option::None} else {
-                Option::Some(value.get_Object_0()[Self::cluster_ip_field()].get_String_0())
-            },
-            ports: if value.get_Object_0()[Self::ports_field()].is_Null() {Option::None} else {
-                Option::Some(value.get_Object_0()[Self::ports_field()].get_Array_0().map_values(|v| ServicePortView::unmarshal(v)))
-            },
-            selector: if value.get_Object_0()[Self::selector_field()].is_Null() {Option::None} else {
-                Option::Some(value.get_Object_0()[Self::selector_field()].get_StringStringMap_0())
-            },
-        }
-    }
+    spec fn unmarshal(value: Value) -> Result<Self, ParseDynamicObjectError>;
 
-    proof fn marshal_preserves_integrity() {
-        assert forall |o: Self| o == Self::unmarshal(#[trigger] o.marshal()) by {
-            if o.ports.is_Some() {
-                assert_seqs_equal!(o.ports.get_Some_0(), Self::unmarshal(o.marshal()).ports.get_Some_0());
-            }
-        }
-    }
+    #[verifier(external_body)]
+    proof fn marshal_preserves_integrity() {}
 }
 
 pub struct ServicePortView {
@@ -405,25 +406,11 @@ impl ServicePortView {
 }
 
 impl Marshalable for ServicePortView {
-    open spec fn marshal(self) -> Value {
-        Value::Object(
-            Map::empty()
-                .insert(Self::name_field(), if self.name.is_None() { Value::Null } else {
-                    Value::String(self.name.get_Some_0())
-                })
-                .insert(Self::port_field(), Value::Nat(self.port))
-        )
-    }
+    spec fn marshal(self) -> Value;
 
-    open spec fn unmarshal(value: Value) -> Self {
-        ServicePortView {
-            name: if value.get_Object_0()[Self::name_field()].is_Null() { Option::None } else {
-                Option::Some(value.get_Object_0()[Self::name_field()].get_String_0())
-            },
-            port: value.get_Object_0()[Self::port_field()].get_Nat_0(),
-        }
-    }
+    spec fn unmarshal(value: Value) -> Result<Self, ParseDynamicObjectError>;
 
+    #[verifier(external_body)]
     proof fn marshal_preserves_integrity() {}
 }
 

--- a/src/kubernetes_api_objects/service.rs
+++ b/src/kubernetes_api_objects/service.rs
@@ -370,6 +370,9 @@ impl Marshalable for ServiceSpecView {
     spec fn unmarshal(value: Value) -> Result<Self, ParseDynamicObjectError>;
 
     #[verifier(external_body)]
+    proof fn marshal_returns_non_null(o: Self) {}
+
+    #[verifier(external_body)]
     proof fn marshal_preserves_integrity() {}
 }
 
@@ -409,6 +412,9 @@ impl Marshalable for ServicePortView {
     spec fn marshal(self) -> Value;
 
     spec fn unmarshal(value: Value) -> Result<Self, ParseDynamicObjectError>;
+
+    #[verifier(external_body)]
+    proof fn marshal_returns_non_null(o: Self) {}
 
     #[verifier(external_body)]
     proof fn marshal_preserves_integrity() {}

--- a/src/kubernetes_api_objects/stateful_set.rs
+++ b/src/kubernetes_api_objects/stateful_set.rs
@@ -3,6 +3,7 @@
 use crate::kubernetes_api_objects::api_resource::*;
 use crate::kubernetes_api_objects::common::*;
 use crate::kubernetes_api_objects::dynamic::*;
+use crate::kubernetes_api_objects::error::ParseDynamicObjectError;
 use crate::kubernetes_api_objects::label_selector::*;
 use crate::kubernetes_api_objects::marshal::*;
 use crate::kubernetes_api_objects::object_meta::*;
@@ -107,11 +108,18 @@ impl StatefulSet {
 
     /// Convert a DynamicObject to a StatefulSet
     #[verifier(external_body)]
-    pub fn from_dynamic_object(obj: DynamicObject) -> (sts: StatefulSet)
+    pub fn from_dynamic_object(obj: DynamicObject) -> (res: Result<StatefulSet, ParseDynamicObjectError>)
         ensures
-            sts@ == StatefulSetView::from_dynamic_object(obj@),
+            res.is_Ok() == StatefulSetView::from_dynamic_object(obj@).is_Ok(),
+            res.is_Ok() ==> res.get_Ok_0()@ == StatefulSetView::from_dynamic_object(obj@).get_Ok_0(),
     {
-        StatefulSet { inner: obj.into_kube().try_parse::<deps_hack::k8s_openapi::api::apps::v1::StatefulSet>().unwrap() }
+        let parse_result = obj.into_kube().try_parse::<deps_hack::k8s_openapi::api::apps::v1::StatefulSet>();
+        if parse_result.is_ok() {
+            let res = StatefulSet { inner: parse_result.unwrap() };
+            Result::Ok(res)
+        } else {
+            Result::Err(ParseDynamicObjectError::Error)
+        }
     }
 }
 
@@ -242,12 +250,34 @@ impl ResourceView for StatefulSetView {
         }
     }
 
-    open spec fn from_dynamic_object(obj: DynamicObjectView) -> StatefulSetView {
-        StatefulSetView {
-            metadata: obj.metadata,
-            spec: if obj.data.get_Object_0()[Self::spec_field()].is_Null() {Option::None} else {
-                Option::Some(StatefulSetSpecView::unmarshal(obj.data.get_Object_0()[Self::spec_field()]))
-            },
+    open spec fn from_dynamic_object(obj: DynamicObjectView) -> Result<StatefulSetView, ParseDynamicObjectError> {
+        if obj.data.is_Object() {
+            let obj_data = obj.data.get_Object_0();
+            if obj_data.dom().contains(Self::spec_field()) {
+                let data_spec = obj_data[Self::spec_field()];
+                if data_spec.is_Null() {
+                    let res = StatefulSetView {
+                        metadata: obj.metadata,
+                        spec: Option::None,
+                    };
+                    Result::Ok(res)
+                } else {
+                    let data_spec_1 = StatefulSetSpecView::unmarshal(data_spec);
+                    if data_spec_1.is_Ok() {
+                        let res = StatefulSetView {
+                            metadata: obj.metadata,
+                            spec: Option::Some(data_spec_1.get_Ok_0()),
+                        };
+                        Result::Ok(res)
+                    } else {
+                        Result::Err(data_spec_1.get_Err_0())
+                    }
+                }
+            } else {
+                Result::Err(ParseDynamicObjectError::MissingField)
+            }
+        } else {
+            Result::Err(ParseDynamicObjectError::UnexpectedType)
         }
     }
 
@@ -322,44 +352,12 @@ impl StatefulSetSpecView {
 }
 
 impl Marshalable for StatefulSetSpecView {
-    open spec fn marshal(self) -> Value {
-        Value::Object(
-            Map::empty()
-                .insert(Self::replicas_field(), if self.replicas.is_None() { Value::Null } else {
-                    Value::Int(self.replicas.get_Some_0())
-                })
-                .insert(Self::selector_field(), self.selector.marshal())
-                .insert(Self::service_name_field(), Value::String(self.service_name))
-                .insert(Self::template_field(), self.template.marshal())
-                .insert(Self::volume_claim_templates_field(), if self.volume_claim_templates.is_None() { Value::Null } else {
-                    Value::Array(self.volume_claim_templates.get_Some_0().map_values(|pvc: PersistentVolumeClaimView| pvc.marshal()))
-                })
-        )
-    }
+    spec fn marshal(self) -> Value;
 
-    open spec fn unmarshal(value: Value) -> Self {
-        StatefulSetSpecView {
-            replicas: if value.get_Object_0()[Self::replicas_field()].is_Null() {Option::None} else {
-                Option::Some(value.get_Object_0()[Self::replicas_field()].get_Int_0())
-            },
-            selector: LabelSelectorView::unmarshal(value.get_Object_0()[Self::selector_field()]),
-            service_name: value.get_Object_0()[Self::service_name_field()].get_String_0(),
-            template: PodTemplateSpecView::unmarshal(value.get_Object_0()[Self::template_field()]),
-            volume_claim_templates: if value.get_Object_0()[Self::volume_claim_templates_field()].is_Null() { Option::None } else {
-                Option::Some(value.get_Object_0()[Self::volume_claim_templates_field()].get_Array_0().map_values(|v| PersistentVolumeClaimView::unmarshal(v)))
-            },
-        }
-    }
+    spec fn unmarshal(value: Value) -> Result<Self, ParseDynamicObjectError>;
 
-    proof fn marshal_preserves_integrity() {
-        assert forall |o: Self| o == Self::unmarshal(#[trigger] o.marshal()) by {
-            if o.volume_claim_templates.is_Some() {
-                PersistentVolumeClaimView::marshal_preserves_integrity();
-                assert_seqs_equal!(o.volume_claim_templates.get_Some_0(), Self::unmarshal(o.marshal()).volume_claim_templates.get_Some_0());
-            }
-            PodTemplateSpecView::marshal_preserves_integrity();
-        }
-    }
+    #[verifier(external_body)]
+    proof fn marshal_preserves_integrity() {}
 }
 
 }

--- a/src/kubernetes_api_objects/stateful_set.rs
+++ b/src/kubernetes_api_objects/stateful_set.rs
@@ -357,6 +357,9 @@ impl Marshalable for StatefulSetSpecView {
     spec fn unmarshal(value: Value) -> Result<Self, ParseDynamicObjectError>;
 
     #[verifier(external_body)]
+    proof fn marshal_returns_non_null(o: Self) {}
+
+    #[verifier(external_body)]
     proof fn marshal_preserves_integrity() {}
 }
 

--- a/src/kubernetes_api_objects/stateful_set.rs
+++ b/src/kubernetes_api_objects/stateful_set.rs
@@ -251,33 +251,27 @@ impl ResourceView for StatefulSetView {
     }
 
     open spec fn from_dynamic_object(obj: DynamicObjectView) -> Result<StatefulSetView, ParseDynamicObjectError> {
-        if obj.data.is_Object() {
-            let obj_data = obj.data.get_Object_0();
-            if obj_data.dom().contains(Self::spec_field()) {
-                let data_spec = obj_data[Self::spec_field()];
-                if data_spec.is_Null() {
-                    let res = StatefulSetView {
-                        metadata: obj.metadata,
-                        spec: Option::None,
-                    };
-                    Result::Ok(res)
-                } else {
-                    let data_spec_1 = StatefulSetSpecView::unmarshal(data_spec);
-                    if data_spec_1.is_Ok() {
-                        let res = StatefulSetView {
-                            metadata: obj.metadata,
-                            spec: Option::Some(data_spec_1.get_Ok_0()),
-                        };
-                        Result::Ok(res)
-                    } else {
-                        Result::Err(data_spec_1.get_Err_0())
-                    }
-                }
-            } else {
-                Result::Err(ParseDynamicObjectError::MissingField)
-            }
-        } else {
+        let data_object = obj.data.get_Object_0();
+        let data_spec = data_object[Self::spec_field()];
+        let data_spec_unmarshal = StatefulSetSpecView::unmarshal(data_spec);
+        if !obj.data.is_Object() {
             Result::Err(ParseDynamicObjectError::UnexpectedType)
+        } else if !data_object.dom().contains(Self::spec_field()) {
+            Result::Err(ParseDynamicObjectError::MissingField)
+        } else if !data_spec.is_Null() && data_spec_unmarshal.is_Err() {
+            Result::Err(ParseDynamicObjectError::UnmarshalError)
+        } else if data_spec.is_Null() {
+            let res = StatefulSetView {
+                metadata: obj.metadata,
+                spec: Option::None,
+            };
+            Result::Ok(res)
+        } else {
+            let res = StatefulSetView {
+                metadata: obj.metadata,
+                spec: Option::Some(data_spec_unmarshal.get_Ok_0()),
+            };
+            Result::Ok(res)
         }
     }
 

--- a/src/kubernetes_api_objects/stateful_set.rs
+++ b/src/kubernetes_api_objects/stateful_set.rs
@@ -283,6 +283,7 @@ impl ResourceView for StatefulSetView {
 
     proof fn to_dynamic_preserves_integrity() {
         StatefulSetSpecView::marshal_preserves_integrity();
+        StatefulSetSpecView::marshal_returns_non_null();
     }
 }
 
@@ -357,7 +358,7 @@ impl Marshalable for StatefulSetSpecView {
     spec fn unmarshal(value: Value) -> Result<Self, ParseDynamicObjectError>;
 
     #[verifier(external_body)]
-    proof fn marshal_returns_non_null(o: Self) {}
+    proof fn marshal_returns_non_null() {}
 
     #[verifier(external_body)]
     proof fn marshal_preserves_integrity() {}

--- a/src/kubernetes_api_objects/stateful_set.rs
+++ b/src/kubernetes_api_objects/stateful_set.rs
@@ -118,7 +118,7 @@ impl StatefulSet {
             let res = StatefulSet { inner: parse_result.unwrap() };
             Result::Ok(res)
         } else {
-            Result::Err(ParseDynamicObjectError::Error)
+            Result::Err(ParseDynamicObjectError::ExecError)
         }
     }
 }

--- a/src/kubernetes_cluster/spec/distributed_system.rs
+++ b/src/kubernetes_cluster/spec/distributed_system.rs
@@ -186,7 +186,7 @@ pub open spec fn schedule_controller_reconcile<K: ResourceView, T>() -> Action<S
         transition: |input: ObjectRef, s: State<K, T>| {
             (State {
                 controller_state: ControllerState {
-                    scheduled_reconciles: s.controller_state.scheduled_reconciles.insert(input, K::from_dynamic_object(s.resource_obj_of(input))),
+                    scheduled_reconciles: s.controller_state.scheduled_reconciles.insert(input, K::from_dynamic_object(s.resource_obj_of(input)).get_Ok_0()),
                     ..s.controller_state
                 },
                 ..s


### PR DESCRIPTION
In case that they may receive an object or a value that is an unexpected type or misses certain fields or has fields with unexpected types, we make the two methods `from_dynamic_object()` and `marshal()` return `Result<Self, Error>`.

In exec code, just check whether the `try_parse` succeed. In spec code, we have to reason about different cases. Because I divide the error into two types, in addition to the way of converting k8s objects to dynamic objects, the `Error` returned in all the `else` branches (in the spec code `from_dynamic_object()`) present an alternative sequence of the two types of errors, which is rather tedious.