### PR TITLE
Prove pending requests with old chan_id eventually are all gone

### DIFF
--- a/src/kubernetes_cluster/spec/distributed_system.rs
+++ b/src/kubernetes_cluster/spec/distributed_system.rs
@@ -73,6 +73,10 @@ impl<K: ResourceView, T> State<K, T> {
     pub open spec fn reconcile_scheduled_for(self, key: ObjectRef) -> bool {
         self.controller_state.scheduled_reconciles.contains_key(key)
     }
+
+    pub open spec fn chan_id_is_no_smaller_than(self, chan_id: nat) -> bool {
+        self.chan_manager.cur_chan_id >= chan_id
+    }
 }
 
 pub open spec fn init<K: ResourceView, T, ReconcilerType: Reconciler<K ,T>>() -> StatePred<State<K, T>> {

--- a/src/pervasive_ext/mod.rs
+++ b/src/pervasive_ext/mod.rs
@@ -1,5 +1,6 @@
 // Copyright 2022 VMware, Inc.
 // SPDX-License-Identifier: MIT
+pub mod multiset_lemmas;
 pub mod seq_lemmas;
 pub mod string_map;
 pub mod string_view;

--- a/src/pervasive_ext/multiset_lemmas.rs
+++ b/src/pervasive_ext/multiset_lemmas.rs
@@ -1,0 +1,21 @@
+// Copyright 2022 VMware, Inc.
+// SPDX-License-Identifier: MIT
+#![allow(unused_imports)]
+use builtin::*;
+use builtin_macros::*;
+use vstd::multiset::*;
+
+verus! {
+
+pub proof fn len_is_zero_if_count_for_each_value_is_zero<V>(m: Multiset<V>)
+    requires
+        forall |v| m.count(v) == 0,
+    ensures
+        m.len() == 0,
+{
+    if m.len() != 0 {
+        assert(m.count(m.choose()) > 0);
+    }
+}
+
+}

--- a/src/temporal_logic/rules.rs
+++ b/src/temporal_logic/rules.rs
@@ -871,23 +871,6 @@ pub proof fn leads_to_exists_intro<T, A>(spec: TempPred<T>, a_to_p: FnSpec(A) ->
     };
 }
 
-/// If we have proved that forall |a| spec |= p.and(a_to_q(a)) ~> r,
-/// and we know that exists |a| a_to_q(a) is always true,
-/// then we can conclude spec |= p ~> r
-pub proof fn merge_all_cases_for_leads_to<T, A>(spec: TempPred<T>, p: TempPred<T>, a_to_q: FnSpec(A) -> TempPred<T>, r: TempPred<T>)
-    requires
-        forall |a: A| #[trigger] spec.entails(p.and(a_to_q(a)).leads_to(r)),
-        tla_exists(a_to_q) == true_pred::<T>(),
-    ensures
-        spec.entails(p.leads_to(r)),
-{
-    let a_to_p_and_q = |a: A| p.and(a_to_q(a));
-    leads_to_exists_intro(spec, a_to_p_and_q, r);
-    a_to_temp_pred_equality(|a: A| p.and(a_to_q(a)), |a: A| a_to_q(a).and(p));
-    tla_exists_and_equality(a_to_q, p);
-    temp_pred_equality(true_pred::<T>().and(p), p);
-}
-
 /// This lemmas instantiates tla_forall for a.
 pub proof fn use_tla_forall<T, A>(spec: TempPred<T>, a_to_p: FnSpec(A) -> TempPred<T>, a: A)
     requires


### PR DESCRIPTION
This PR proves that from any arbitrary state (`true_pred()`), all the APIRequest messages sent to the Kubernetes API with a chan_id smaller than a specific nat will eventually leave the network.

This lemma is particularly important when proving the object remains in a particular state stably given that update operations are supported in the Kubernetes API state machine. Although it is obvious that the controller always tries to maintain the object in a stable state (by updating the object with the same spec, assuming the CR remains unchanged),
we also need to somehow show that there are no other update requests in the network that can drive the object to a different state -- such requests might come from the previously crashed controller (they crash right after sending out an update request). An important step in the liveness proof here is to prove such requests will eventually leave the network (i.e., all get handled by the Kubernetes API) so they no longer update the object managed by the controller. And after that point the controller will update the object to the desired state and no one will interfere with the object again.

Note that this lemma will become even more useful if later we add the specification for other controllers that might interfere with our verified controller (by updating the object managed by the controller) but eventually stop interfering.

To prove this lemma, we also need some more support from vstd::multiset: https://github.com/verus-lang/verus/pull/579.