### PR TITLE
Update statefulset for zookeeper controller

### DIFF
--- a/src/controller_examples/zookeeper_controller/common/mod.rs
+++ b/src/controller_examples/zookeeper_controller/common/mod.rs
@@ -13,6 +13,7 @@ pub enum ZookeeperReconcileStep {
     AfterCreateClientService,
     AfterCreateAdminServerService,
     AfterCreateConfigMap,
+    AfterGetStatefulSet,
     Done,
     Error,
 }

--- a/src/controller_examples/zookeeper_controller/exec/reconciler.rs
+++ b/src/controller_examples/zookeeper_controller/exec/reconciler.rs
@@ -185,17 +185,16 @@ pub fn reconcile_core(
                 let get_sts_resp = resp_o.unwrap().into_get_response().res;
                 if get_sts_resp.is_ok() {
                     // update
-                    let old_sts_o = get_sts_resp.unwrap();
-                    let update_sts = StatefulSet::from_dynamic_object(old_sts_o);
-                    if update_sts.is_ok() {
-                        let mut update_sts = update_sts.unwrap();
-                        update_sts.set_spec(stateful_set.spec().unwrap());
+                    let found_stateful_set = StatefulSet::from_dynamic_object(get_sts_resp.unwrap());
+                    if found_stateful_set.is_ok() {
+                        let mut new_stateful_set = found_stateful_set.unwrap();
+                        new_stateful_set.set_spec(stateful_set.spec().unwrap());
                         let req_o = Option::Some(KubeAPIRequest::UpdateRequest(
                             KubeUpdateRequest {
                                 api_resource: StatefulSet::api_resource(),
                                 name: stateful_set.metadata().name().unwrap(),
                                 namespace: zk.namespace().unwrap(),
-                                obj: update_sts.to_dynamic_object(),
+                                obj: new_stateful_set.to_dynamic_object(),
                             }
                         ));
                         let state_prime = ZookeeperReconcileState {

--- a/src/controller_examples/zookeeper_controller/spec/reconciler.rs
+++ b/src/controller_examples/zookeeper_controller/spec/reconciler.rs
@@ -121,9 +121,8 @@ pub open spec fn reconcile_core(
                 let get_sts_resp = resp_o.get_Some_0().get_GetResponse_0().res;
                 if get_sts_resp.is_Ok() {
                     // update
-                    let old_sts_o = get_sts_resp.get_Ok_0();
-                    let update_sts_obj = StatefulSetView::from_dynamic_object(old_sts_o);
-                    if update_sts_obj.is_Ok() {
+                    let found_stateful_set = StatefulSetView::from_dynamic_object(get_sts_resp.get_Ok_0(););
+                    if found_stateful_set.is_Ok() {
                         let req_o = Option::Some(APIRequest::UpdateRequest(
                             UpdateRequest {
                                 key: ObjectRef {
@@ -131,7 +130,7 @@ pub open spec fn reconcile_core(
                                     name: stateful_set.metadata.name.get_Some_0(),
                                     namespace: zk.metadata.namespace.get_Some_0(),
                                 },
-                                obj: update_sts_obj.get_Ok_0().set_spec(stateful_set.spec.get_Some_0()).to_dynamic_object(),
+                                obj: found_stateful_set.get_Ok_0().set_spec(stateful_set.spec.get_Some_0()).to_dynamic_object(),
                             }
                         ));
                         let state_prime = ZookeeperReconcileState {

--- a/src/controller_examples/zookeeper_controller/spec/reconciler.rs
+++ b/src/controller_examples/zookeeper_controller/spec/reconciler.rs
@@ -121,7 +121,7 @@ pub open spec fn reconcile_core(
                 let get_sts_resp = resp_o.get_Some_0().get_GetResponse_0().res;
                 if get_sts_resp.is_Ok() {
                     // update
-                    let found_stateful_set = StatefulSetView::from_dynamic_object(get_sts_resp.get_Ok_0(););
+                    let found_stateful_set = StatefulSetView::from_dynamic_object(get_sts_resp.get_Ok_0());
                     if found_stateful_set.is_Ok() {
                         let req_o = Option::Some(APIRequest::UpdateRequest(
                             UpdateRequest {

--- a/src/kubernetes_api_objects/config_map.rs
+++ b/src/kubernetes_api_objects/config_map.rs
@@ -46,7 +46,7 @@ impl ConfigMap {
         ensures
             metadata@ == self@.metadata,
     {
-        todo!()
+        ObjectMeta::from_kube(self.inner.metadata.clone())
     }
 
     #[verifier(external_body)]

--- a/src/kubernetes_api_objects/dynamic.rs
+++ b/src/kubernetes_api_objects/dynamic.rs
@@ -34,7 +34,7 @@ impl DynamicObject {
         ensures
             metadata@ == self@.metadata,
     {
-        todo!()
+        ObjectMeta::from_kube(self.inner.metadata.clone())
     }
 
     #[verifier(external_body)]

--- a/src/kubernetes_api_objects/error.rs
+++ b/src/kubernetes_api_objects/error.rs
@@ -25,4 +25,15 @@ pub enum ParseDynamicObjectError {
     ExecError,
 }
 
+impl APIError {
+    pub fn is_object_not_found(&self) -> (res: bool)
+        ensures res <==> self.is_ObjectNotFound(),
+    {
+        match self {
+            APIError::ObjectNotFound => true,
+            _ => false,
+        }
+    }
+}
+
 }

--- a/src/kubernetes_api_objects/persistent_volume_claim.rs
+++ b/src/kubernetes_api_objects/persistent_volume_claim.rs
@@ -47,7 +47,7 @@ impl PersistentVolumeClaim {
         ensures
             metadata@ == self@.metadata,
     {
-        todo!()
+        ObjectMeta::from_kube(self.inner.metadata.clone())
     }
 
     #[verifier(external_body)]

--- a/src/kubernetes_api_objects/persistent_volume_claim.rs
+++ b/src/kubernetes_api_objects/persistent_volume_claim.rs
@@ -78,7 +78,7 @@ impl PersistentVolumeClaim {
     #[verifier(external_body)]
     pub fn api_resource() -> (res: ApiResource)
         ensures
-            res@.kind == Kind::CustomResourceKind,
+            res@.kind == Kind::PersistentVolumeClaimKind,
     {
         ApiResource::from_kube(deps_hack::kube::api::ApiResource::erase::<deps_hack::k8s_openapi::api::core::v1::PersistentVolumeClaim>(&()))
     }

--- a/src/kubernetes_api_objects/pod.rs
+++ b/src/kubernetes_api_objects/pod.rs
@@ -86,7 +86,7 @@ impl Pod {
     #[verifier(external_body)]
     pub fn api_resource() -> (res: ApiResource)
         ensures
-            res@.kind == Kind::CustomResourceKind,
+            res@.kind == Kind::PodKind,
     {
         ApiResource::from_kube(deps_hack::kube::api::ApiResource::erase::<deps_hack::k8s_openapi::api::core::v1::Pod>(&()))
     }

--- a/src/kubernetes_api_objects/pod.rs
+++ b/src/kubernetes_api_objects/pod.rs
@@ -50,7 +50,7 @@ impl Pod {
         ensures
             metadata@ == self@.metadata,
     {
-        todo!()
+        ObjectMeta::from_kube(self.inner.metadata.clone())
     }
 
     #[verifier(external_body)]

--- a/src/kubernetes_api_objects/service.rs
+++ b/src/kubernetes_api_objects/service.rs
@@ -48,7 +48,7 @@ impl Service {
         ensures
             metadata@ == self@.metadata,
     {
-        todo!()
+        ObjectMeta::from_kube(self.inner.metadata.clone())
     }
 
     #[verifier(external_body)]

--- a/src/kubernetes_api_objects/service.rs
+++ b/src/kubernetes_api_objects/service.rs
@@ -84,7 +84,7 @@ impl Service {
     #[verifier(external_body)]
     pub fn api_resource() -> (res: ApiResource)
         ensures
-            res@.kind == Kind::CustomResourceKind,
+            res@.kind == Kind::ServiceKind,
     {
         ApiResource::from_kube(deps_hack::kube::api::ApiResource::erase::<deps_hack::k8s_openapi::api::core::v1::Service>(&()))
     }

--- a/src/kubernetes_api_objects/stateful_set.rs
+++ b/src/kubernetes_api_objects/stateful_set.rs
@@ -54,7 +54,7 @@ impl StatefulSet {
         ensures
             metadata@ == self@.metadata,
     {
-        todo!()
+        ObjectMeta::from_kube(self.inner.metadata.clone())
     }
 
     #[verifier(external_body)]
@@ -63,7 +63,11 @@ impl StatefulSet {
             self@.spec.is_Some() == spec.is_Some(),
             spec.is_Some() ==> spec.get_Some_0()@ == self@.spec.get_Some_0(),
     {
-        todo!()
+        if self.inner.spec.is_none() {
+            Option::None
+        } else {
+            Option::Some(StatefulSetSpec::from_kube(self.inner.spec.get_some().clone()))
+        }
     }
 
     #[verifier(external_body)]

--- a/src/kubernetes_api_objects/stateful_set.rs
+++ b/src/kubernetes_api_objects/stateful_set.rs
@@ -66,7 +66,7 @@ impl StatefulSet {
         if self.inner.spec.is_none() {
             Option::None
         } else {
-            Option::Some(StatefulSetSpec::from_kube(self.inner.spec.get_some().clone()))
+            Option::Some(StatefulSetSpec::from_kube(self.inner.spec.as_ref().unwrap().clone()))
         }
     }
 
@@ -86,15 +86,10 @@ impl StatefulSet {
         self.inner.spec = std::option::Option::Some(spec.into_kube());
     }
 
-    #[verifier(external)]
-    pub fn into_kube(self) -> deps_hack::k8s_openapi::api::apps::v1::StatefulSet {
-        self.inner
-    }
-
     #[verifier(external_body)]
     pub fn api_resource() -> (res: ApiResource)
         ensures
-            res@.kind == Kind::CustomResourceKind,
+            res@.kind == Kind::StatefulSetKind,
     {
         ApiResource::from_kube(deps_hack::kube::api::ApiResource::erase::<deps_hack::k8s_openapi::api::apps::v1::StatefulSet>(&()))
     }
@@ -124,6 +119,18 @@ impl StatefulSet {
         } else {
             Result::Err(ParseDynamicObjectError::ExecError)
         }
+    }
+}
+
+impl ResourceWrapper<deps_hack::k8s_openapi::api::apps::v1::StatefulSet> for StatefulSet {
+    #[verifier(external)]
+    fn from_kube(inner: deps_hack::k8s_openapi::api::apps::v1::StatefulSet) -> StatefulSet {
+        StatefulSet { inner: inner }
+    }
+
+    #[verifier(external)]
+    fn into_kube(self) -> deps_hack::k8s_openapi::api::apps::v1::StatefulSet {
+        self.inner
     }
 }
 
@@ -187,8 +194,17 @@ impl StatefulSetSpec {
         )
     }
 
+
+}
+
+impl ResourceWrapper<deps_hack::k8s_openapi::api::apps::v1::StatefulSetSpec> for StatefulSetSpec {
     #[verifier(external)]
-    pub fn into_kube(self) -> deps_hack::k8s_openapi::api::apps::v1::StatefulSetSpec {
+    fn from_kube(inner: deps_hack::k8s_openapi::api::apps::v1::StatefulSetSpec) -> StatefulSetSpec {
+        StatefulSetSpec { inner: inner }
+    }
+
+    #[verifier(external)]
+    fn into_kube(self) -> deps_hack::k8s_openapi::api::apps::v1::StatefulSetSpec {
         self.inner
     }
 }

--- a/src/shim_layer/mod.rs
+++ b/src/shim_layer/mod.rs
@@ -184,7 +184,7 @@ where
                     );
                     let pp = PostParams::default();
                     let obj_to_update = update_req.obj.into_kube();
-                    match api.replace(update_req.name.as_rust_string_ref(), &&pp, &obj_to_update).await {
+                    match api.replace(update_req.name.as_rust_string_ref(), &pp, &obj_to_update).await {
                         std::result::Result::Err(err) => {
                             resp_option = Option::Some(KubeAPIResponse::UpdateResponse(
                                 KubeUpdateResponse{

--- a/src/shim_layer/mod.rs
+++ b/src/shim_layer/mod.rs
@@ -178,6 +178,31 @@ where
                         },
                     }
                 },
+                KubeAPIRequest::UpdateRequest(update_req) => {
+                    let api = Api::<deps_hack::kube::api::DynamicObject>::namespaced_with(
+                        client.clone(), update_req.namespace.as_rust_string_ref(), update_req.api_resource.as_kube_ref()
+                    );
+                    let pp = PostParams::default();
+                    let obj_to_update = update_req.obj.into_kube();
+                    match api.replace(update_req.name.as_rust_string_ref(), &&pp, &obj_to_update).await {
+                        std::result::Result::Err(err) => {
+                            resp_option = Option::Some(KubeAPIResponse::UpdateResponse(
+                                KubeUpdateResponse{
+                                    res: vstd::result::Result::Err(kube_error_to_ghost(&err)),
+                                }
+                            ));
+                            println!("Update failed with error: {}", err);
+                        },
+                        std::result::Result::Ok(obj) => {
+                            resp_option = Option::Some(KubeAPIResponse::UpdateResponse(
+                                KubeUpdateResponse{
+                                    res: vstd::result::Result::Ok(DynamicObject::from_kube(obj)),
+                                }
+                            ));
+                            println!("Update done");
+                        },
+                    }
+                },
                 _ => {
                     panic!("Not supported yet");
                 }


### PR DESCRIPTION
In `reconcile_core` of the zookeeper controller, after creating config map, first send a get request to check whether the statefulset already exists in etcd.