### PR TITLE
Make kind() an associated function, instead of a method

### DIFF
--- a/src/controller_examples/rabbitmq_controller/spec/rabbitmqcluster.rs
+++ b/src/controller_examples/rabbitmq_controller/spec/rabbitmqcluster.rs
@@ -62,7 +62,7 @@ impl RabbitmqCluster {
     #[verifier(external_body)]
     pub fn api_resource() -> (res: ApiResource)
         ensures
-            res@.kind == Kind::CustomResourceKind,
+            res@.kind == RabbitmqClusterView::kind(),
     {
         ApiResource::from_kube(deps_hack::kube::api::ApiResource::erase::<deps_hack::RabbitmqCluster>(&()))
     }
@@ -135,13 +135,13 @@ impl ResourceView for RabbitmqClusterView {
         self.metadata
     }
 
-    open spec fn kind(self) -> Kind {
+    open spec fn kind() -> Kind {
         Kind::CustomResourceKind
     }
 
     open spec fn object_ref(self) -> ObjectRef {
         ObjectRef {
-            kind: self.kind(),
+            kind: Self::kind(),
             name: self.metadata.name.get_Some_0(),
             namespace: self.metadata.namespace.get_Some_0(),
         }
@@ -149,7 +149,7 @@ impl ResourceView for RabbitmqClusterView {
 
     open spec fn to_dynamic_object(self) -> DynamicObjectView {
         DynamicObjectView {
-            kind: self.kind(),
+            kind: Self::kind(),
             metadata: self.metadata,
             data: RabbitmqClusterView::marshal_spec(self.spec)
         }

--- a/src/controller_examples/simple_controller/spec/custom_resource.rs
+++ b/src/controller_examples/simple_controller/spec/custom_resource.rs
@@ -30,7 +30,7 @@ impl CustomResource {
     #[verifier(external_body)]
     pub fn api_resource() -> (res: ApiResource)
         ensures
-            res@.kind == Kind::CustomResourceKind,
+            res@.kind == CustomResourceView::kind(),
     {
         ApiResource::from_kube(deps_hack::kube::api::ApiResource::erase::<deps_hack::SimpleCR>(&()))
     }
@@ -115,13 +115,13 @@ impl ResourceView for CustomResourceView {
         self.metadata
     }
 
-    open spec fn kind(self) -> Kind {
+    open spec fn kind() -> Kind {
         Kind::CustomResourceKind
     }
 
     open spec fn object_ref(self) -> ObjectRef {
         ObjectRef {
-            kind: self.kind(),
+            kind: Self::kind(),
             name: self.metadata.name.get_Some_0(),
             namespace: self.metadata.namespace.get_Some_0(),
         }
@@ -129,7 +129,7 @@ impl ResourceView for CustomResourceView {
 
     open spec fn to_dynamic_object(self) -> DynamicObjectView {
         DynamicObjectView {
-            kind: self.kind(),
+            kind: Self::kind(),
             metadata: self.metadata,
             data: CustomResourceView::marshal_spec(self.spec),
         }

--- a/src/controller_examples/zookeeper_controller/spec/reconciler.rs
+++ b/src/controller_examples/zookeeper_controller/spec/reconciler.rs
@@ -102,11 +102,10 @@ pub open spec fn reconcile_core(
             (state_prime, req_o)
         },
         ZookeeperReconcileStep::AfterCreateConfigMap => {
-            let stateful_set = make_stateful_set(zk);
             let req_o = Option::Some(APIRequest::GetRequest(GetRequest{
                 key: ObjectRef {
                     kind: StatefulSetView::kind(),
-                    name: stateful_set.metadata.name.get_Some_0(),
+                    name: make_stateful_set(zk).metadata.name.get_Some_0(),
                     namespace: zk.metadata.namespace.get_Some_0(),
                 }
             }));

--- a/src/controller_examples/zookeeper_controller/spec/reconciler.rs
+++ b/src/controller_examples/zookeeper_controller/spec/reconciler.rs
@@ -105,8 +105,9 @@ pub open spec fn reconcile_core(
             let stateful_set = make_stateful_set(zk);
             let req_o = Option::Some(APIRequest::GetRequest(GetRequest{
                 key: ObjectRef {
-                    kind: stateful_set.kind(),
-                    ..zk.object_ref()
+                    kind: StatefulSetView::kind(),
+                    name: stateful_set.metadata.name.get_Some_0(),
+                    namespace: zk.metadata.namespace.get_Some_0(),
                 }
             }));
             let state_prime = ZookeeperReconcileState {
@@ -126,7 +127,7 @@ pub open spec fn reconcile_core(
                         let req_o = Option::Some(APIRequest::UpdateRequest(
                             UpdateRequest {
                                 key: ObjectRef {
-                                    kind: stateful_set.kind(),
+                                    kind: StatefulSetView::kind(),
                                     name: stateful_set.metadata.name.get_Some_0(),
                                     namespace: zk.metadata.namespace.get_Some_0(),
                                 },

--- a/src/controller_examples/zookeeper_controller/spec/zookeepercluster.rs
+++ b/src/controller_examples/zookeeper_controller/spec/zookeepercluster.rs
@@ -57,7 +57,7 @@ impl ZookeeperCluster {
     #[verifier(external_body)]
     pub fn api_resource() -> (res: ApiResource)
         ensures
-            res@.kind == Kind::CustomResourceKind,
+            res@.kind == ZookeeperClusterView::kind(),
     {
         ApiResource::from_kube(deps_hack::kube::api::ApiResource::erase::<deps_hack::ZookeeperCluster>(&()))
     }
@@ -130,13 +130,13 @@ impl ResourceView for ZookeeperClusterView {
         self.metadata
     }
 
-    open spec fn kind(self) -> Kind {
+    open spec fn kind() -> Kind {
         Kind::CustomResourceKind
     }
 
     open spec fn object_ref(self) -> ObjectRef {
         ObjectRef {
-            kind: self.kind(),
+            kind: Self::kind(),
             name: self.metadata.name.get_Some_0(),
             namespace: self.metadata.namespace.get_Some_0(),
         }
@@ -144,7 +144,7 @@ impl ResourceView for ZookeeperClusterView {
 
     open spec fn to_dynamic_object(self) -> DynamicObjectView {
         DynamicObjectView {
-            kind: self.kind(),
+            kind: Self::kind(),
             metadata: self.metadata,
             data: ZookeeperClusterView::marshal_spec(self.spec),
         }

--- a/src/kubernetes_api_objects/config_map.rs
+++ b/src/kubernetes_api_objects/config_map.rs
@@ -77,7 +77,7 @@ impl ConfigMap {
     #[verifier(external_body)]
     pub fn api_resource() -> (res: ApiResource)
         ensures
-            res@.kind == Kind::ConfigMapKind,
+            res@.kind == ConfigMapView::kind(),
     {
         ApiResource::from_kube(deps_hack::kube::api::ApiResource::erase::<deps_hack::k8s_openapi::api::core::v1::ConfigMap>(&()))
     }
@@ -179,13 +179,13 @@ impl ResourceView for ConfigMapView {
         self.metadata
     }
 
-    open spec fn kind(self) -> Kind {
+    open spec fn kind() -> Kind {
         Kind::ConfigMapKind
     }
 
     open spec fn object_ref(self) -> ObjectRef {
         ObjectRef {
-            kind: self.kind(),
+            kind: Self::kind(),
             name: self.metadata.name.get_Some_0(),
             namespace: self.metadata.namespace.get_Some_0(),
         }
@@ -193,7 +193,7 @@ impl ResourceView for ConfigMapView {
 
     open spec fn to_dynamic_object(self) -> DynamicObjectView {
         DynamicObjectView {
-            kind: self.kind(),
+            kind: Self::kind(),
             metadata: self.metadata,
             data: ConfigMapView::marshal_spec((self.data, ())),
         }

--- a/src/kubernetes_api_objects/persistent_volume_claim.rs
+++ b/src/kubernetes_api_objects/persistent_volume_claim.rs
@@ -78,7 +78,7 @@ impl PersistentVolumeClaim {
     #[verifier(external_body)]
     pub fn api_resource() -> (res: ApiResource)
         ensures
-            res@.kind == Kind::PersistentVolumeClaimKind,
+            res@.kind == PersistentVolumeClaimView::kind(),
     {
         ApiResource::from_kube(deps_hack::kube::api::ApiResource::erase::<deps_hack::k8s_openapi::api::core::v1::PersistentVolumeClaim>(&()))
     }
@@ -221,13 +221,13 @@ impl ResourceView for PersistentVolumeClaimView {
         self.metadata
     }
 
-    open spec fn kind(self) -> Kind {
+    open spec fn kind() -> Kind {
         Kind::PersistentVolumeClaimKind
     }
 
     open spec fn object_ref(self) -> ObjectRef {
         ObjectRef {
-            kind: self.kind(),
+            kind: Self::kind(),
             name: self.metadata.name.get_Some_0(),
             namespace: self.metadata.namespace.get_Some_0(),
         }
@@ -235,7 +235,7 @@ impl ResourceView for PersistentVolumeClaimView {
 
     open spec fn to_dynamic_object(self) -> DynamicObjectView {
         DynamicObjectView {
-            kind: self.kind(),
+            kind: Self::kind(),
             metadata: self.metadata,
             data: PersistentVolumeClaimView::marshal_spec(self.spec),
         }

--- a/src/kubernetes_api_objects/pod.rs
+++ b/src/kubernetes_api_objects/pod.rs
@@ -86,7 +86,7 @@ impl Pod {
     #[verifier(external_body)]
     pub fn api_resource() -> (res: ApiResource)
         ensures
-            res@.kind == Kind::PodKind,
+            res@.kind == PodView::kind(),
     {
         ApiResource::from_kube(deps_hack::kube::api::ApiResource::erase::<deps_hack::k8s_openapi::api::core::v1::Pod>(&()))
     }
@@ -916,13 +916,13 @@ impl ResourceView for PodView {
         self.metadata
     }
 
-    open spec fn kind(self) -> Kind {
+    open spec fn kind() -> Kind {
         Kind::PodKind
     }
 
     open spec fn object_ref(self) -> ObjectRef {
         ObjectRef {
-            kind: self.kind(),
+            kind: Self::kind(),
             name: self.metadata.name.get_Some_0(),
             namespace: self.metadata.namespace.get_Some_0(),
         }
@@ -930,7 +930,7 @@ impl ResourceView for PodView {
 
     open spec fn to_dynamic_object(self) -> DynamicObjectView {
         DynamicObjectView {
-            kind: self.kind(),
+            kind: Self::kind(),
             metadata: self.metadata,
             data: PodView::marshal_spec(self.spec),
         }

--- a/src/kubernetes_api_objects/resource.rs
+++ b/src/kubernetes_api_objects/resource.rs
@@ -28,7 +28,7 @@ pub trait ResourceView: Sized {
 
     /// Get the kind of the object
 
-    open spec fn kind(self) -> Kind;
+    open spec fn kind() -> Kind;
 
     /// Get the reference of the object,
     /// which consists of kind, name and namespace

--- a/src/kubernetes_api_objects/role.rs
+++ b/src/kubernetes_api_objects/role.rs
@@ -74,7 +74,7 @@ impl Role {
     #[verifier(external_body)]
     pub fn api_resource() -> (res: ApiResource)
         ensures
-        res@.kind == Kind::RoleKind,
+        res@.kind == RoleView::kind(),
     {
         ApiResource::from_kube(deps_hack::kube::api::ApiResource::erase::<deps_hack::k8s_openapi::api::rbac::v1::Role>(&()))
     }
@@ -208,13 +208,13 @@ impl ResourceView for RoleView {
         self.metadata
     }
 
-    open spec fn kind(self) -> Kind {
+    open spec fn kind() -> Kind {
         Kind::RoleKind
     }
 
     open spec fn object_ref(self) -> ObjectRef {
         ObjectRef {
-            kind: self.kind(),
+            kind: Self::kind(),
             name: self.metadata.name.get_Some_0(),
             namespace: self.metadata.namespace.get_Some_0(),
         }
@@ -222,7 +222,7 @@ impl ResourceView for RoleView {
 
     open spec fn to_dynamic_object(self) -> DynamicObjectView {
         DynamicObjectView {
-            kind: self.kind(),
+            kind: Self::kind(),
             metadata: self.metadata,
             data: RoleView::marshal_spec((self.policy_rules, ())),
         }

--- a/src/kubernetes_api_objects/role_binding.rs
+++ b/src/kubernetes_api_objects/role_binding.rs
@@ -85,7 +85,7 @@ impl RoleBinding {
     #[verifier(external_body)]
     pub fn api_resource() -> (res: ApiResource)
         ensures
-            res@.kind == Kind::RoleBindingKind,
+            res@.kind == RoleBindingView::kind(),
     {
         ApiResource::from_kube(deps_hack::kube::api::ApiResource::erase::<deps_hack::k8s_openapi::api::rbac::v1::RoleBinding>(&()))
     }
@@ -277,13 +277,13 @@ impl ResourceView for RoleBindingView {
         self.metadata
     }
 
-    open spec fn kind(self) -> Kind {
+    open spec fn kind() -> Kind {
         Kind::RoleBindingKind
     }
 
     open spec fn object_ref(self) -> ObjectRef {
         ObjectRef {
-            kind: self.kind(),
+            kind: Self::kind(),
             name: self.metadata.name.get_Some_0(),
             namespace: self.metadata.namespace.get_Some_0(),
         }
@@ -291,7 +291,7 @@ impl ResourceView for RoleBindingView {
 
     open spec fn to_dynamic_object(self) -> DynamicObjectView {
         DynamicObjectView {
-            kind: self.kind(),
+            kind: Self::kind(),
             metadata: self.metadata,
             data: RoleBindingView::marshal_spec((self.role_ref, self.subjects)),
         }

--- a/src/kubernetes_api_objects/secret.rs
+++ b/src/kubernetes_api_objects/secret.rs
@@ -103,7 +103,7 @@ impl Secret {
     #[verifier(external_body)]
     pub fn api_resource() -> (res: ApiResource)
         ensures
-            res@.kind == Kind::SecretKind,
+            res@.kind == SecretView::kind(),
     {
         ApiResource::from_kube(deps_hack::kube::api::ApiResource::erase::<deps_hack::k8s_openapi::api::core::v1::Secret>(&()))
     }
@@ -192,13 +192,13 @@ impl ResourceView for SecretView {
         self.metadata
     }
 
-    open spec fn kind(self) -> Kind {
+    open spec fn kind() -> Kind {
         Kind::SecretKind
     }
 
     open spec fn object_ref(self) -> ObjectRef {
         ObjectRef {
-            kind: self.kind(),
+            kind: Self::kind(),
             name: self.metadata.name.get_Some_0(),
             namespace: self.metadata.namespace.get_Some_0(),
         }
@@ -206,7 +206,7 @@ impl ResourceView for SecretView {
 
     open spec fn to_dynamic_object(self) -> DynamicObjectView {
         DynamicObjectView {
-            kind: self.kind(),
+            kind: Self::kind(),
             metadata: self.metadata,
             data: SecretView::marshal_spec((self.data, self.type_)),
         }

--- a/src/kubernetes_api_objects/service.rs
+++ b/src/kubernetes_api_objects/service.rs
@@ -84,7 +84,7 @@ impl Service {
     #[verifier(external_body)]
     pub fn api_resource() -> (res: ApiResource)
         ensures
-            res@.kind == Kind::ServiceKind,
+            res@.kind == ServiceView::kind(),
     {
         ApiResource::from_kube(deps_hack::kube::api::ApiResource::erase::<deps_hack::k8s_openapi::api::core::v1::Service>(&()))
     }
@@ -279,13 +279,13 @@ impl ResourceView for ServiceView {
         self.metadata
     }
 
-    open spec fn kind(self) -> Kind {
+    open spec fn kind() -> Kind {
         Kind::ServiceKind
     }
 
     open spec fn object_ref(self) -> ObjectRef {
         ObjectRef {
-            kind: self.kind(),
+            kind: Self::kind(),
             name: self.metadata.name.get_Some_0(),
             namespace: self.metadata.namespace.get_Some_0(),
         }
@@ -293,7 +293,7 @@ impl ResourceView for ServiceView {
 
     open spec fn to_dynamic_object(self) -> DynamicObjectView {
         DynamicObjectView {
-            kind: self.kind(),
+            kind: Self::kind(),
             metadata: self.metadata,
             data: ServiceView::marshal_spec(self.spec),
         }

--- a/src/kubernetes_api_objects/service_account.rs
+++ b/src/kubernetes_api_objects/service_account.rs
@@ -72,7 +72,7 @@ impl ServiceAccount {
     #[verifier(external_body)]
     pub fn api_resource() -> (res: ApiResource)
         ensures
-            res@.kind == Kind::ServiceAccountKind,
+            res@.kind == ServiceAccountView::kind(),
     {
         ApiResource::from_kube(deps_hack::kube::api::ApiResource::erase::<deps_hack::k8s_openapi::api::core::v1::ServiceAccount>(&()))
     }
@@ -132,13 +132,13 @@ impl ResourceView for ServiceAccountView {
         self.metadata
     }
 
-    open spec fn kind(self) -> Kind {
+    open spec fn kind() -> Kind {
         Kind::ServiceAccountKind
     }
 
     open spec fn object_ref(self) -> ObjectRef {
         ObjectRef {
-            kind: self.kind(),
+            kind: Self::kind(),
             name: self.metadata.name.get_Some_0(),
             namespace: self.metadata.namespace.get_Some_0(),
         }
@@ -146,7 +146,7 @@ impl ResourceView for ServiceAccountView {
 
     open spec fn to_dynamic_object(self) -> DynamicObjectView {
         DynamicObjectView {
-            kind: self.kind(),
+            kind: Self::kind(),
             metadata: self.metadata,
             data: Value::Null,
         }

--- a/src/kubernetes_api_objects/stateful_set.rs
+++ b/src/kubernetes_api_objects/stateful_set.rs
@@ -89,7 +89,7 @@ impl StatefulSet {
     #[verifier(external_body)]
     pub fn api_resource() -> (res: ApiResource)
         ensures
-            res@.kind == Kind::StatefulSetKind,
+            res@.kind == StatefulSetView::kind(),
     {
         ApiResource::from_kube(deps_hack::kube::api::ApiResource::erase::<deps_hack::k8s_openapi::api::apps::v1::StatefulSet>(&()))
     }
@@ -265,13 +265,13 @@ impl ResourceView for StatefulSetView {
         self.metadata
     }
 
-    open spec fn kind(self) -> Kind {
+    open spec fn kind() -> Kind {
         Kind::StatefulSetKind
     }
 
     open spec fn object_ref(self) -> ObjectRef {
         ObjectRef {
-            kind: self.kind(),
+            kind: Self::kind(),
             name: self.metadata.name.get_Some_0(),
             namespace: self.metadata.namespace.get_Some_0(),
         }
@@ -279,7 +279,7 @@ impl ResourceView for StatefulSetView {
 
     open spec fn to_dynamic_object(self) -> DynamicObjectView {
         DynamicObjectView {
-            kind: self.kind(),
+            kind: Self::kind(),
             metadata: self.metadata,
             data: StatefulSetView::marshal_spec(self.spec),
         }


### PR DESCRIPTION
Previously kind() was implemented as a method, which is unnecessary because it does not need any object information. This PR changes it to an associated function of the ResourceView trait.