### PR TITLE
Support update operations for rabbitmq controller

### DIFF
--- a/src/controller_examples/rabbitmq_controller/common/mod.rs
+++ b/src/controller_examples/rabbitmq_controller/common/mod.rs
@@ -18,6 +18,7 @@ pub enum RabbitmqReconcileStep {
     AfterCreateServiceAccount,
     AfterCreateRole,
     AfterCreateRoleBinding,
+    AfterGetStatefulSet,
     Done,
     Error,
 }

--- a/src/controller_examples/rabbitmq_controller/common/mod.rs
+++ b/src/controller_examples/rabbitmq_controller/common/mod.rs
@@ -19,6 +19,8 @@ pub enum RabbitmqReconcileStep {
     AfterCreateRole,
     AfterCreateRoleBinding,
     AfterGetStatefulSet,
+    AfterCreateStatefulSet,
+    AfterUpdateStatefulSet,
     Done,
     Error,
 }

--- a/src/controller_examples/rabbitmq_controller/exec/reconciler.rs
+++ b/src/controller_examples/rabbitmq_controller/exec/reconciler.rs
@@ -280,8 +280,7 @@ pub fn reconcile_core(rabbitmq: &RabbitmqCluster, resp_o: Option<KubeAPIResponse
                                 return (state_prime, req_o);
                         }
                     }
-                }
-                else if get_sts_resp.unwrap_err().is_object_not_found() {
+                } else if get_sts_resp.unwrap_err().is_object_not_found() {
                     // create
                     let req_o = Option::Some(KubeAPIRequest::CreateRequest(
                         KubeCreateRequest {

--- a/src/controller_examples/rabbitmq_controller/exec/reconciler.rs
+++ b/src/controller_examples/rabbitmq_controller/exec/reconciler.rs
@@ -238,18 +238,68 @@ pub fn reconcile_core(rabbitmq: &RabbitmqCluster, resp_o: Option<KubeAPIResponse
             return (state_prime, req_o);
         },
         RabbitmqReconcileStep::AfterCreateRoleBinding => {
-            let stateful_set = make_stateful_set(rabbitmq);
-            let req_o = Option::Some(KubeAPIRequest::CreateRequest(
-                KubeCreateRequest {
+            let req_o = Option::Some(KubeAPIRequest::GetRequest(
+                KubeGetRequest {
                     api_resource: StatefulSet::api_resource(),
+                    name: rabbitmq.name().unwrap().concat(new_strlit("-server")),
                     namespace: rabbitmq.namespace().unwrap(),
-                    obj: stateful_set.to_dynamic_object(),
                 }
             ));
             let state_prime = RabbitmqReconcileState {
-                reconcile_step: RabbitmqReconcileStep::Done,
+                reconcile_step: RabbitmqReconcileStep::AfterGetStatefulSet,
                 ..state
             };
+            return (state_prime, req_o);
+        },
+        RabbitmqReconcileStep::AfterGetStatefulSet => {
+            if resp_o.is_some() && resp_o.as_ref().unwrap().is_get_response() {
+                let stateful_set = make_stateful_set(rabbitmq);
+                let get_sts_resp = resp_o.unwrap().into_get_response().res;
+                if get_sts_resp.is_ok() {
+                    // update
+                    let found_stateful_set = StatefulSet::from_dynamic_object(get_sts_resp.unwrap());
+                    if found_stateful_set.is_ok(){
+                        let mut new_stateful_set = found_stateful_set.unwrap();
+                        // rabbitmq controller doesn't support scale down, so new replicas must be greater than or equal to old replicas
+                        new_stateful_set.set_spec(stateful_set.spec().unwrap());
+                        let req_o = Option::Some(KubeAPIRequest::UpdateRequest(
+                            KubeUpdateRequest {
+                                api_resource: StatefulSet::api_resource(),
+                                name: stateful_set.metadata().name().unwrap(),
+                                namespace: rabbitmq.namespace().unwrap(),
+                                obj: new_stateful_set.to_dynamic_object(),
+                            }
+                        ));
+                        let state_prime = RabbitmqReconcileState {
+                            reconcile_step: RabbitmqReconcileStep::Done,
+                            ..state
+                        };
+                        return (state_prime, req_o);
+                    }
+                }
+                else if get_sts_resp.unwrap_err().is_object_not_found() {
+                    // create
+                    let req_o = Option::Some(KubeAPIRequest::CreateRequest(
+                        KubeCreateRequest {
+                            api_resource: StatefulSet::api_resource(),
+                            namespace: rabbitmq.namespace().unwrap(),
+                            obj: stateful_set.to_dynamic_object(),
+                        }
+                    ));
+                    let state_prime = RabbitmqReconcileState {
+                        reconcile_step: RabbitmqReconcileStep::Done,
+                        ..state
+                    };
+                    return (state_prime, req_o);
+                }
+
+            }
+            // return error state
+            let state_prime = RabbitmqReconcileState {
+                reconcile_step: RabbitmqReconcileStep::Error,
+                ..state
+            };
+            let req_o = Option::None;
             return (state_prime, req_o);
         },
         _ => {

--- a/src/controller_examples/rabbitmq_controller/exec/reconciler.rs
+++ b/src/controller_examples/rabbitmq_controller/exec/reconciler.rs
@@ -274,7 +274,7 @@ pub fn reconcile_core(rabbitmq: &RabbitmqCluster, resp_o: Option<KubeAPIResponse
                                     }
                                 ));
                                 let state_prime = RabbitmqReconcileState {
-                                    reconcile_step: RabbitmqReconcileStep::Done,
+                                    reconcile_step: RabbitmqReconcileStep::AfterUpdateStatefulSet,
                                     ..state
                                 };
                                 return (state_prime, req_o);
@@ -291,7 +291,7 @@ pub fn reconcile_core(rabbitmq: &RabbitmqCluster, resp_o: Option<KubeAPIResponse
                         }
                     ));
                     let state_prime = RabbitmqReconcileState {
-                        reconcile_step: RabbitmqReconcileStep::Done,
+                        reconcile_step: RabbitmqReconcileStep::AfterCreateStatefulSet,
                         ..state
                     };
                     return (state_prime, req_o);
@@ -304,6 +304,22 @@ pub fn reconcile_core(rabbitmq: &RabbitmqCluster, resp_o: Option<KubeAPIResponse
                 ..state
             };
             let req_o = Option::None;
+            (state_prime, req_o)
+        },
+        RabbitmqReconcileStep::AfterCreateStatefulSet => {
+            let req_o = Option::None;
+            let state_prime = RabbitmqReconcileState {
+                reconcile_step: RabbitmqReconcileStep::Done,
+                ..state
+            };
+            (state_prime, req_o)
+        },
+        RabbitmqReconcileStep::AfterUpdateStatefulSet => {
+            let req_o = Option::None;
+            let state_prime = RabbitmqReconcileState {
+                reconcile_step: RabbitmqReconcileStep::Done,
+                ..state
+            };
             (state_prime, req_o)
         },
         _ => {

--- a/src/controller_examples/rabbitmq_controller/exec/reconciler.rs
+++ b/src/controller_examples/rabbitmq_controller/exec/reconciler.rs
@@ -263,7 +263,7 @@ pub fn reconcile_core(rabbitmq: &RabbitmqCluster, resp_o: Option<KubeAPIResponse
                         // rabbitmq controller doesn't support scale down, so new replicas must be greater than or equal to old replicas
                         if new_stateful_set.spec().is_some()
                             && new_stateful_set.spec().unwrap().replicas().is_some()
-                            && new_stateful_set.spec().unwrap().replicas().unwrap() < rabbitmq.replica() {
+                            && new_stateful_set.spec().unwrap().replicas().unwrap() <= rabbitmq.replica() {
                                 new_stateful_set.set_spec(stateful_set.spec().unwrap());
                                 let req_o = Option::Some(KubeAPIRequest::UpdateRequest(
                                     KubeUpdateRequest {
@@ -304,7 +304,7 @@ pub fn reconcile_core(rabbitmq: &RabbitmqCluster, resp_o: Option<KubeAPIResponse
                 ..state
             };
             let req_o = Option::None;
-            return (state_prime, req_o);
+            (state_prime, req_o)
         },
         _ => {
             let state_prime = RabbitmqReconcileState {

--- a/src/controller_examples/rabbitmq_controller/spec/reconciler.rs
+++ b/src/controller_examples/rabbitmq_controller/spec/reconciler.rs
@@ -198,8 +198,8 @@ pub open spec fn reconcile_core(
             (state_prime, req_o)
         },
         RabbitmqReconcileStep::AfterGetStatefulSet => {
-            let stateful_set = make_stateful_set(rabbitmq);
             if resp_o.is_Some() && resp_o.get_Some_0().is_GetResponse() {
+                let stateful_set = make_stateful_set(rabbitmq);
                 let get_sts_resp = resp_o.get_Some_0().get_GetResponse_0().res;
                 if get_sts_resp.is_Ok() {
                     // update

--- a/src/controller_examples/rabbitmq_controller/spec/reconciler.rs
+++ b/src/controller_examples/rabbitmq_controller/spec/reconciler.rs
@@ -204,7 +204,11 @@ pub open spec fn reconcile_core(
                 if get_sts_resp.is_Ok() {
                     // update
                     let found_stateful_set = StatefulSetView::from_dynamic_object(get_sts_resp.get_Ok_0());
-                    if found_stateful_set.is_Ok(){
+                    if found_stateful_set.is_Ok()
+                        && found_stateful_set.get_Ok_0().spec.is_Some()
+                        && found_stateful_set.get_Ok_0().spec.get_Some_0().replicas.is_Some()
+                        && found_stateful_set.get_Ok_0().spec.get_Some_0().replicas.get_Some_0() <= rabbitmq.spec.replica
+                    {
                         let req_o = Option::Some(APIRequest::UpdateRequest(
                             UpdateRequest {
                                 key: ObjectRef {

--- a/src/controller_examples/rabbitmq_controller/spec/reconciler.rs
+++ b/src/controller_examples/rabbitmq_controller/spec/reconciler.rs
@@ -220,7 +220,7 @@ pub open spec fn reconcile_core(
                             }
                         ));
                         let state_prime = RabbitmqReconcileState {
-                            reconcile_step: RabbitmqReconcileStep::Done,
+                            reconcile_step: RabbitmqReconcileStep::AfterUpdateStatefulSet,
                             ..state
                         };
                         (state_prime, req_o)
@@ -241,7 +241,7 @@ pub open spec fn reconcile_core(
                         }
                     ));
                     let state_prime = RabbitmqReconcileState {
-                        reconcile_step: RabbitmqReconcileStep::Done,
+                        reconcile_step: RabbitmqReconcileStep::AfterCreateStatefulSet,
                         ..state
                     };
                     (state_prime, req_o)
@@ -263,6 +263,22 @@ pub open spec fn reconcile_core(
                 (state_prime, req_o)
             }
 
+        },
+        RabbitmqReconcileStep::AfterCreateStatefulSet => {
+            let req_o = Option::None;
+            let state_prime = RabbitmqReconcileState {
+                reconcile_step: RabbitmqReconcileStep::Done,
+                ..state
+            };
+            (state_prime, req_o)
+        },
+        RabbitmqReconcileStep::AfterUpdateStatefulSet => {
+            let req_o = Option::None;
+            let state_prime = RabbitmqReconcileState {
+                reconcile_step: RabbitmqReconcileStep::Done,
+                ..state
+            };
+            (state_prime, req_o)
         },
         _ => {
             let state_prime = RabbitmqReconcileState {

--- a/src/kubernetes_api_objects/stateful_set.rs
+++ b/src/kubernetes_api_objects/stateful_set.rs
@@ -202,7 +202,18 @@ impl StatefulSetSpec {
         self.inner.pod_management_policy = std::option::Option::Some(pod_management_policy.into_rust_string())
     }
 
-
+    #[verifier(external_body)]
+    pub fn replicas(&self) -> (replicas: Option<i32>)
+        ensures
+            self@.replicas.is_Some() == replicas.is_Some(),
+            replicas.is_Some() ==> replicas.get_Some_0() == self@.replicas.get_Some_0(),
+    {
+        if self.inner.replicas.is_none() {
+            Option::None
+        } else {
+            Option::Some(self.inner.replicas.clone().unwrap())
+        }
+    }
 
 }
 


### PR DESCRIPTION
- In the official rabbitmq controller, only scale-up is supported. When user wants to scale down, rabbitmq controller will reject the request and return `nil` in reconciliation loop. Currently, in our controller, an error will be returned.

- For scale up, the official rabbitmq controller will execute a command `rabbitmq-queues rebalance all`. This command is trying to split different queues' leader to different nodes, which will utilize resources more efficiently. However, this is not necessary if we only want the cluster to perform right functionality.