### PR TITLE
Add downscaling support to the reference Zookeeper controller

### DIFF
--- a/reference-controllers/zookeeper-controller/src/resources.rs
+++ b/reference-controllers/zookeeper-controller/src/resources.rs
@@ -29,6 +29,12 @@ pub fn make_statefulset(zk: &ZookeeperCluster) -> appsv1::StatefulSet {
                 )])),
                 ..metav1::LabelSelector::default()
             },
+            persistent_volume_claim_retention_policy: Some(
+                appsv1::StatefulSetPersistentVolumeClaimRetentionPolicy {
+                    when_deleted: Some("Delete".to_string()),
+                    when_scaled: Some("Delete".to_string()),
+                },
+            ),
             template: corev1::PodTemplateSpec {
                 metadata: Some(metav1::ObjectMeta {
                     generate_name: zk.meta().name.clone(),


### PR DESCRIPTION
The key is to set the `StatefulSetPersistentVolumeClaimRetentionPolicy` field to allow the statefulSet controller to clean up the unused pvc during deletion and downscaling.

There are two fields in `StatefulSetPersistentVolumeClaimRetentionPolicy`: `when_deleted` controls whether to delete the pvcs if the statefulset is deleted, and `when_scaled` controls whether to delete the pvcs which is not used by any pod (the pod that previously used the pvc has been deleted). Note that `when_scaled` will also block upscaling until the pvc gets delete to prevent the pod from using stale pvc. More information can be found here: https://kubernetes.io/blog/2021/12/16/kubernetes-1-23-statefulset-pvc-auto-deletion/

`StatefulSetPersistentVolumeClaimRetentionPolicy` is still in alpha stage for Kubernetes 1.23 ~ 1.26 and beta stage for Kubernetes 1.27 and needs to be explicitly enabled through feature gates. See https://kubernetes.io/docs/reference/command-line-tools-reference/feature-gates/