### PR TITLE
Add trusted lemma `spec_integrity_is_preserved_by_marshal` to each Kubernetes object

### DIFF
--- a/src/controller_examples/simple_controller/spec/custom_resource.rs
+++ b/src/controller_examples/simple_controller/spec/custom_resource.rs
@@ -97,7 +97,18 @@ impl ResourceWrapper<deps_hack::SimpleCR> for CustomResource {
     }
 }
 
-impl CustomResourceView {}
+impl CustomResourceView {
+    pub closed spec fn marshal_spec(s: CustomResourceSpecView) -> Value;
+
+    pub closed spec fn unmarshal_spec(v: Value) -> Result<CustomResourceSpecView, ParseDynamicObjectError>;
+
+    #[verifier(external_body)]
+    pub proof fn spec_integrity_is_preserved_by_marshal()
+        ensures
+            forall |s: CustomResourceSpecView|
+                Self::unmarshal_spec(#[trigger] Self::marshal_spec(s)).is_Ok()
+                && s == Self::unmarshal_spec(Self::marshal_spec(s)).get_Ok_0() {}
+}
 
 impl ResourceView for CustomResourceView {
     open spec fn metadata(self) -> ObjectMetaView {
@@ -120,31 +131,23 @@ impl ResourceView for CustomResourceView {
         DynamicObjectView {
             kind: self.kind(),
             metadata: self.metadata,
-            data: Value::Object(Map::empty().insert(spec_field(), self.spec.marshal())),
+            data: CustomResourceView::marshal_spec(self.spec),
         }
     }
 
     open spec fn from_dynamic_object(obj: DynamicObjectView) -> Result<CustomResourceView, ParseDynamicObjectError> {
-        let data_object = obj.data.get_Object_0();
-        let data_spec_unmarshal = CustomResourceSpecView::unmarshal(data_object[spec_field()]);
-        if !obj.data.is_Object() {
-            Result::Err(ParseDynamicObjectError::UnexpectedType)
-        } else if !data_object.dom().contains(spec_field()) {
-            Result::Err(ParseDynamicObjectError::MissingField)
-        } else if data_spec_unmarshal.is_Err() {
+        if !CustomResourceView::unmarshal_spec(obj.data).is_Ok() {
             Result::Err(ParseDynamicObjectError::UnmarshalError)
         } else {
-            let res = CustomResourceView {
+            Result::Ok(CustomResourceView {
                 metadata: obj.metadata,
-                spec: data_spec_unmarshal.get_Ok_0(),
-            };
-            Result::Ok(res)
+                spec: CustomResourceView::unmarshal_spec(obj.data).get_Ok_0(),
+            })
         }
     }
 
     proof fn to_dynamic_preserves_integrity() {
-        CustomResourceSpecView::marshal_preserves_integrity();
-        CustomResourceSpecView::marshal_returns_non_null();
+        CustomResourceView::spec_integrity_is_preserved_by_marshal();
     }
 }
 
@@ -180,10 +183,5 @@ impl Marshalable for CustomResourceSpecView {
     #[verifier(external_body)]
     proof fn marshal_preserves_integrity() {}
 }
-
-
-pub open spec fn spec_field() -> nat {0}
-
-pub open spec fn spec_content_field() -> nat {0}
 
 }

--- a/src/kubernetes_api_objects/config_map.rs
+++ b/src/kubernetes_api_objects/config_map.rs
@@ -130,6 +130,14 @@ pub struct ConfigMapView {
     pub data: Option<Map<StringView, StringView>>,
 }
 
+/// This ConfigMapSpecView is defined only to call marshal_spec and unmarshal_spec conveniently
+/// Unlike most other Kubernetes objects, a ConfigMap does not have a spec field,
+/// but its data, binary_data and immutable fields are treated similarly as spec of other objects.
+/// Here we use a tuple to wrap around ConfigMap's fields (we will implement more fields like binary_data later)
+/// instead of defining another struct.
+///
+/// We use a unit type in the tuple because there has to be at least two members in a tuple.
+/// The unit type will be replaced once we support other fields than data.
 type ConfigMapSpecView = (Option<Map<StringView, StringView>>, ());
 
 impl ConfigMapView {

--- a/src/kubernetes_api_objects/resource.rs
+++ b/src/kubernetes_api_objects/resource.rs
@@ -3,6 +3,7 @@
 use crate::kubernetes_api_objects::common::*;
 use crate::kubernetes_api_objects::dynamic::*;
 use crate::kubernetes_api_objects::error::ParseDynamicObjectError;
+use crate::kubernetes_api_objects::marshal::*;
 use crate::kubernetes_api_objects::object_meta::*;
 use crate::pervasive_ext::string_view::*;
 use vstd::prelude::*;


### PR DESCRIPTION
This PR adds a trusted lemma `spec_integrity_is_preserved_by_marshal` to each Kubernetes object, which says that the spec field of each object, after marshal and unmarshal, remains unchanged.

The main purpose is to help simplify reasoning about any execution where the controller creates an object and later gets the object and makes decisions based on the object's spec field. This lemma can help prove that the object's spec remains the same as when the controller creates the object if no updates happen to the object.

The existing lemma `to_dynamic_preserves_integrity` seems can do the same job but actually not: every time when creating or updating the object, the k8s API state machine will set certain fields in metadata such as resource_version, so the DynamicObject stored in etcd is not exactly the same one that was sent on the controller's create/update request.

This is inspired by the change made by #132 .
