### PR TITLE
Prove liveness for the zookeeper controller with update operations

### DIFF
--- a/src/controller_examples/rabbitmq_controller/spec/rabbitmqcluster.rs
+++ b/src/controller_examples/rabbitmq_controller/spec/rabbitmqcluster.rs
@@ -147,6 +147,8 @@ impl ResourceView for RabbitmqClusterView {
         }
     }
 
+    proof fn object_ref_is_well_formed() {}
+
     open spec fn to_dynamic_object(self) -> DynamicObjectView {
         DynamicObjectView {
             kind: Self::kind(),
@@ -156,7 +158,9 @@ impl ResourceView for RabbitmqClusterView {
     }
 
     open spec fn from_dynamic_object(obj: DynamicObjectView) -> Result<RabbitmqClusterView, ParseDynamicObjectError> {
-        if !RabbitmqClusterView::unmarshal_spec(obj.spec).is_Ok() {
+        if obj.kind != Self::kind() {
+            Result::Err(ParseDynamicObjectError::UnmarshalError)
+        } else if !RabbitmqClusterView::unmarshal_spec(obj.spec).is_Ok() {
             Result::Err(ParseDynamicObjectError::UnmarshalError)
         } else {
             Result::Ok(RabbitmqClusterView {
@@ -169,6 +173,10 @@ impl ResourceView for RabbitmqClusterView {
     proof fn to_dynamic_preserves_integrity() {
         RabbitmqClusterView::spec_integrity_is_preserved_by_marshal();
     }
+
+    proof fn from_dynamic_preserves_metadata() {}
+
+    proof fn from_dynamic_preserves_kind() {}
 }
 
 #[verifier(external_body)]

--- a/src/controller_examples/simple_controller/spec/custom_resource.rs
+++ b/src/controller_examples/simple_controller/spec/custom_resource.rs
@@ -127,6 +127,8 @@ impl ResourceView for CustomResourceView {
         }
     }
 
+    proof fn object_ref_is_well_formed() {}
+
     open spec fn to_dynamic_object(self) -> DynamicObjectView {
         DynamicObjectView {
             kind: Self::kind(),
@@ -136,7 +138,9 @@ impl ResourceView for CustomResourceView {
     }
 
     open spec fn from_dynamic_object(obj: DynamicObjectView) -> Result<CustomResourceView, ParseDynamicObjectError> {
-        if !CustomResourceView::unmarshal_spec(obj.spec).is_Ok() {
+        if obj.kind != Self::kind() {
+            Result::Err(ParseDynamicObjectError::UnmarshalError)
+        } else if !CustomResourceView::unmarshal_spec(obj.spec).is_Ok() {
             Result::Err(ParseDynamicObjectError::UnmarshalError)
         } else {
             Result::Ok(CustomResourceView {
@@ -149,6 +153,10 @@ impl ResourceView for CustomResourceView {
     proof fn to_dynamic_preserves_integrity() {
         CustomResourceView::spec_integrity_is_preserved_by_marshal();
     }
+
+    proof fn from_dynamic_preserves_metadata() {}
+
+    proof fn from_dynamic_preserves_kind() {}
 }
 
 #[verifier(external_body)]

--- a/src/controller_examples/zookeeper_controller/common/mod.rs
+++ b/src/controller_examples/zookeeper_controller/common/mod.rs
@@ -14,6 +14,8 @@ pub enum ZookeeperReconcileStep {
     AfterCreateAdminServerService,
     AfterCreateConfigMap,
     AfterGetStatefulSet,
+    AfterCreateStatefulSet,
+    AfterUpdateStatefulSet,
     Done,
     Error,
 }

--- a/src/controller_examples/zookeeper_controller/exec/reconciler.rs
+++ b/src/controller_examples/zookeeper_controller/exec/reconciler.rs
@@ -198,7 +198,7 @@ pub fn reconcile_core(
                             }
                         ));
                         let state_prime = ZookeeperReconcileState {
-                            reconcile_step: ZookeeperReconcileStep::Done,
+                            reconcile_step: ZookeeperReconcileStep::AfterUpdateStatefulSet,
                             ..state
                         };
                         return (state_prime, req_o);
@@ -213,7 +213,7 @@ pub fn reconcile_core(
                         }
                     ));
                     let state_prime = ZookeeperReconcileState {
-                        reconcile_step: ZookeeperReconcileStep::Done,
+                        reconcile_step: ZookeeperReconcileStep::AfterCreateStatefulSet,
                         ..state
                     };
                     return (state_prime, req_o);
@@ -226,7 +226,23 @@ pub fn reconcile_core(
             };
             let req_o = Option::None;
             return (state_prime, req_o);
-        }
+        },
+        ZookeeperReconcileStep::AfterCreateStatefulSet => {
+            let req_o = Option::None;
+            let state_prime = ZookeeperReconcileState {
+                reconcile_step: ZookeeperReconcileStep::Done,
+                ..state
+            };
+            return (state_prime, req_o);
+        },
+        ZookeeperReconcileStep::AfterUpdateStatefulSet => {
+            let req_o = Option::None;
+            let state_prime = ZookeeperReconcileState {
+                reconcile_step: ZookeeperReconcileStep::Done,
+                ..state
+            };
+            return (state_prime, req_o);
+        },
         _ => {
             let state_prime = ZookeeperReconcileState {
                 reconcile_step: step,
@@ -465,7 +481,7 @@ fn make_stateful_set_name(zk: &ZookeeperCluster) -> (name: String)
     requires
         zk@.metadata.name.is_Some(),
     ensures
-        name@ == zk_spec::make_stateful_set_name(zk@),
+        name@ == zk_spec::make_stateful_set_name(zk@.metadata.name.get_Some_0()),
 {
     zk.metadata().name().unwrap()
 }

--- a/src/controller_examples/zookeeper_controller/exec/reconciler.rs
+++ b/src/controller_examples/zookeeper_controller/exec/reconciler.rs
@@ -110,7 +110,7 @@ pub fn reconcile_core(
             let req_o = Option::Some(KubeAPIRequest::CreateRequest(
                 KubeCreateRequest {
                     api_resource: Service::api_resource(),
-                    namespace: zk.namespace().unwrap(),
+                    namespace: zk.metadata().namespace().unwrap(),
                     obj: headless_service.to_dynamic_object(),
                 }
             ));
@@ -125,7 +125,7 @@ pub fn reconcile_core(
             let req_o = Option::Some(KubeAPIRequest::CreateRequest(
                 KubeCreateRequest {
                     api_resource: Service::api_resource(),
-                    namespace: zk.namespace().unwrap(),
+                    namespace: zk.metadata().namespace().unwrap(),
                     obj: client_service.to_dynamic_object(),
                 }
             ));
@@ -140,7 +140,7 @@ pub fn reconcile_core(
             let req_o = Option::Some(KubeAPIRequest::CreateRequest(
                 KubeCreateRequest {
                     api_resource: Service::api_resource(),
-                    namespace: zk.namespace().unwrap(),
+                    namespace: zk.metadata().namespace().unwrap(),
                     obj: admin_server_service.to_dynamic_object(),
                 }
             ));
@@ -155,7 +155,7 @@ pub fn reconcile_core(
             let req_o = Option::Some(KubeAPIRequest::CreateRequest(
                 KubeCreateRequest {
                     api_resource: ConfigMap::api_resource(),
-                    namespace: zk.namespace().unwrap(),
+                    namespace: zk.metadata().namespace().unwrap(),
                     obj: config_map.to_dynamic_object(),
                 }
             ));
@@ -170,7 +170,7 @@ pub fn reconcile_core(
                 KubeGetRequest {
                     api_resource: StatefulSet::api_resource(),
                     name: make_stateful_set_name(zk),
-                    namespace: zk.namespace().unwrap(),
+                    namespace: zk.metadata().namespace().unwrap(),
                 }
             ));
             let state_prime = ZookeeperReconcileState {
@@ -193,7 +193,7 @@ pub fn reconcile_core(
                             KubeUpdateRequest {
                                 api_resource: StatefulSet::api_resource(),
                                 name: stateful_set.metadata().name().unwrap(),
-                                namespace: zk.namespace().unwrap(),
+                                namespace: zk.metadata().namespace().unwrap(),
                                 obj: new_stateful_set.to_dynamic_object(),
                             }
                         ));
@@ -208,7 +208,7 @@ pub fn reconcile_core(
                     let req_o = Option::Some(KubeAPIRequest::CreateRequest(
                         KubeCreateRequest {
                             api_resource: StatefulSet::api_resource(),
-                            namespace: zk.namespace().unwrap(),
+                            namespace: zk.metadata().namespace().unwrap(),
                             obj: stateful_set.to_dynamic_object(),
                         }
                     ));
@@ -261,7 +261,7 @@ fn make_headless_service(zk: &ZookeeperCluster) -> (service: Service)
         );
     }
 
-    make_service(zk, zk.name().unwrap().concat(new_strlit("-headless")), ports, false)
+    make_service(zk, zk.metadata().name().unwrap().concat(new_strlit("-headless")), ports, false)
 }
 
 /// Client Service is used for any client to connect to the zookeeper server
@@ -283,7 +283,7 @@ fn make_client_service(zk: &ZookeeperCluster) -> (service: Service)
         );
     }
 
-    make_service(zk, zk.name().unwrap().concat(new_strlit("-client")), ports, true)
+    make_service(zk, zk.metadata().name().unwrap().concat(new_strlit("-client")), ports, true)
 }
 
 /// Admin-server Service is used for client to connect to admin server
@@ -305,7 +305,7 @@ fn make_admin_server_service(zk: &ZookeeperCluster) -> (service: Service)
         );
     }
 
-    make_service(zk, zk.name().unwrap().concat(new_strlit("-admin-server")), ports, true)
+    make_service(zk, zk.metadata().name().unwrap().concat(new_strlit("-admin-server")), ports, true)
 }
 
 /// make_service constructs the Service object given the name, ports and cluster_ip
@@ -322,7 +322,7 @@ fn make_service(zk: &ZookeeperCluster, name: String, ports: Vec<ServicePort>, cl
         metadata.set_name(name);
         metadata.set_labels({
             let mut labels = StringMap::empty();
-            labels.insert(new_strlit("app").to_string(), zk.name().unwrap());
+            labels.insert(new_strlit("app").to_string(), zk.metadata().name().unwrap());
             labels
         });
         metadata
@@ -335,7 +335,7 @@ fn make_service(zk: &ZookeeperCluster, name: String, ports: Vec<ServicePort>, cl
         service_spec.set_ports(ports);
         service_spec.set_selector({
             let mut selector = StringMap::empty();
-            selector.insert(new_strlit("app").to_string(), zk.name().unwrap());
+            selector.insert(new_strlit("app").to_string(), zk.metadata().name().unwrap());
             selector
         });
         service_spec
@@ -356,10 +356,10 @@ fn make_config_map(zk: &ZookeeperCluster) -> (config_map: ConfigMap)
 
     config_map.set_metadata({
         let mut metadata = ObjectMeta::default();
-        metadata.set_name(zk.name().unwrap().concat(new_strlit("-configmap")));
+        metadata.set_name(zk.metadata().name().unwrap().concat(new_strlit("-configmap")));
         metadata.set_labels({
             let mut labels = StringMap::empty();
-            labels.insert(new_strlit("app").to_string(), zk.name().unwrap());
+            labels.insert(new_strlit("app").to_string(), zk.metadata().name().unwrap());
             labels
         });
         metadata
@@ -444,8 +444,8 @@ fn make_env_config(zk: &ZookeeperCluster) -> (s: String)
     ensures
         s@ == zk_spec::make_env_config(zk@),
 {
-    let name = zk.name().unwrap();
-    let namespace = zk.namespace().unwrap();
+    let name = zk.metadata().name().unwrap();
+    let namespace = zk.metadata().namespace().unwrap();
 
     new_strlit(
         "#!/usr/bin/env bash\n\n\
@@ -467,7 +467,7 @@ fn make_stateful_set_name(zk: &ZookeeperCluster) -> (name: String)
     ensures
         name@ == zk_spec::make_stateful_set_name(zk@),
 {
-    zk.name().unwrap()
+    zk.metadata().name().unwrap()
 }
 
 /// The StatefulSet manages the zookeeper server containers (as Pods)
@@ -485,7 +485,7 @@ fn make_stateful_set(zk: &ZookeeperCluster) -> (stateful_set: StatefulSet)
         metadata.set_name(make_stateful_set_name(zk));
         metadata.set_labels({
             let mut labels = StringMap::empty();
-            labels.insert(new_strlit("app").to_string(), zk.name().unwrap());
+            labels.insert(new_strlit("app").to_string(), zk.metadata().name().unwrap());
             labels
         });
         metadata
@@ -495,13 +495,13 @@ fn make_stateful_set(zk: &ZookeeperCluster) -> (stateful_set: StatefulSet)
         // Set the replica number
         stateful_set_spec.set_replicas(zk.replica());
         // Set the headless service to assign DNS entry to each zookeeper server
-        stateful_set_spec.set_service_name(zk.name().unwrap().concat(new_strlit("-headless")));
+        stateful_set_spec.set_service_name(zk.metadata().name().unwrap().concat(new_strlit("-headless")));
         // Set the selector used for querying pods of this stateful set
         stateful_set_spec.set_selector({
             let mut selector = LabelSelector::default();
             selector.set_match_labels({
                 let mut match_labels = StringMap::empty();
-                match_labels.insert(new_strlit("app").to_string(), zk.name().unwrap());
+                match_labels.insert(new_strlit("app").to_string(), zk.metadata().name().unwrap());
                 match_labels
             });
             selector
@@ -511,10 +511,10 @@ fn make_stateful_set(zk: &ZookeeperCluster) -> (stateful_set: StatefulSet)
             let mut pod_template_spec = PodTemplateSpec::default();
             pod_template_spec.set_metadata({
                 let mut metadata = ObjectMeta::default();
-                metadata.set_generate_name(zk.name().unwrap());
+                metadata.set_generate_name(zk.metadata().name().unwrap());
                 metadata.set_labels({
                     let mut labels = StringMap::empty();
-                    labels.insert(new_strlit("app").to_string(), zk.name().unwrap());
+                    labels.insert(new_strlit("app").to_string(), zk.metadata().name().unwrap());
                     labels.insert(new_strlit("kind").to_string(), new_strlit("ZookeeperMember").to_string());
                     labels
                 });
@@ -533,7 +533,7 @@ fn make_stateful_set(zk: &ZookeeperCluster) -> (stateful_set: StatefulSet)
                     metadata.set_name(new_strlit("data").to_string());
                     metadata.set_labels({
                         let mut labels = StringMap::empty();
-                        labels.insert(new_strlit("app").to_string(), zk.name().unwrap());
+                        labels.insert(new_strlit("app").to_string(), zk.metadata().name().unwrap());
                         labels
                     });
                     metadata
@@ -658,7 +658,7 @@ fn make_zk_pod_spec(zk: &ZookeeperCluster) -> (pod_spec: PodSpec)
             volume.set_name(new_strlit("conf").to_string());
             volume.set_config_map({
                 let mut config_map = ConfigMapVolumeSource::default();
-                config_map.set_name(zk.name().unwrap().concat(new_strlit("-configmap")));
+                config_map.set_name(zk.metadata().name().unwrap().concat(new_strlit("-configmap")));
                 config_map
             });
             volume

--- a/src/controller_examples/zookeeper_controller/proof/common.rs
+++ b/src/controller_examples/zookeeper_controller/proof/common.rs
@@ -1,0 +1,562 @@
+// Copyright 2022 VMware, Inc.
+// SPDX-License-Identifier: MIT
+#![allow(unused_imports)]
+use crate::kubernetes_api_objects::{
+    api_method::*, common::*, dynamic::*, resource::*, stateful_set::*,
+};
+use crate::kubernetes_cluster::spec::{
+    cluster::*,
+    controller::common::{controller_req_msg, ControllerActionInput, ControllerStep},
+    controller::controller_runtime::{continue_reconcile, end_reconcile, run_scheduled_reconcile},
+    message::*,
+};
+use crate::temporal_logic::defs::*;
+use crate::zookeeper_controller::spec::{reconciler::*, zookeepercluster::*};
+use builtin::*;
+use builtin_macros::*;
+use vstd::*;
+use vstd::{option::*, result::*};
+
+verus! {
+
+pub type ClusterState = State<ZookeeperClusterView, ZookeeperReconcileState>;
+
+pub open spec fn cluster_spec() -> TempPred<ClusterState> {
+    sm_spec::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>()
+}
+
+// Handy abbreviation for Init step
+
+pub open spec fn at_init_step(zk: ZookeeperClusterView) -> StatePred<ClusterState> {
+    |s: ClusterState| {
+        &&& s.reconcile_state_contains(zk.object_ref())
+        &&& s.reconcile_state_of(zk.object_ref()).triggering_cr.object_ref() == zk.object_ref()
+        &&& s.reconcile_state_of(zk.object_ref()).triggering_cr.spec == zk.spec
+        &&& s.reconcile_state_of(zk.object_ref()).local_state.reconcile_step.is_Init()
+    }
+}
+
+pub open spec fn at_init_step_with_no_pending_req(zk: ZookeeperClusterView) -> StatePred<ClusterState> {
+    |s: ClusterState| {
+        &&& at_init_step(zk)(s)
+        &&& s.reconcile_state_of(zk.object_ref()).pending_req_msg.is_None()
+    }
+}
+
+// Handy abbreviation for AfterCreateHeadlessService step
+
+pub open spec fn at_after_create_headless_service_step_with_zk(zk: ZookeeperClusterView) -> StatePred<ClusterState> {
+    |s: ClusterState| {
+        &&& s.reconcile_state_contains(zk.object_ref())
+        &&& s.reconcile_state_of(zk.object_ref()).triggering_cr.object_ref() == zk.object_ref()
+        &&& s.reconcile_state_of(zk.object_ref()).triggering_cr.spec == zk.spec
+        &&& s.reconcile_state_of(zk.object_ref()).local_state.reconcile_step.is_AfterCreateHeadlessService()
+    }
+}
+
+pub open spec fn is_create_headless_service_request_msg(msg: Message, zk: ZookeeperClusterView) -> bool {
+    &&& msg.src == HostId::CustomController
+    &&& msg.dst == HostId::KubernetesAPI
+    &&& msg.content.is_create_request()
+    &&& msg.content.get_create_request().namespace == zk.metadata.namespace.get_Some_0()
+    &&& msg.content.get_create_request().obj == make_headless_service(zk).to_dynamic_object()
+}
+
+pub open spec fn at_after_create_headless_service_step_with_zk_and_pending_req_in_flight(
+    zk: ZookeeperClusterView
+) -> StatePred<ClusterState> {
+    |s: ClusterState| {
+        &&& at_after_create_headless_service_step_with_zk(zk)(s)
+        &&& s.reconcile_state_of(zk.object_ref()).pending_req_msg.is_Some()
+        &&& s.message_in_flight(s.pending_req_of(zk.object_ref()))
+        &&& is_create_headless_service_request_msg(s.pending_req_of(zk.object_ref()), zk)
+    }
+}
+
+pub open spec fn req_msg_is_the_in_flight_pending_req_at_after_create_headless_service_step_with_zk(
+    zk: ZookeeperClusterView, req_msg: Message
+) -> StatePred<ClusterState> {
+    |s: ClusterState| {
+        &&& at_after_create_headless_service_step_with_zk(zk)(s)
+        &&& s.reconcile_state_of(zk.object_ref()).pending_req_msg == Option::Some(req_msg)
+        &&& s.message_in_flight(req_msg)
+        &&& is_create_headless_service_request_msg(req_msg, zk)
+    }
+}
+
+pub open spec fn at_after_create_headless_service_step_with_zk_and_exists_resp_in_flight(
+    zk: ZookeeperClusterView
+) -> StatePred<ClusterState> {
+    |s: ClusterState| {
+        &&& at_after_create_headless_service_step_with_zk(zk)(s)
+        &&& s.reconcile_state_of(zk.object_ref()).pending_req_msg.is_Some()
+        &&& is_create_headless_service_request_msg(s.pending_req_of(zk.object_ref()), zk)
+        &&& exists |resp_msg| {
+            &&& #[trigger] s.message_in_flight(resp_msg)
+            &&& resp_msg_matches_req_msg(resp_msg, s.pending_req_of(zk.object_ref()))
+        }
+    }
+}
+
+pub open spec fn resp_msg_is_the_in_flight_resp_at_after_create_headless_service_step_with_zk(
+    zk: ZookeeperClusterView, resp_msg: Message
+) -> StatePred<ClusterState> {
+    |s: ClusterState| {
+        &&& at_after_create_headless_service_step_with_zk(zk)(s)
+        &&& s.reconcile_state_of(zk.object_ref()).pending_req_msg.is_Some()
+        &&& is_create_headless_service_request_msg(s.pending_req_of(zk.object_ref()), zk)
+        &&& s.message_in_flight(resp_msg)
+        &&& resp_msg_matches_req_msg(resp_msg, s.pending_req_of(zk.object_ref()))
+    }
+}
+
+// Handy abbreviation for AfterCreateClientService step
+
+pub open spec fn at_after_create_client_service_step_with_zk(zk: ZookeeperClusterView) -> StatePred<ClusterState> {
+    |s: ClusterState| {
+        &&& s.reconcile_state_contains(zk.object_ref())
+        &&& s.reconcile_state_of(zk.object_ref()).triggering_cr.object_ref() == zk.object_ref()
+        &&& s.reconcile_state_of(zk.object_ref()).triggering_cr.spec == zk.spec
+        &&& s.reconcile_state_of(zk.object_ref()).local_state.reconcile_step.is_AfterCreateClientService()
+    }
+}
+
+pub open spec fn is_create_client_service_request_msg(msg: Message, zk: ZookeeperClusterView) -> bool {
+    &&& msg.src == HostId::CustomController
+    &&& msg.dst == HostId::KubernetesAPI
+    &&& msg.content.is_create_request()
+    &&& msg.content.get_create_request().namespace == zk.metadata.namespace.get_Some_0()
+    &&& msg.content.get_create_request().obj == make_client_service(zk).to_dynamic_object()
+}
+
+pub open spec fn at_after_create_client_service_step_with_zk_and_pending_req_in_flight(
+    zk: ZookeeperClusterView
+) -> StatePred<ClusterState> {
+    |s: ClusterState| {
+        &&& at_after_create_client_service_step_with_zk(zk)(s)
+        &&& s.reconcile_state_of(zk.object_ref()).pending_req_msg.is_Some()
+        &&& s.message_in_flight(s.pending_req_of(zk.object_ref()))
+        &&& is_create_client_service_request_msg(s.pending_req_of(zk.object_ref()), zk)
+    }
+}
+
+pub open spec fn req_msg_is_the_in_flight_pending_req_at_after_create_client_service_step_with_zk(
+    zk: ZookeeperClusterView, req_msg: Message
+) -> StatePred<ClusterState> {
+    |s: ClusterState| {
+        &&& at_after_create_client_service_step_with_zk(zk)(s)
+        &&& s.reconcile_state_of(zk.object_ref()).pending_req_msg == Option::Some(req_msg)
+        &&& s.message_in_flight(req_msg)
+        &&& is_create_client_service_request_msg(req_msg, zk)
+    }
+}
+
+pub open spec fn at_after_create_client_service_step_with_zk_and_exists_resp_in_flight(
+    zk: ZookeeperClusterView
+) -> StatePred<ClusterState> {
+    |s: ClusterState| {
+        &&& at_after_create_client_service_step_with_zk(zk)(s)
+        &&& s.reconcile_state_of(zk.object_ref()).pending_req_msg.is_Some()
+        &&& is_create_client_service_request_msg(s.pending_req_of(zk.object_ref()), zk)
+        &&& exists |resp_msg| {
+            &&& #[trigger] s.message_in_flight(resp_msg)
+            &&& resp_msg_matches_req_msg(resp_msg, s.pending_req_of(zk.object_ref()))
+        }
+    }
+}
+
+pub open spec fn resp_msg_is_the_in_flight_resp_at_after_create_client_service_step_with_zk(
+    zk: ZookeeperClusterView, resp_msg: Message
+) -> StatePred<ClusterState> {
+    |s: ClusterState| {
+        &&& at_after_create_client_service_step_with_zk(zk)(s)
+        &&& s.reconcile_state_of(zk.object_ref()).pending_req_msg.is_Some()
+        &&& is_create_client_service_request_msg(s.pending_req_of(zk.object_ref()), zk)
+        &&& s.message_in_flight(resp_msg)
+        &&& resp_msg_matches_req_msg(resp_msg, s.pending_req_of(zk.object_ref()))
+    }
+}
+
+// Handy abbreviation for AfterCreateAdminServerService step
+
+pub open spec fn at_after_create_admin_server_service_step_with_zk(zk: ZookeeperClusterView) -> StatePred<ClusterState> {
+    |s: ClusterState| {
+        &&& s.reconcile_state_contains(zk.object_ref())
+        &&& s.reconcile_state_of(zk.object_ref()).triggering_cr.object_ref() == zk.object_ref()
+        &&& s.reconcile_state_of(zk.object_ref()).triggering_cr.spec == zk.spec
+        &&& s.reconcile_state_of(zk.object_ref()).local_state.reconcile_step.is_AfterCreateAdminServerService()
+    }
+}
+
+pub open spec fn is_create_admin_server_service_request_msg(msg: Message, zk: ZookeeperClusterView) -> bool {
+    &&& msg.src == HostId::CustomController
+    &&& msg.dst == HostId::KubernetesAPI
+    &&& msg.content.is_create_request()
+    &&& msg.content.get_create_request().namespace == zk.metadata.namespace.get_Some_0()
+    &&& msg.content.get_create_request().obj == make_admin_server_service(zk).to_dynamic_object()
+}
+
+pub open spec fn at_after_create_admin_server_service_step_with_zk_and_pending_req_in_flight(
+    zk: ZookeeperClusterView
+) -> StatePred<ClusterState> {
+    |s: ClusterState| {
+        &&& at_after_create_admin_server_service_step_with_zk(zk)(s)
+        &&& s.reconcile_state_of(zk.object_ref()).pending_req_msg.is_Some()
+        &&& s.message_in_flight(s.pending_req_of(zk.object_ref()))
+        &&& is_create_admin_server_service_request_msg(s.pending_req_of(zk.object_ref()), zk)
+    }
+}
+
+pub open spec fn req_msg_is_the_in_flight_pending_req_at_after_create_admin_server_service_step_with_zk(
+    zk: ZookeeperClusterView, req_msg: Message
+) -> StatePred<ClusterState> {
+    |s: ClusterState| {
+        &&& at_after_create_admin_server_service_step_with_zk(zk)(s)
+        &&& s.reconcile_state_of(zk.object_ref()).pending_req_msg == Option::Some(req_msg)
+        &&& s.message_in_flight(req_msg)
+        &&& is_create_admin_server_service_request_msg(req_msg, zk)
+    }
+}
+
+pub open spec fn at_after_create_admin_server_service_step_with_zk_and_exists_resp_in_flight(
+    zk: ZookeeperClusterView
+) -> StatePred<ClusterState> {
+    |s: ClusterState| {
+        &&& at_after_create_admin_server_service_step_with_zk(zk)(s)
+        &&& s.reconcile_state_of(zk.object_ref()).pending_req_msg.is_Some()
+        &&& is_create_admin_server_service_request_msg(s.pending_req_of(zk.object_ref()), zk)
+        &&& exists |resp_msg| {
+            &&& #[trigger] s.message_in_flight(resp_msg)
+            &&& resp_msg_matches_req_msg(resp_msg, s.pending_req_of(zk.object_ref()))
+        }
+    }
+}
+
+pub open spec fn resp_msg_is_the_in_flight_resp_at_after_create_admin_server_service_step_with_zk(
+    zk: ZookeeperClusterView, resp_msg: Message
+) -> StatePred<ClusterState> {
+    |s: ClusterState| {
+        &&& at_after_create_admin_server_service_step_with_zk(zk)(s)
+        &&& s.reconcile_state_of(zk.object_ref()).pending_req_msg.is_Some()
+        &&& is_create_admin_server_service_request_msg(s.pending_req_of(zk.object_ref()), zk)
+        &&& s.message_in_flight(resp_msg)
+        &&& resp_msg_matches_req_msg(resp_msg, s.pending_req_of(zk.object_ref()))
+    }
+}
+
+// Handy abbreviation for AfterCreateConfigMap step
+
+pub open spec fn at_after_create_config_map_step_with_zk(zk: ZookeeperClusterView) -> StatePred<ClusterState> {
+    |s: ClusterState| {
+        &&& s.reconcile_state_contains(zk.object_ref())
+        &&& s.reconcile_state_of(zk.object_ref()).triggering_cr.object_ref() == zk.object_ref()
+        &&& s.reconcile_state_of(zk.object_ref()).triggering_cr.spec == zk.spec
+        &&& s.reconcile_state_of(zk.object_ref()).local_state.reconcile_step.is_AfterCreateConfigMap()
+    }
+}
+
+pub open spec fn is_create_config_map_request_msg(msg: Message, zk: ZookeeperClusterView) -> bool {
+    &&& msg.src == HostId::CustomController
+    &&& msg.dst == HostId::KubernetesAPI
+    &&& msg.content.is_create_request()
+    &&& msg.content.get_create_request().namespace == zk.metadata.namespace.get_Some_0()
+    &&& msg.content.get_create_request().obj == make_config_map(zk).to_dynamic_object()
+}
+
+pub open spec fn at_after_create_config_map_step_with_zk_and_pending_req_in_flight(
+    zk: ZookeeperClusterView
+) -> StatePred<ClusterState> {
+    |s: ClusterState| {
+        &&& at_after_create_config_map_step_with_zk(zk)(s)
+        &&& s.reconcile_state_of(zk.object_ref()).pending_req_msg.is_Some()
+        &&& s.message_in_flight(s.pending_req_of(zk.object_ref()))
+        &&& is_create_config_map_request_msg(s.pending_req_of(zk.object_ref()), zk)
+    }
+}
+
+pub open spec fn req_msg_is_the_in_flight_pending_req_at_after_create_config_map_step_with_zk(
+    zk: ZookeeperClusterView, req_msg: Message
+) -> StatePred<ClusterState> {
+    |s: ClusterState| {
+        &&& at_after_create_config_map_step_with_zk(zk)(s)
+        &&& s.reconcile_state_of(zk.object_ref()).pending_req_msg == Option::Some(req_msg)
+        &&& s.message_in_flight(req_msg)
+        &&& is_create_config_map_request_msg(req_msg, zk)
+    }
+}
+
+pub open spec fn at_after_create_config_map_step_with_zk_and_exists_resp_in_flight(
+    zk: ZookeeperClusterView
+) -> StatePred<ClusterState> {
+    |s: ClusterState| {
+        &&& at_after_create_config_map_step_with_zk(zk)(s)
+        &&& s.reconcile_state_of(zk.object_ref()).pending_req_msg.is_Some()
+        &&& is_create_config_map_request_msg(s.pending_req_of(zk.object_ref()), zk)
+        &&& exists |resp_msg| {
+            &&& #[trigger] s.message_in_flight(resp_msg)
+            &&& resp_msg_matches_req_msg(resp_msg, s.pending_req_of(zk.object_ref()))
+        }
+    }
+}
+
+pub open spec fn resp_msg_is_the_in_flight_resp_at_after_create_config_map_step_with_zk(
+    zk: ZookeeperClusterView, resp_msg: Message
+) -> StatePred<ClusterState> {
+    |s: ClusterState| {
+        &&& at_after_create_config_map_step_with_zk(zk)(s)
+        &&& s.reconcile_state_of(zk.object_ref()).pending_req_msg.is_Some()
+        &&& is_create_config_map_request_msg(s.pending_req_of(zk.object_ref()), zk)
+        &&& s.message_in_flight(resp_msg)
+        &&& resp_msg_matches_req_msg(resp_msg, s.pending_req_of(zk.object_ref()))
+    }
+}
+
+// Handy abbreviation for AfterGetStatefulSet step
+
+pub open spec fn at_after_get_stateful_set_step(key: ObjectRef) -> StatePred<ClusterState>
+    recommends
+        key.kind.is_CustomResourceKind(),
+{
+    |s: ClusterState| {
+        &&& s.reconcile_state_contains(key)
+        &&& s.reconcile_state_of(key).local_state.reconcile_step.is_AfterGetStatefulSet()
+    }
+}
+
+pub open spec fn at_after_get_stateful_set_step_with_zk(zk: ZookeeperClusterView) -> StatePred<ClusterState> {
+    |s: ClusterState| {
+        &&& at_after_get_stateful_set_step(zk.object_ref())(s)
+        &&& s.reconcile_state_of(zk.object_ref()).triggering_cr.object_ref() == zk.object_ref()
+        &&& s.reconcile_state_of(zk.object_ref()).triggering_cr.spec == zk.spec
+    }
+}
+
+pub open spec fn is_get_stateful_set_request_msg(msg: Message, zk: ZookeeperClusterView) -> bool
+    recommends
+        zk.well_formed(),
+{
+    &&& msg.src == HostId::CustomController
+    &&& msg.dst == HostId::KubernetesAPI
+    &&& msg.content.is_get_request()
+    &&& msg.content.get_get_request().key == ObjectRef {
+        kind: StatefulSetView::kind(),
+        name: make_stateful_set_name(zk.metadata.name.get_Some_0()),
+        namespace: zk.metadata.namespace.get_Some_0(),
+    }
+}
+
+pub open spec fn at_after_get_stateful_set_step_with_zk_and_pending_req_in_flight(
+    zk: ZookeeperClusterView
+) -> StatePred<ClusterState> {
+    |s: ClusterState| {
+        &&& at_after_get_stateful_set_step_with_zk(zk)(s)
+        &&& s.reconcile_state_of(zk.object_ref()).pending_req_msg.is_Some()
+        &&& s.message_in_flight(s.pending_req_of(zk.object_ref()))
+        &&& is_get_stateful_set_request_msg(s.pending_req_of(zk.object_ref()), zk)
+    }
+}
+
+pub open spec fn req_msg_is_the_in_flight_pending_req_at_after_get_stateful_set_step_with_zk(
+    zk: ZookeeperClusterView, req_msg: Message
+) -> StatePred<ClusterState> {
+    |s: ClusterState| {
+        &&& at_after_get_stateful_set_step_with_zk(zk)(s)
+        &&& s.reconcile_state_of(zk.object_ref()).pending_req_msg == Option::Some(req_msg)
+        &&& s.message_in_flight(req_msg)
+        &&& is_get_stateful_set_request_msg(req_msg, zk)
+    }
+}
+
+pub open spec fn at_after_get_stateful_set_step_with_zk_and_exists_ok_resp_in_flight(
+    zk: ZookeeperClusterView, object: DynamicObjectView
+) -> StatePred<ClusterState> {
+    |s: ClusterState| {
+        &&& at_after_get_stateful_set_step_with_zk(zk)(s)
+        &&& s.reconcile_state_of(zk.object_ref()).pending_req_msg.is_Some()
+        &&& is_get_stateful_set_request_msg(s.pending_req_of(zk.object_ref()), zk)
+        &&& exists |resp_msg| {
+            &&& #[trigger] s.message_in_flight(resp_msg)
+            &&& resp_msg_matches_req_msg(resp_msg, s.pending_req_of(zk.object_ref()))
+            &&& resp_msg.content.get_get_response().res.is_Ok()
+            &&& resp_msg.content.get_get_response().res.get_Ok_0() == object
+        }
+    }
+}
+
+pub open spec fn at_after_get_stateful_set_step_with_zk_and_exists_not_found_resp_in_flight(
+    zk: ZookeeperClusterView
+) -> StatePred<ClusterState> {
+    |s: ClusterState| {
+        &&& at_after_get_stateful_set_step_with_zk(zk)(s)
+        &&& s.reconcile_state_of(zk.object_ref()).pending_req_msg.is_Some()
+        &&& is_get_stateful_set_request_msg(s.pending_req_of(zk.object_ref()), zk)
+        &&& exists |resp_msg| {
+            &&& #[trigger] s.message_in_flight(resp_msg)
+            &&& resp_msg_matches_req_msg(resp_msg, s.pending_req_of(zk.object_ref()))
+            &&& resp_msg.content.get_get_response().res.is_Err()
+            &&& resp_msg.content.get_get_response().res.get_Err_0().is_ObjectNotFound()
+        }
+    }
+}
+
+pub open spec fn at_after_get_stateful_set_step_with_zk_and_exists_not_found_err_resp_in_flight(
+    zk: ZookeeperClusterView
+) -> StatePred<ClusterState> {
+    |s: ClusterState| {
+        &&& at_after_get_stateful_set_step_with_zk(zk)(s)
+        &&& s.reconcile_state_of(zk.object_ref()).pending_req_msg.is_Some()
+        &&& is_get_stateful_set_request_msg(s.pending_req_of(zk.object_ref()), zk)
+        &&& exists |resp_msg| {
+            &&& #[trigger] s.message_in_flight(resp_msg)
+            &&& resp_msg_matches_req_msg(resp_msg, s.pending_req_of(zk.object_ref()))
+            &&& resp_msg.content.get_get_response().res.is_Err()
+            &&& resp_msg.content.get_get_response().res.get_Err_0().is_ObjectNotFound()
+        }
+    }
+}
+
+pub open spec fn resp_msg_is_the_in_flight_resp_at_after_get_stateful_set_step_with_zk(
+    zk: ZookeeperClusterView, resp_msg: Message
+) -> StatePred<ClusterState> {
+    |s: ClusterState| {
+        &&& at_after_get_stateful_set_step_with_zk(zk)(s)
+        &&& s.reconcile_state_of(zk.object_ref()).pending_req_msg.is_Some()
+        &&& is_get_stateful_set_request_msg(s.pending_req_of(zk.object_ref()), zk)
+        &&& s.message_in_flight(resp_msg)
+        &&& resp_msg_matches_req_msg(resp_msg, s.pending_req_of(zk.object_ref()))
+    }
+}
+
+// Handy abbreviation for AfterCreateStatefulSet step
+
+pub open spec fn at_after_create_stateful_set_step(key: ObjectRef) -> StatePred<ClusterState>
+    recommends
+        key.kind.is_CustomResourceKind(),
+{
+    |s: ClusterState| {
+        &&& s.reconcile_state_contains(key)
+        &&& s.reconcile_state_of(key).local_state.reconcile_step.is_AfterCreateStatefulSet()
+    }
+}
+
+pub open spec fn at_after_create_stateful_set_step_with_zk(zk: ZookeeperClusterView) -> StatePred<ClusterState> {
+    |s: ClusterState| {
+        &&& at_after_create_stateful_set_step(zk.object_ref())(s)
+        &&& s.reconcile_state_of(zk.object_ref()).triggering_cr.object_ref() == zk.object_ref()
+        &&& s.reconcile_state_of(zk.object_ref()).triggering_cr.spec == zk.spec
+    }
+}
+
+pub open spec fn is_create_stateful_set_request_msg(
+    msg: Message, zk: ZookeeperClusterView
+) -> bool
+    recommends
+        zk.well_formed(),
+{
+    &&& msg.src == HostId::CustomController
+    &&& msg.dst == HostId::KubernetesAPI
+    &&& msg.content.is_create_request()
+    &&& msg.content.get_create_request().namespace == zk.metadata.namespace.get_Some_0()
+    &&& msg.content.get_create_request().obj == make_stateful_set(zk).to_dynamic_object()
+}
+
+pub open spec fn at_after_create_stateful_set_step_with_zk_and_pending_req_in_flight(
+    zk: ZookeeperClusterView
+) -> StatePred<ClusterState> {
+    |s: ClusterState| {
+        &&& at_after_create_stateful_set_step_with_zk(zk)(s)
+        &&& s.reconcile_state_of(zk.object_ref()).pending_req_msg.is_Some()
+        &&& s.message_in_flight(s.pending_req_of(zk.object_ref()))
+        &&& is_create_stateful_set_request_msg(s.pending_req_of(zk.object_ref()), zk)
+    }
+}
+
+pub open spec fn req_msg_is_the_in_flight_pending_req_at_after_create_stateful_set_step_with_zk(
+    zk: ZookeeperClusterView, req_msg: Message
+) -> StatePred<ClusterState> {
+    |s: ClusterState| {
+        &&& at_after_create_stateful_set_step_with_zk(zk)(s)
+        &&& s.reconcile_state_of(zk.object_ref()).pending_req_msg == Option::Some(req_msg)
+        &&& s.message_in_flight(req_msg)
+        &&& is_create_stateful_set_request_msg(req_msg, zk)
+    }
+}
+
+// Handy abbreviation for AfterUpdateStatefulSet step
+
+pub open spec fn at_after_update_stateful_set_step(key: ObjectRef) -> StatePred<ClusterState>
+    recommends
+        key.kind.is_CustomResourceKind(),
+{
+    |s: ClusterState| {
+        &&& s.reconcile_state_contains(key)
+        &&& s.reconcile_state_of(key).local_state.reconcile_step.is_AfterUpdateStatefulSet()
+    }
+}
+
+pub open spec fn at_after_update_stateful_set_step_with_zk(zk: ZookeeperClusterView) -> StatePred<ClusterState> {
+    |s: ClusterState| {
+        &&& at_after_update_stateful_set_step(zk.object_ref())(s)
+        &&& s.reconcile_state_of(zk.object_ref()).triggering_cr.object_ref() == zk.object_ref()
+        &&& s.reconcile_state_of(zk.object_ref()).triggering_cr.spec == zk.spec
+    }
+}
+
+pub open spec fn is_update_stateful_set_request_msg(
+    msg: Message, zk: ZookeeperClusterView, object: DynamicObjectView
+) -> bool
+    recommends
+        zk.well_formed(),
+{
+    &&& msg.src == HostId::CustomController
+    &&& msg.dst == HostId::KubernetesAPI
+    &&& msg.content.is_update_request()
+    &&& msg.content.get_update_request().key == make_stateful_set_key(zk.object_ref())
+    &&& msg.content.get_update_request().obj == update_stateful_set(
+        zk, StatefulSetView::from_dynamic_object(object).get_Ok_0()
+    ).to_dynamic_object()
+}
+
+pub open spec fn at_after_update_stateful_set_step_with_zk_and_pending_req_in_flight(
+    zk: ZookeeperClusterView, object: DynamicObjectView
+) -> StatePred<ClusterState> {
+    |s: ClusterState| {
+        &&& at_after_update_stateful_set_step_with_zk(zk)(s)
+        &&& s.reconcile_state_of(zk.object_ref()).pending_req_msg.is_Some()
+        &&& s.message_in_flight(s.pending_req_of(zk.object_ref()))
+        &&& is_update_stateful_set_request_msg(s.pending_req_of(zk.object_ref()), zk, object)
+    }
+}
+
+pub open spec fn req_msg_is_the_in_flight_pending_req_at_after_update_stateful_set_step_with_zk(
+    zk: ZookeeperClusterView, req_msg: Message, object: DynamicObjectView
+) -> StatePred<ClusterState> {
+    |s: ClusterState| {
+        &&& at_after_update_stateful_set_step_with_zk(zk)(s)
+        &&& s.reconcile_state_of(zk.object_ref()).pending_req_msg == Option::Some(req_msg)
+        &&& s.message_in_flight(req_msg)
+        &&& is_update_stateful_set_request_msg(req_msg, zk, object)
+    }
+}
+
+// Handy abbreviation for Done step
+
+pub open spec fn at_done_step(key: ObjectRef) -> StatePred<ClusterState>
+    recommends
+        key.kind.is_CustomResourceKind(),
+{
+    |s: ClusterState| {
+        &&& s.reconcile_state_contains(key)
+        &&& s.reconcile_state_of(key).local_state.reconcile_step.is_Done()
+    }
+}
+
+pub open spec fn at_done_step_with_zk(zk: ZookeeperClusterView) -> StatePred<ClusterState> {
+    |s: ClusterState| {
+        &&& at_done_step(zk.object_ref())(s)
+        &&& s.reconcile_state_of(zk.object_ref()).triggering_cr.object_ref() == zk.object_ref()
+        &&& s.reconcile_state_of(zk.object_ref()).triggering_cr.spec == zk.spec
+    }
+}
+
+}

--- a/src/controller_examples/zookeeper_controller/proof/liveness.rs
+++ b/src/controller_examples/zookeeper_controller/proof/liveness.rs
@@ -1,0 +1,2148 @@
+// Copyright 2022 VMware, Inc.
+// SPDX-License-Identifier: MIT
+#![allow(unused_imports)]
+use crate::kubernetes_api_objects::{
+    api_method::*, common::*, dynamic::*, resource::*, stateful_set::*,
+};
+use crate::kubernetes_cluster::{
+    proof::{
+        cluster::*, cluster_safety, controller_runtime_liveness, controller_runtime_safety,
+        kubernetes_api_liveness, kubernetes_api_safety,
+    },
+    spec::{
+        cluster::*,
+        controller::common::{controller_req_msg, ControllerActionInput, ControllerStep},
+        controller::controller_runtime::{
+            continue_reconcile, end_reconcile, run_scheduled_reconcile,
+        },
+        controller::state_machine::controller,
+        kubernetes_api::state_machine::{
+            handle_create_request, handle_get_request, handle_request, update_is_noop,
+        },
+        message::*,
+    },
+};
+use crate::temporal_logic::{defs::*, rules::*};
+use crate::zookeeper_controller::{
+    proof::{common::*, safety, terminate},
+    spec::{reconciler::*, zookeepercluster::*},
+};
+use builtin::*;
+use builtin_macros::*;
+use vstd::*;
+use vstd::{option::*, result::*};
+
+verus! {
+
+spec fn desired_state_exists(zk: ZookeeperClusterView) -> StatePred<ClusterState> {
+    |s: ClusterState| {
+        &&& s.resource_key_exists(zk.object_ref())
+        &&& ZookeeperClusterView::from_dynamic_object(s.resource_obj_of(zk.object_ref())).is_Ok()
+    }
+}
+
+spec fn desired_state_is(zk: ZookeeperClusterView) -> StatePred<ClusterState> {
+    |s: ClusterState| {
+        &&& s.resource_key_exists(zk.object_ref())
+        &&& ZookeeperClusterView::from_dynamic_object(s.resource_obj_of(zk.object_ref())).is_Ok()
+        &&& ZookeeperClusterView::from_dynamic_object(s.resource_obj_of(zk.object_ref())).get_Ok_0().spec == zk.spec
+    }
+}
+
+spec fn current_state_matches(zk: ZookeeperClusterView) -> StatePred<ClusterState> {
+    |s: ClusterState| {
+        &&& s.resource_key_exists(make_stateful_set_key(zk.object_ref()))
+        &&& StatefulSetView::from_dynamic_object(s.resource_obj_of(make_stateful_set_key(zk.object_ref()))).is_Ok()
+        &&& StatefulSetView::from_dynamic_object(s.resource_obj_of(make_stateful_set_key(zk.object_ref()))).get_Ok_0().spec == make_stateful_set(zk).spec
+    }
+}
+
+spec fn liveness(zk: ZookeeperClusterView) -> TempPred<ClusterState>
+    recommends
+        zk.well_formed(),
+{
+    always(lift_state(desired_state_is(zk))).leads_to(always(lift_state(current_state_matches(zk))))
+}
+
+proof fn liveness_proof_forall_zk()
+    ensures
+        forall |zk: ZookeeperClusterView| zk.well_formed() ==> #[trigger] cluster_spec().entails(liveness(zk)),
+{
+    assert forall |zk: ZookeeperClusterView| zk.well_formed()
+    implies #[trigger] cluster_spec().entails(liveness(zk)) by {
+        liveness_proof(zk);
+    };
+}
+
+#[verifier(external_body)]
+proof fn lemma_always_desired_state_exists(spec: TempPred<ClusterState>, zk: ZookeeperClusterView)
+    requires
+        spec.entails(always(lift_state(desired_state_is(zk)))),
+    ensures
+        spec.entails(always(lift_state(desired_state_exists(zk)))),
+{}
+
+// TODO: generalize this
+proof fn lemma_true_leads_to_always_the_object_in_schedule_has_spec_as(spec: TempPred<ClusterState>, zk: ZookeeperClusterView)
+    requires
+        zk.well_formed(),
+        spec.entails(always(lift_action(next::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>()))),
+        spec.entails(tla_forall(|i| schedule_controller_reconcile().weak_fairness(i))),
+        spec.entails(always(lift_state(desired_state_is(zk)))),
+        spec.entails(always(lift_state(cluster_safety::each_object_in_etcd_is_well_formed()))),
+    ensures
+        spec.entails(true_pred().leads_to(always(lift_state(safety::the_object_in_schedule_has_spec_as(zk))))),
+{
+    let pre = |s: ClusterState| true;
+    let post = safety::the_object_in_schedule_has_spec_as(zk);
+    let input = zk.object_ref();
+    let stronger_next = |s, s_prime: ClusterState| {
+        &&& next::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>()(s, s_prime)
+        &&& desired_state_is(zk)(s)
+        &&& cluster_safety::each_object_in_etcd_is_well_formed()(s)
+    };
+    entails_always_and_n!(
+        spec,
+        lift_action(next::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>()),
+        lift_state(desired_state_is(zk)),
+        lift_state(cluster_safety::each_object_in_etcd_is_well_formed())
+    );
+    temp_pred_equality(
+        lift_action(stronger_next),
+        lift_action(next::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>())
+        .and(lift_state(desired_state_is(zk)))
+        .and(lift_state(cluster_safety::each_object_in_etcd_is_well_formed()))
+    );
+
+    lemma_always_desired_state_exists(spec, zk);
+    temp_pred_equality::<ClusterState>(
+        lift_state(desired_state_exists(zk)), lift_state(schedule_controller_reconcile().pre(input))
+    );
+
+    spec_implies_pre(spec, lift_state(pre), lift_state(schedule_controller_reconcile().pre(input)));
+    use_tla_forall::<ClusterState, ObjectRef>(spec, |key| schedule_controller_reconcile().weak_fairness(key), input);
+
+    schedule_controller_reconcile().wf1(input, spec, stronger_next, pre, post);
+    leads_to_stable_temp(spec, lift_action(stronger_next), lift_state(pre), lift_state(post));
+}
+
+// TODO: generalize this
+#[verifier(external_body)]
+proof fn lemma_true_leads_to_always_the_object_in_reconcile_has_spec_as(spec: TempPred<ClusterState>, zk: ZookeeperClusterView)
+    requires
+        zk.well_formed(),
+        spec.entails(always(lift_action(next::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>()))),
+        spec.entails(tla_forall(|i| schedule_controller_reconcile().weak_fairness(i))),
+        spec.entails(always(lift_state(desired_state_is(zk)))),
+        spec.entails(always(lift_state(cluster_safety::each_object_in_etcd_is_well_formed()))),
+    ensures
+        spec.entails(true_pred().leads_to(always(lift_state(safety::the_object_in_reconcile_has_spec_as(zk))))),
+{}
+
+spec fn next_with_wf() -> TempPred<ClusterState> {
+    always(lift_action(next::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>()))
+    .and(tla_forall(|input| kubernetes_api_next().weak_fairness(input)))
+    .and(tla_forall(|input| controller_next::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>().weak_fairness(input)))
+    .and(tla_forall(|input| schedule_controller_reconcile().weak_fairness(input)))
+    .and(disable_crash().weak_fairness(()))
+}
+
+spec fn assumptions(zk: ZookeeperClusterView) -> TempPred<ClusterState> {
+    always(lift_state(crash_disabled()))
+    .and(always(lift_state(desired_state_is(zk))))
+    .and(always(lift_state(safety::the_object_in_schedule_has_spec_as(zk))))
+    .and(always(lift_state(safety::the_object_in_reconcile_has_spec_as(zk))))
+}
+
+spec fn invariants(zk: ZookeeperClusterView) -> TempPred<ClusterState> {
+    always(lift_state(controller_runtime_safety::every_in_flight_msg_has_unique_id()))
+    .and(always(lift_state(controller_runtime_safety::each_resp_matches_at_most_one_pending_req(zk.object_ref()))))
+    .and(always(lift_state(controller_runtime_safety::each_resp_if_matches_pending_req_then_no_other_resp_matches(zk.object_ref()))))
+    .and(always(lift_state(controller_runtime_safety::every_in_flight_msg_has_lower_id_than_allocator())))
+    .and(always(lift_state(cluster_safety::each_object_in_etcd_is_well_formed())))
+    .and(always(lift_state(cluster_safety::each_scheduled_key_is_consistent_with_its_object())))
+    .and(always(lift_state(cluster_safety::each_key_in_reconcile_is_consistent_with_its_object())))
+    .and(always(lift_state(safety::pending_msg_at_after_create_stateful_set_step_is_create_sts_req(zk.object_ref()))))
+    .and(always(lift_state(safety::pending_msg_at_after_update_stateful_set_step_is_update_sts_req(zk.object_ref()))))
+}
+
+spec fn invariants_since_rest_id(zk: ZookeeperClusterView, rest_id: RestId) -> TempPred<ClusterState> {
+    always(lift_state(rest_id_counter_is_no_smaller_than(rest_id)))
+    .and(always(lift_state(safety::at_most_one_create_sts_req_since_rest_id_is_in_flight(zk.object_ref(), rest_id))))
+    .and(always(lift_state(safety::at_most_one_update_sts_req_since_rest_id_is_in_flight(zk.object_ref(), rest_id))))
+    .and(always(lift_state(safety::no_delete_sts_req_since_rest_id_is_in_flight(zk.object_ref(), rest_id))))
+    .and(always(lift_state(safety::every_update_sts_req_since_rest_id_does_the_same(zk, rest_id))))
+}
+
+spec fn invariants_led_to_by_rest_id(zk: ZookeeperClusterView, rest_id: RestId) -> TempPred<ClusterState> {
+    always(lift_state(kubernetes_api_liveness::no_req_before_rest_id_is_in_flight(rest_id)))
+}
+
+proof fn liveness_proof(zk: ZookeeperClusterView)
+    requires
+        zk.well_formed(),
+    ensures
+        cluster_spec().entails(liveness(zk)),
+{
+    assert_by(
+        next_with_wf().and(invariants(zk)).and(assumptions(zk))
+        .entails(
+            true_pred().leads_to(always(lift_state(current_state_matches(zk))))
+        ),
+        {
+            let spec = next_with_wf().and(invariants(zk)).and(assumptions(zk));
+
+            let idle = lift_state(|s: ClusterState| !s.reconcile_state_contains(zk.object_ref()));
+            let idle_and_rest_id_is = |rest_id| lift_state(rest_id_counter_is(rest_id)).and(idle);
+            assert forall |rest_id|
+            spec.entails(#[trigger] idle_and_rest_id_is(rest_id).leads_to(always(lift_state(current_state_matches(zk))))) by {
+                lemma_true_leads_to_always_current_state_matches_zk_from_idle_with_rest_id(zk, rest_id);
+                assume(valid(stable(spec)));
+                temp_pred_equality(
+                    lift_state(rest_id_counter_is(rest_id))
+                    .and(lift_state(|s: ClusterState| !s.reconcile_state_contains(zk.object_ref())))
+                    .and(next_with_wf()).and(invariants(zk)).and(assumptions(zk)),
+                    spec.and(idle_and_rest_id_is(rest_id))
+                );
+                unpack_conditions_from_spec(spec, idle_and_rest_id_is(rest_id), true_pred(), always(lift_state(current_state_matches(zk))));
+                temp_pred_equality(true_pred().and(idle_and_rest_id_is(rest_id)), idle_and_rest_id_is(rest_id));
+            }
+
+            leads_to_exists_intro(spec, idle_and_rest_id_is, always(lift_state(current_state_matches(zk))));
+
+            assert_by(
+                tla_exists(idle_and_rest_id_is) == idle,
+                {
+                    assert forall |ex| #[trigger] idle.satisfied_by(ex)
+                    implies tla_exists(idle_and_rest_id_is).satisfied_by(ex) by {
+                        let rest_id = ex.head().rest_id_allocator.rest_id_counter;
+                        assert(idle_and_rest_id_is(rest_id).satisfied_by(ex));
+                    }
+                    temp_pred_equality(tla_exists(idle_and_rest_id_is), idle);
+                }
+            );
+
+            terminate::reconcile_eventually_terminates(spec, zk);
+
+            leads_to_trans_temp(spec, true_pred(), idle, always(lift_state(current_state_matches(zk))));
+        }
+    );
+
+    assert_by(
+        next_with_wf().and(invariants(zk)).and(always(lift_state(desired_state_is(zk))))
+        .entails(
+            true_pred().leads_to(always(lift_state(current_state_matches(zk))))
+        ),
+        {
+            let spec = next_with_wf().and(invariants(zk)).and(always(lift_state(desired_state_is(zk))));
+            let other_assumptions = always(lift_state(crash_disabled()))
+                .and(always(lift_state(safety::the_object_in_schedule_has_spec_as(zk))))
+                .and(always(lift_state(safety::the_object_in_reconcile_has_spec_as(zk))));
+            temp_pred_equality(
+                next_with_wf().and(invariants(zk)).and(assumptions(zk)),
+                next_with_wf().and(invariants(zk)).and(always(lift_state(desired_state_is(zk)))).and(other_assumptions)
+            );
+            assume(valid(stable(spec)));
+            unpack_conditions_from_spec(spec, other_assumptions, true_pred(), always(lift_state(current_state_matches(zk))));
+            temp_pred_equality(true_pred().and(other_assumptions), other_assumptions);
+
+            lemma_true_leads_to_crash_always_disabled::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>(spec);
+            lemma_true_leads_to_always_the_object_in_schedule_has_spec_as(spec, zk);
+            lemma_true_leads_to_always_the_object_in_reconcile_has_spec_as(spec, zk);
+
+            leads_to_always_combine_n!(
+                spec, true_pred(),
+                lift_state(crash_disabled()),
+                lift_state(safety::the_object_in_schedule_has_spec_as(zk)),
+                lift_state(safety::the_object_in_reconcile_has_spec_as(zk))
+            );
+
+            always_and_equality_n!(
+                lift_state(crash_disabled()),
+                lift_state(safety::the_object_in_schedule_has_spec_as(zk)),
+                lift_state(safety::the_object_in_reconcile_has_spec_as(zk))
+            );
+
+            leads_to_trans_temp(spec, true_pred(), other_assumptions, always(lift_state(current_state_matches(zk))));
+        }
+    );
+
+    assert_by(
+        next_with_wf().and(invariants(zk))
+        .entails(
+            always(lift_state(desired_state_is(zk))).leads_to(always(lift_state(current_state_matches(zk))))
+        ),
+        {
+            let spec = next_with_wf().and(invariants(zk));
+            let assumption = always(lift_state(desired_state_is(zk)));
+            assume(valid(stable(spec)));
+            unpack_conditions_from_spec(spec, assumption, true_pred(), always(lift_state(current_state_matches(zk))));
+            temp_pred_equality(true_pred().and(assumption), assumption);
+        }
+    );
+
+    assert_by(
+        cluster_spec()
+        .entails(
+            always(lift_state(desired_state_is(zk))).leads_to(always(lift_state(current_state_matches(zk))))
+        ),
+        {
+            let spec = cluster_spec();
+
+            entails_trans(
+                spec.and(invariants(zk)), next_with_wf().and(invariants(zk)),
+                always(lift_state(desired_state_is(zk))).leads_to(always(lift_state(current_state_matches(zk))))
+            );
+
+            controller_runtime_safety::lemma_always_every_in_flight_msg_has_unique_id::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>();
+            controller_runtime_safety::lemma_always_each_resp_matches_at_most_one_pending_req::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>(zk.object_ref());
+            controller_runtime_safety::lemma_always_each_resp_if_matches_pending_req_then_no_other_resp_matches::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>(zk.object_ref());
+            controller_runtime_safety::lemma_always_every_in_flight_msg_has_lower_id_than_allocator::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>();
+            cluster_safety::lemma_always_each_object_in_etcd_is_well_formed::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>(spec);
+            cluster_safety::lemma_always_each_scheduled_key_is_consistent_with_its_object::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>(spec);
+            cluster_safety::lemma_always_each_key_in_reconcile_is_consistent_with_its_object::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>(spec);
+            safety::lemma_always_pending_msg_at_after_create_stateful_set_step_is_create_sts_req(spec, zk.object_ref());
+            safety::lemma_always_pending_msg_at_after_update_stateful_set_step_is_update_sts_req(spec, zk.object_ref());
+
+            entails_and_n!(
+                spec,
+                always(lift_state(controller_runtime_safety::every_in_flight_msg_has_unique_id())),
+                always(lift_state(controller_runtime_safety::each_resp_matches_at_most_one_pending_req(zk.object_ref()))),
+                always(lift_state(controller_runtime_safety::each_resp_if_matches_pending_req_then_no_other_resp_matches(zk.object_ref()))),
+                always(lift_state(controller_runtime_safety::every_in_flight_msg_has_lower_id_than_allocator())),
+                always(lift_state(cluster_safety::each_object_in_etcd_is_well_formed())),
+                always(lift_state(cluster_safety::each_scheduled_key_is_consistent_with_its_object())),
+                always(lift_state(cluster_safety::each_key_in_reconcile_is_consistent_with_its_object())),
+                always(lift_state(safety::pending_msg_at_after_create_stateful_set_step_is_create_sts_req(zk.object_ref()))),
+                always(lift_state(safety::pending_msg_at_after_update_stateful_set_step_is_update_sts_req(zk.object_ref())))
+            );
+
+            simplify_predicate(spec, invariants(zk));
+        }
+    );
+
+}
+
+proof fn lemma_true_leads_to_always_current_state_matches_zk_from_idle_with_rest_id(zk: ZookeeperClusterView, rest_id: RestId)
+    requires
+        zk.well_formed(),
+    ensures
+        lift_state(rest_id_counter_is(rest_id))
+        .and(lift_state(|s: ClusterState| !s.reconcile_state_contains(zk.object_ref())))
+        .and(next_with_wf()).and(invariants(zk)).and(assumptions(zk))
+        .entails(
+            true_pred().leads_to(always(lift_state(current_state_matches(zk))))
+        ),
+{
+    let stable_spec = next_with_wf().and(invariants(zk)).and(assumptions(zk));
+    let spec = lift_state(rest_id_counter_is(rest_id))
+        .and(lift_state(|s: ClusterState| !s.reconcile_state_contains(zk.object_ref())))
+        .and(next_with_wf())
+        .and(invariants(zk))
+        .and(assumptions(zk));
+
+    assert_by(
+        spec.and(invariants_since_rest_id(zk, rest_id)).entails(
+            invariants_led_to_by_rest_id(zk, rest_id).leads_to(always(lift_state(current_state_matches(zk))))
+        ),
+        {
+            lemma_true_leads_to_always_current_state_matches_zk_under_eventual_invariants(zk, rest_id);
+            assume(valid(stable(stable_spec.and(invariants_since_rest_id(zk, rest_id)))));
+            unpack_conditions_from_spec(
+                stable_spec.and(invariants_since_rest_id(zk, rest_id)),
+                invariants_led_to_by_rest_id(zk, rest_id),
+                true_pred(),
+                always(lift_state(current_state_matches(zk)))
+            );
+            temp_pred_equality(
+                true_pred().and(invariants_led_to_by_rest_id(zk, rest_id)),
+                invariants_led_to_by_rest_id(zk, rest_id)
+            );
+            entails_trans(
+                spec.and(invariants_since_rest_id(zk, rest_id)),
+                stable_spec.and(invariants_since_rest_id(zk, rest_id)),
+                invariants_led_to_by_rest_id(zk, rest_id).leads_to(always(lift_state(current_state_matches(zk))))
+            );
+        }
+    );
+
+    kubernetes_api_liveness::lemma_true_leads_to_always_no_req_before_rest_id_is_in_flight::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>(
+        spec.and(invariants_since_rest_id(zk, rest_id)), rest_id
+    );
+
+    leads_to_trans_temp(spec.and(invariants_since_rest_id(zk, rest_id)), true_pred(), invariants_led_to_by_rest_id(zk, rest_id), always(lift_state(current_state_matches(zk))));
+
+    assert_by(
+        spec.entails(invariants_since_rest_id(zk, rest_id)),
+        {
+            eliminate_always(spec, lift_state(controller_runtime_safety::every_in_flight_msg_has_lower_id_than_allocator()));
+            eliminate_always(spec, lift_state(safety::pending_msg_at_after_create_stateful_set_step_is_create_sts_req(zk.object_ref())));
+            eliminate_always(spec, lift_state(safety::pending_msg_at_after_update_stateful_set_step_is_update_sts_req(zk.object_ref())));
+
+            cluster_safety::lemma_always_rest_id_counter_is_no_smaller_than::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>(spec, rest_id);
+            safety::lemma_always_at_most_one_create_sts_req_since_rest_id_is_in_flight(spec, zk.object_ref(), rest_id);
+            safety::lemma_always_at_most_one_update_sts_req_since_rest_id_is_in_flight(spec, zk.object_ref(), rest_id);
+            safety::lemma_always_no_delete_sts_req_since_rest_id_is_in_flight(spec, zk.object_ref(), rest_id);
+            safety::lemma_always_every_update_sts_req_since_rest_id_does_the_same(spec, zk, rest_id);
+
+            entails_and_n!(
+                spec,
+                always(lift_state(rest_id_counter_is_no_smaller_than(rest_id))),
+                always(lift_state(safety::at_most_one_create_sts_req_since_rest_id_is_in_flight(zk.object_ref(), rest_id))),
+                always(lift_state(safety::at_most_one_update_sts_req_since_rest_id_is_in_flight(zk.object_ref(), rest_id))),
+                always(lift_state(safety::no_delete_sts_req_since_rest_id_is_in_flight(zk.object_ref(), rest_id))),
+                always(lift_state(safety::every_update_sts_req_since_rest_id_does_the_same(zk, rest_id)))
+            );
+        }
+    );
+
+    simplify_predicate(spec, invariants_since_rest_id(zk, rest_id));
+}
+
+
+proof fn lemma_true_leads_to_always_current_state_matches_zk_under_eventual_invariants(zk: ZookeeperClusterView, rest_id: RestId)
+    requires
+        zk.well_formed(),
+    ensures
+        next_with_wf()
+        .and(invariants(zk))
+        .and(assumptions(zk))
+        .and(invariants_since_rest_id(zk, rest_id))
+        .and(invariants_led_to_by_rest_id(zk, rest_id))
+        .entails(
+            true_pred().leads_to(always(lift_state(current_state_matches(zk))))
+        ),
+{
+    let spec = next_with_wf()
+        .and(invariants(zk))
+        .and(assumptions(zk))
+        .and(invariants_since_rest_id(zk, rest_id))
+        .and(invariants_led_to_by_rest_id(zk, rest_id));
+
+    lemma_always_desired_state_exists(spec, zk);
+
+    assert_by(
+        spec.entails(
+            true_pred().leads_to(lift_state(|s: ClusterState| !s.reconcile_state_contains(zk.object_ref())))
+        ),
+        {
+            terminate::reconcile_eventually_terminates(spec, zk);
+        }
+    );
+
+    assert_by(
+        spec.entails(
+            lift_state(|s: ClusterState| !s.reconcile_state_contains(zk.object_ref()))
+                .leads_to(lift_state(at_init_step_with_no_pending_req(zk)))
+        ),
+        {
+            let unscheduled_and_not_in_reconcile = lift_state(|s: ClusterState| {
+                &&& !s.reconcile_state_contains(zk.object_ref())
+                &&& !s.reconcile_scheduled_for(zk.object_ref())
+            });
+            let scheduled_and_not_in_reconcile = lift_state(|s: ClusterState| {
+                &&& !s.reconcile_state_contains(zk.object_ref())
+                &&& s.reconcile_scheduled_for(zk.object_ref())
+            });
+            lemma_from_unscheduled_to_scheduled(spec, zk);
+            lemma_from_scheduled_to_init_step(spec, zk);
+            leads_to_trans_temp(
+                spec,
+                unscheduled_and_not_in_reconcile,
+                scheduled_and_not_in_reconcile,
+                lift_state(at_init_step_with_no_pending_req(zk))
+            );
+            or_leads_to_combine_temp(
+                spec,
+                unscheduled_and_not_in_reconcile,
+                scheduled_and_not_in_reconcile,
+                lift_state(at_init_step_with_no_pending_req(zk))
+            );
+            temp_pred_equality(
+                lift_state(|s: ClusterState| !s.reconcile_state_contains(zk.object_ref())),
+                unscheduled_and_not_in_reconcile.or(scheduled_and_not_in_reconcile)
+            );
+        }
+    );
+
+    assert_by(
+        spec.entails(
+            lift_state(at_init_step_with_no_pending_req(zk))
+                .leads_to(lift_state(at_after_create_headless_service_step_with_zk_and_pending_req_in_flight(zk)))
+        ),
+        {
+            lemma_from_init_step_to_after_create_headless_service_step(spec, zk);
+        }
+    );
+
+    assert_by(
+        spec.entails(
+            lift_state(at_after_create_headless_service_step_with_zk_and_pending_req_in_flight(zk))
+                .leads_to(lift_state(at_after_create_client_service_step_with_zk_and_pending_req_in_flight(zk)))
+        ),
+        {
+            let pre_and_req_in_flight = |req_msg| lift_state(
+                req_msg_is_the_in_flight_pending_req_at_after_create_headless_service_step_with_zk(zk, req_msg)
+            );
+            let pre_and_exists_resp_in_flight = lift_state(
+                at_after_create_headless_service_step_with_zk_and_exists_resp_in_flight(zk)
+            );
+            let pre_and_resp_in_flight = |resp_msg| lift_state(
+                resp_msg_is_the_in_flight_resp_at_after_create_headless_service_step_with_zk(zk, resp_msg)
+            );
+            assert forall |req_msg|
+                spec.entails(#[trigger] pre_and_req_in_flight(req_msg).leads_to(pre_and_exists_resp_in_flight))
+            by {
+                lemma_receives_some_resp_at_after_create_headless_service_step_with_zk(spec, zk, req_msg);
+            }
+            leads_to_exists_intro(spec, pre_and_req_in_flight, pre_and_exists_resp_in_flight);
+            assert_by(
+                tla_exists(pre_and_req_in_flight) == lift_state(at_after_create_headless_service_step_with_zk_and_pending_req_in_flight(zk)),
+                {
+                    assert forall |ex|
+                        #[trigger] lift_state(at_after_create_headless_service_step_with_zk_and_pending_req_in_flight(zk)).satisfied_by(ex)
+                    implies tla_exists(pre_and_req_in_flight).satisfied_by(ex) by {
+                        let req_msg = ex.head().pending_req_of(zk.object_ref());
+                        assert(pre_and_req_in_flight(req_msg).satisfied_by(ex));
+                    }
+                    temp_pred_equality(
+                        tla_exists(pre_and_req_in_flight),
+                        lift_state(at_after_create_headless_service_step_with_zk_and_pending_req_in_flight(zk))
+                    );
+                }
+            );
+
+            assert forall |resp_msg|
+                spec.entails(
+                    #[trigger] pre_and_resp_in_flight(resp_msg)
+                        .leads_to(lift_state(at_after_create_client_service_step_with_zk_and_pending_req_in_flight(zk)))
+                )
+            by {
+                lemma_from_after_create_headless_service_step_to_after_create_client_service_step(spec, zk, resp_msg);
+            }
+            leads_to_exists_intro(
+                spec,
+                pre_and_resp_in_flight,
+                lift_state(at_after_create_client_service_step_with_zk_and_pending_req_in_flight(zk))
+            );
+            assert_by(
+                tla_exists(pre_and_resp_in_flight) == pre_and_exists_resp_in_flight,
+                {
+                    assert forall |ex| #[trigger] pre_and_exists_resp_in_flight.satisfied_by(ex)
+                    implies tla_exists(pre_and_resp_in_flight).satisfied_by(ex) by {
+                        let resp_msg = choose |resp_msg| {
+                            &&& #[trigger] ex.head().message_in_flight(resp_msg)
+                            &&& resp_msg_matches_req_msg(resp_msg, ex.head().pending_req_of(zk.object_ref()))
+                        };
+                        assert(pre_and_resp_in_flight(resp_msg).satisfied_by(ex));
+                    }
+                    temp_pred_equality(tla_exists(pre_and_resp_in_flight), pre_and_exists_resp_in_flight);
+                }
+            );
+
+            leads_to_trans_temp(
+                spec,
+                lift_state(at_after_create_headless_service_step_with_zk_and_pending_req_in_flight(zk)),
+                pre_and_exists_resp_in_flight,
+                lift_state(at_after_create_client_service_step_with_zk_and_pending_req_in_flight(zk))
+            );
+        }
+    );
+
+    assert_by(
+        spec.entails(
+            lift_state(at_after_create_client_service_step_with_zk_and_pending_req_in_flight(zk))
+                .leads_to(lift_state(at_after_create_admin_server_service_step_with_zk_and_pending_req_in_flight(zk)))
+        ),
+        {
+            let pre_and_req_in_flight = |req_msg| lift_state(
+                req_msg_is_the_in_flight_pending_req_at_after_create_client_service_step_with_zk(zk, req_msg)
+            );
+            let pre_and_exists_resp_in_flight = lift_state(
+                at_after_create_client_service_step_with_zk_and_exists_resp_in_flight(zk)
+            );
+            let pre_and_resp_in_flight = |resp_msg| lift_state(
+                resp_msg_is_the_in_flight_resp_at_after_create_client_service_step_with_zk(zk, resp_msg)
+            );
+            assert forall |req_msg|
+                spec.entails(#[trigger] pre_and_req_in_flight(req_msg).leads_to(pre_and_exists_resp_in_flight))
+            by {
+                lemma_receives_some_resp_at_after_create_client_service_step_with_zk(spec, zk, req_msg);
+            }
+            leads_to_exists_intro(spec, pre_and_req_in_flight, pre_and_exists_resp_in_flight);
+            assert_by(
+                tla_exists(pre_and_req_in_flight) == lift_state(at_after_create_client_service_step_with_zk_and_pending_req_in_flight(zk)),
+                {
+                    assert forall |ex|
+                        #[trigger] lift_state(at_after_create_client_service_step_with_zk_and_pending_req_in_flight(zk)).satisfied_by(ex)
+                    implies tla_exists(pre_and_req_in_flight).satisfied_by(ex) by {
+                        let req_msg = ex.head().pending_req_of(zk.object_ref());
+                        assert(pre_and_req_in_flight(req_msg).satisfied_by(ex));
+                    }
+                    temp_pred_equality(
+                        tla_exists(pre_and_req_in_flight),
+                        lift_state(at_after_create_client_service_step_with_zk_and_pending_req_in_flight(zk))
+                    );
+                }
+            );
+
+            assert forall |resp_msg|
+                spec.entails(
+                    #[trigger] pre_and_resp_in_flight(resp_msg)
+                        .leads_to(lift_state(at_after_create_admin_server_service_step_with_zk_and_pending_req_in_flight(zk)))
+                )
+            by {
+                lemma_from_after_create_client_service_step_to_after_create_admin_server_service_step(spec, zk, resp_msg);
+            }
+            leads_to_exists_intro(
+                spec,
+                pre_and_resp_in_flight,
+                lift_state(at_after_create_admin_server_service_step_with_zk_and_pending_req_in_flight(zk))
+            );
+            assert_by(
+                tla_exists(pre_and_resp_in_flight) == pre_and_exists_resp_in_flight,
+                {
+                    assert forall |ex| #[trigger] pre_and_exists_resp_in_flight.satisfied_by(ex)
+                    implies tla_exists(pre_and_resp_in_flight).satisfied_by(ex) by {
+                        let resp_msg = choose |resp_msg| {
+                            &&& #[trigger] ex.head().message_in_flight(resp_msg)
+                            &&& resp_msg_matches_req_msg(resp_msg, ex.head().pending_req_of(zk.object_ref()))
+                        };
+                        assert(pre_and_resp_in_flight(resp_msg).satisfied_by(ex));
+                    }
+                    temp_pred_equality(tla_exists(pre_and_resp_in_flight), pre_and_exists_resp_in_flight);
+                }
+            );
+
+            leads_to_trans_temp(
+                spec,
+                lift_state(at_after_create_client_service_step_with_zk_and_pending_req_in_flight(zk)),
+                pre_and_exists_resp_in_flight,
+                lift_state(at_after_create_admin_server_service_step_with_zk_and_pending_req_in_flight(zk))
+            );
+        }
+    );
+
+    assert_by(
+        spec.entails(
+            lift_state(at_after_create_admin_server_service_step_with_zk_and_pending_req_in_flight(zk))
+                .leads_to(lift_state(at_after_create_config_map_step_with_zk_and_pending_req_in_flight(zk)))
+        ),
+        {
+            let pre_and_req_in_flight = |req_msg| lift_state(
+                req_msg_is_the_in_flight_pending_req_at_after_create_admin_server_service_step_with_zk(zk, req_msg)
+            );
+            let pre_and_exists_resp_in_flight = lift_state(
+                at_after_create_admin_server_service_step_with_zk_and_exists_resp_in_flight(zk)
+            );
+            let pre_and_resp_in_flight = |resp_msg| lift_state(
+                resp_msg_is_the_in_flight_resp_at_after_create_admin_server_service_step_with_zk(zk, resp_msg)
+            );
+            assert forall |req_msg|
+                spec.entails(#[trigger] pre_and_req_in_flight(req_msg).leads_to(pre_and_exists_resp_in_flight))
+            by {
+                lemma_receives_some_resp_at_after_create_admin_server_service_step_with_zk(spec, zk, req_msg);
+            }
+            leads_to_exists_intro(spec, pre_and_req_in_flight, pre_and_exists_resp_in_flight);
+            assert_by(
+                tla_exists(pre_and_req_in_flight) == lift_state(at_after_create_admin_server_service_step_with_zk_and_pending_req_in_flight(zk)),
+                {
+                    assert forall |ex|
+                        #[trigger] lift_state(at_after_create_admin_server_service_step_with_zk_and_pending_req_in_flight(zk)).satisfied_by(ex)
+                    implies tla_exists(pre_and_req_in_flight).satisfied_by(ex) by {
+                        let req_msg = ex.head().pending_req_of(zk.object_ref());
+                        assert(pre_and_req_in_flight(req_msg).satisfied_by(ex));
+                    }
+                    temp_pred_equality(
+                        tla_exists(pre_and_req_in_flight),
+                        lift_state(at_after_create_admin_server_service_step_with_zk_and_pending_req_in_flight(zk))
+                    );
+                }
+            );
+
+            assert forall |resp_msg|
+                spec.entails(
+                    #[trigger] pre_and_resp_in_flight(resp_msg)
+                        .leads_to(lift_state(at_after_create_config_map_step_with_zk_and_pending_req_in_flight(zk)))
+                )
+            by {
+                lemma_from_after_create_admin_server_service_step_to_after_create_config_map_step(spec, zk, resp_msg);
+            }
+            leads_to_exists_intro(
+                spec,
+                pre_and_resp_in_flight,
+                lift_state(at_after_create_config_map_step_with_zk_and_pending_req_in_flight(zk))
+            );
+            assert_by(
+                tla_exists(pre_and_resp_in_flight) == pre_and_exists_resp_in_flight,
+                {
+                    assert forall |ex| #[trigger] pre_and_exists_resp_in_flight.satisfied_by(ex)
+                    implies tla_exists(pre_and_resp_in_flight).satisfied_by(ex) by {
+                        let resp_msg = choose |resp_msg| {
+                            &&& #[trigger] ex.head().message_in_flight(resp_msg)
+                            &&& resp_msg_matches_req_msg(resp_msg, ex.head().pending_req_of(zk.object_ref()))
+                        };
+                        assert(pre_and_resp_in_flight(resp_msg).satisfied_by(ex));
+                    }
+                    temp_pred_equality(tla_exists(pre_and_resp_in_flight), pre_and_exists_resp_in_flight);
+                }
+            );
+
+            leads_to_trans_temp(
+                spec,
+                lift_state(at_after_create_admin_server_service_step_with_zk_and_pending_req_in_flight(zk)),
+                pre_and_exists_resp_in_flight,
+                lift_state(at_after_create_config_map_step_with_zk_and_pending_req_in_flight(zk))
+            );
+        }
+    );
+
+    assert_by(
+        spec.entails(
+            lift_state(at_after_create_config_map_step_with_zk_and_pending_req_in_flight(zk))
+                .leads_to(lift_state(at_after_get_stateful_set_step_with_zk_and_pending_req_in_flight(zk)))
+        ),
+        {
+            let pre_and_req_in_flight = |req_msg| lift_state(
+                req_msg_is_the_in_flight_pending_req_at_after_create_config_map_step_with_zk(zk, req_msg)
+            );
+            let pre_and_exists_resp_in_flight = lift_state(
+                at_after_create_config_map_step_with_zk_and_exists_resp_in_flight(zk)
+            );
+            let pre_and_resp_in_flight = |resp_msg| lift_state(
+                resp_msg_is_the_in_flight_resp_at_after_create_config_map_step_with_zk(zk, resp_msg)
+            );
+            assert forall |req_msg|
+                spec.entails(#[trigger] pre_and_req_in_flight(req_msg).leads_to(pre_and_exists_resp_in_flight))
+            by {
+                lemma_receives_some_resp_at_after_create_config_map_step_with_zk(spec, zk, req_msg);
+            }
+            leads_to_exists_intro(spec, pre_and_req_in_flight, pre_and_exists_resp_in_flight);
+            assert_by(
+                tla_exists(pre_and_req_in_flight) == lift_state(at_after_create_config_map_step_with_zk_and_pending_req_in_flight(zk)),
+                {
+                    assert forall |ex|
+                        #[trigger] lift_state(at_after_create_config_map_step_with_zk_and_pending_req_in_flight(zk)).satisfied_by(ex)
+                    implies tla_exists(pre_and_req_in_flight).satisfied_by(ex) by {
+                        let req_msg = ex.head().pending_req_of(zk.object_ref());
+                        assert(pre_and_req_in_flight(req_msg).satisfied_by(ex));
+                    }
+                    temp_pred_equality(
+                        tla_exists(pre_and_req_in_flight),
+                        lift_state(at_after_create_config_map_step_with_zk_and_pending_req_in_flight(zk))
+                    );
+                }
+            );
+
+            assert forall |resp_msg|
+                spec.entails(
+                    #[trigger] pre_and_resp_in_flight(resp_msg)
+                        .leads_to(lift_state(at_after_get_stateful_set_step_with_zk_and_pending_req_in_flight(zk)))
+                )
+            by {
+                lemma_from_after_create_config_map_step_to_after_get_stateful_set_step(spec, zk, resp_msg);
+            }
+            leads_to_exists_intro(
+                spec,
+                pre_and_resp_in_flight,
+                lift_state(at_after_get_stateful_set_step_with_zk_and_pending_req_in_flight(zk))
+            );
+            assert_by(
+                tla_exists(pre_and_resp_in_flight) == pre_and_exists_resp_in_flight,
+                {
+                    assert forall |ex| #[trigger] pre_and_exists_resp_in_flight.satisfied_by(ex)
+                    implies tla_exists(pre_and_resp_in_flight).satisfied_by(ex) by {
+                        let resp_msg = choose |resp_msg| {
+                            &&& #[trigger] ex.head().message_in_flight(resp_msg)
+                            &&& resp_msg_matches_req_msg(resp_msg, ex.head().pending_req_of(zk.object_ref()))
+                        };
+                        assert(pre_and_resp_in_flight(resp_msg).satisfied_by(ex));
+                    }
+                    temp_pred_equality(tla_exists(pre_and_resp_in_flight), pre_and_exists_resp_in_flight);
+                }
+            );
+
+            leads_to_trans_temp(
+                spec,
+                lift_state(at_after_create_config_map_step_with_zk_and_pending_req_in_flight(zk)),
+                pre_and_exists_resp_in_flight,
+                lift_state(at_after_get_stateful_set_step_with_zk_and_pending_req_in_flight(zk))
+            );
+        }
+    );
+
+    assert_by(
+        spec.entails(
+            lift_state(|s: ClusterState| {
+                &&& !s.resource_key_exists(make_stateful_set_key(zk.object_ref()))
+                &&& at_after_get_stateful_set_step_with_zk_and_pending_req_in_flight(zk)(s)
+            })
+                .leads_to(lift_state(current_state_matches(zk)))
+        ),
+        {
+            let pre = lift_state(|s: ClusterState| {
+                &&& !s.resource_key_exists(make_stateful_set_key(zk.object_ref()))
+                &&& at_after_get_stateful_set_step_with_zk_and_pending_req_in_flight(zk)(s)
+            });
+            let post = lift_state(|s: ClusterState| {
+                &&& !s.resource_key_exists(make_stateful_set_key(zk.object_ref()))
+                &&& at_after_create_stateful_set_step_with_zk_and_pending_req_in_flight(zk)(s)
+            });
+            let pre_and_req_in_flight = |req_msg| lift_state(
+                |s: ClusterState| {
+                    &&& !s.resource_key_exists(make_stateful_set_key(zk.object_ref()))
+                    &&& req_msg_is_the_in_flight_pending_req_at_after_get_stateful_set_step_with_zk(zk, req_msg)(s)
+                }
+            );
+            let pre_and_exists_resp_in_flight = lift_state(
+                |s: ClusterState| {
+                    &&& !s.resource_key_exists(make_stateful_set_key(zk.object_ref()))
+                    &&& at_after_get_stateful_set_step_with_zk_and_exists_not_found_resp_in_flight(zk)(s)
+                }
+            );
+            let pre_and_resp_in_flight = |resp_msg| lift_state(
+                |s: ClusterState| {
+                    &&& !s.resource_key_exists(make_stateful_set_key(zk.object_ref()))
+                    &&& resp_msg_is_the_in_flight_resp_at_after_get_stateful_set_step_with_zk(zk, resp_msg)(s)
+                    &&& resp_msg.content.get_get_response().res.is_Err()
+                    &&& resp_msg.content.get_get_response().res.get_Err_0().is_ObjectNotFound()
+                }
+            );
+            let post_and_req_in_flight = |req_msg| lift_state(
+                |s: ClusterState| {
+                    &&& !s.resource_key_exists(make_stateful_set_key(zk.object_ref()))
+                    &&& req_msg_is_the_in_flight_pending_req_at_after_create_stateful_set_step_with_zk(zk, req_msg)(s)
+                }
+            );
+            assert forall |req_msg| spec.entails(#[trigger] pre_and_req_in_flight(req_msg).leads_to(pre_and_exists_resp_in_flight))
+            by {
+                lemma_receives_not_found_resp_at_after_get_stateful_set_step_with_zk(spec, zk, rest_id, req_msg);
+            }
+            leads_to_exists_intro(spec, pre_and_req_in_flight, pre_and_exists_resp_in_flight);
+            assert_by(
+                tla_exists(pre_and_req_in_flight) == pre,
+                {
+                    assert forall |ex| #[trigger] pre.satisfied_by(ex)
+                    implies tla_exists(pre_and_req_in_flight).satisfied_by(ex) by {
+                        let req_msg = ex.head().pending_req_of(zk.object_ref());
+                        assert(pre_and_req_in_flight(req_msg).satisfied_by(ex));
+                    }
+                    temp_pred_equality(tla_exists(pre_and_req_in_flight), pre);
+                }
+            );
+
+            assert forall |resp_msg| spec.entails(#[trigger] pre_and_resp_in_flight(resp_msg).leads_to(post))
+            by {
+                lemma_from_after_get_stateful_set_step_to_after_create_stateful_set_step(spec, zk, rest_id, resp_msg);
+            }
+            leads_to_exists_intro(spec, pre_and_resp_in_flight, post);
+            assert_by(
+                tla_exists(pre_and_resp_in_flight) == pre_and_exists_resp_in_flight,
+                {
+                    assert forall |ex| #[trigger] pre_and_exists_resp_in_flight.satisfied_by(ex)
+                    implies tla_exists(pre_and_resp_in_flight).satisfied_by(ex) by {
+                        let resp_msg = choose |resp_msg| {
+                            &&& #[trigger] ex.head().message_in_flight(resp_msg)
+                            &&& resp_msg_matches_req_msg(resp_msg, ex.head().pending_req_of(zk.object_ref()))
+                            &&& resp_msg.content.get_get_response().res.is_Err()
+                            &&& resp_msg.content.get_get_response().res.get_Err_0().is_ObjectNotFound()
+                        };
+                        assert(pre_and_resp_in_flight(resp_msg).satisfied_by(ex));
+                    }
+                    temp_pred_equality(tla_exists(pre_and_resp_in_flight), pre_and_exists_resp_in_flight);
+                }
+            );
+
+            assert forall |req_msg| spec.entails(#[trigger] post_and_req_in_flight(req_msg).leads_to(lift_state(current_state_matches(zk))))
+            by {
+                lemma_sts_is_created_at_after_create_stateful_set_step_with_zk(spec, zk, rest_id, req_msg);
+            }
+            leads_to_exists_intro(spec, post_and_req_in_flight, lift_state(current_state_matches(zk)));
+            assert_by(
+                tla_exists(post_and_req_in_flight) == post,
+                {
+                    assert forall |ex| #[trigger] post.satisfied_by(ex)
+                    implies tla_exists(post_and_req_in_flight).satisfied_by(ex) by {
+                        let req_msg = ex.head().pending_req_of(zk.object_ref());
+                        assert(post_and_req_in_flight(req_msg).satisfied_by(ex));
+                    }
+                    temp_pred_equality(tla_exists(post_and_req_in_flight), post);
+                }
+            );
+
+            leads_to_trans_temp(spec, pre, pre_and_exists_resp_in_flight, post);
+            leads_to_trans_temp(spec, pre, post, lift_state(current_state_matches(zk)));
+        }
+    );
+
+    assert_by(
+        spec.entails(
+            lift_state(|s: ClusterState| {
+                &&& s.resource_key_exists(make_stateful_set_key(zk.object_ref()))
+                &&& at_after_get_stateful_set_step_with_zk_and_pending_req_in_flight(zk)(s)
+            })
+                .leads_to(lift_state(current_state_matches(zk)))
+        ),
+        {
+            let pre = lift_state(|s: ClusterState| {
+                &&& s.resource_key_exists(make_stateful_set_key(zk.object_ref()))
+                &&& at_after_get_stateful_set_step_with_zk_and_pending_req_in_flight(zk)(s)
+            });
+            let pre_with_object = |object| lift_state(
+                |s: ClusterState| {
+                    &&& s.resource_key_exists(make_stateful_set_key(zk.object_ref()))
+                    &&& s.resource_obj_of(make_stateful_set_key(zk.object_ref())) == object
+                    &&& at_after_get_stateful_set_step_with_zk_and_pending_req_in_flight(zk)(s)
+                }
+            );
+            assert forall |object: DynamicObjectView| spec.entails(#[trigger] pre_with_object(object).leads_to(lift_state(current_state_matches(zk))))
+            by {
+                let p1 = lift_state(|s: ClusterState| {
+                    &&& s.resource_key_exists(make_stateful_set_key(zk.object_ref()))
+                    &&& s.resource_obj_of(make_stateful_set_key(zk.object_ref())) == object
+                    &&& at_after_get_stateful_set_step_with_zk_and_pending_req_in_flight(zk)(s)
+                });
+                let p2 = lift_state(|s: ClusterState| {
+                    &&& s.resource_key_exists(make_stateful_set_key(zk.object_ref()))
+                    &&& s.resource_obj_of(make_stateful_set_key(zk.object_ref())) == object
+                    &&& at_after_update_stateful_set_step_with_zk_and_pending_req_in_flight(zk, object)(s)
+                });
+
+                assert_by(
+                    spec.entails(p1.leads_to(p2)),
+                    {
+                        let pre_and_req_in_flight = |req_msg| lift_state(
+                            |s: ClusterState| {
+                                &&& s.resource_key_exists(make_stateful_set_key(zk.object_ref()))
+                                &&& s.resource_obj_of(make_stateful_set_key(zk.object_ref())) == object
+                                &&& req_msg_is_the_in_flight_pending_req_at_after_get_stateful_set_step_with_zk(zk, req_msg)(s)
+                            }
+                        );
+                        let pre_and_exists_resp_in_flight = lift_state(
+                            |s: ClusterState| {
+                                &&& s.resource_key_exists(make_stateful_set_key(zk.object_ref()))
+                                &&& s.resource_obj_of(make_stateful_set_key(zk.object_ref())) == object
+                                &&& at_after_get_stateful_set_step_with_zk_and_exists_ok_resp_in_flight(zk, object)(s)
+                            }
+                        );
+                        let pre_and_resp_in_flight = |resp_msg| lift_state(
+                            |s: ClusterState| {
+                                &&& s.resource_key_exists(make_stateful_set_key(zk.object_ref()))
+                                &&& s.resource_obj_of(make_stateful_set_key(zk.object_ref())) == object
+                                &&& resp_msg_is_the_in_flight_resp_at_after_get_stateful_set_step_with_zk(zk, resp_msg)(s)
+                                &&& resp_msg.content.get_get_response().res.is_Ok()
+                                &&& resp_msg.content.get_get_response().res.get_Ok_0() == object
+                            }
+                        );
+
+                        assert forall |req_msg| spec.entails(#[trigger] pre_and_req_in_flight(req_msg).leads_to(pre_and_exists_resp_in_flight))
+                        by {
+                            lemma_receives_ok_resp_at_after_get_stateful_set_step_with_zk(spec, zk, rest_id, req_msg, object);
+                        }
+                        leads_to_exists_intro(spec, pre_and_req_in_flight, pre_and_exists_resp_in_flight);
+                        assert_by(
+                            tla_exists(pre_and_req_in_flight) == p1,
+                            {
+                                assert forall |ex| #[trigger] p1.satisfied_by(ex)
+                                implies tla_exists(pre_and_req_in_flight).satisfied_by(ex) by {
+                                    let req_msg = ex.head().pending_req_of(zk.object_ref());
+                                    assert(pre_and_req_in_flight(req_msg).satisfied_by(ex));
+                                }
+                                temp_pred_equality(tla_exists(pre_and_req_in_flight), p1);
+                            }
+                        );
+
+                        assert forall |resp_msg| spec.entails(#[trigger] pre_and_resp_in_flight(resp_msg).leads_to(p2))
+                        by {
+                            lemma_from_after_get_stateful_set_step_to_after_update_stateful_set_step(spec, zk, rest_id, resp_msg, object);
+                        }
+                        leads_to_exists_intro(spec, pre_and_resp_in_flight, p2);
+                        assert_by(
+                            tla_exists(pre_and_resp_in_flight) == pre_and_exists_resp_in_flight,
+                            {
+                                assert forall |ex| #[trigger] pre_and_exists_resp_in_flight.satisfied_by(ex)
+                                implies tla_exists(pre_and_resp_in_flight).satisfied_by(ex) by {
+                                    let resp_msg = choose |resp_msg| {
+                                        &&& #[trigger] ex.head().message_in_flight(resp_msg)
+                                        &&& resp_msg_matches_req_msg(resp_msg, ex.head().pending_req_of(zk.object_ref()))
+                                        &&& resp_msg.content.get_get_response().res.is_Ok()
+                                        &&& resp_msg.content.get_get_response().res.get_Ok_0() == object
+                                    };
+                                    assert(pre_and_resp_in_flight(resp_msg).satisfied_by(ex));
+                                }
+                                temp_pred_equality(tla_exists(pre_and_resp_in_flight), pre_and_exists_resp_in_flight);
+                            }
+                        );
+
+                        leads_to_trans_temp(spec, p1, pre_and_exists_resp_in_flight, p2);
+                    }
+                );
+
+                assert_by(
+                    spec.entails(p2.leads_to(lift_state(current_state_matches(zk)))),
+                    {
+                        let pre_and_req_in_flight = |req_msg| lift_state(
+                            |s: ClusterState| {
+                                &&& s.resource_key_exists(make_stateful_set_key(zk.object_ref()))
+                                &&& s.resource_obj_of(make_stateful_set_key(zk.object_ref())) == object
+                                &&& req_msg_is_the_in_flight_pending_req_at_after_update_stateful_set_step_with_zk(zk, req_msg, object)(s)
+                            }
+                        );
+                        assert forall |req_msg| spec.entails(#[trigger] pre_and_req_in_flight(req_msg).leads_to(lift_state(current_state_matches(zk))))
+                        by {
+                            lemma_sts_is_updated_at_after_update_stateful_set_step_with_zk(spec, zk, rest_id, req_msg, object);
+                        }
+                        leads_to_exists_intro(spec, pre_and_req_in_flight, lift_state(current_state_matches(zk)));
+                        assert_by(
+                            tla_exists(pre_and_req_in_flight) == p2,
+                            {
+                                assert forall |ex| #[trigger] p2.satisfied_by(ex)
+                                implies tla_exists(pre_and_req_in_flight).satisfied_by(ex) by {
+                                    let req_msg = ex.head().pending_req_of(zk.object_ref());
+                                    assert(pre_and_req_in_flight(req_msg).satisfied_by(ex));
+                                }
+                                temp_pred_equality(tla_exists(pre_and_req_in_flight), p2);
+                            }
+                        );
+                    }
+                );
+
+                leads_to_trans_temp(spec, p1, p2, lift_state(current_state_matches(zk)));
+            }
+            leads_to_exists_intro(spec, pre_with_object, lift_state(current_state_matches(zk)));
+            assert_by(
+                tla_exists(pre_with_object) == pre,
+                {
+                    assert forall |ex| #[trigger] pre.satisfied_by(ex)
+                    implies tla_exists(pre_with_object).satisfied_by(ex) by {
+                        let object = ex.head().resource_obj_of(make_stateful_set_key(zk.object_ref()));
+                        assert(pre_with_object(object).satisfied_by(ex));
+                    }
+                    temp_pred_equality(tla_exists(pre_with_object), pre);
+                }
+            );
+        }
+    );
+
+    assert_by(
+        spec.entails(
+            lift_state(at_after_get_stateful_set_step_with_zk_and_pending_req_in_flight(zk))
+                .leads_to(lift_state(current_state_matches(zk)))
+        ),
+        {
+            let p1 = lift_state(|s: ClusterState| {
+                &&& !s.resource_key_exists(make_stateful_set_key(zk.object_ref()))
+                &&& at_after_get_stateful_set_step_with_zk_and_pending_req_in_flight(zk)(s)
+            });
+            let p2 = lift_state(|s: ClusterState| {
+                &&& s.resource_key_exists(make_stateful_set_key(zk.object_ref()))
+                &&& at_after_get_stateful_set_step_with_zk_and_pending_req_in_flight(zk)(s)
+            });
+            or_leads_to_combine_temp(spec, p1, p2, lift_state(current_state_matches(zk)));
+            temp_pred_equality(p1.or(p2), lift_state(at_after_get_stateful_set_step_with_zk_and_pending_req_in_flight(zk)));
+        }
+    );
+
+    assert_by(
+        spec.entails(
+            lift_state(current_state_matches(zk))
+                .leads_to(always(lift_state(current_state_matches(zk))))
+        ),
+        {
+            leads_to_self_temp(lift_state(current_state_matches(zk)));
+            lemma_stateful_set_is_stable(spec, zk, rest_id, lift_state(current_state_matches(zk)));
+        }
+    );
+
+    leads_to_trans_n!(
+        spec,
+        true_pred(),
+        lift_state(|s: ClusterState| !s.reconcile_state_contains(zk.object_ref())),
+        lift_state(at_init_step_with_no_pending_req(zk)),
+        lift_state(at_after_create_headless_service_step_with_zk_and_pending_req_in_flight(zk)),
+        lift_state(at_after_create_client_service_step_with_zk_and_pending_req_in_flight(zk)),
+        lift_state(at_after_create_admin_server_service_step_with_zk_and_pending_req_in_flight(zk)),
+        lift_state(at_after_create_config_map_step_with_zk_and_pending_req_in_flight(zk)),
+        lift_state(at_after_get_stateful_set_step_with_zk_and_pending_req_in_flight(zk)),
+        lift_state(current_state_matches(zk)),
+        always(lift_state(current_state_matches(zk)))
+    );
+}
+
+proof fn lemma_from_unscheduled_to_scheduled(spec: TempPred<ClusterState>, zk: ZookeeperClusterView)
+    requires
+        spec.entails(always(lift_action(next::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>()))),
+        spec.entails(tla_forall(|i| schedule_controller_reconcile().weak_fairness(i))),
+        spec.entails(always(lift_state(desired_state_exists(zk)))),
+        zk.well_formed(),
+    ensures
+        spec.entails(
+            lift_state(|s: ClusterState| {
+                &&& !s.reconcile_state_contains(zk.object_ref())
+                &&& !s.reconcile_scheduled_for(zk.object_ref())
+            })
+                .leads_to(lift_state(|s: ClusterState| {
+                    &&& !s.reconcile_state_contains(zk.object_ref())
+                    &&& s.reconcile_scheduled_for(zk.object_ref())
+                }))
+        ),
+{
+    let pre = |s: ClusterState| {
+        &&& !s.reconcile_state_contains(zk.object_ref())
+        &&& !s.reconcile_scheduled_for(zk.object_ref())
+    };
+    let post = |s: ClusterState| {
+        &&& !s.reconcile_state_contains(zk.object_ref())
+        &&& s.reconcile_scheduled_for(zk.object_ref())
+    };
+    let input = zk.object_ref();
+    let stronger_next = |s, s_prime: ClusterState| {
+        &&& next::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>()(s, s_prime)
+        &&& desired_state_exists(zk)(s)
+    };
+    entails_always_and_n!(
+        spec,
+        lift_action(next::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>()),
+        lift_state(desired_state_exists(zk))
+    );
+    temp_pred_equality(
+        lift_action(stronger_next),
+        lift_action(next::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>())
+        .and(lift_state(desired_state_exists(zk)))
+    );
+
+    temp_pred_equality::<ClusterState>(
+        lift_state(desired_state_exists(zk)), lift_state(schedule_controller_reconcile().pre(input))
+    );
+    spec_implies_pre(spec, lift_state(pre), lift_state(schedule_controller_reconcile().pre(input)));
+    use_tla_forall::<ClusterState, ObjectRef>(spec, |key| schedule_controller_reconcile().weak_fairness(key), input);
+    schedule_controller_reconcile().wf1(input, spec, stronger_next, pre, post);
+}
+
+proof fn lemma_from_scheduled_to_init_step(spec: TempPred<ClusterState>, zk: ZookeeperClusterView)
+    requires
+        spec.entails(always(lift_action(next::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>()))),
+        spec.entails(tla_forall(|i| controller_next::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>().weak_fairness(i))),
+        spec.entails(always(lift_state(crash_disabled()))),
+        spec.entails(always(lift_state(cluster_safety::each_scheduled_key_is_consistent_with_its_object()))),
+        spec.entails(always(lift_state(safety::the_object_in_schedule_has_spec_as(zk)))),
+        zk.well_formed(),
+    ensures
+        spec.entails(
+            lift_state(|s: ClusterState| {
+                &&& !s.reconcile_state_contains(zk.object_ref())
+                &&& s.reconcile_scheduled_for(zk.object_ref())
+            })
+                .leads_to(lift_state(at_init_step_with_no_pending_req(zk)))
+        ),
+{
+    let pre = |s: ClusterState| {
+        &&& !s.reconcile_state_contains(zk.object_ref())
+        &&& s.reconcile_scheduled_for(zk.object_ref())
+    };
+    let post = at_init_step_with_no_pending_req(zk);
+    let input = (Option::None, Option::Some(zk.object_ref()));
+    let stronger_next = |s, s_prime: ClusterState| {
+        &&& next::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>()(s, s_prime)
+        &&& crash_disabled()(s)
+        &&& cluster_safety::each_scheduled_key_is_consistent_with_its_object()(s)
+        &&& safety::the_object_in_schedule_has_spec_as(zk)(s)
+    };
+    entails_always_and_n!(
+        spec,
+        lift_action(next::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>()),
+        lift_state(crash_disabled()),
+        lift_state(cluster_safety::each_scheduled_key_is_consistent_with_its_object()),
+        lift_state(safety::the_object_in_schedule_has_spec_as(zk))
+    );
+    temp_pred_equality(
+        lift_action(stronger_next),
+        lift_action(next::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>())
+        .and(lift_state(crash_disabled()))
+        .and(lift_state(cluster_safety::each_scheduled_key_is_consistent_with_its_object()))
+        .and(lift_state(safety::the_object_in_schedule_has_spec_as(zk)))
+    );
+
+    controller_runtime_liveness::lemma_pre_leads_to_post_by_controller::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>(
+        spec, input, stronger_next,
+        run_scheduled_reconcile::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>(), pre, post
+    );
+}
+
+proof fn lemma_from_init_step_to_after_create_headless_service_step(
+    spec: TempPred<ClusterState>, zk: ZookeeperClusterView
+)
+    requires
+        spec.entails(always(lift_action(next::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>()))),
+        spec.entails(tla_forall(|i| controller_next::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>().weak_fairness(i))),
+        spec.entails(always(lift_state(crash_disabled()))),
+        zk.well_formed(),
+    ensures
+        spec.entails(
+            lift_state(at_init_step_with_no_pending_req(zk))
+                .leads_to(lift_state(at_after_create_headless_service_step_with_zk_and_pending_req_in_flight(zk)))
+        ),
+{
+    let pre = at_init_step_with_no_pending_req(zk);
+    let post = at_after_create_headless_service_step_with_zk_and_pending_req_in_flight(zk);
+    let input = (Option::None, Option::Some(zk.object_ref()));
+    let stronger_next = |s, s_prime: ClusterState| {
+        &&& next::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>()(s, s_prime)
+        &&& crash_disabled()(s)
+    };
+    entails_always_and_n!(
+        spec,
+        lift_action(next::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>()),
+        lift_state(crash_disabled())
+    );
+    temp_pred_equality(
+        lift_action(stronger_next),
+        lift_action(next::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>())
+        .and(lift_state(crash_disabled()))
+    );
+
+    controller_runtime_liveness::lemma_pre_leads_to_post_by_controller::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>(
+        spec, input, stronger_next,
+        continue_reconcile::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>(), pre, post
+    );
+}
+
+proof fn lemma_receives_some_resp_at_after_create_headless_service_step_with_zk(
+    spec: TempPred<ClusterState>, zk: ZookeeperClusterView, req_msg: Message
+)
+    requires
+        spec.entails(always(lift_action(next::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>()))),
+        spec.entails(tla_forall(|i| kubernetes_api_next().weak_fairness(i))),
+        spec.entails(always(lift_state(crash_disabled()))),
+        spec.entails(always(lift_state(controller_runtime_safety::every_in_flight_msg_has_unique_id()))),
+        zk.well_formed(),
+    ensures
+        spec.entails(
+            lift_state(req_msg_is_the_in_flight_pending_req_at_after_create_headless_service_step_with_zk(zk, req_msg))
+                .leads_to(lift_state(at_after_create_headless_service_step_with_zk_and_exists_resp_in_flight(zk)))
+        ),
+{
+    let pre = req_msg_is_the_in_flight_pending_req_at_after_create_headless_service_step_with_zk(zk, req_msg);
+    let post = at_after_create_headless_service_step_with_zk_and_exists_resp_in_flight(zk);
+    let input = Option::Some(req_msg);
+    let stronger_next = |s, s_prime: ClusterState| {
+        &&& next::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>()(s, s_prime)
+        &&& crash_disabled()(s)
+        &&& controller_runtime_safety::every_in_flight_msg_has_unique_id()(s)
+    };
+    entails_always_and_n!(
+        spec,
+        lift_action(next::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>()),
+        lift_state(crash_disabled()),
+        lift_state(controller_runtime_safety::every_in_flight_msg_has_unique_id())
+    );
+    temp_pred_equality(
+        lift_action(stronger_next),
+        lift_action(next::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>())
+        .and(lift_state(crash_disabled()))
+        .and(lift_state(controller_runtime_safety::every_in_flight_msg_has_unique_id()))
+    );
+
+    assert forall |s, s_prime|
+        pre(s) && #[trigger] stronger_next(s, s_prime) && kubernetes_api_next().forward(input)(s, s_prime)
+    implies post(s_prime) by {
+        let resp_msg = handle_create_request(req_msg, s.kubernetes_api_state).1;
+        assert({
+            &&& s_prime.message_in_flight(resp_msg)
+            &&& resp_msg_matches_req_msg(resp_msg, req_msg)
+        });
+    }
+
+    kubernetes_api_liveness::lemma_pre_leads_to_post_by_kubernetes_api::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>(
+        spec, input, stronger_next, handle_request(), pre, post
+    );
+}
+
+proof fn lemma_from_after_create_headless_service_step_to_after_create_client_service_step(
+    spec: TempPred<ClusterState>, zk: ZookeeperClusterView, resp_msg: Message
+)
+    requires
+        spec.entails(always(lift_action(next::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>()))),
+        spec.entails(tla_forall(|i| controller_next::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>().weak_fairness(i))),
+        spec.entails(always(lift_state(crash_disabled()))),
+        spec.entails(always(lift_state(controller_runtime_safety::each_resp_matches_at_most_one_pending_req(zk.object_ref())))),
+        zk.well_formed(),
+    ensures
+        spec.entails(
+            lift_state(resp_msg_is_the_in_flight_resp_at_after_create_headless_service_step_with_zk(zk, resp_msg))
+                .leads_to(lift_state(at_after_create_client_service_step_with_zk_and_pending_req_in_flight(zk)))
+        ),
+{
+    let pre = resp_msg_is_the_in_flight_resp_at_after_create_headless_service_step_with_zk(zk, resp_msg);
+    let post = at_after_create_client_service_step_with_zk_and_pending_req_in_flight(zk);
+    let input = (Option::Some(resp_msg), Option::Some(zk.object_ref()));
+    let stronger_next = |s, s_prime: ClusterState| {
+        &&& next::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>()(s, s_prime)
+        &&& crash_disabled()(s)
+        &&& controller_runtime_safety::each_resp_matches_at_most_one_pending_req(zk.object_ref())(s)
+    };
+
+    entails_always_and_n!(
+        spec,
+        lift_action(next::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>()),
+        lift_state(crash_disabled()),
+        lift_state(controller_runtime_safety::each_resp_matches_at_most_one_pending_req(zk.object_ref()))
+    );
+    temp_pred_equality(
+        lift_action(stronger_next),
+        lift_action(next::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>())
+        .and(lift_state(crash_disabled()))
+        .and(lift_state(controller_runtime_safety::each_resp_matches_at_most_one_pending_req(zk.object_ref())))
+    );
+
+    controller_runtime_liveness::lemma_pre_leads_to_post_by_controller::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>(
+        spec, input, stronger_next,
+        continue_reconcile::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>(), pre, post
+    );
+}
+
+proof fn lemma_receives_some_resp_at_after_create_client_service_step_with_zk(
+    spec: TempPred<ClusterState>, zk: ZookeeperClusterView, req_msg: Message
+)
+    requires
+        spec.entails(always(lift_action(next::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>()))),
+        spec.entails(tla_forall(|i| kubernetes_api_next().weak_fairness(i))),
+        spec.entails(always(lift_state(crash_disabled()))),
+        spec.entails(always(lift_state(controller_runtime_safety::every_in_flight_msg_has_unique_id()))),
+        zk.well_formed(),
+    ensures
+        spec.entails(
+            lift_state(req_msg_is_the_in_flight_pending_req_at_after_create_client_service_step_with_zk(zk, req_msg))
+                .leads_to(lift_state(at_after_create_client_service_step_with_zk_and_exists_resp_in_flight(zk)))
+        ),
+{
+    let pre = req_msg_is_the_in_flight_pending_req_at_after_create_client_service_step_with_zk(zk, req_msg);
+    let post = at_after_create_client_service_step_with_zk_and_exists_resp_in_flight(zk);
+    let input = Option::Some(req_msg);
+    let stronger_next = |s, s_prime: ClusterState| {
+        &&& next::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>()(s, s_prime)
+        &&& crash_disabled()(s)
+        &&& controller_runtime_safety::every_in_flight_msg_has_unique_id()(s)
+    };
+    entails_always_and_n!(
+        spec,
+        lift_action(next::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>()),
+        lift_state(crash_disabled()),
+        lift_state(controller_runtime_safety::every_in_flight_msg_has_unique_id())
+    );
+    temp_pred_equality(
+        lift_action(stronger_next),
+        lift_action(next::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>())
+        .and(lift_state(crash_disabled()))
+        .and(lift_state(controller_runtime_safety::every_in_flight_msg_has_unique_id()))
+    );
+
+    assert forall |s, s_prime| pre(s) && #[trigger] stronger_next(s, s_prime) && kubernetes_api_next().forward(input)(s, s_prime)
+    implies post(s_prime) by {
+        let resp_msg = handle_create_request(req_msg, s.kubernetes_api_state).1;
+        assert({
+            &&& s_prime.message_in_flight(resp_msg)
+            &&& resp_msg_matches_req_msg(resp_msg, req_msg)
+        });
+    }
+
+    kubernetes_api_liveness::lemma_pre_leads_to_post_by_kubernetes_api::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>(
+        spec, input, stronger_next, handle_request(), pre, post
+    );
+}
+
+proof fn lemma_from_after_create_client_service_step_to_after_create_admin_server_service_step(
+    spec: TempPred<ClusterState>, zk: ZookeeperClusterView, resp_msg: Message
+)
+    requires
+        spec.entails(always(lift_action(next::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>()))),
+        spec.entails(tla_forall(|i| controller_next::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>().weak_fairness(i))),
+        spec.entails(always(lift_state(crash_disabled()))),
+        spec.entails(always(lift_state(controller_runtime_safety::each_resp_matches_at_most_one_pending_req(zk.object_ref())))),
+        zk.well_formed(),
+    ensures
+        spec.entails(
+            lift_state(resp_msg_is_the_in_flight_resp_at_after_create_client_service_step_with_zk(zk, resp_msg))
+                .leads_to(lift_state(at_after_create_admin_server_service_step_with_zk_and_pending_req_in_flight(zk)))
+        ),
+{
+    let pre = resp_msg_is_the_in_flight_resp_at_after_create_client_service_step_with_zk(zk, resp_msg);
+    let post = at_after_create_admin_server_service_step_with_zk_and_pending_req_in_flight(zk);
+    let input = (Option::Some(resp_msg), Option::Some(zk.object_ref()));
+    let stronger_next = |s, s_prime: ClusterState| {
+        &&& next::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>()(s, s_prime)
+        &&& crash_disabled()(s)
+        &&& controller_runtime_safety::each_resp_matches_at_most_one_pending_req(zk.object_ref())(s)
+    };
+
+    entails_always_and_n!(
+        spec,
+        lift_action(next::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>()),
+        lift_state(crash_disabled()),
+        lift_state(controller_runtime_safety::each_resp_matches_at_most_one_pending_req(zk.object_ref()))
+    );
+    temp_pred_equality(
+        lift_action(stronger_next),
+        lift_action(next::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>())
+        .and(lift_state(crash_disabled()))
+        .and(lift_state(controller_runtime_safety::each_resp_matches_at_most_one_pending_req(zk.object_ref())))
+    );
+
+    controller_runtime_liveness::lemma_pre_leads_to_post_by_controller::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>(
+        spec, input, stronger_next,
+        continue_reconcile::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>(), pre, post
+    );
+}
+
+proof fn lemma_receives_some_resp_at_after_create_admin_server_service_step_with_zk(
+    spec: TempPred<ClusterState>, zk: ZookeeperClusterView, req_msg: Message
+)
+    requires
+        spec.entails(always(lift_action(next::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>()))),
+        spec.entails(tla_forall(|i| kubernetes_api_next().weak_fairness(i))),
+        spec.entails(always(lift_state(crash_disabled()))),
+        spec.entails(always(lift_state(controller_runtime_safety::every_in_flight_msg_has_unique_id()))),
+        zk.well_formed(),
+    ensures
+        spec.entails(
+            lift_state(req_msg_is_the_in_flight_pending_req_at_after_create_admin_server_service_step_with_zk(zk, req_msg))
+                .leads_to(lift_state(at_after_create_admin_server_service_step_with_zk_and_exists_resp_in_flight(zk)))
+        ),
+{
+    let pre = req_msg_is_the_in_flight_pending_req_at_after_create_admin_server_service_step_with_zk(zk, req_msg);
+    let post = at_after_create_admin_server_service_step_with_zk_and_exists_resp_in_flight(zk);
+    let input = Option::Some(req_msg);
+    let stronger_next = |s, s_prime: ClusterState| {
+        &&& next::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>()(s, s_prime)
+        &&& crash_disabled()(s)
+        &&& controller_runtime_safety::every_in_flight_msg_has_unique_id()(s)
+    };
+    entails_always_and_n!(
+        spec,
+        lift_action(next::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>()),
+        lift_state(crash_disabled()),
+        lift_state(controller_runtime_safety::every_in_flight_msg_has_unique_id())
+    );
+    temp_pred_equality(
+        lift_action(stronger_next),
+        lift_action(next::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>())
+        .and(lift_state(crash_disabled()))
+        .and(lift_state(controller_runtime_safety::every_in_flight_msg_has_unique_id()))
+    );
+
+    assert forall |s, s_prime| pre(s) && #[trigger] stronger_next(s, s_prime) && kubernetes_api_next().forward(input)(s, s_prime)
+    implies post(s_prime) by {
+        let resp_msg = handle_create_request(req_msg, s.kubernetes_api_state).1;
+        assert({
+            &&& s_prime.message_in_flight(resp_msg)
+            &&& resp_msg_matches_req_msg(resp_msg, req_msg)
+        });
+    }
+
+    kubernetes_api_liveness::lemma_pre_leads_to_post_by_kubernetes_api::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>(
+        spec, input, stronger_next, handle_request(), pre, post
+    );
+}
+
+proof fn lemma_from_after_create_admin_server_service_step_to_after_create_config_map_step(
+    spec: TempPred<ClusterState>, zk: ZookeeperClusterView, resp_msg: Message
+)
+    requires
+        spec.entails(always(lift_action(next::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>()))),
+        spec.entails(tla_forall(|i| controller_next::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>().weak_fairness(i))),
+        spec.entails(always(lift_state(crash_disabled()))),
+        spec.entails(always(lift_state(controller_runtime_safety::each_resp_matches_at_most_one_pending_req(zk.object_ref())))),
+        zk.well_formed(),
+    ensures
+        spec.entails(
+            lift_state(resp_msg_is_the_in_flight_resp_at_after_create_admin_server_service_step_with_zk(zk, resp_msg))
+                .leads_to(lift_state(at_after_create_config_map_step_with_zk_and_pending_req_in_flight(zk)))
+        ),
+{
+    let pre = resp_msg_is_the_in_flight_resp_at_after_create_admin_server_service_step_with_zk(zk, resp_msg);
+    let post = at_after_create_config_map_step_with_zk_and_pending_req_in_flight(zk);
+    let input = (Option::Some(resp_msg), Option::Some(zk.object_ref()));
+    let stronger_next = |s, s_prime: ClusterState| {
+        &&& next::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>()(s, s_prime)
+        &&& crash_disabled()(s)
+        &&& controller_runtime_safety::each_resp_matches_at_most_one_pending_req(zk.object_ref())(s)
+    };
+
+    entails_always_and_n!(
+        spec,
+        lift_action(next::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>()),
+        lift_state(crash_disabled()),
+        lift_state(controller_runtime_safety::each_resp_matches_at_most_one_pending_req(zk.object_ref()))
+    );
+    temp_pred_equality(
+        lift_action(stronger_next),
+        lift_action(next::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>())
+        .and(lift_state(crash_disabled()))
+        .and(lift_state(controller_runtime_safety::each_resp_matches_at_most_one_pending_req(zk.object_ref())))
+    );
+
+    controller_runtime_liveness::lemma_pre_leads_to_post_by_controller::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>(
+        spec, input, stronger_next,
+        continue_reconcile::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>(), pre, post
+    );
+}
+
+proof fn lemma_receives_some_resp_at_after_create_config_map_step_with_zk(
+    spec: TempPred<ClusterState>, zk: ZookeeperClusterView, req_msg: Message
+)
+    requires
+        spec.entails(always(lift_action(next::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>()))),
+        spec.entails(tla_forall(|i| kubernetes_api_next().weak_fairness(i))),
+        spec.entails(always(lift_state(crash_disabled()))),
+        spec.entails(always(lift_state(controller_runtime_safety::every_in_flight_msg_has_unique_id()))),
+        zk.well_formed(),
+    ensures
+        spec.entails(
+            lift_state(req_msg_is_the_in_flight_pending_req_at_after_create_config_map_step_with_zk(zk, req_msg))
+                .leads_to(lift_state(at_after_create_config_map_step_with_zk_and_exists_resp_in_flight(zk)))
+        ),
+{
+    let pre = req_msg_is_the_in_flight_pending_req_at_after_create_config_map_step_with_zk(zk, req_msg);
+    let post = at_after_create_config_map_step_with_zk_and_exists_resp_in_flight(zk);
+    let input = Option::Some(req_msg);
+    let stronger_next = |s, s_prime: ClusterState| {
+        &&& next::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>()(s, s_prime)
+        &&& crash_disabled()(s)
+        &&& controller_runtime_safety::every_in_flight_msg_has_unique_id()(s)
+    };
+    entails_always_and_n!(
+        spec,
+        lift_action(next::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>()),
+        lift_state(crash_disabled()),
+        lift_state(controller_runtime_safety::every_in_flight_msg_has_unique_id())
+    );
+    temp_pred_equality(
+        lift_action(stronger_next),
+        lift_action(next::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>())
+        .and(lift_state(crash_disabled()))
+        .and(lift_state(controller_runtime_safety::every_in_flight_msg_has_unique_id()))
+    );
+
+    assert forall |s, s_prime| pre(s) && #[trigger] stronger_next(s, s_prime) && kubernetes_api_next().forward(input)(s, s_prime)
+    implies post(s_prime) by {
+        let resp_msg = handle_create_request(req_msg, s.kubernetes_api_state).1;
+        assert({
+            &&& s_prime.message_in_flight(resp_msg)
+            &&& resp_msg_matches_req_msg(resp_msg, req_msg)
+        });
+    }
+
+    kubernetes_api_liveness::lemma_pre_leads_to_post_by_kubernetes_api::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>(
+        spec, input, stronger_next, handle_request(), pre, post
+    );
+}
+
+proof fn lemma_from_after_create_config_map_step_to_after_get_stateful_set_step(
+    spec: TempPred<ClusterState>, zk: ZookeeperClusterView, resp_msg: Message
+)
+    requires
+        spec.entails(always(lift_action(next::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>()))),
+        spec.entails(tla_forall(|i| controller_next::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>().weak_fairness(i))),
+        spec.entails(always(lift_state(crash_disabled()))),
+        spec.entails(always(lift_state(controller_runtime_safety::each_resp_matches_at_most_one_pending_req(zk.object_ref())))),
+        zk.well_formed(),
+    ensures
+        spec.entails(
+            lift_state(resp_msg_is_the_in_flight_resp_at_after_create_config_map_step_with_zk(zk, resp_msg))
+                .leads_to(lift_state(at_after_get_stateful_set_step_with_zk_and_pending_req_in_flight(zk)))
+        ),
+{
+    let pre = resp_msg_is_the_in_flight_resp_at_after_create_config_map_step_with_zk(zk, resp_msg);
+    let post = at_after_get_stateful_set_step_with_zk_and_pending_req_in_flight(zk);
+    let input = (Option::Some(resp_msg), Option::Some(zk.object_ref()));
+    let stronger_next = |s, s_prime: ClusterState| {
+        &&& next::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>()(s, s_prime)
+        &&& crash_disabled()(s)
+        &&& controller_runtime_safety::each_resp_matches_at_most_one_pending_req(zk.object_ref())(s)
+    };
+
+    entails_always_and_n!(
+        spec,
+        lift_action(next::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>()),
+        lift_state(crash_disabled()),
+        lift_state(controller_runtime_safety::each_resp_matches_at_most_one_pending_req(zk.object_ref()))
+    );
+    temp_pred_equality(
+        lift_action(stronger_next),
+        lift_action(next::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>())
+        .and(lift_state(crash_disabled()))
+        .and(lift_state(controller_runtime_safety::each_resp_matches_at_most_one_pending_req(zk.object_ref())))
+    );
+
+    controller_runtime_liveness::lemma_pre_leads_to_post_by_controller::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>(
+        spec, input, stronger_next,
+        continue_reconcile::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>(), pre, post
+    );
+}
+
+proof fn lemma_receives_ok_resp_at_after_get_stateful_set_step_with_zk(
+    spec: TempPred<ClusterState>, zk: ZookeeperClusterView, rest_id: nat, req_msg: Message, object: DynamicObjectView
+)
+    requires
+        spec.entails(always(lift_action(next::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>()))),
+        spec.entails(tla_forall(|i| kubernetes_api_next().weak_fairness(i))),
+        spec.entails(always(lift_state(crash_disabled()))),
+        spec.entails(always(lift_state(controller_runtime_safety::every_in_flight_msg_has_unique_id()))),
+        spec.entails(always(lift_state(kubernetes_api_liveness::no_req_before_rest_id_is_in_flight(rest_id)))),
+        spec.entails(always(lift_state(safety::at_most_one_update_sts_req_since_rest_id_is_in_flight(zk.object_ref(), rest_id)))),
+        spec.entails(always(lift_state(safety::no_delete_sts_req_since_rest_id_is_in_flight(zk.object_ref(), rest_id)))),
+        zk.well_formed(),
+    ensures
+        spec.entails(
+            lift_state(
+                |s: ClusterState| {
+                    &&& s.resource_key_exists(make_stateful_set_key(zk.object_ref()))
+                    &&& s.resource_obj_of(make_stateful_set_key(zk.object_ref())) == object
+                    &&& req_msg_is_the_in_flight_pending_req_at_after_get_stateful_set_step_with_zk(zk, req_msg)(s)
+                }
+            )
+                .leads_to(lift_state(
+                    |s: ClusterState| {
+                        &&& s.resource_key_exists(make_stateful_set_key(zk.object_ref()))
+                        &&& s.resource_obj_of(make_stateful_set_key(zk.object_ref())) == object
+                        &&& at_after_get_stateful_set_step_with_zk_and_exists_ok_resp_in_flight(zk, object)(s)
+                    }
+                ))
+        ),
+{
+    let pre = |s: ClusterState| {
+        &&& s.resource_key_exists(make_stateful_set_key(zk.object_ref()))
+        &&& s.resource_obj_of(make_stateful_set_key(zk.object_ref())) == object
+        &&& req_msg_is_the_in_flight_pending_req_at_after_get_stateful_set_step_with_zk(zk, req_msg)(s)
+    };
+    let post = |s: ClusterState| {
+        &&& s.resource_key_exists(make_stateful_set_key(zk.object_ref()))
+        &&& s.resource_obj_of(make_stateful_set_key(zk.object_ref())) == object
+        &&& at_after_get_stateful_set_step_with_zk_and_exists_ok_resp_in_flight(zk, object)(s)
+    };
+    let input = Option::Some(req_msg);
+    let stronger_next = |s, s_prime: ClusterState| {
+        &&& next::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>()(s, s_prime)
+        &&& crash_disabled()(s)
+        &&& controller_runtime_safety::every_in_flight_msg_has_unique_id()(s)
+        &&& kubernetes_api_liveness::no_req_before_rest_id_is_in_flight(rest_id)(s)
+        &&& safety::at_most_one_update_sts_req_since_rest_id_is_in_flight(zk.object_ref(), rest_id)(s)
+        &&& safety::no_delete_sts_req_since_rest_id_is_in_flight(zk.object_ref(), rest_id)(s)
+    };
+    entails_always_and_n!(
+        spec,
+        lift_action(next::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>()),
+        lift_state(crash_disabled()),
+        lift_state(controller_runtime_safety::every_in_flight_msg_has_unique_id()),
+        lift_state(kubernetes_api_liveness::no_req_before_rest_id_is_in_flight(rest_id)),
+        lift_state(safety::at_most_one_update_sts_req_since_rest_id_is_in_flight(zk.object_ref(), rest_id)),
+        lift_state(safety::no_delete_sts_req_since_rest_id_is_in_flight(zk.object_ref(), rest_id))
+    );
+    temp_pred_equality(
+        lift_action(stronger_next),
+        lift_action(next::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>())
+        .and(lift_state(crash_disabled()))
+        .and(lift_state(controller_runtime_safety::every_in_flight_msg_has_unique_id()))
+        .and(lift_state(kubernetes_api_liveness::no_req_before_rest_id_is_in_flight(rest_id)))
+        .and(lift_state(safety::at_most_one_update_sts_req_since_rest_id_is_in_flight(zk.object_ref(), rest_id)))
+        .and(lift_state(safety::no_delete_sts_req_since_rest_id_is_in_flight(zk.object_ref(), rest_id)))
+    );
+
+    assert forall |s, s_prime| pre(s) && #[trigger] stronger_next(s, s_prime) implies pre(s_prime) || post(s_prime) by {
+        let step = choose |step| next_step::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>(s, s_prime, step);
+        match step {
+            Step::KubernetesAPIStep(input) => {
+                if input.get_Some_0() == req_msg {
+                    let resp_msg = handle_get_request(req_msg, s.kubernetes_api_state).1;
+                    assert({
+                        &&& s_prime.message_in_flight(resp_msg)
+                        &&& resp_msg_matches_req_msg(resp_msg, req_msg)
+                        &&& resp_msg.content.get_get_response().res.is_Ok()
+                        &&& resp_msg.content.get_get_response().res.get_Ok_0() == object
+                    });
+                }
+            },
+            _ => {}
+        }
+    }
+
+    assert forall |s, s_prime| pre(s) && #[trigger] stronger_next(s, s_prime) && kubernetes_api_next().forward(input)(s, s_prime)
+    implies post(s_prime) by {
+        let resp_msg = handle_get_request(req_msg, s.kubernetes_api_state).1;
+        assert({
+            &&& s_prime.message_in_flight(resp_msg)
+            &&& resp_msg_matches_req_msg(resp_msg, req_msg)
+            &&& resp_msg.content.get_get_response().res.is_Ok()
+            &&& resp_msg.content.get_get_response().res.get_Ok_0() == object
+        });
+    }
+
+    kubernetes_api_liveness::lemma_pre_leads_to_post_by_kubernetes_api::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>(
+        spec, input, stronger_next, handle_request(), pre, post
+    );
+}
+
+proof fn lemma_from_after_get_stateful_set_step_to_after_update_stateful_set_step(
+    spec: TempPred<ClusterState>, zk: ZookeeperClusterView, rest_id: nat, resp_msg: Message, object: DynamicObjectView
+)
+    requires
+        spec.entails(always(lift_action(next::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>()))),
+        spec.entails(tla_forall(|i| controller_next::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>().weak_fairness(i))),
+        spec.entails(always(lift_state(crash_disabled()))),
+        spec.entails(always(lift_state(controller_runtime_safety::each_resp_matches_at_most_one_pending_req(zk.object_ref())))),
+        spec.entails(always(lift_state(controller_runtime_safety::each_resp_if_matches_pending_req_then_no_other_resp_matches(zk.object_ref())))),
+        spec.entails(always(lift_state(kubernetes_api_liveness::no_req_before_rest_id_is_in_flight(rest_id)))),
+        spec.entails(always(lift_state(cluster_safety::each_object_in_etcd_is_well_formed()))),
+        spec.entails(always(lift_state(safety::at_most_one_update_sts_req_since_rest_id_is_in_flight(zk.object_ref(), rest_id)))),
+        spec.entails(always(lift_state(safety::no_delete_sts_req_since_rest_id_is_in_flight(zk.object_ref(), rest_id)))),
+        zk.well_formed(),
+    ensures
+        spec.entails(
+            lift_state(|s: ClusterState| {
+                &&& s.resource_key_exists(make_stateful_set_key(zk.object_ref()))
+                &&& s.resource_obj_of(make_stateful_set_key(zk.object_ref())) == object
+                &&& resp_msg_is_the_in_flight_resp_at_after_get_stateful_set_step_with_zk(zk, resp_msg)(s)
+                &&& resp_msg.content.get_get_response().res.is_Ok()
+                &&& resp_msg.content.get_get_response().res.get_Ok_0() == object
+            })
+                .leads_to(lift_state(|s: ClusterState| {
+                    &&& s.resource_key_exists(make_stateful_set_key(zk.object_ref()))
+                    &&& s.resource_obj_of(make_stateful_set_key(zk.object_ref())) == object
+                    &&& at_after_update_stateful_set_step_with_zk_and_pending_req_in_flight(zk, object)(s)
+                }))
+        ),
+{
+    let pre = |s: ClusterState| {
+        &&& s.resource_key_exists(make_stateful_set_key(zk.object_ref()))
+        &&& s.resource_obj_of(make_stateful_set_key(zk.object_ref())) == object
+        &&& resp_msg_is_the_in_flight_resp_at_after_get_stateful_set_step_with_zk(zk, resp_msg)(s)
+        &&& resp_msg.content.get_get_response().res.is_Ok()
+        &&& resp_msg.content.get_get_response().res.get_Ok_0() == object
+    };
+    let post = |s: ClusterState| {
+        &&& s.resource_key_exists(make_stateful_set_key(zk.object_ref()))
+        &&& s.resource_obj_of(make_stateful_set_key(zk.object_ref())) == object
+        &&& at_after_update_stateful_set_step_with_zk_and_pending_req_in_flight(zk, object)(s)
+    };
+    let input = (Option::Some(resp_msg), Option::Some(zk.object_ref()));
+    let stronger_next = |s, s_prime: ClusterState| {
+        &&& next::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>()(s, s_prime)
+        &&& crash_disabled()(s)
+        &&& controller_runtime_safety::each_resp_matches_at_most_one_pending_req(zk.object_ref())(s)
+        &&& controller_runtime_safety::each_resp_if_matches_pending_req_then_no_other_resp_matches(zk.object_ref())(s)
+        &&& kubernetes_api_liveness::no_req_before_rest_id_is_in_flight(rest_id)(s)
+        &&& cluster_safety::each_object_in_etcd_is_well_formed()(s)
+        &&& safety::at_most_one_update_sts_req_since_rest_id_is_in_flight(zk.object_ref(), rest_id)(s)
+        &&& safety::no_delete_sts_req_since_rest_id_is_in_flight(zk.object_ref(), rest_id)(s)
+    };
+
+    entails_always_and_n!(
+        spec,
+        lift_action(next::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>()),
+        lift_state(crash_disabled()),
+        lift_state(controller_runtime_safety::each_resp_matches_at_most_one_pending_req(zk.object_ref())),
+        lift_state(controller_runtime_safety::each_resp_if_matches_pending_req_then_no_other_resp_matches(zk.object_ref())),
+        lift_state(kubernetes_api_liveness::no_req_before_rest_id_is_in_flight(rest_id)),
+        lift_state(cluster_safety::each_object_in_etcd_is_well_formed()),
+        lift_state(safety::at_most_one_update_sts_req_since_rest_id_is_in_flight(zk.object_ref(), rest_id)),
+        lift_state(safety::no_delete_sts_req_since_rest_id_is_in_flight(zk.object_ref(), rest_id))
+    );
+    temp_pred_equality(
+        lift_action(stronger_next),
+        lift_action(next::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>())
+        .and(lift_state(crash_disabled()))
+        .and(lift_state(controller_runtime_safety::each_resp_matches_at_most_one_pending_req(zk.object_ref())))
+        .and(lift_state(controller_runtime_safety::each_resp_if_matches_pending_req_then_no_other_resp_matches(zk.object_ref())))
+        .and(lift_state(kubernetes_api_liveness::no_req_before_rest_id_is_in_flight(rest_id)))
+        .and(lift_state(cluster_safety::each_object_in_etcd_is_well_formed()))
+        .and(lift_state(safety::at_most_one_update_sts_req_since_rest_id_is_in_flight(zk.object_ref(), rest_id)))
+        .and(lift_state(safety::no_delete_sts_req_since_rest_id_is_in_flight(zk.object_ref(), rest_id)))
+    );
+
+    controller_runtime_liveness::lemma_pre_leads_to_post_by_controller::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>(
+        spec, input, stronger_next,
+        continue_reconcile::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>(), pre, post
+    );
+}
+
+proof fn lemma_sts_is_updated_at_after_update_stateful_set_step_with_zk(
+    spec: TempPred<ClusterState>, zk: ZookeeperClusterView, rest_id: nat, req_msg: Message, object: DynamicObjectView
+)
+    requires
+        spec.entails(always(lift_action(next::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>()))),
+        spec.entails(tla_forall(|i| kubernetes_api_next().weak_fairness(i))),
+        spec.entails(always(lift_state(crash_disabled()))),
+        spec.entails(always(lift_state(controller_runtime_safety::every_in_flight_msg_has_unique_id()))),
+        spec.entails(always(lift_state(kubernetes_api_liveness::no_req_before_rest_id_is_in_flight(rest_id)))),
+        spec.entails(always(lift_state(cluster_safety::each_object_in_etcd_is_well_formed()))),
+        spec.entails(always(lift_state(safety::at_most_one_update_sts_req_since_rest_id_is_in_flight(zk.object_ref(), rest_id)))),
+        spec.entails(always(lift_state(safety::no_delete_sts_req_since_rest_id_is_in_flight(zk.object_ref(), rest_id)))),
+        zk.well_formed(),
+    ensures
+        spec.entails(
+            lift_state(
+                |s: ClusterState| {
+                    &&& s.resource_key_exists(make_stateful_set_key(zk.object_ref()))
+                    &&& s.resource_obj_of(make_stateful_set_key(zk.object_ref())) == object
+                    &&& req_msg_is_the_in_flight_pending_req_at_after_update_stateful_set_step_with_zk(zk, req_msg, object)(s)
+                }
+            )
+                .leads_to(lift_state(
+                    |s: ClusterState| {
+                        &&& s.resource_key_exists(make_stateful_set_key(zk.object_ref()))
+                        &&& StatefulSetView::from_dynamic_object(s.resource_obj_of(make_stateful_set_key(zk.object_ref()))).is_Ok()
+                        &&& StatefulSetView::from_dynamic_object(s.resource_obj_of(make_stateful_set_key(zk.object_ref()))).get_Ok_0().spec == make_stateful_set(zk).spec
+                    }
+                ))
+        ),
+{
+    let pre = |s: ClusterState| {
+        &&& s.resource_key_exists(make_stateful_set_key(zk.object_ref()))
+        &&& s.resource_obj_of(make_stateful_set_key(zk.object_ref())) == object
+        &&& req_msg_is_the_in_flight_pending_req_at_after_update_stateful_set_step_with_zk(zk, req_msg, object)(s)
+    };
+    let post = |s: ClusterState| {
+        &&& s.resource_key_exists(make_stateful_set_key(zk.object_ref()))
+        &&& StatefulSetView::from_dynamic_object(s.resource_obj_of(make_stateful_set_key(zk.object_ref()))).is_Ok()
+        &&& StatefulSetView::from_dynamic_object(s.resource_obj_of(make_stateful_set_key(zk.object_ref()))).get_Ok_0().spec == make_stateful_set(zk).spec
+    };
+    let input = Option::Some(req_msg);
+    let stronger_next = |s, s_prime: ClusterState| {
+        &&& next::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>()(s, s_prime)
+        &&& crash_disabled()(s)
+        &&& controller_runtime_safety::every_in_flight_msg_has_unique_id()(s)
+        &&& kubernetes_api_liveness::no_req_before_rest_id_is_in_flight(rest_id)(s)
+        &&& cluster_safety::each_object_in_etcd_is_well_formed()(s)
+        &&& safety::at_most_one_update_sts_req_since_rest_id_is_in_flight(zk.object_ref(), rest_id)(s)
+        &&& safety::no_delete_sts_req_since_rest_id_is_in_flight(zk.object_ref(), rest_id)(s)
+    };
+    entails_always_and_n!(
+        spec,
+        lift_action(next::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>()),
+        lift_state(crash_disabled()),
+        lift_state(controller_runtime_safety::every_in_flight_msg_has_unique_id()),
+        lift_state(kubernetes_api_liveness::no_req_before_rest_id_is_in_flight(rest_id)),
+        lift_state(cluster_safety::each_object_in_etcd_is_well_formed()),
+        lift_state(safety::at_most_one_update_sts_req_since_rest_id_is_in_flight(zk.object_ref(), rest_id)),
+        lift_state(safety::no_delete_sts_req_since_rest_id_is_in_flight(zk.object_ref(), rest_id))
+    );
+    temp_pred_equality(
+        lift_action(stronger_next),
+        lift_action(next::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>())
+        .and(lift_state(crash_disabled()))
+        .and(lift_state(controller_runtime_safety::every_in_flight_msg_has_unique_id()))
+        .and(lift_state(kubernetes_api_liveness::no_req_before_rest_id_is_in_flight(rest_id)))
+        .and(lift_state(cluster_safety::each_object_in_etcd_is_well_formed()))
+        .and(lift_state(safety::at_most_one_update_sts_req_since_rest_id_is_in_flight(zk.object_ref(), rest_id)))
+        .and(lift_state(safety::no_delete_sts_req_since_rest_id_is_in_flight(zk.object_ref(), rest_id)))
+    );
+
+    assert forall |s, s_prime| pre(s) && #[trigger] stronger_next(s, s_prime) implies pre(s_prime) || post(s_prime) by {
+        let step = choose |step| next_step::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>(s, s_prime, step);
+        match step {
+            Step::KubernetesAPIStep(input) => {
+                StatefulSetView::spec_integrity_is_preserved_by_marshal();
+            },
+            _ => {}
+        }
+    }
+
+    assert forall |s, s_prime| pre(s) && #[trigger] stronger_next(s, s_prime) && kubernetes_api_next().forward(input)(s, s_prime)
+    implies post(s_prime) by {
+        StatefulSetView::spec_integrity_is_preserved_by_marshal();
+    }
+
+    kubernetes_api_liveness::lemma_pre_leads_to_post_by_kubernetes_api::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>(
+        spec, input, stronger_next, handle_request(), pre, post
+    );
+}
+
+proof fn lemma_receives_not_found_resp_at_after_get_stateful_set_step_with_zk(
+    spec: TempPred<ClusterState>, zk: ZookeeperClusterView, rest_id: nat, req_msg: Message
+)
+    requires
+        spec.entails(always(lift_action(next::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>()))),
+        spec.entails(tla_forall(|i| kubernetes_api_next().weak_fairness(i))),
+        spec.entails(always(lift_state(crash_disabled()))),
+        spec.entails(always(lift_state(controller_runtime_safety::every_in_flight_msg_has_unique_id()))),
+        spec.entails(always(lift_state(kubernetes_api_liveness::no_req_before_rest_id_is_in_flight(rest_id)))),
+        spec.entails(always(lift_state(safety::at_most_one_create_sts_req_since_rest_id_is_in_flight(zk.object_ref(), rest_id)))),
+        zk.well_formed(),
+    ensures
+        spec.entails(
+            lift_state(
+                |s: ClusterState| {
+                    &&& !s.resource_key_exists(make_stateful_set_key(zk.object_ref()))
+                    &&& req_msg_is_the_in_flight_pending_req_at_after_get_stateful_set_step_with_zk(zk, req_msg)(s)
+                }
+            )
+                .leads_to(lift_state(
+                    |s: ClusterState| {
+                        &&& !s.resource_key_exists(make_stateful_set_key(zk.object_ref()))
+                        &&& at_after_get_stateful_set_step_with_zk_and_exists_not_found_resp_in_flight(zk)(s)
+                    }
+                ))
+        ),
+{
+    let pre = |s: ClusterState| {
+        &&& !s.resource_key_exists(make_stateful_set_key(zk.object_ref()))
+        &&& req_msg_is_the_in_flight_pending_req_at_after_get_stateful_set_step_with_zk(zk, req_msg)(s)
+    };
+    let post = |s: ClusterState| {
+        &&& !s.resource_key_exists(make_stateful_set_key(zk.object_ref()))
+        &&& at_after_get_stateful_set_step_with_zk_and_exists_not_found_resp_in_flight(zk)(s)
+    };
+    let input = Option::Some(req_msg);
+    let stronger_next = |s, s_prime: ClusterState| {
+        &&& next::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>()(s, s_prime)
+        &&& crash_disabled()(s)
+        &&& controller_runtime_safety::every_in_flight_msg_has_unique_id()(s)
+        &&& kubernetes_api_liveness::no_req_before_rest_id_is_in_flight(rest_id)(s)
+        &&& safety::at_most_one_create_sts_req_since_rest_id_is_in_flight(zk.object_ref(), rest_id)(s)
+    };
+    entails_always_and_n!(
+        spec,
+        lift_action(next::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>()),
+        lift_state(crash_disabled()),
+        lift_state(controller_runtime_safety::every_in_flight_msg_has_unique_id()),
+        lift_state(kubernetes_api_liveness::no_req_before_rest_id_is_in_flight(rest_id)),
+        lift_state(safety::at_most_one_create_sts_req_since_rest_id_is_in_flight(zk.object_ref(), rest_id))
+    );
+    temp_pred_equality(
+        lift_action(stronger_next),
+        lift_action(next::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>())
+        .and(lift_state(crash_disabled()))
+        .and(lift_state(controller_runtime_safety::every_in_flight_msg_has_unique_id()))
+        .and(lift_state(kubernetes_api_liveness::no_req_before_rest_id_is_in_flight(rest_id)))
+        .and(lift_state(safety::at_most_one_create_sts_req_since_rest_id_is_in_flight(zk.object_ref(), rest_id)))
+    );
+
+    assert forall |s, s_prime| pre(s) && #[trigger] stronger_next(s, s_prime) implies pre(s_prime) || post(s_prime) by {
+        let step = choose |step| next_step::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>(s, s_prime, step);
+        match step {
+            Step::KubernetesAPIStep(input) => {
+                if input.get_Some_0() == req_msg {
+                    let resp_msg = handle_get_request(req_msg, s.kubernetes_api_state).1;
+                    assert({
+                        &&& s_prime.message_in_flight(resp_msg)
+                        &&& resp_msg_matches_req_msg(resp_msg, req_msg)
+                        &&& resp_msg.content.get_get_response().res.is_Err()
+                        &&& resp_msg.content.get_get_response().res.get_Err_0().is_ObjectNotFound()
+                    });
+                }
+            },
+            _ => {}
+        }
+    }
+
+    assert forall |s, s_prime| pre(s) && #[trigger] stronger_next(s, s_prime) && kubernetes_api_next().forward(input)(s, s_prime)
+    implies post(s_prime) by {
+        let resp_msg = handle_get_request(req_msg, s.kubernetes_api_state).1;
+        assert({
+            &&& s_prime.message_in_flight(resp_msg)
+            &&& resp_msg_matches_req_msg(resp_msg, req_msg)
+            &&& resp_msg.content.get_get_response().res.is_Err()
+            &&& resp_msg.content.get_get_response().res.get_Err_0().is_ObjectNotFound()
+        });
+    }
+
+    kubernetes_api_liveness::lemma_pre_leads_to_post_by_kubernetes_api::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>(
+        spec, input, stronger_next, handle_request(), pre, post
+    );
+}
+
+proof fn lemma_from_after_get_stateful_set_step_to_after_create_stateful_set_step(
+    spec: TempPred<ClusterState>, zk: ZookeeperClusterView, rest_id: nat, resp_msg: Message
+)
+    requires
+        spec.entails(always(lift_action(next::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>()))),
+        spec.entails(tla_forall(|i| controller_next::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>().weak_fairness(i))),
+        spec.entails(always(lift_state(crash_disabled()))),
+        spec.entails(always(lift_state(controller_runtime_safety::each_resp_matches_at_most_one_pending_req(zk.object_ref())))),
+        spec.entails(always(lift_state(controller_runtime_safety::each_resp_if_matches_pending_req_then_no_other_resp_matches(zk.object_ref())))),
+        spec.entails(always(lift_state(kubernetes_api_liveness::no_req_before_rest_id_is_in_flight(rest_id)))),
+        spec.entails(always(lift_state(safety::at_most_one_create_sts_req_since_rest_id_is_in_flight(zk.object_ref(), rest_id)))),
+        zk.well_formed(),
+    ensures
+        spec.entails(
+            lift_state(|s: ClusterState| {
+                &&& !s.resource_key_exists(make_stateful_set_key(zk.object_ref()))
+                &&& resp_msg_is_the_in_flight_resp_at_after_get_stateful_set_step_with_zk(zk, resp_msg)(s)
+                &&& resp_msg.content.get_get_response().res.is_Err()
+                &&& resp_msg.content.get_get_response().res.get_Err_0().is_ObjectNotFound()
+            })
+                .leads_to(lift_state(|s: ClusterState| {
+                    &&& !s.resource_key_exists(make_stateful_set_key(zk.object_ref()))
+                    &&& at_after_create_stateful_set_step_with_zk_and_pending_req_in_flight(zk)(s)
+                }))
+        ),
+{
+    let pre = |s: ClusterState| {
+        &&& !s.resource_key_exists(make_stateful_set_key(zk.object_ref()))
+        &&& resp_msg_is_the_in_flight_resp_at_after_get_stateful_set_step_with_zk(zk, resp_msg)(s)
+        &&& resp_msg.content.get_get_response().res.is_Err()
+        &&& resp_msg.content.get_get_response().res.get_Err_0().is_ObjectNotFound()
+    };
+    let post = |s: ClusterState| {
+        &&& !s.resource_key_exists(make_stateful_set_key(zk.object_ref()))
+        &&& at_after_create_stateful_set_step_with_zk_and_pending_req_in_flight(zk)(s)
+    };
+    let input = (Option::Some(resp_msg), Option::Some(zk.object_ref()));
+    let stronger_next = |s, s_prime: ClusterState| {
+        &&& next::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>()(s, s_prime)
+        &&& crash_disabled()(s)
+        &&& controller_runtime_safety::each_resp_matches_at_most_one_pending_req(zk.object_ref())(s)
+        &&& controller_runtime_safety::each_resp_if_matches_pending_req_then_no_other_resp_matches(zk.object_ref())(s)
+        &&& kubernetes_api_liveness::no_req_before_rest_id_is_in_flight(rest_id)(s)
+        &&& safety::at_most_one_create_sts_req_since_rest_id_is_in_flight(zk.object_ref(), rest_id)(s)
+    };
+
+    entails_always_and_n!(
+        spec,
+        lift_action(next::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>()),
+        lift_state(crash_disabled()),
+        lift_state(controller_runtime_safety::each_resp_matches_at_most_one_pending_req(zk.object_ref())),
+        lift_state(controller_runtime_safety::each_resp_if_matches_pending_req_then_no_other_resp_matches(zk.object_ref())),
+        lift_state(kubernetes_api_liveness::no_req_before_rest_id_is_in_flight(rest_id)),
+        lift_state(safety::at_most_one_create_sts_req_since_rest_id_is_in_flight(zk.object_ref(), rest_id))
+    );
+    temp_pred_equality(
+        lift_action(stronger_next),
+        lift_action(next::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>())
+        .and(lift_state(crash_disabled()))
+        .and(lift_state(controller_runtime_safety::each_resp_matches_at_most_one_pending_req(zk.object_ref())))
+        .and(lift_state(controller_runtime_safety::each_resp_if_matches_pending_req_then_no_other_resp_matches(zk.object_ref())))
+        .and(lift_state(kubernetes_api_liveness::no_req_before_rest_id_is_in_flight(rest_id)))
+        .and(lift_state(safety::at_most_one_create_sts_req_since_rest_id_is_in_flight(zk.object_ref(), rest_id)))
+    );
+
+    controller_runtime_liveness::lemma_pre_leads_to_post_by_controller::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>(
+        spec, input, stronger_next,
+        continue_reconcile::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>(), pre, post
+    );
+}
+
+proof fn lemma_sts_is_created_at_after_create_stateful_set_step_with_zk(
+    spec: TempPred<ClusterState>, zk: ZookeeperClusterView, rest_id: nat, req_msg: Message
+)
+    requires
+        spec.entails(always(lift_action(next::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>()))),
+        spec.entails(tla_forall(|i| kubernetes_api_next().weak_fairness(i))),
+        spec.entails(always(lift_state(crash_disabled()))),
+        spec.entails(always(lift_state(controller_runtime_safety::every_in_flight_msg_has_unique_id()))),
+        spec.entails(always(lift_state(kubernetes_api_liveness::no_req_before_rest_id_is_in_flight(rest_id)))),
+        spec.entails(always(lift_state(safety::at_most_one_create_sts_req_since_rest_id_is_in_flight(zk.object_ref(), rest_id)))),
+        zk.well_formed(),
+    ensures
+        spec.entails(
+            lift_state(
+                |s: ClusterState| {
+                    &&& !s.resource_key_exists(make_stateful_set_key(zk.object_ref()))
+                    &&& req_msg_is_the_in_flight_pending_req_at_after_create_stateful_set_step_with_zk(zk, req_msg)(s)
+                }
+            )
+                .leads_to(lift_state(
+                    |s: ClusterState| {
+                        &&& s.resource_key_exists(make_stateful_set_key(zk.object_ref()))
+                        &&& StatefulSetView::from_dynamic_object(s.resource_obj_of(make_stateful_set_key(zk.object_ref()))).is_Ok()
+                        &&& StatefulSetView::from_dynamic_object(s.resource_obj_of(make_stateful_set_key(zk.object_ref()))).get_Ok_0().spec == make_stateful_set(zk).spec
+                    }
+                ))
+        ),
+{
+    let pre = |s: ClusterState| {
+        &&& !s.resource_key_exists(make_stateful_set_key(zk.object_ref()))
+        &&& req_msg_is_the_in_flight_pending_req_at_after_create_stateful_set_step_with_zk(zk, req_msg)(s)
+    };
+    let post = |s: ClusterState| {
+        &&& s.resource_key_exists(make_stateful_set_key(zk.object_ref()))
+        &&& StatefulSetView::from_dynamic_object(s.resource_obj_of(make_stateful_set_key(zk.object_ref()))).is_Ok()
+        &&& StatefulSetView::from_dynamic_object(s.resource_obj_of(make_stateful_set_key(zk.object_ref()))).get_Ok_0().spec == make_stateful_set(zk).spec
+    };
+    let input = Option::Some(req_msg);
+    let stronger_next = |s, s_prime: ClusterState| {
+        &&& next::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>()(s, s_prime)
+        &&& crash_disabled()(s)
+        &&& controller_runtime_safety::every_in_flight_msg_has_unique_id()(s)
+        &&& kubernetes_api_liveness::no_req_before_rest_id_is_in_flight(rest_id)(s)
+        &&& safety::at_most_one_create_sts_req_since_rest_id_is_in_flight(zk.object_ref(), rest_id)(s)
+    };
+    entails_always_and_n!(
+        spec,
+        lift_action(next::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>()),
+        lift_state(crash_disabled()),
+        lift_state(controller_runtime_safety::every_in_flight_msg_has_unique_id()),
+        lift_state(kubernetes_api_liveness::no_req_before_rest_id_is_in_flight(rest_id)),
+        lift_state(safety::at_most_one_create_sts_req_since_rest_id_is_in_flight(zk.object_ref(), rest_id))
+    );
+    temp_pred_equality(
+        lift_action(stronger_next),
+        lift_action(next::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>())
+        .and(lift_state(crash_disabled()))
+        .and(lift_state(controller_runtime_safety::every_in_flight_msg_has_unique_id()))
+        .and(lift_state(kubernetes_api_liveness::no_req_before_rest_id_is_in_flight(rest_id)))
+        .and(lift_state(safety::at_most_one_create_sts_req_since_rest_id_is_in_flight(zk.object_ref(), rest_id)))
+    );
+
+    assert forall |s, s_prime| pre(s) && #[trigger] stronger_next(s, s_prime) implies pre(s_prime) || post(s_prime) by {
+        let step = choose |step| next_step::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>(s, s_prime, step);
+        match step {
+            Step::KubernetesAPIStep(input) => {
+                StatefulSetView::spec_integrity_is_preserved_by_marshal();
+            },
+            _ => {}
+        }
+    }
+
+    assert forall |s, s_prime| pre(s) && #[trigger] stronger_next(s, s_prime) && kubernetes_api_next().forward(input)(s, s_prime)
+    implies post(s_prime) by {
+        StatefulSetView::spec_integrity_is_preserved_by_marshal();
+    }
+
+    kubernetes_api_liveness::lemma_pre_leads_to_post_by_kubernetes_api::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>(
+        spec, input, stronger_next, handle_request(), pre, post
+    );
+}
+
+proof fn lemma_stateful_set_is_stable(
+    spec: TempPred<ClusterState>, zk: ZookeeperClusterView, rest_id: nat, p: TempPred<ClusterState>
+)
+    requires
+        spec.entails(p.leads_to(lift_state(current_state_matches(zk)))),
+        spec.entails(always(lift_action(next::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>()))),
+        spec.entails(always(lift_state(kubernetes_api_liveness::no_req_before_rest_id_is_in_flight(rest_id)))),
+        spec.entails(always(lift_state(safety::no_delete_sts_req_since_rest_id_is_in_flight(zk.object_ref(), rest_id)))),
+        spec.entails(always(lift_state(safety::every_update_sts_req_since_rest_id_does_the_same(zk, rest_id)))),
+    ensures
+        spec.entails(p.leads_to(always(lift_state(current_state_matches(zk))))),
+{
+    let post = current_state_matches(zk);
+    let stronger_next = |s, s_prime: ClusterState| {
+        &&& next::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>()(s, s_prime)
+        &&& kubernetes_api_liveness::no_req_before_rest_id_is_in_flight(rest_id)(s)
+        &&& safety::no_delete_sts_req_since_rest_id_is_in_flight(zk.object_ref(), rest_id)(s)
+        &&& safety::every_update_sts_req_since_rest_id_does_the_same(zk, rest_id)(s)
+    };
+    entails_always_and_n!(
+        spec,
+        lift_action(next::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>()),
+        lift_state(kubernetes_api_liveness::no_req_before_rest_id_is_in_flight(rest_id)),
+        lift_state(safety::no_delete_sts_req_since_rest_id_is_in_flight(zk.object_ref(), rest_id)),
+        lift_state(safety::every_update_sts_req_since_rest_id_does_the_same(zk, rest_id))
+    );
+    temp_pred_equality(
+        lift_action(stronger_next),
+        lift_action(next::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>())
+        .and(lift_state(kubernetes_api_liveness::no_req_before_rest_id_is_in_flight(rest_id)))
+        .and(lift_state(safety::no_delete_sts_req_since_rest_id_is_in_flight(zk.object_ref(), rest_id)))
+        .and(lift_state(safety::every_update_sts_req_since_rest_id_does_the_same(zk, rest_id)))
+    );
+
+    assert forall |s, s_prime| post(s) && #[trigger] stronger_next(s, s_prime) implies post(s_prime) by {
+        StatefulSetView::spec_integrity_is_preserved_by_marshal();
+    }
+
+    leads_to_stable_temp(spec, lift_action(stronger_next), p, lift_state(post));
+}
+
+}

--- a/src/controller_examples/zookeeper_controller/proof/mod.rs
+++ b/src/controller_examples/zookeeper_controller/proof/mod.rs
@@ -1,6 +1,6 @@
 // Copyright 2022 VMware, Inc.
 // SPDX-License-Identifier: MIT
 pub mod common;
-pub mod exec;
-pub mod proof;
-pub mod spec;
+pub mod liveness;
+pub mod safety;
+pub mod terminate;

--- a/src/controller_examples/zookeeper_controller/proof/safety.rs
+++ b/src/controller_examples/zookeeper_controller/proof/safety.rs
@@ -1,0 +1,909 @@
+// Copyright 2022 VMware, Inc.
+// SPDX-License-Identifier: MIT
+#![allow(unused_imports)]
+use crate::kubernetes_api_objects::{api_method::*, common::*, resource::*, stateful_set::*};
+use crate::kubernetes_cluster::{
+    proof::{
+        cluster::*,
+        cluster_safety::{
+            each_key_in_reconcile_is_consistent_with_its_object,
+            lemma_always_each_key_in_reconcile_is_consistent_with_its_object,
+        },
+        controller_runtime_safety::{
+            every_in_flight_msg_has_lower_id_than_allocator, every_in_flight_msg_has_unique_id,
+        },
+        kubernetes_api_safety,
+    },
+    spec::{
+        cluster::*,
+        controller::common::{controller_req_msg, ControllerActionInput, ControllerStep},
+        controller::controller_runtime::{
+            continue_reconcile, end_reconcile, run_scheduled_reconcile,
+        },
+        controller::state_machine::controller,
+        kubernetes_api::state_machine::{
+            handle_create_request, handle_request, object_has_well_formed_spec,
+        },
+        message::*,
+    },
+};
+use crate::pervasive_ext::multiset_lemmas;
+use crate::temporal_logic::{defs::*, rules::*};
+use crate::zookeeper_controller::{
+    proof::common::*,
+    spec::{reconciler::*, zookeepercluster::*},
+};
+use builtin::*;
+use builtin_macros::*;
+use vstd::{multiset::*, prelude::*};
+
+verus! {
+
+pub open spec fn sts_create_request_msg(key: ObjectRef) -> FnSpec(Message) -> bool {
+    |msg: Message|
+        msg.dst.is_KubernetesAPI()
+        && msg.content.is_create_request()
+        && msg.content.get_create_request().namespace == make_stateful_set_key(key).namespace
+        && msg.content.get_create_request().obj.metadata.name.get_Some_0() == make_stateful_set_key(key).name
+        && msg.content.get_create_request().obj.kind == make_stateful_set_key(key).kind
+}
+
+pub open spec fn sts_create_request_msg_since(key: ObjectRef, rest_id: RestId) -> FnSpec(Message) -> bool {
+    |msg: Message|
+        sts_create_request_msg(key)(msg)
+        && msg.content.get_rest_id() >= rest_id
+}
+
+pub open spec fn pending_msg_at_after_create_stateful_set_step_is_create_sts_req(
+    key: ObjectRef
+) -> StatePred<ClusterState>
+    recommends
+        key.kind.is_CustomResourceKind(),
+{
+    |s: ClusterState| {
+        at_after_create_stateful_set_step(key)(s)
+            ==> {
+                &&& s.reconcile_state_of(key).pending_req_msg.is_Some()
+                &&& sts_create_request_msg(key)(s.pending_req_of(key))
+            }
+    }
+}
+
+pub proof fn lemma_always_pending_msg_at_after_create_stateful_set_step_is_create_sts_req(
+    spec: TempPred<ClusterState>, key: ObjectRef
+)
+    requires
+        spec.entails(lift_state(init::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>())),
+        spec.entails(always(lift_action(next::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>()))),
+    ensures
+        spec.entails(
+            always(lift_state(pending_msg_at_after_create_stateful_set_step_is_create_sts_req(key)))
+        ),
+{
+    let invariant = pending_msg_at_after_create_stateful_set_step_is_create_sts_req(key);
+    let init = init::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>();
+    let stronger_next = |s, s_prime| {
+        &&& next::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>()(s, s_prime)
+        &&& each_key_in_reconcile_is_consistent_with_its_object()(s)
+    };
+
+    lemma_always_each_key_in_reconcile_is_consistent_with_its_object::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>(spec);
+
+    entails_always_and_n!(
+        spec,
+        lift_action(next::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>()),
+        lift_state(each_key_in_reconcile_is_consistent_with_its_object())
+    );
+    temp_pred_equality(
+        lift_action(stronger_next),
+        lift_action(next::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>())
+        .and(lift_state(each_key_in_reconcile_is_consistent_with_its_object()))
+    );
+
+    init_invariant(spec, init, stronger_next, invariant);
+}
+
+pub open spec fn filtered_create_sts_req_len_is_at_most_one(
+    key: ObjectRef, rest_id: RestId
+) -> StatePred<ClusterState>
+    recommends
+        key.kind.is_CustomResourceKind(),
+{
+    |s: ClusterState| {
+        if !at_after_create_stateful_set_step(key)(s) {
+            s.network_state.in_flight.filter(sts_create_request_msg_since(key, rest_id)).len() == 0
+        } else {
+            if s.pending_req_of(key).content.get_rest_id() >= rest_id {
+                ||| {
+                    &&& s.message_in_flight(s.pending_req_of(key))
+                    &&& s.network_state.in_flight.filter(sts_create_request_msg_since(key, rest_id)).len() == 1
+                }
+                ||| s.network_state.in_flight.filter(sts_create_request_msg_since(key, rest_id)).len() == 0
+            } else {
+                s.network_state.in_flight.filter(sts_create_request_msg_since(key, rest_id)).len() == 0
+            }
+        }
+    }
+}
+
+proof fn lemma_always_filtered_create_sts_req_len_is_at_most_one(
+    spec: TempPred<ClusterState>, key: ObjectRef, rest_id: RestId
+)
+    requires
+        spec.entails(lift_state(rest_id_counter_is(rest_id))),
+        spec.entails(lift_state(every_in_flight_msg_has_lower_id_than_allocator())),
+        spec.entails(lift_state(pending_msg_at_after_create_stateful_set_step_is_create_sts_req(key))),
+        spec.entails(always(lift_action(next::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>()))),
+        spec.entails(always(lift_state(crash_disabled()))),
+        spec.entails(always(lift_state(pending_msg_at_after_create_stateful_set_step_is_create_sts_req(key)))),
+        spec.entails(always(lift_state(each_key_in_reconcile_is_consistent_with_its_object()))),
+        spec.entails(always(lift_state(rest_id_counter_is_no_smaller_than(rest_id)))),
+        spec.entails(always(lift_state(every_in_flight_msg_has_unique_id()))),
+        key.kind.is_CustomResourceKind(),
+    ensures
+        spec.entails(
+            always(lift_state(filtered_create_sts_req_len_is_at_most_one(key, rest_id)))
+        ),
+{
+    let init = |s: ClusterState| {
+        &&& rest_id_counter_is(rest_id)(s)
+        &&& every_in_flight_msg_has_lower_id_than_allocator()(s)
+        &&& pending_msg_at_after_create_stateful_set_step_is_create_sts_req(key)(s)
+    };
+    let stronger_next = |s, s_prime: ClusterState| {
+        &&& next::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>()(s, s_prime)
+        &&& crash_disabled()(s)
+        &&& pending_msg_at_after_create_stateful_set_step_is_create_sts_req(key)(s)
+        &&& each_key_in_reconcile_is_consistent_with_its_object()(s)
+        &&& rest_id_counter_is_no_smaller_than(rest_id)(s)
+        &&& every_in_flight_msg_has_unique_id()(s)
+    };
+    let invariant = filtered_create_sts_req_len_is_at_most_one(key, rest_id);
+
+    entails_and_n!(
+        spec,
+        lift_state(rest_id_counter_is(rest_id)),
+        lift_state(every_in_flight_msg_has_lower_id_than_allocator()),
+        lift_state(pending_msg_at_after_create_stateful_set_step_is_create_sts_req(key))
+    );
+    temp_pred_equality(
+        lift_state(init),
+        lift_state(rest_id_counter_is(rest_id))
+        .and(lift_state(every_in_flight_msg_has_lower_id_than_allocator()))
+        .and(lift_state(pending_msg_at_after_create_stateful_set_step_is_create_sts_req(key)))
+    );
+
+    entails_always_and_n!(
+        spec,
+        lift_action(next::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>()),
+        lift_state(crash_disabled()),
+        lift_state(pending_msg_at_after_create_stateful_set_step_is_create_sts_req(key)),
+        lift_state(each_key_in_reconcile_is_consistent_with_its_object()),
+        lift_state(rest_id_counter_is_no_smaller_than(rest_id)),
+        lift_state(every_in_flight_msg_has_unique_id())
+    );
+    temp_pred_equality(
+        lift_action(stronger_next),
+        lift_action(next::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>())
+        .and(lift_state(crash_disabled()))
+        .and(lift_state(pending_msg_at_after_create_stateful_set_step_is_create_sts_req(key)))
+        .and(lift_state(each_key_in_reconcile_is_consistent_with_its_object()))
+        .and(lift_state(rest_id_counter_is_no_smaller_than(rest_id)))
+        .and(lift_state(every_in_flight_msg_has_unique_id()))
+    );
+
+    assert forall |s: ClusterState| #[trigger] init(s) implies invariant(s) by {
+        let sts_create_req_multiset = s.network_state.in_flight.filter(sts_create_request_msg_since(key, rest_id));
+
+        assert forall |msg| sts_create_req_multiset.count(msg) == 0 by {
+            assert(!(s.message_in_flight(msg) && sts_create_request_msg_since(key, rest_id)(msg)));
+        }
+        multiset_lemmas::len_is_zero_means_count_for_each_value_is_zero(sts_create_req_multiset);
+    }
+
+    assert forall |s, s_prime: ClusterState| invariant(s) && #[trigger] stronger_next(s, s_prime)
+    implies invariant(s_prime) by {
+        let sts_create_req_multiset = s.network_state.in_flight.filter(sts_create_request_msg_since(key, rest_id));
+        let sts_create_req_multiset_prime = s_prime.network_state.in_flight.filter(sts_create_request_msg_since(key, rest_id));
+        let step = choose |step| next_step::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>(s, s_prime, step);
+        match step {
+            Step::KubernetesAPIStep(input) => {
+                if !at_after_create_stateful_set_step(key)(s) {
+                    // If not at AfterUpdateStatefulSet step,
+                    // due to inductive hypothesis, the set of messages remains unchanged (len() = 0)
+                    // between s and s_prime.
+                    assert(sts_create_req_multiset =~= sts_create_req_multiset_prime);
+                } else {
+                    // If at AfterUpdateStatefulSet step,
+                    // we need to split the case.
+                    let chosen_msg = input.get_Some_0();
+                    if sts_create_request_msg_since(key, rest_id)(chosen_msg) {
+                        // If the chosen message to handle is the one that creates StatefulSet,
+                        // then the message set shrinks by one.
+                        assert(sts_create_req_multiset.remove(chosen_msg) =~= sts_create_req_multiset_prime);
+                    } else {
+                        // Otherwise the set remains unchanged.
+                        assert(sts_create_req_multiset =~= sts_create_req_multiset_prime);
+                    }
+                }
+            },
+            Step::ControllerStep(input) => {
+                let chosen_key = input.1.get_Some_0();
+                if chosen_key == key {
+                    // If the state machine chooses the reconciler for our key to take the next transition...
+                    if at_after_create_stateful_set_step(key)(s_prime) {
+                        // If transition to AfterUpdateStatefulSet step,
+                        // then there must be a StatefulSet create request message just sent to the network.
+                        // And thanks to rest_id_counter_is_no_smaller_than, we know that the newly sent request
+                        // has a no-smaller id than rest_id.
+                        // So We go ahead and prove s.network_state.in_flight.filter(sts_create_request_msg_since(key, rest_id)).len() == 1
+                        // using extensional equality here.
+                        assert(sts_create_req_multiset.insert(s_prime.pending_req_of(key)) =~= sts_create_req_multiset_prime);
+                    } else if at_done_step(key)(s_prime) {
+                        if at_after_create_stateful_set_step(key)(s) {
+                            if s.pending_req_of(key).content.get_rest_id() >= rest_id {
+                                // This is the most tricky path: we need to show
+                                // s.network_state.in_flight.filter(sts_create_request_msg_since(key, rest_id)).len() == 0
+                                // since this transition won't remove any req_msg from the network.
+                                // The reasoning is that the transition can only happen
+                                // if the response message is in the network,
+                                // which shares the same rest_id with the request message.
+                                // Thanks to every_in_flight_msg_has_unique_id(), we know that
+                                // if the response message is in the network, then the request message is not,
+                                // which means s.network_state.in_flight.filter(sts_create_request_msg_since(key, rest_id)).len() == 0
+                                // has to be true (due to inductive hypothesis).
+                                assert(sts_create_req_multiset =~= sts_create_req_multiset_prime);
+                            } else {
+                                assert(sts_create_req_multiset =~= sts_create_req_multiset_prime);
+                            }
+                        } else {
+                            assert(sts_create_req_multiset =~= sts_create_req_multiset_prime);
+                        }
+                    } else {
+                        assert(sts_create_req_multiset =~= sts_create_req_multiset_prime);
+                    }
+                } else {
+                    // If the state machine chooses the reconciler for a different key to take the next transition...
+                    // It is trivial because of the isolation between different reconcilers:
+                    // each reconciler does not touch other reconcilers' resources.
+                    // The isolation property comes from the way each reconciler names its owned resources.
+                    // Note that here we implicitly use each_key_in_reconcile_is_consistent_with_its_object
+                    // because the reconciler uses zk, instead of the key of zk, when naming the resources.
+                    assert(sts_create_req_multiset =~= sts_create_req_multiset_prime);
+                }
+            },
+            Step::ClientStep(input) => {
+                assert(sts_create_req_multiset =~= sts_create_req_multiset_prime);
+            },
+            _ => {
+            }
+        }
+    }
+
+    init_invariant(spec, init, stronger_next, invariant);
+}
+
+pub open spec fn at_most_one_create_sts_req_since_rest_id_is_in_flight(
+    key: ObjectRef, rest_id: RestId
+) -> StatePred<ClusterState>
+    recommends
+        key.kind.is_CustomResourceKind(),
+{
+    |s: ClusterState| {
+        if !at_after_create_stateful_set_step(key)(s) {
+            forall |msg| !{
+                    &&& #[trigger] s.network_state.in_flight.contains(msg)
+                    &&& sts_create_request_msg_since(key, rest_id)(msg)
+                }
+        } else {
+            if s.pending_req_of(key).content.get_rest_id() >= rest_id {
+                ||| {
+                    &&& s.message_in_flight(s.pending_req_of(key))
+                    &&& forall |msg| {
+                        &&& #[trigger] s.network_state.in_flight.contains(msg)
+                        &&& sts_create_request_msg_since(key, rest_id)(msg)
+                    } ==> {
+                        &&& s.network_state.in_flight.count(msg) == 1
+                        &&& {
+                            &&& exists |other_msg| {
+                                &&& #[trigger] s.network_state.in_flight.contains(other_msg)
+                                &&& sts_create_request_msg_since(key, rest_id)(other_msg)
+                            }
+                            &&& forall |other_msg| {
+                                &&& #[trigger] s.network_state.in_flight.contains(other_msg)
+                                &&& sts_create_request_msg_since(key, rest_id)(other_msg)
+                            } ==> msg == other_msg
+                        }
+                    }
+                }
+                ||| forall |msg| !{
+                    &&& #[trigger] s.network_state.in_flight.contains(msg)
+                    &&& sts_create_request_msg_since(key, rest_id)(msg)
+                }
+            } else {
+                forall |msg| !{
+                    &&& #[trigger] s.network_state.in_flight.contains(msg)
+                    &&& sts_create_request_msg_since(key, rest_id)(msg)
+                }
+            }
+        }
+    }
+}
+
+pub proof fn lemma_always_at_most_one_create_sts_req_since_rest_id_is_in_flight(
+    spec: TempPred<ClusterState>, key: ObjectRef, rest_id: RestId
+)
+    requires
+        spec.entails(lift_state(rest_id_counter_is(rest_id))),
+        spec.entails(lift_state(every_in_flight_msg_has_lower_id_than_allocator())),
+        spec.entails(lift_state(pending_msg_at_after_create_stateful_set_step_is_create_sts_req(key))),
+        spec.entails(always(lift_action(next::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>()))),
+        spec.entails(always(lift_state(crash_disabled()))),
+        spec.entails(always(lift_state(pending_msg_at_after_create_stateful_set_step_is_create_sts_req(key)))),
+        spec.entails(always(lift_state(each_key_in_reconcile_is_consistent_with_its_object()))),
+        spec.entails(always(lift_state(rest_id_counter_is_no_smaller_than(rest_id)))),
+        spec.entails(always(lift_state(every_in_flight_msg_has_unique_id()))),
+        key.kind.is_CustomResourceKind(),
+    ensures
+        spec.entails(
+            always(lift_state(at_most_one_create_sts_req_since_rest_id_is_in_flight(key, rest_id)))
+        ),
+{
+    lemma_always_filtered_create_sts_req_len_is_at_most_one(spec, key, rest_id);
+
+    let p = lift_state(at_most_one_create_sts_req_since_rest_id_is_in_flight(key, rest_id));
+    let q = lift_state(filtered_create_sts_req_len_is_at_most_one(key, rest_id));
+
+    assert_by(
+        p == q, {
+            assert forall |ex| p.satisfied_by(ex) implies q.satisfied_by(ex) by {
+                multiset_lemmas::filtered_size_is_zero_means_no_such_value(
+                    ex.head().network_state.in_flight, sts_create_request_msg_since(key, rest_id)
+                );
+                multiset_lemmas::filtered_size_is_one_means_only_one_such_value(
+                    ex.head().network_state.in_flight, sts_create_request_msg_since(key, rest_id)
+                );
+            }
+
+            assert forall |ex| q.satisfied_by(ex) implies p.satisfied_by(ex) by {
+                multiset_lemmas::filtered_size_is_zero_means_no_such_value(
+                    ex.head().network_state.in_flight, sts_create_request_msg_since(key, rest_id)
+                );
+                multiset_lemmas::filtered_size_is_one_means_only_one_such_value(
+                    ex.head().network_state.in_flight, sts_create_request_msg_since(key, rest_id)
+                );
+            }
+
+            temp_pred_equality(p, q);
+        }
+    );
+}
+
+
+pub open spec fn sts_update_request_msg(key: ObjectRef) -> FnSpec(Message) -> bool {
+    |msg: Message|
+        msg.dst.is_KubernetesAPI()
+        && msg.content.is_update_request()
+        && msg.content.get_update_request().key == make_stateful_set_key(key)
+}
+
+pub open spec fn sts_update_request_msg_since(key: ObjectRef, rest_id: RestId) -> FnSpec(Message) -> bool {
+    |msg: Message|
+        sts_update_request_msg(key)(msg)
+        && msg.content.get_rest_id() >= rest_id
+}
+
+pub open spec fn pending_msg_at_after_update_stateful_set_step_is_update_sts_req(
+    key: ObjectRef
+) -> StatePred<ClusterState>
+    recommends
+        key.kind.is_CustomResourceKind(),
+{
+    |s: ClusterState| {
+        at_after_update_stateful_set_step(key)(s)
+            ==> {
+                &&& s.reconcile_state_of(key).pending_req_msg.is_Some()
+                &&& sts_update_request_msg(key)(s.pending_req_of(key))
+            }
+    }
+}
+
+pub proof fn lemma_always_pending_msg_at_after_update_stateful_set_step_is_update_sts_req(
+    spec: TempPred<ClusterState>, key: ObjectRef
+)
+    requires
+        spec.entails(lift_state(init::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>())),
+        spec.entails(always(lift_action(next::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>()))),
+    ensures
+        spec.entails(
+            always(lift_state(pending_msg_at_after_update_stateful_set_step_is_update_sts_req(key)))
+        ),
+{
+    let invariant = pending_msg_at_after_update_stateful_set_step_is_update_sts_req(key);
+    let init = init::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>();
+    let stronger_next = |s, s_prime| {
+        &&& next::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>()(s, s_prime)
+        &&& each_key_in_reconcile_is_consistent_with_its_object()(s)
+    };
+
+    lemma_always_each_key_in_reconcile_is_consistent_with_its_object::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>(spec);
+
+    entails_always_and_n!(
+        spec,
+        lift_action(next::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>()),
+        lift_state(each_key_in_reconcile_is_consistent_with_its_object())
+    );
+    temp_pred_equality(
+        lift_action(stronger_next),
+        lift_action(next::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>())
+        .and(lift_state(each_key_in_reconcile_is_consistent_with_its_object()))
+    );
+
+    init_invariant(spec, init, stronger_next, invariant);
+}
+
+pub open spec fn filtered_update_sts_req_len_is_at_most_one(
+    key: ObjectRef, rest_id: RestId
+) -> StatePred<ClusterState>
+    recommends
+        key.kind.is_CustomResourceKind(),
+{
+    |s: ClusterState| {
+        if !at_after_update_stateful_set_step(key)(s) {
+            s.network_state.in_flight.filter(sts_update_request_msg_since(key, rest_id)).len() == 0
+        } else {
+            if s.pending_req_of(key).content.get_rest_id() >= rest_id {
+                ||| {
+                    &&& s.message_in_flight(s.pending_req_of(key))
+                    &&& s.network_state.in_flight.filter(sts_update_request_msg_since(key, rest_id)).len() == 1
+                }
+                ||| s.network_state.in_flight.filter(sts_update_request_msg_since(key, rest_id)).len() == 0
+            } else {
+                s.network_state.in_flight.filter(sts_update_request_msg_since(key, rest_id)).len() == 0
+            }
+        }
+    }
+}
+
+proof fn lemma_always_filtered_update_sts_req_len_is_at_most_one(
+    spec: TempPred<ClusterState>, key: ObjectRef, rest_id: RestId
+)
+    requires
+        spec.entails(lift_state(rest_id_counter_is(rest_id))),
+        spec.entails(lift_state(every_in_flight_msg_has_lower_id_than_allocator())),
+        spec.entails(lift_state(pending_msg_at_after_update_stateful_set_step_is_update_sts_req(key))),
+        spec.entails(always(lift_action(next::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>()))),
+        spec.entails(always(lift_state(crash_disabled()))),
+        spec.entails(always(lift_state(pending_msg_at_after_update_stateful_set_step_is_update_sts_req(key)))),
+        spec.entails(always(lift_state(each_key_in_reconcile_is_consistent_with_its_object()))),
+        spec.entails(always(lift_state(rest_id_counter_is_no_smaller_than(rest_id)))),
+        spec.entails(always(lift_state(every_in_flight_msg_has_unique_id()))),
+        key.kind.is_CustomResourceKind(),
+    ensures
+        spec.entails(
+            always(lift_state(filtered_update_sts_req_len_is_at_most_one(key, rest_id)))
+        ),
+{
+    let init = |s: ClusterState| {
+        &&& rest_id_counter_is(rest_id)(s)
+        &&& every_in_flight_msg_has_lower_id_than_allocator()(s)
+        &&& pending_msg_at_after_update_stateful_set_step_is_update_sts_req(key)(s)
+    };
+    let stronger_next = |s, s_prime: ClusterState| {
+        &&& next::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>()(s, s_prime)
+        &&& crash_disabled()(s)
+        &&& pending_msg_at_after_update_stateful_set_step_is_update_sts_req(key)(s)
+        &&& each_key_in_reconcile_is_consistent_with_its_object()(s)
+        &&& rest_id_counter_is_no_smaller_than(rest_id)(s)
+        &&& every_in_flight_msg_has_unique_id()(s)
+    };
+    let invariant = filtered_update_sts_req_len_is_at_most_one(key, rest_id);
+
+    entails_and_n!(
+        spec,
+        lift_state(rest_id_counter_is(rest_id)),
+        lift_state(every_in_flight_msg_has_lower_id_than_allocator()),
+        lift_state(pending_msg_at_after_update_stateful_set_step_is_update_sts_req(key))
+    );
+    temp_pred_equality(
+        lift_state(init),
+        lift_state(rest_id_counter_is(rest_id))
+        .and(lift_state(every_in_flight_msg_has_lower_id_than_allocator()))
+        .and(lift_state(pending_msg_at_after_update_stateful_set_step_is_update_sts_req(key)))
+    );
+
+    entails_always_and_n!(
+        spec,
+        lift_action(next::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>()),
+        lift_state(crash_disabled()),
+        lift_state(pending_msg_at_after_update_stateful_set_step_is_update_sts_req(key)),
+        lift_state(each_key_in_reconcile_is_consistent_with_its_object()),
+        lift_state(rest_id_counter_is_no_smaller_than(rest_id)),
+        lift_state(every_in_flight_msg_has_unique_id())
+    );
+    temp_pred_equality(
+        lift_action(stronger_next),
+        lift_action(next::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>())
+        .and(lift_state(crash_disabled()))
+        .and(lift_state(pending_msg_at_after_update_stateful_set_step_is_update_sts_req(key)))
+        .and(lift_state(each_key_in_reconcile_is_consistent_with_its_object()))
+        .and(lift_state(rest_id_counter_is_no_smaller_than(rest_id)))
+        .and(lift_state(every_in_flight_msg_has_unique_id()))
+    );
+
+    assert forall |s: ClusterState| #[trigger] init(s) implies invariant(s) by {
+        let sts_update_req_multiset = s.network_state.in_flight.filter(sts_update_request_msg_since(key, rest_id));
+
+        assert forall |msg| sts_update_req_multiset.count(msg) == 0 by {
+            assert(!(s.message_in_flight(msg) && sts_update_request_msg_since(key, rest_id)(msg)));
+        }
+        multiset_lemmas::len_is_zero_means_count_for_each_value_is_zero(sts_update_req_multiset);
+    }
+
+    assert forall |s, s_prime: ClusterState| invariant(s) && #[trigger] stronger_next(s, s_prime)
+    implies invariant(s_prime) by {
+        let sts_update_req_multiset = s.network_state.in_flight.filter(sts_update_request_msg_since(key, rest_id));
+        let sts_update_req_multiset_prime = s_prime.network_state.in_flight.filter(sts_update_request_msg_since(key, rest_id));
+        let step = choose |step| next_step::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>(s, s_prime, step);
+        match step {
+            Step::KubernetesAPIStep(input) => {
+                if !at_after_update_stateful_set_step(key)(s) {
+                    // If not at AfterUpdateStatefulSet step,
+                    // due to inductive hypothesis, the set of messages remains unchanged (len() = 0)
+                    // between s and s_prime.
+                    assert(sts_update_req_multiset =~= sts_update_req_multiset_prime);
+                } else {
+                    // If at AfterUpdateStatefulSet step,
+                    // we need to split the case.
+                    let chosen_msg = input.get_Some_0();
+                    if sts_update_request_msg_since(key, rest_id)(chosen_msg) {
+                        // If the chosen message to handle is the one that updates StatefulSet,
+                        // then the message set shrinks by one.
+                        assert(sts_update_req_multiset.remove(chosen_msg) =~= sts_update_req_multiset_prime);
+                    } else {
+                        // Otherwise the set remains unchanged.
+                        assert(sts_update_req_multiset =~= sts_update_req_multiset_prime);
+                    }
+                }
+            },
+            Step::ControllerStep(input) => {
+                let chosen_key = input.1.get_Some_0();
+                if chosen_key == key {
+                    // If the state machine chooses the reconciler for our key to take the next transition...
+                    if at_after_update_stateful_set_step(key)(s_prime) {
+                        // If transition to AfterUpdateStatefulSet step,
+                        // then there must be a StatefulSet update request message just sent to the network.
+                        // And thanks to rest_id_counter_is_no_smaller_than, we know that the newly sent request
+                        // has a no-smaller id than rest_id.
+                        // So We go ahead and prove s.network_state.in_flight.filter(sts_update_request_msg_since(key, rest_id)).len() == 1
+                        // using extensional equality here.
+                        assert(sts_update_req_multiset.insert(s_prime.pending_req_of(key)) =~= sts_update_req_multiset_prime);
+                    } else if at_done_step(key)(s_prime) {
+                        if at_after_update_stateful_set_step(key)(s) {
+                            if s.pending_req_of(key).content.get_rest_id() >= rest_id {
+                                // This is the most tricky path: we need to show
+                                // s.network_state.in_flight.filter(sts_update_request_msg_since(key, rest_id)).len() == 0
+                                // since this transition won't remove any req_msg from the network.
+                                // The reasoning is that the transition can only happen
+                                // if the response message is in the network,
+                                // which shares the same rest_id with the request message.
+                                // Thanks to every_in_flight_msg_has_unique_id(), we know that
+                                // if the response message is in the network, then the request message is not,
+                                // which means s.network_state.in_flight.filter(sts_update_request_msg_since(key, rest_id)).len() == 0
+                                // has to be true (due to inductive hypothesis).
+                                assert(sts_update_req_multiset =~= sts_update_req_multiset_prime);
+                            } else {
+                                assert(sts_update_req_multiset =~= sts_update_req_multiset_prime);
+                            }
+                        } else {
+                            assert(sts_update_req_multiset =~= sts_update_req_multiset_prime);
+                        }
+                    } else {
+                        assert(sts_update_req_multiset =~= sts_update_req_multiset_prime);
+                    }
+                } else {
+                    // If the state machine chooses the reconciler for a different key to take the next transition...
+                    // It is trivial because of the isolation between different reconcilers:
+                    // each reconciler does not touch other reconcilers' resources.
+                    // The isolation property comes from the way each reconciler names its owned resources.
+                    // Note that here we implicitly use each_key_in_reconcile_is_consistent_with_its_object
+                    // because the reconciler uses zk, instead of the key of zk, when naming the resources.
+                    assert(sts_update_req_multiset =~= sts_update_req_multiset_prime);
+                }
+            },
+            Step::ClientStep(input) => {
+                assert(sts_update_req_multiset =~= sts_update_req_multiset_prime);
+            },
+            _ => {
+            }
+        }
+    }
+
+    init_invariant(spec, init, stronger_next, invariant);
+}
+
+pub open spec fn at_most_one_update_sts_req_since_rest_id_is_in_flight(
+    key: ObjectRef, rest_id: RestId
+) -> StatePred<ClusterState>
+    recommends
+        key.kind.is_CustomResourceKind(),
+{
+    |s: ClusterState| {
+        if !at_after_update_stateful_set_step(key)(s) {
+            forall |msg| !{
+                    &&& #[trigger] s.network_state.in_flight.contains(msg)
+                    &&& sts_update_request_msg_since(key, rest_id)(msg)
+                }
+        } else {
+            if s.pending_req_of(key).content.get_rest_id() >= rest_id {
+                ||| {
+                    &&& s.message_in_flight(s.pending_req_of(key))
+                    &&& forall |msg| {
+                        &&& #[trigger] s.network_state.in_flight.contains(msg)
+                        &&& sts_update_request_msg_since(key, rest_id)(msg)
+                    } ==> {
+                        &&& s.network_state.in_flight.count(msg) == 1
+                        &&& {
+                            &&& exists |other_msg| {
+                                &&& #[trigger] s.network_state.in_flight.contains(other_msg)
+                                &&& sts_update_request_msg_since(key, rest_id)(other_msg)
+                            }
+                            &&& forall |other_msg| {
+                                &&& #[trigger] s.network_state.in_flight.contains(other_msg)
+                                &&& sts_update_request_msg_since(key, rest_id)(other_msg)
+                            } ==> msg == other_msg
+                        }
+                    }
+                }
+                ||| forall |msg| !{
+                    &&& #[trigger] s.network_state.in_flight.contains(msg)
+                    &&& sts_update_request_msg_since(key, rest_id)(msg)
+                }
+            } else {
+                forall |msg| !{
+                    &&& #[trigger] s.network_state.in_flight.contains(msg)
+                    &&& sts_update_request_msg_since(key, rest_id)(msg)
+                }
+            }
+        }
+    }
+}
+
+pub proof fn lemma_always_at_most_one_update_sts_req_since_rest_id_is_in_flight(
+    spec: TempPred<ClusterState>, key: ObjectRef, rest_id: RestId
+)
+    requires
+        spec.entails(lift_state(rest_id_counter_is(rest_id))),
+        spec.entails(lift_state(every_in_flight_msg_has_lower_id_than_allocator())),
+        spec.entails(lift_state(pending_msg_at_after_update_stateful_set_step_is_update_sts_req(key))),
+        spec.entails(always(lift_action(next::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>()))),
+        spec.entails(always(lift_state(crash_disabled()))),
+        spec.entails(always(lift_state(pending_msg_at_after_update_stateful_set_step_is_update_sts_req(key)))),
+        spec.entails(always(lift_state(each_key_in_reconcile_is_consistent_with_its_object()))),
+        spec.entails(always(lift_state(rest_id_counter_is_no_smaller_than(rest_id)))),
+        spec.entails(always(lift_state(every_in_flight_msg_has_unique_id()))),
+        key.kind.is_CustomResourceKind(),
+    ensures
+        spec.entails(
+            always(lift_state(at_most_one_update_sts_req_since_rest_id_is_in_flight(key, rest_id)))
+        ),
+{
+    lemma_always_filtered_update_sts_req_len_is_at_most_one(spec, key, rest_id);
+
+    let p = lift_state(at_most_one_update_sts_req_since_rest_id_is_in_flight(key, rest_id));
+    let q = lift_state(filtered_update_sts_req_len_is_at_most_one(key, rest_id));
+
+    assert_by(
+        p == q, {
+            assert forall |ex| p.satisfied_by(ex) implies q.satisfied_by(ex) by {
+                multiset_lemmas::filtered_size_is_zero_means_no_such_value(
+                    ex.head().network_state.in_flight, sts_update_request_msg_since(key, rest_id)
+                );
+                multiset_lemmas::filtered_size_is_one_means_only_one_such_value(
+                    ex.head().network_state.in_flight, sts_update_request_msg_since(key, rest_id)
+                );
+            }
+
+            assert forall |ex| q.satisfied_by(ex) implies p.satisfied_by(ex) by {
+                multiset_lemmas::filtered_size_is_zero_means_no_such_value(
+                    ex.head().network_state.in_flight, sts_update_request_msg_since(key, rest_id)
+                );
+                multiset_lemmas::filtered_size_is_one_means_only_one_such_value(
+                    ex.head().network_state.in_flight, sts_update_request_msg_since(key, rest_id)
+                );
+            }
+
+            temp_pred_equality(p, q);
+        }
+    );
+}
+
+// TODO: generalize this
+pub open spec fn the_object_in_schedule_has_spec_as(zk: ZookeeperClusterView) -> StatePred<ClusterState> {
+    |s: ClusterState| s.reconcile_scheduled_for(zk.object_ref()) ==> s.reconcile_scheduled_obj_of(zk.object_ref()).spec == zk.spec
+}
+
+// TODO: generalize this
+pub open spec fn the_object_in_reconcile_has_spec_as(zk: ZookeeperClusterView) -> StatePred<ClusterState> {
+    |s: ClusterState| s.reconcile_state_contains(zk.object_ref()) ==> s.triggering_cr_of(zk.object_ref()).spec == zk.spec
+}
+
+// pub proof fn lemma_always_the_object_in_reconcile_has_spec_as(
+//     spec: TempPred<ClusterState>, zk: ZookeeperClusterView
+// )
+//     requires
+//         spec.entails(lift_state(|s: ClusterState| !s.reconcile_state_contains(zk.object_ref()))),
+//         spec.entails(always(lift_action(next::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>()))),
+//         spec.entails(always(lift_state(the_object_in_schedule_has_spec_as(zk)))),
+//     ensures
+//         spec.entails(always(lift_state(the_object_in_reconcile_has_spec_as(zk)))),
+// {
+//     let init = |s: ClusterState| !s.reconcile_state_contains(zk.object_ref());
+//     let stronger_next = |s, s_prime: ClusterState| {
+//         &&& next::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>()(s, s_prime)
+//         &&& the_object_in_schedule_has_spec_as(zk)(s)
+//     };
+//     let invariant = the_object_in_reconcile_has_spec_as(zk);
+
+//     entails_always_and_n!(
+//         spec,
+//         lift_action(next::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>()),
+//         lift_state(the_object_in_schedule_has_spec_as(zk))
+//     );
+//     temp_pred_equality(
+//         lift_action(stronger_next),
+//         lift_action(next::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>())
+//         .and(lift_state(the_object_in_schedule_has_spec_as(zk)))
+//     );
+
+//     init_invariant(spec, init, stronger_next, invariant);
+// }
+
+pub open spec fn every_update_sts_req_since_rest_id_does_the_same(
+    zk: ZookeeperClusterView, rest_id: RestId
+) -> StatePred<ClusterState>
+    recommends
+        zk.well_formed(),
+{
+    |s: ClusterState| {
+        forall |msg: Message| {
+            &&& #[trigger] s.network_state.in_flight.contains(msg)
+            &&& sts_update_request_msg_since(zk.object_ref(), rest_id)(msg)
+        } ==> msg.content.get_update_request().obj.spec == StatefulSetView::marshal_spec(make_stateful_set(zk).spec)
+    }
+}
+
+pub proof fn lemma_always_every_update_sts_req_since_rest_id_does_the_same(
+    spec: TempPred<ClusterState>, zk: ZookeeperClusterView, rest_id: RestId
+)
+    requires
+        spec.entails(lift_state(rest_id_counter_is(rest_id))),
+        spec.entails(lift_state(every_in_flight_msg_has_lower_id_than_allocator())),
+        spec.entails(always(lift_action(next::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>()))),
+        spec.entails(always(lift_state(each_key_in_reconcile_is_consistent_with_its_object()))),
+        spec.entails(always(lift_state(rest_id_counter_is_no_smaller_than(rest_id)))),
+        spec.entails(always(lift_state(the_object_in_reconcile_has_spec_as(zk)))),
+    ensures
+        spec.entails(always(lift_state(every_update_sts_req_since_rest_id_does_the_same(zk, rest_id)))),
+{
+    let init = |s: ClusterState| {
+        &&& rest_id_counter_is(rest_id)(s)
+        &&& every_in_flight_msg_has_lower_id_than_allocator()(s)
+    };
+    let stronger_next = |s, s_prime: ClusterState| {
+        &&& next::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>()(s, s_prime)
+        &&& each_key_in_reconcile_is_consistent_with_its_object()(s)
+        &&& rest_id_counter_is_no_smaller_than(rest_id)(s)
+        &&& the_object_in_reconcile_has_spec_as(zk)(s)
+    };
+    let invariant = every_update_sts_req_since_rest_id_does_the_same(zk, rest_id);
+
+    entails_and_n!(
+        spec,
+        lift_state(rest_id_counter_is(rest_id)),
+        lift_state(every_in_flight_msg_has_lower_id_than_allocator())
+    );
+    temp_pred_equality(
+        lift_state(init),
+        lift_state(rest_id_counter_is(rest_id))
+        .and(lift_state(every_in_flight_msg_has_lower_id_than_allocator()))
+    );
+
+    entails_always_and_n!(
+        spec,
+        lift_action(next::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>()),
+        lift_state(each_key_in_reconcile_is_consistent_with_its_object()),
+        lift_state(rest_id_counter_is_no_smaller_than(rest_id)),
+        lift_state(the_object_in_reconcile_has_spec_as(zk))
+    );
+    temp_pred_equality(
+        lift_action(stronger_next),
+        lift_action(next::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>())
+        .and(lift_state(each_key_in_reconcile_is_consistent_with_its_object()))
+        .and(lift_state(rest_id_counter_is_no_smaller_than(rest_id)))
+        .and(lift_state(the_object_in_reconcile_has_spec_as(zk)))
+    );
+
+    assert forall |s, s_prime: ClusterState| invariant(s) && #[trigger] stronger_next(s, s_prime)
+    implies invariant(s_prime) by {
+        assert forall |msg: Message|
+            #[trigger] s_prime.network_state.in_flight.contains(msg)
+            && sts_update_request_msg_since(zk.object_ref(), rest_id)(msg)
+        implies msg.content.get_update_request().obj.spec == StatefulSetView::marshal_spec(make_stateful_set(zk).spec) by {
+            if s.network_state.in_flight.contains(msg) {} else {}
+        }
+    }
+
+    init_invariant(spec, init, stronger_next, invariant);
+}
+
+pub open spec fn sts_delete_request_msg(key: ObjectRef) -> FnSpec(Message) -> bool {
+    |msg: Message|
+        msg.dst.is_KubernetesAPI()
+        && msg.content.is_delete_request()
+        && msg.content.get_delete_request().key == make_stateful_set_key(key)
+}
+
+pub open spec fn sts_delete_request_msg_since(key: ObjectRef, rest_id: RestId) -> FnSpec(Message) -> bool {
+    |msg: Message|
+        sts_delete_request_msg(key)(msg)
+        && msg.content.get_rest_id() >= rest_id
+}
+
+pub open spec fn no_delete_sts_req_since_rest_id_is_in_flight(
+    key: ObjectRef, rest_id: RestId
+) -> StatePred<ClusterState>
+    recommends
+        key.kind.is_CustomResourceKind(),
+{
+    |s: ClusterState| {
+        forall |msg: Message| !{
+            &&& #[trigger] s.message_in_flight(msg)
+            &&& sts_delete_request_msg_since(key, rest_id)(msg)
+        }
+    }
+}
+
+pub proof fn lemma_always_no_delete_sts_req_since_rest_id_is_in_flight(
+    spec: TempPred<ClusterState>, key: ObjectRef, rest_id: RestId
+)
+    requires
+        spec.entails(lift_state(rest_id_counter_is(rest_id))),
+        spec.entails(lift_state(every_in_flight_msg_has_lower_id_than_allocator())),
+        spec.entails(always(lift_action(next::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>()))),
+        key.kind.is_CustomResourceKind(),
+    ensures
+        spec.entails(
+            always(lift_state(no_delete_sts_req_since_rest_id_is_in_flight(key, rest_id)))
+        ),
+{
+    let init = |s: ClusterState| {
+        &&& rest_id_counter_is(rest_id)(s)
+        &&& every_in_flight_msg_has_lower_id_than_allocator()(s)
+    };
+    let next = next::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>();
+    let invariant = no_delete_sts_req_since_rest_id_is_in_flight(key, rest_id);
+
+    entails_and_n!(
+        spec,
+        lift_state(rest_id_counter_is(rest_id)),
+        lift_state(every_in_flight_msg_has_lower_id_than_allocator())
+    );
+    temp_pred_equality(
+        lift_state(init),
+        lift_state(rest_id_counter_is(rest_id))
+        .and(lift_state(every_in_flight_msg_has_lower_id_than_allocator()))
+    );
+
+    assert forall |s, s_prime: ClusterState| invariant(s) && #[trigger] next(s, s_prime)
+    implies invariant(s_prime) by {
+        assert forall |msg: Message|
+        !(#[trigger] s_prime.message_in_flight(msg) && sts_delete_request_msg_since(key, rest_id)(msg)) by {
+            if s.message_in_flight(msg) {} else {}
+        }
+    }
+
+    init_invariant(spec, init, next, invariant);
+}
+
+}

--- a/src/controller_examples/zookeeper_controller/proof/terminate.rs
+++ b/src/controller_examples/zookeeper_controller/proof/terminate.rs
@@ -1,0 +1,62 @@
+// Copyright 2022 VMware, Inc.
+// SPDX-License-Identifier: MIT
+#![allow(unused_imports)]
+use crate::kubernetes_api_objects::{
+    api_method::*, common::*, dynamic::*, resource::*, stateful_set::*,
+};
+use crate::kubernetes_cluster::{
+    proof::{
+        cluster::*,
+        controller_runtime_liveness::{
+            lemma_pre_leads_to_post_by_controller,
+            lemma_pre_leads_to_post_by_schedule_controller_reconcile,
+        },
+        controller_runtime_safety,
+        kubernetes_api_liveness::{
+            lemma_pre_leads_to_post_by_kubernetes_api, no_req_before_rest_id_is_in_flight,
+        },
+        kubernetes_api_safety,
+    },
+    spec::{
+        cluster::*,
+        controller::common::{controller_req_msg, ControllerActionInput, ControllerStep},
+        controller::controller_runtime::{
+            continue_reconcile, end_reconcile, run_scheduled_reconcile,
+        },
+        controller::state_machine::controller,
+        kubernetes_api::state_machine::{
+            handle_create_request, handle_get_request, handle_request, update_is_noop,
+        },
+        message::*,
+    },
+};
+use crate::temporal_logic::{defs::*, rules::*};
+use crate::zookeeper_controller::{
+    proof::{common::*, safety},
+    spec::{reconciler::*, zookeepercluster::*},
+};
+use builtin::*;
+use builtin_macros::*;
+use vstd::*;
+use vstd::{option::*, result::*};
+
+verus! {
+
+#[verifier(external_body)]
+pub proof fn reconcile_eventually_terminates(spec: TempPred<ClusterState>, zk: ZookeeperClusterView)
+    requires
+        zk.well_formed(),
+        spec.entails(always(lift_action(next::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>()))),
+        spec.entails(tla_forall(|i| kubernetes_api_next().weak_fairness(i))),
+        spec.entails(tla_forall(|i| controller_next::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>().weak_fairness(i))),
+        spec.entails(always(lift_state(crash_disabled()))),
+        spec.entails(always(lift_state(controller_runtime_safety::every_in_flight_msg_has_unique_id()))),
+        spec.entails(always(lift_state(controller_runtime_safety::each_resp_matches_at_most_one_pending_req(zk.object_ref())))),
+        spec.entails(always(lift_state(controller_runtime_safety::each_resp_if_matches_pending_req_then_no_other_resp_matches(zk.object_ref())))),
+    ensures
+        spec.entails(
+            true_pred().leads_to(lift_state(|s: ClusterState| !s.reconcile_state_contains(zk.object_ref())))
+        ),
+{}
+
+}

--- a/src/controller_examples/zookeeper_controller/spec/zookeepercluster.rs
+++ b/src/controller_examples/zookeeper_controller/spec/zookeepercluster.rs
@@ -23,27 +23,11 @@ impl ZookeeperCluster {
     pub spec fn view(&self) -> ZookeeperClusterView;
 
     #[verifier(external_body)]
-    pub fn name(&self) -> (name: Option<String>)
+    pub fn metadata(&self) -> (metadata: ObjectMeta)
         ensures
-            self@.name().is_Some() == name.is_Some(),
-            name.is_Some() ==> name.get_Some_0()@ == self@.name().get_Some_0(),
+            metadata@ == self@.metadata,
     {
-        match &self.inner.metadata.name {
-            std::option::Option::Some(n) => Option::Some(String::from_rust_string(n.to_string())),
-            std::option::Option::None => Option::None,
-        }
-    }
-
-    #[verifier(external_body)]
-    pub fn namespace(&self) -> (namespace: Option<String>)
-        ensures
-            self@.namespace().is_Some() == namespace.is_Some(),
-            namespace.is_Some() ==> namespace.get_Some_0()@ == self@.namespace().get_Some_0(),
-    {
-        match &self.inner.metadata.namespace {
-            std::option::Option::Some(n) => Option::Some(String::from_rust_string(n.to_string())),
-            std::option::Option::None => Option::None,
-        }
+        ObjectMeta::from_kube(self.inner.metadata.clone())
     }
 
     #[verifier(external_body)]
@@ -105,12 +89,9 @@ impl ResourceWrapper<deps_hack::ZookeeperCluster> for ZookeeperCluster {
 }
 
 impl ZookeeperClusterView {
-    pub open spec fn name(self) -> Option<StringView> {
-        self.metadata.name
-    }
-
-    pub open spec fn namespace(self) -> Option<StringView> {
-        self.metadata.namespace
+    pub open spec fn well_formed(self) -> bool {
+        &&& self.metadata.name.is_Some()
+        &&& self.metadata.namespace.is_Some()
     }
 
     pub closed spec fn marshal_spec(s: ZookeeperClusterSpecView) -> Value;

--- a/src/controller_examples/zookeeper_controller/spec/zookeepercluster.rs
+++ b/src/controller_examples/zookeeper_controller/spec/zookeepercluster.rs
@@ -123,6 +123,8 @@ impl ResourceView for ZookeeperClusterView {
         }
     }
 
+    proof fn object_ref_is_well_formed() {}
+
     open spec fn to_dynamic_object(self) -> DynamicObjectView {
         DynamicObjectView {
             kind: Self::kind(),
@@ -132,7 +134,9 @@ impl ResourceView for ZookeeperClusterView {
     }
 
     open spec fn from_dynamic_object(obj: DynamicObjectView) -> Result<ZookeeperClusterView, ParseDynamicObjectError> {
-        if !ZookeeperClusterView::unmarshal_spec(obj.spec).is_Ok() {
+        if obj.kind != Self::kind() {
+            Result::Err(ParseDynamicObjectError::UnmarshalError)
+        } else if !ZookeeperClusterView::unmarshal_spec(obj.spec).is_Ok() {
             Result::Err(ParseDynamicObjectError::UnmarshalError)
         } else {
             Result::Ok(ZookeeperClusterView {
@@ -145,6 +149,10 @@ impl ResourceView for ZookeeperClusterView {
     proof fn to_dynamic_preserves_integrity() {
         ZookeeperClusterView::spec_integrity_is_preserved_by_marshal();
     }
+
+    proof fn from_dynamic_preserves_metadata() {}
+
+    proof fn from_dynamic_preserves_kind() {}
 }
 
 #[verifier(external_body)]

--- a/src/kubernetes_api_objects/config_map.rs
+++ b/src/kubernetes_api_objects/config_map.rs
@@ -191,6 +191,8 @@ impl ResourceView for ConfigMapView {
         }
     }
 
+    proof fn object_ref_is_well_formed() {}
+
     open spec fn to_dynamic_object(self) -> DynamicObjectView {
         DynamicObjectView {
             kind: Self::kind(),
@@ -200,7 +202,9 @@ impl ResourceView for ConfigMapView {
     }
 
     open spec fn from_dynamic_object(obj: DynamicObjectView) -> Result<ConfigMapView, ParseDynamicObjectError> {
-        if !ConfigMapView::unmarshal_spec(obj.spec).is_Ok() {
+        if obj.kind != Self::kind() {
+            Result::Err(ParseDynamicObjectError::UnmarshalError)
+        } else if !ConfigMapView::unmarshal_spec(obj.spec).is_Ok() {
             Result::Err(ParseDynamicObjectError::UnmarshalError)
         } else {
             Result::Ok(ConfigMapView {
@@ -213,6 +217,10 @@ impl ResourceView for ConfigMapView {
     proof fn to_dynamic_preserves_integrity() {
         ConfigMapView::spec_integrity_is_preserved_by_marshal();
     }
+
+    proof fn from_dynamic_preserves_metadata() {}
+
+    proof fn from_dynamic_preserves_kind() {}
 }
 
 }

--- a/src/kubernetes_api_objects/error.rs
+++ b/src/kubernetes_api_objects/error.rs
@@ -12,6 +12,7 @@ verus! {
 pub enum APIError {
     BadRequest,
     Conflict,
+    Invalid,
     ObjectNotFound,
     ObjectAlreadyExists,
     NotSupported,

--- a/src/kubernetes_api_objects/persistent_volume_claim.rs
+++ b/src/kubernetes_api_objects/persistent_volume_claim.rs
@@ -233,6 +233,8 @@ impl ResourceView for PersistentVolumeClaimView {
         }
     }
 
+    proof fn object_ref_is_well_formed() {}
+
     open spec fn to_dynamic_object(self) -> DynamicObjectView {
         DynamicObjectView {
             kind: Self::kind(),
@@ -242,7 +244,9 @@ impl ResourceView for PersistentVolumeClaimView {
     }
 
     open spec fn from_dynamic_object(obj: DynamicObjectView) -> Result<PersistentVolumeClaimView, ParseDynamicObjectError> {
-        if !PersistentVolumeClaimView::unmarshal_spec(obj.spec).is_Ok() {
+        if obj.kind != Self::kind() {
+            Result::Err(ParseDynamicObjectError::UnmarshalError)
+        } else if !PersistentVolumeClaimView::unmarshal_spec(obj.spec).is_Ok() {
             Result::Err(ParseDynamicObjectError::UnmarshalError)
         } else {
             Result::Ok(PersistentVolumeClaimView {
@@ -255,6 +259,10 @@ impl ResourceView for PersistentVolumeClaimView {
     proof fn to_dynamic_preserves_integrity() {
         PersistentVolumeClaimView::spec_integrity_is_preserved_by_marshal();
     }
+
+    proof fn from_dynamic_preserves_metadata() {}
+
+    proof fn from_dynamic_preserves_kind() {}
 }
 
 impl Marshalable for PersistentVolumeClaimView {

--- a/src/kubernetes_api_objects/pod.rs
+++ b/src/kubernetes_api_objects/pod.rs
@@ -366,7 +366,6 @@ impl EnvVar {
     }
 }
 
-
 #[verifier(external_body)]
 pub struct VolumeMount {
     inner: deps_hack::k8s_openapi::api::core::v1::VolumeMount,
@@ -538,6 +537,7 @@ impl ConfigMapVolumeSource {
 pub struct SecretVolumeSource {
     inner: deps_hack::k8s_openapi::api::core::v1::SecretVolumeSource,
 }
+
 impl SecretVolumeSource {
     pub spec fn view(&self) -> SecretVolumeSourceView;
 
@@ -564,8 +564,6 @@ impl SecretVolumeSource {
         self.inner
     }
 }
-
-
 
 #[verifier(external_body)]
 pub struct ProjectedVolumeSource {
@@ -600,7 +598,6 @@ impl ProjectedVolumeSource {
         self.inner
     }
 }
-
 
 #[verifier(external_body)]
 pub struct VolumeProjection {
@@ -642,11 +639,11 @@ impl VolumeProjection {
     }
 }
 
-
 #[verifier(external_body)]
 pub struct ConfigMapProjection {
     inner: deps_hack::k8s_openapi::api::core::v1::ConfigMapProjection,
 }
+
 impl ConfigMapProjection {
     pub spec fn view(&self) -> ConfigMapProjectionView;
 
@@ -688,6 +685,7 @@ impl ConfigMapProjection {
 pub struct SecretProjection {
     inner: deps_hack::k8s_openapi::api::core::v1::SecretProjection,
 }
+
 impl SecretProjection {
     pub spec fn view(&self) -> SecretProjectionView;
 
@@ -725,11 +723,11 @@ impl SecretProjection {
     }
 }
 
-
 #[verifier(external_body)]
 pub struct KeyToPath {
     inner: deps_hack::k8s_openapi::api::core::v1::KeyToPath,
 }
+
 impl KeyToPath {
     pub spec fn view(&self) -> KeyToPathView;
 
@@ -769,6 +767,7 @@ impl KeyToPath {
 pub struct DownwardAPIVolumeSource {
     inner: deps_hack::k8s_openapi::api::core::v1::DownwardAPIVolumeSource,
 }
+
 impl DownwardAPIVolumeSource {
     pub spec fn view(&self) -> DownwardAPIVolumeSourceView;
 
@@ -802,6 +801,7 @@ impl DownwardAPIVolumeSource {
 pub struct DownwardAPIVolumeFile {
     inner: deps_hack::k8s_openapi::api::core::v1::DownwardAPIVolumeFile,
 }
+
 impl DownwardAPIVolumeFile {
     pub spec fn view(&self) -> DownwardAPIVolumeFileView;
 
@@ -928,6 +928,8 @@ impl ResourceView for PodView {
         }
     }
 
+    proof fn object_ref_is_well_formed() {}
+
     open spec fn to_dynamic_object(self) -> DynamicObjectView {
         DynamicObjectView {
             kind: Self::kind(),
@@ -937,7 +939,9 @@ impl ResourceView for PodView {
     }
 
     open spec fn from_dynamic_object(obj: DynamicObjectView) -> Result<PodView, ParseDynamicObjectError> {
-        if !PodView::unmarshal_spec(obj.spec).is_Ok() {
+        if obj.kind != Self::kind() {
+            Result::Err(ParseDynamicObjectError::UnmarshalError)
+        } else if !PodView::unmarshal_spec(obj.spec).is_Ok() {
             Result::Err(ParseDynamicObjectError::UnmarshalError)
         } else {
             Result::Ok(PodView {
@@ -950,6 +954,10 @@ impl ResourceView for PodView {
     proof fn to_dynamic_preserves_integrity() {
         PodView::spec_integrity_is_preserved_by_marshal();
     }
+
+    proof fn from_dynamic_preserves_metadata() {}
+
+    proof fn from_dynamic_preserves_kind() {}
 }
 
 pub struct PodSpecView {

--- a/src/kubernetes_api_objects/resource.rs
+++ b/src/kubernetes_api_objects/resource.rs
@@ -36,6 +36,15 @@ pub trait ResourceView: Sized {
     // TODO: object_ref can be implemented here if default implementation is supported by Verus
     open spec fn object_ref(self) -> ObjectRef;
 
+    proof fn object_ref_is_well_formed()
+        ensures
+            forall |o: Self|
+                #[trigger] o.object_ref() == (ObjectRef {
+                    kind: Self::kind(),
+                    name: o.metadata().name.get_Some_0(),
+                    namespace: o.metadata().namespace.get_Some_0(),
+                });
+
     /// Convert the object to a dynamic object
 
     open spec fn to_dynamic_object(self) -> DynamicObjectView;
@@ -50,6 +59,18 @@ pub trait ResourceView: Sized {
         ensures
             forall |o: Self| Self::from_dynamic_object(#[trigger] o.to_dynamic_object()).is_Ok()
                             && o == Self::from_dynamic_object(o.to_dynamic_object()).get_Ok_0();
+
+    proof fn from_dynamic_preserves_metadata()
+        ensures
+            forall |d: DynamicObjectView|
+                #[trigger] Self::from_dynamic_object(d).is_Ok()
+                    ==> d.metadata == Self::from_dynamic_object(d).get_Ok_0().metadata();
+
+    proof fn from_dynamic_preserves_kind()
+        ensures
+            forall |d: DynamicObjectView|
+                #[trigger] Self::from_dynamic_object(d).is_Ok()
+                    ==> d.kind == Self::kind();
 }
 
 }

--- a/src/kubernetes_api_objects/role.rs
+++ b/src/kubernetes_api_objects/role.rs
@@ -220,6 +220,8 @@ impl ResourceView for RoleView {
         }
     }
 
+    proof fn object_ref_is_well_formed() {}
+
     open spec fn to_dynamic_object(self) -> DynamicObjectView {
         DynamicObjectView {
             kind: Self::kind(),
@@ -229,7 +231,9 @@ impl ResourceView for RoleView {
     }
 
     open spec fn from_dynamic_object(obj: DynamicObjectView) -> Result<RoleView, ParseDynamicObjectError> {
-        if !RoleView::unmarshal_spec(obj.spec).is_Ok() {
+        if obj.kind != Self::kind() {
+            Result::Err(ParseDynamicObjectError::UnmarshalError)
+        } else if !RoleView::unmarshal_spec(obj.spec).is_Ok() {
             Result::Err(ParseDynamicObjectError::UnmarshalError)
         } else {
             Result::Ok(RoleView {
@@ -242,6 +246,10 @@ impl ResourceView for RoleView {
     proof fn to_dynamic_preserves_integrity() {
         RoleView::spec_integrity_is_preserved_by_marshal();
     }
+
+    proof fn from_dynamic_preserves_metadata() {}
+
+    proof fn from_dynamic_preserves_kind() {}
 }
 
 pub struct PolicyRuleView {

--- a/src/kubernetes_api_objects/role_binding.rs
+++ b/src/kubernetes_api_objects/role_binding.rs
@@ -215,9 +215,6 @@ impl Subject {
     }
 }
 
-
-
-
 /// RoleBindingView is the ghost type of RoleBinding.
 /// It is supposed to be used in spec and proof code.
 
@@ -289,6 +286,8 @@ impl ResourceView for RoleBindingView {
         }
     }
 
+    proof fn object_ref_is_well_formed() {}
+
     open spec fn to_dynamic_object(self) -> DynamicObjectView {
         DynamicObjectView {
             kind: Self::kind(),
@@ -298,7 +297,9 @@ impl ResourceView for RoleBindingView {
     }
 
     open spec fn from_dynamic_object(obj: DynamicObjectView) -> Result<RoleBindingView, ParseDynamicObjectError> {
-        if !RoleBindingView::unmarshal_spec(obj.spec).is_Ok() {
+        if obj.kind != Self::kind() {
+            Result::Err(ParseDynamicObjectError::UnmarshalError)
+        } else if !RoleBindingView::unmarshal_spec(obj.spec).is_Ok() {
             Result::Err(ParseDynamicObjectError::UnmarshalError)
         } else {
             Result::Ok(RoleBindingView {
@@ -312,6 +313,10 @@ impl ResourceView for RoleBindingView {
     proof fn to_dynamic_preserves_integrity() {
         RoleBindingView::spec_integrity_is_preserved_by_marshal();
     }
+
+    proof fn from_dynamic_preserves_metadata() {}
+
+    proof fn from_dynamic_preserves_kind() {}
 }
 
 pub struct RoleRefView {

--- a/src/kubernetes_api_objects/secret.rs
+++ b/src/kubernetes_api_objects/secret.rs
@@ -204,6 +204,8 @@ impl ResourceView for SecretView {
         }
     }
 
+    proof fn object_ref_is_well_formed() {}
+
     open spec fn to_dynamic_object(self) -> DynamicObjectView {
         DynamicObjectView {
             kind: Self::kind(),
@@ -213,7 +215,9 @@ impl ResourceView for SecretView {
     }
 
     open spec fn from_dynamic_object(obj: DynamicObjectView) -> Result<SecretView, ParseDynamicObjectError> {
-        if !SecretView::unmarshal_spec(obj.spec).is_Ok() {
+        if obj.kind != Self::kind() {
+            Result::Err(ParseDynamicObjectError::UnmarshalError)
+        } else if !SecretView::unmarshal_spec(obj.spec).is_Ok() {
             Result::Err(ParseDynamicObjectError::UnmarshalError)
         } else {
             Result::Ok(SecretView {
@@ -227,6 +231,10 @@ impl ResourceView for SecretView {
     proof fn to_dynamic_preserves_integrity() {
         SecretView::spec_integrity_is_preserved_by_marshal();
     }
+
+    proof fn from_dynamic_preserves_metadata() {}
+
+    proof fn from_dynamic_preserves_kind() {}
 }
 
 }

--- a/src/kubernetes_api_objects/service.rs
+++ b/src/kubernetes_api_objects/service.rs
@@ -291,6 +291,8 @@ impl ResourceView for ServiceView {
         }
     }
 
+    proof fn object_ref_is_well_formed() {}
+
     open spec fn to_dynamic_object(self) -> DynamicObjectView {
         DynamicObjectView {
             kind: Self::kind(),
@@ -300,7 +302,9 @@ impl ResourceView for ServiceView {
     }
 
     open spec fn from_dynamic_object(obj: DynamicObjectView) -> Result<ServiceView, ParseDynamicObjectError> {
-        if !ServiceView::unmarshal_spec(obj.spec).is_Ok() {
+        if obj.kind != Self::kind() {
+            Result::Err(ParseDynamicObjectError::UnmarshalError)
+        } else if !ServiceView::unmarshal_spec(obj.spec).is_Ok() {
             Result::Err(ParseDynamicObjectError::UnmarshalError)
         } else {
             Result::Ok(ServiceView {
@@ -313,6 +317,10 @@ impl ResourceView for ServiceView {
     proof fn to_dynamic_preserves_integrity() {
         ServiceView::spec_integrity_is_preserved_by_marshal();
     }
+
+    proof fn from_dynamic_preserves_metadata() {}
+
+    proof fn from_dynamic_preserves_kind() {}
 }
 
 pub struct ServiceSpecView {

--- a/src/kubernetes_api_objects/service_account.rs
+++ b/src/kubernetes_api_objects/service_account.rs
@@ -144,6 +144,8 @@ impl ResourceView for ServiceAccountView {
         }
     }
 
+    proof fn object_ref_is_well_formed() {}
+
     open spec fn to_dynamic_object(self) -> DynamicObjectView {
         DynamicObjectView {
             kind: Self::kind(),
@@ -153,15 +155,20 @@ impl ResourceView for ServiceAccountView {
     }
 
     open spec fn from_dynamic_object(obj: DynamicObjectView) -> Result<ServiceAccountView, ParseDynamicObjectError> {
-            Result::Ok(ServiceAccountView {
-                metadata: obj.metadata,
-            })
+            if obj.kind != Self::kind() {
+                Result::Err(ParseDynamicObjectError::UnmarshalError)
+            } else {
+                Result::Ok(ServiceAccountView {
+                    metadata: obj.metadata,
+                })
+            }
     }
 
+    proof fn to_dynamic_preserves_integrity() {}
 
-    proof fn to_dynamic_preserves_integrity() {
+    proof fn from_dynamic_preserves_metadata() {}
 
-    }
+    proof fn from_dynamic_preserves_kind() {}
 }
 
 }

--- a/src/kubernetes_api_objects/stateful_set.rs
+++ b/src/kubernetes_api_objects/stateful_set.rs
@@ -277,6 +277,8 @@ impl ResourceView for StatefulSetView {
         }
     }
 
+    proof fn object_ref_is_well_formed() {}
+
     open spec fn to_dynamic_object(self) -> DynamicObjectView {
         DynamicObjectView {
             kind: Self::kind(),
@@ -286,7 +288,9 @@ impl ResourceView for StatefulSetView {
     }
 
     open spec fn from_dynamic_object(obj: DynamicObjectView) -> Result<StatefulSetView, ParseDynamicObjectError> {
-        if !StatefulSetView::unmarshal_spec(obj.spec).is_Ok() {
+        if obj.kind != Self::kind() {
+            Result::Err(ParseDynamicObjectError::UnmarshalError)
+        } else if !StatefulSetView::unmarshal_spec(obj.spec).is_Ok() {
             Result::Err(ParseDynamicObjectError::UnmarshalError)
         } else {
             Result::Ok(StatefulSetView {
@@ -299,6 +303,10 @@ impl ResourceView for StatefulSetView {
     proof fn to_dynamic_preserves_integrity() {
         StatefulSetView::spec_integrity_is_preserved_by_marshal();
     }
+
+    proof fn from_dynamic_preserves_metadata() {}
+
+    proof fn from_dynamic_preserves_kind() {}
 }
 
 pub struct StatefulSetSpecView {

--- a/src/kubernetes_cluster/proof/cluster_safety.rs
+++ b/src/kubernetes_cluster/proof/cluster_safety.rs
@@ -1,0 +1,176 @@
+// Copyright 2022 VMware, Inc.
+// SPDX-License-Identifier: MIT
+#![allow(unused_imports)]
+use crate::kubernetes_api_objects::{
+    api_method::*, common::*, config_map::*, persistent_volume_claim::*, pod::*, resource::*,
+    role::*, role_binding::*, secret::*, service::*, service_account::*, stateful_set::*,
+};
+use crate::kubernetes_cluster::spec::{cluster::*, message::*};
+use crate::reconciler::spec::Reconciler;
+use crate::temporal_logic::{defs::*, rules::*};
+use vstd::{option::*, prelude::*, result::*};
+
+verus! {
+
+pub proof fn lemma_always_rest_id_counter_is_no_smaller_than<K: ResourceView, T, ReconcilerType: Reconciler<K, T>>(
+    spec: TempPred<State<K, T>>, rest_id: RestId
+)
+    requires
+        spec.entails(lift_state(rest_id_counter_is(rest_id))),
+        spec.entails(always(lift_action(next::<K, T, ReconcilerType>()))),
+    ensures
+        spec.entails(always(lift_state(rest_id_counter_is_no_smaller_than::<K, T>(rest_id)))),
+{
+    let invariant = rest_id_counter_is_no_smaller_than::<K, T>(rest_id);
+    init_invariant::<State<K, T>>(spec, rest_id_counter_is(rest_id), next::<K, T, ReconcilerType>(), invariant);
+}
+
+pub open spec fn object_is_well_formed<K: ResourceView, T>(key: ObjectRef) -> StatePred<State<K, T>> {
+    |s: State<K, T>| {
+        &&& s.resource_obj_of(key).object_ref() == key
+        &&& s.resource_obj_of(key).metadata.name.is_Some()
+        &&& s.resource_obj_of(key).metadata.namespace.is_Some()
+        &&& s.resource_obj_of(key).metadata.resource_version.is_Some()
+        &&& {
+            &&& key.kind == ConfigMapView::kind() ==> ConfigMapView::from_dynamic_object(s.resource_obj_of(key)).is_Ok()
+            &&& key.kind == PersistentVolumeClaimView::kind() ==> PersistentVolumeClaimView::from_dynamic_object(s.resource_obj_of(key)).is_Ok()
+            &&& key.kind == PodView::kind() ==> PodView::from_dynamic_object(s.resource_obj_of(key)).is_Ok()
+            &&& key.kind == RoleBindingView::kind() ==> RoleBindingView::from_dynamic_object(s.resource_obj_of(key)).is_Ok()
+            &&& key.kind == RoleView::kind() ==> RoleView::from_dynamic_object(s.resource_obj_of(key)).is_Ok()
+            &&& key.kind == SecretView::kind() ==> SecretView::from_dynamic_object(s.resource_obj_of(key)).is_Ok()
+            &&& key.kind == ServiceView::kind() ==> ServiceView::from_dynamic_object(s.resource_obj_of(key)).is_Ok()
+            &&& key.kind == StatefulSetView::kind() ==> StatefulSetView::from_dynamic_object(s.resource_obj_of(key)).is_Ok()
+        }
+    }
+}
+
+pub open spec fn each_object_in_etcd_is_well_formed<K: ResourceView, T>() -> StatePred<State<K, T>> {
+    |s: State<K, T>| {
+        forall |key: ObjectRef|
+            #[trigger] s.resource_key_exists(key) ==> object_is_well_formed(key)(s)
+    }
+}
+
+pub proof fn lemma_always_each_object_in_etcd_is_well_formed<K: ResourceView, T, ReconcilerType: Reconciler<K, T>>(
+    spec: TempPred<State<K, T>>
+)
+    requires
+        spec.entails(lift_state(init::<K, T, ReconcilerType>())),
+        spec.entails(always(lift_action(next::<K, T, ReconcilerType>()))),
+    ensures
+        spec.entails(always(lift_state(each_object_in_etcd_is_well_formed::<K, T>()))),
+{
+    let invariant = each_object_in_etcd_is_well_formed::<K, T>();
+
+    assert forall |s, s_prime: State<K, T>| invariant(s) && #[trigger] next::<K, T, ReconcilerType>()(s, s_prime)
+    implies invariant(s_prime) by {
+        assert forall |key: ObjectRef| #[trigger] s_prime.resource_key_exists(key)
+        implies object_is_well_formed(key)(s_prime) by {
+            if s.resource_key_exists(key) {} else {}
+        }
+    }
+
+    init_invariant(spec, init::<K, T, ReconcilerType>(), next::<K, T, ReconcilerType>(), invariant);
+}
+
+pub open spec fn each_scheduled_key_is_consistent_with_its_object<K: ResourceView, T>() -> StatePred<State<K, T>> {
+    |s: State<K, T>| {
+        forall |key: ObjectRef|
+            #[trigger] s.reconcile_scheduled_for(key)
+                ==> s.reconcile_scheduled_obj_of(key).object_ref() == key
+    }
+}
+
+pub proof fn lemma_always_each_scheduled_key_is_consistent_with_its_object<K: ResourceView, T, ReconcilerType: Reconciler<K, T>>(
+    spec: TempPred<State<K, T>>
+)
+    requires
+        spec.entails(lift_state(init::<K, T, ReconcilerType>())),
+        spec.entails(always(lift_action(next::<K, T, ReconcilerType>()))),
+    ensures
+        spec.entails(always(lift_state(each_scheduled_key_is_consistent_with_its_object::<K, T>()))),
+{
+    let invariant = each_scheduled_key_is_consistent_with_its_object::<K, T>();
+
+    lemma_always_each_object_in_etcd_is_well_formed::<K, T, ReconcilerType>(spec);
+
+    let stronger_next = |s, s_prime: State<K, T>| {
+        &&& next::<K, T, ReconcilerType>()(s, s_prime)
+        &&& each_object_in_etcd_is_well_formed()(s)
+    };
+
+    strengthen_next(spec, next::<K, T, ReconcilerType>(), each_object_in_etcd_is_well_formed(), stronger_next);
+
+    assert forall |s, s_prime: State<K, T>| invariant(s) && #[trigger] stronger_next(s, s_prime)
+    implies invariant(s_prime) by {
+        let step = choose |step| next_step::<K, T, ReconcilerType>(s, s_prime, step);
+        match step {
+            Step::ScheduleControllerReconcileStep(input) => {
+                assert forall |key: ObjectRef| #[trigger] s_prime.reconcile_scheduled_for(key)
+                implies s_prime.reconcile_scheduled_obj_of(key).object_ref() == key by {
+                    if input == key {
+                        K::from_dynamic_preserves_metadata();
+                        K::from_dynamic_preserves_kind();
+                        K::object_ref_is_well_formed();
+                    } else {
+                        assert(s.reconcile_scheduled_for(key));
+                    }
+                }
+            },
+            _ => {
+                assert forall |key: ObjectRef| #[trigger] s_prime.reconcile_scheduled_for(key)
+                implies s_prime.reconcile_scheduled_obj_of(key).object_ref() == key by {
+                    assert(s.reconcile_scheduled_for(key));
+                }
+            }
+        }
+    }
+
+    init_invariant(spec, init::<K, T, ReconcilerType>(), stronger_next, invariant);
+}
+
+pub open spec fn each_key_in_reconcile_is_consistent_with_its_object<K: ResourceView, T>() -> StatePred<State<K, T>> {
+    |s: State<K, T>| {
+        forall |key: ObjectRef|
+            #[trigger] s.reconcile_state_contains(key)
+                ==> s.triggering_cr_of(key).object_ref() == key
+    }
+}
+
+pub proof fn lemma_always_each_key_in_reconcile_is_consistent_with_its_object<K: ResourceView, T, ReconcilerType: Reconciler<K, T>>(
+    spec: TempPred<State<K, T>>
+)
+    requires
+        spec.entails(lift_state(init::<K, T, ReconcilerType>())),
+        spec.entails(always(lift_action(next::<K, T, ReconcilerType>()))),
+    ensures
+        spec.entails(always(lift_state(each_key_in_reconcile_is_consistent_with_its_object::<K, T>()))),
+{
+    let invariant = each_key_in_reconcile_is_consistent_with_its_object::<K, T>();
+
+    lemma_always_each_scheduled_key_is_consistent_with_its_object::<K, T, ReconcilerType>(spec);
+
+    let stronger_next = |s, s_prime: State<K, T>| {
+        &&& next::<K, T, ReconcilerType>()(s, s_prime)
+        &&& each_scheduled_key_is_consistent_with_its_object()(s)
+    };
+
+    strengthen_next(spec, next::<K, T, ReconcilerType>(), each_scheduled_key_is_consistent_with_its_object(), stronger_next);
+
+    assert forall |s, s_prime: State<K, T>| invariant(s) && #[trigger] stronger_next(s, s_prime)
+    implies invariant(s_prime) by {
+        assert forall |key: ObjectRef| #[trigger] s_prime.reconcile_state_contains(key)
+        implies s_prime.triggering_cr_of(key).object_ref() == key by {
+            if s.reconcile_state_contains(key) {
+            } else {
+                assert(s.reconcile_scheduled_for(key));
+            }
+        }
+    }
+
+    init_invariant(spec, init::<K, T, ReconcilerType>(), stronger_next, invariant);
+}
+
+
+
+}

--- a/src/kubernetes_cluster/proof/mod.rs
+++ b/src/kubernetes_cluster/proof/mod.rs
@@ -1,6 +1,7 @@
 // Copyright 2022 VMware, Inc.
 // SPDX-License-Identifier: MIT
 pub mod cluster;
+pub mod cluster_safety;
 pub mod controller_runtime_liveness;
 pub mod controller_runtime_safety;
 pub mod kubernetes_api_liveness;

--- a/src/kubernetes_cluster/spec/controller/controller_runtime.rs
+++ b/src/kubernetes_cluster/spec/controller/controller_runtime.rs
@@ -17,6 +17,7 @@ pub open spec fn run_scheduled_reconcile<K: ResourceView, T, ReconcilerType: Rec
     Action {
         precondition: |input: ControllerActionInput, s: ControllerState<K, T>| {
             &&& input.scheduled_cr_key.is_Some()
+            &&& input.scheduled_cr_key.get_Some_0().kind == K::kind()
             &&& s.scheduled_reconciles.contains_key(input.scheduled_cr_key.get_Some_0())
             &&& input.recv.is_None()
             &&& !s.ongoing_reconciles.dom().contains(input.scheduled_cr_key.get_Some_0())
@@ -45,6 +46,7 @@ pub open spec fn continue_reconcile<K: ResourceView, T, ReconcilerType: Reconcil
             if input.scheduled_cr_key.is_Some() {
                 let cr_key = input.scheduled_cr_key.get_Some_0();
 
+                &&& cr_key.kind == K::kind()
                 &&& s.ongoing_reconciles.dom().contains(cr_key)
                 &&& !ReconcilerType::reconcile_done(s.ongoing_reconciles[cr_key].local_state)
                 &&& !ReconcilerType::reconcile_error(s.ongoing_reconciles[cr_key].local_state)
@@ -101,6 +103,7 @@ pub open spec fn end_reconcile<K: ResourceView, T, ReconcilerType: Reconciler<K,
             if input.scheduled_cr_key.is_Some() {
                 let cr_key = input.scheduled_cr_key.get_Some_0();
 
+                &&& cr_key.kind == K::kind()
                 &&& s.ongoing_reconciles.dom().contains(cr_key)
                 &&& (ReconcilerType::reconcile_done(s.ongoing_reconciles[cr_key].local_state) || ReconcilerType::reconcile_error(s.ongoing_reconciles[cr_key].local_state))
                 &&& input.recv.is_None()

--- a/src/kubernetes_cluster/spec/message.rs
+++ b/src/kubernetes_cluster/spec/message.rs
@@ -362,4 +362,11 @@ pub open spec fn update_resp_msg_content(res: Result<DynamicObjectView, APIError
     }), resp_id)
 }
 
+pub open spec fn api_request_msg_before(rest_id: RestId) -> FnSpec(Message) -> bool {
+    |msg: Message|
+        msg.dst.is_KubernetesAPI()
+        && msg.content.is_APIRequest()
+        && msg.content.get_rest_id() < rest_id
+}
+
 }

--- a/src/pervasive_ext/multiset_lemmas.rs
+++ b/src/pervasive_ext/multiset_lemmas.rs
@@ -7,14 +7,83 @@ use vstd::multiset::*;
 
 verus! {
 
-pub proof fn len_is_zero_if_count_for_each_value_is_zero<V>(m: Multiset<V>)
-    requires
-        forall |v| m.count(v) == 0,
+pub proof fn len_is_zero_means_count_for_each_value_is_zero<V>(m: Multiset<V>)
     ensures
-        m.len() == 0,
+        (forall |v| m.count(v) == 0) == (m.len() == 0),
 {
     if m.len() != 0 {
         assert(m.count(m.choose()) > 0);
+    }
+}
+
+pub proof fn filtered_size_is_zero_means_no_such_value<V>(m: Multiset<V>, f: FnSpec(V) -> bool)
+    ensures
+        (m.filter(f).len() == 0) == (forall |v: V| !(#[trigger] m.contains(v) && f(v)))
+{
+    if forall |v: V| !(#[trigger] m.contains(v) && f(v)) {
+        assert forall |v| m.filter(f).count(v) == 0 by {
+            if m.contains(v) {
+                assert(!f(v));
+            }
+        }
+        len_is_zero_means_count_for_each_value_is_zero(m.filter(f));
+    }
+
+    if !forall |v: V| !(#[trigger] m.contains(v) && f(v)) {
+        let v = choose |v| m.contains(v) && f(v);
+        assert(m.filter(f).contains(v));
+    }
+}
+
+pub proof fn filtered_size_is_one_means_only_one_such_value<V>(m: Multiset<V>, f: FnSpec(V) -> bool)
+    ensures
+        (m.filter(f).len() == 1) == {
+            &&& exists |v| #[trigger] m.contains(v) && f(v)
+            &&& forall |v| #[trigger] m.contains(v) && f(v) ==> {
+                &&& m.count(v) == 1
+                &&& forall |u: V| #[trigger] m.contains(u) && f(u) ==> u == v
+            }
+        }
+{
+    if m.filter(f).len() == 1 {
+        len_is_zero_means_count_for_each_value_is_zero(m.filter(f));
+        let v = m.filter(f).choose();
+        assert(m.contains(v) && f(v));
+
+        assert forall |v| #[trigger] m.contains(v) && f(v) implies m.count(v) == 1 by {
+            if m.count(v) == 0 {
+                assert(!m.contains(v))
+            }
+            if m.count(v) > 1 {
+                assert(m.filter(f).count(v) > 1);
+                assert(m.filter(f).len() > 1);
+            }
+        }
+        assert forall |v| #[trigger] m.contains(v) && f(v)
+        implies (forall |u| #[trigger] m.contains(u) && f(u) ==> v == u) by {
+            assert forall |u| #[trigger] m.contains(u) && f(u) implies v == u by {
+                if v != u {
+                    assert(m.filter(f).remove(v).len() == 0);
+                    assert(!m.filter(f).remove(v).contains(u));
+                    assert(!m.filter(f).contains(u));
+                }
+            }
+        }
+    }
+
+    if m.filter(f).len() != 1 {
+        if m.filter(f).len() == 0 {
+            filtered_size_is_zero_means_no_such_value(m, f);
+        }
+        if m.filter(f).len() > 1 {
+            assert forall |v| #[trigger] m.contains(v) && f(v) && m.count(v) == 1
+            implies !(forall |u: V| #[trigger] m.contains(u) && f(u) ==> u == v) by {
+                assert(m.filter(f).remove(v).len() > 0);
+                let u = m.filter(f).remove(v).choose();
+                assert(m.filter(f).remove(v).contains(u) && m.contains(u) && f(u));
+                assert(u != v);
+            }
+        }
     }
 }
 


### PR DESCRIPTION
Proves the liveness property of the zookeeper controller that if the zookeeper cr always exists and its spec remains unchanged, then the zookeeper statefulset eventually always exists and its spec remains unchanged (desired state is matched by the current state).

The key challenge is to prove the statefulset's spec remains unchanged even with update requests pending in the network that come from the previously crashed controllers working on a different zookeeper cr's spec. Our strategy is to first prove that the desired state is achieved and stable in a context where there are no more disruptive pending requests, and then prove from `init /\ next /\ wf` the top level cluster eventually reaches a state that all the disruptive pending requests are gone.

There are still a few lemmas not proved yet. We will finish proving all such lemmas in the following PRs.
