### PR TITLE
Cosmetic changes in ZookeeperCluster

### DIFF
--- a/deploy/zookeeper/crd.yaml
+++ b/deploy/zookeeper/crd.yaml
@@ -21,11 +21,11 @@ spec:
           properties:
             spec:
               properties:
-                replica:
+                replicas:
                   format: int32
                   type: integer
               required:
-                - replica
+                - replicas
               type: object
           required:
             - spec

--- a/reference-controllers/zookeeper-controller/src/main.rs
+++ b/reference-controllers/zookeeper-controller/src/main.rs
@@ -238,7 +238,7 @@ async fn reconcile_zk_node(zk: &ZookeeperCluster, client: Client) -> Result<(), 
         .map_err(Error::GetStatefulSetFailed)?;
     if sts.status.is_some()
         && sts.status.clone().unwrap().ready_replicas.is_some()
-        && sts.status.unwrap().ready_replicas.unwrap() == zk.spec.replica
+        && sts.status.unwrap().ready_replicas.unwrap() == zk.spec.replicas
     {
         let path = cluster_size_zk_node_path(zk);
         info!("Try to create {} node since all replicas are ready", path);
@@ -258,7 +258,7 @@ async fn reconcile_zk_node(zk: &ZookeeperCluster, client: Client) -> Result<(), 
                 zk_client
                     .create(
                         "/zookeeper-operator",
-                        format!("CLUSTER_SIZE={}", zk.spec.replica)
+                        format!("CLUSTER_SIZE={}", zk.spec.replicas)
                             .as_str()
                             .as_bytes()
                             .to_vec(),
@@ -269,7 +269,7 @@ async fn reconcile_zk_node(zk: &ZookeeperCluster, client: Client) -> Result<(), 
                 zk_client
                     .create(
                         &path,
-                        format!("CLUSTER_SIZE={}", zk.spec.replica)
+                        format!("CLUSTER_SIZE={}", zk.spec.replicas)
                             .as_str()
                             .as_bytes()
                             .to_vec(),

--- a/reference-controllers/zookeeper-controller/src/resources.rs
+++ b/reference-controllers/zookeeper-controller/src/resources.rs
@@ -19,7 +19,7 @@ pub fn make_statefulset(zk: &ZookeeperCluster) -> appsv1::StatefulSet {
             ..ObjectMeta::default()
         },
         spec: Some(appsv1::StatefulSetSpec {
-            replicas: Some(zk.spec.replica),
+            replicas: Some(zk.spec.replicas),
             service_name: headless_service_name(zk),
             selector: metav1::LabelSelector {
                 match_labels: Some(BTreeMap::from([(
@@ -336,9 +336,9 @@ fn make_env_config(zk: &ZookeeperCluster) -> String {
         ADMIN_SERVER_HOST={name}-admin-server\n\
         ADMIN_SERVER_PORT=8080\n\
         CLUSTER_NAME={name}\n\
-        CLUSTER_SIZE={replica}\n",
+        CLUSTER_SIZE={replicas}\n",
         name = zk.meta().name.as_ref().unwrap().clone(),
         namespace = zk.meta().namespace.as_ref().unwrap().clone(),
-        replica = zk.spec.replica
+        replicas = zk.spec.replicas
     )
 }

--- a/reference-controllers/zookeeper-controller/src/zookeepercluster_types.rs
+++ b/reference-controllers/zookeeper-controller/src/zookeepercluster_types.rs
@@ -7,5 +7,5 @@ use std::vec;
 #[kube(group = "anvil.dev", version = "v1", kind = "ZookeeperCluster")]
 #[kube(shortname = "zk", namespaced)]
 pub struct ZookeeperClusterSpec {
-    pub replica: i32,
+    pub replicas: i32,
 }

--- a/src/controller_examples/zookeeper_controller/exec/mod.rs
+++ b/src/controller_examples/zookeeper_controller/exec/mod.rs
@@ -1,3 +1,4 @@
 // Copyright 2022 VMware, Inc.
 // SPDX-License-Identifier: MIT
 pub mod reconciler;
+pub mod zookeepercluster;

--- a/src/controller_examples/zookeeper_controller/exec/reconciler.rs
+++ b/src/controller_examples/zookeeper_controller/exec/reconciler.rs
@@ -10,6 +10,7 @@ use crate::pervasive_ext::string_map::StringMap;
 use crate::pervasive_ext::string_view::*;
 use crate::reconciler::exec::*;
 use crate::zookeeper_controller::common::*;
+use crate::zookeeper_controller::exec::zookeepercluster::*;
 use crate::zookeeper_controller::spec::reconciler as zk_spec;
 use crate::zookeeper_controller::spec::zookeepercluster::*;
 use vstd::prelude::*;
@@ -471,7 +472,7 @@ fn make_env_config(zk: &ZookeeperCluster) -> (s: String)
         ADMIN_SERVER_HOST=")).concat(name.as_str()).concat(new_strlit("-admin-server\n\
         ADMIN_SERVER_PORT=8080\n\
         CLUSTER_NAME=")).concat(name.as_str()).concat(new_strlit("\n\
-        CLUSTER_SIZE=")).concat(i32_to_string(zk.replica()).as_str()).concat(new_strlit("\n"))
+        CLUSTER_SIZE=")).concat(i32_to_string(zk.spec().replica()).as_str()).concat(new_strlit("\n"))
 }
 
 fn make_stateful_set_name(zk: &ZookeeperCluster) -> (name: String)
@@ -506,7 +507,7 @@ fn make_stateful_set(zk: &ZookeeperCluster) -> (stateful_set: StatefulSet)
     stateful_set.set_spec({
         let mut stateful_set_spec = StatefulSetSpec::default();
         // Set the replica number
-        stateful_set_spec.set_replicas(zk.replica());
+        stateful_set_spec.set_replicas(zk.spec().replica());
         // Set the headless service to assign DNS entry to each zookeeper server
         stateful_set_spec.set_service_name(zk.metadata().name().unwrap().concat(new_strlit("-headless")));
         // Set the selector used for querying pods of this stateful set

--- a/src/controller_examples/zookeeper_controller/exec/reconciler.rs
+++ b/src/controller_examples/zookeeper_controller/exec/reconciler.rs
@@ -472,7 +472,7 @@ fn make_env_config(zk: &ZookeeperCluster) -> (s: String)
         ADMIN_SERVER_HOST=")).concat(name.as_str()).concat(new_strlit("-admin-server\n\
         ADMIN_SERVER_PORT=8080\n\
         CLUSTER_NAME=")).concat(name.as_str()).concat(new_strlit("\n\
-        CLUSTER_SIZE=")).concat(i32_to_string(zk.spec().replica()).as_str()).concat(new_strlit("\n"))
+        CLUSTER_SIZE=")).concat(i32_to_string(zk.spec().replicas()).as_str()).concat(new_strlit("\n"))
 }
 
 fn make_stateful_set_name(zk: &ZookeeperCluster) -> (name: String)
@@ -507,7 +507,7 @@ fn make_stateful_set(zk: &ZookeeperCluster) -> (stateful_set: StatefulSet)
     stateful_set.set_spec({
         let mut stateful_set_spec = StatefulSetSpec::default();
         // Set the replica number
-        stateful_set_spec.set_replicas(zk.spec().replica());
+        stateful_set_spec.set_replicas(zk.spec().replicas());
         // Set the headless service to assign DNS entry to each zookeeper server
         stateful_set_spec.set_service_name(zk.metadata().name().unwrap().concat(new_strlit("-headless")));
         // Set the selector used for querying pods of this stateful set

--- a/src/controller_examples/zookeeper_controller/exec/reconciler.rs
+++ b/src/controller_examples/zookeeper_controller/exec/reconciler.rs
@@ -12,7 +12,6 @@ use crate::reconciler::exec::*;
 use crate::zookeeper_controller::common::*;
 use crate::zookeeper_controller::exec::zookeepercluster::*;
 use crate::zookeeper_controller::spec::reconciler as zk_spec;
-use crate::zookeeper_controller::spec::zookeepercluster::*;
 use vstd::prelude::*;
 use vstd::seq_lib::*;
 use vstd::string::*;

--- a/src/controller_examples/zookeeper_controller/exec/zookeepercluster.rs
+++ b/src/controller_examples/zookeeper_controller/exec/zookeepercluster.rs
@@ -93,11 +93,11 @@ impl ZookeeperClusterSpec {
     pub spec fn view(&self) -> ZookeeperClusterSpecView;
 
     #[verifier(external_body)]
-    pub fn replica(&self) -> (replica: i32)
+    pub fn replicas(&self) -> (replica: i32)
         ensures
-            replica as int == self@.replica,
+            replica as int == self@.replicas,
     {
-        self.inner.replica
+        self.inner.replicas
     }
 }
 

--- a/src/controller_examples/zookeeper_controller/exec/zookeepercluster.rs
+++ b/src/controller_examples/zookeeper_controller/exec/zookeepercluster.rs
@@ -1,0 +1,118 @@
+// Copyright 2022 VMware, Inc.
+// SPDX-License-Identifier: MIT
+use crate::kubernetes_api_objects::{
+    api_resource::*, common::*, dynamic::*, error::ParseDynamicObjectError, marshal::*,
+    object_meta::*, resource::*,
+};
+use crate::pervasive_ext::string_view::*;
+use crate::zookeeper_controller::spec::zookeepercluster::*;
+use vstd::prelude::*;
+
+verus! {
+
+#[verifier(external_body)]
+pub struct ZookeeperCluster {
+    inner: deps_hack::ZookeeperCluster
+}
+
+impl ZookeeperCluster {
+    pub spec fn view(&self) -> ZookeeperClusterView;
+
+    #[verifier(external_body)]
+    pub fn metadata(&self) -> (metadata: ObjectMeta)
+        ensures
+            metadata@ == self@.metadata,
+    {
+        ObjectMeta::from_kube(self.inner.metadata.clone())
+    }
+
+    #[verifier(external_body)]
+    pub fn spec(&self) -> (spec: ZookeeperClusterSpec)
+        ensures
+            spec@ == self@.spec,
+    {
+        ZookeeperClusterSpec::from_kube(self.inner.spec.clone())
+    }
+
+    #[verifier(external_body)]
+    pub fn api_resource() -> (res: ApiResource)
+        ensures
+            res@.kind == ZookeeperClusterView::kind(),
+    {
+        ApiResource::from_kube(deps_hack::kube::api::ApiResource::erase::<deps_hack::ZookeeperCluster>(&()))
+    }
+
+    // NOTE: This function assumes serde_json::to_string won't fail!
+    #[verifier(external_body)]
+    pub fn to_dynamic_object(self) -> (obj: DynamicObject)
+        ensures
+            obj@ == self@.to_dynamic_object(),
+    {
+        // TODO: this might be unnecessarily slow
+        DynamicObject::from_kube(
+            deps_hack::k8s_openapi::serde_json::from_str(&deps_hack::k8s_openapi::serde_json::to_string(&self.inner).unwrap()).unwrap()
+        )
+    }
+
+    #[verifier(external_body)]
+    pub fn from_dynamic_object(obj: DynamicObject) -> (res: Result<ZookeeperCluster, ParseDynamicObjectError>)
+        ensures
+            res.is_Ok() == ZookeeperClusterView::from_dynamic_object(obj@).is_Ok(),
+            res.is_Ok() ==> res.get_Ok_0()@ == ZookeeperClusterView::from_dynamic_object(obj@).get_Ok_0(),
+    {
+        let parse_result = obj.into_kube().try_parse::<deps_hack::ZookeeperCluster>();
+        if parse_result.is_ok() {
+            let res = ZookeeperCluster { inner: parse_result.unwrap() };
+            Result::Ok(res)
+        } else {
+            Result::Err(ParseDynamicObjectError::ExecError)
+        }
+    }
+}
+
+impl ResourceWrapper<deps_hack::ZookeeperCluster> for ZookeeperCluster {
+    #[verifier(external)]
+    fn from_kube(inner: deps_hack::ZookeeperCluster) -> ZookeeperCluster {
+        ZookeeperCluster {
+            inner: inner
+        }
+    }
+
+    #[verifier(external)]
+    fn into_kube(self) -> deps_hack::ZookeeperCluster {
+        self.inner
+    }
+}
+
+#[verifier(external_body)]
+pub struct ZookeeperClusterSpec {
+    inner: deps_hack::ZookeeperClusterSpec,
+}
+
+impl ZookeeperClusterSpec {
+    pub spec fn view(&self) -> ZookeeperClusterSpecView;
+
+    #[verifier(external_body)]
+    pub fn replica(&self) -> (replica: i32)
+        ensures
+            replica as int == self@.replica,
+    {
+        self.inner.replica
+    }
+}
+
+impl ResourceWrapper<deps_hack::ZookeeperClusterSpec> for ZookeeperClusterSpec {
+    #[verifier(external)]
+    fn from_kube(inner: deps_hack::ZookeeperClusterSpec) -> ZookeeperClusterSpec {
+        ZookeeperClusterSpec {
+            inner: inner
+        }
+    }
+
+    #[verifier(external)]
+    fn into_kube(self) -> deps_hack::ZookeeperClusterSpec {
+        self.inner
+    }
+}
+
+}

--- a/src/controller_examples/zookeeper_controller/spec/reconciler.rs
+++ b/src/controller_examples/zookeeper_controller/spec/reconciler.rs
@@ -369,7 +369,7 @@ pub open spec fn make_env_config(zk: ZookeeperClusterView) -> StringView
         ADMIN_SERVER_HOST=")@ + name + new_strlit("-admin-server\n\
         ADMIN_SERVER_PORT=8080\n\
         CLUSTER_NAME=")@ + name + new_strlit("\n\
-        CLUSTER_SIZE=")@ + int_to_string_view(zk.spec.replica) + new_strlit("\n")@
+        CLUSTER_SIZE=")@ + int_to_string_view(zk.spec.replicas) + new_strlit("\n")@
 }
 
 pub open spec fn make_stateful_set_key(key: ObjectRef) -> ObjectRef
@@ -409,7 +409,7 @@ pub open spec fn make_stateful_set(zk: ZookeeperClusterView) -> StatefulSetView
         .set_labels(labels);
 
     let spec = StatefulSetSpecView::default()
-        .set_replicas(zk.spec.replica)
+        .set_replicas(zk.spec.replicas)
         .set_service_name(name + new_strlit("-headless")@)
         .set_selector(LabelSelectorView::default().set_match_labels(labels))
         .set_template(PodTemplateSpecView::default()

--- a/src/controller_examples/zookeeper_controller/spec/zookeepercluster.rs
+++ b/src/controller_examples/zookeeper_controller/spec/zookeepercluster.rs
@@ -82,7 +82,7 @@ impl ResourceView for ZookeeperClusterView {
 }
 
 pub struct ZookeeperClusterSpecView {
-    pub replica: int,
+    pub replicas: int,
 }
 
 impl ZookeeperClusterSpecView {}

--- a/src/controller_examples/zookeeper_controller/spec/zookeepercluster.rs
+++ b/src/controller_examples/zookeeper_controller/spec/zookeepercluster.rs
@@ -9,83 +9,9 @@ use vstd::prelude::*;
 
 verus! {
 
-#[verifier(external_body)]
-pub struct ZookeeperCluster {
-    inner: deps_hack::ZookeeperCluster
-}
-
 pub struct ZookeeperClusterView {
     pub metadata: ObjectMetaView,
     pub spec: ZookeeperClusterSpecView,
-}
-
-impl ZookeeperCluster {
-    pub spec fn view(&self) -> ZookeeperClusterView;
-
-    #[verifier(external_body)]
-    pub fn metadata(&self) -> (metadata: ObjectMeta)
-        ensures
-            metadata@ == self@.metadata,
-    {
-        ObjectMeta::from_kube(self.inner.metadata.clone())
-    }
-
-    #[verifier(external_body)]
-    pub fn replica(&self) -> (replica: i32)
-        ensures
-            replica as int == self@.spec.replica,
-    {
-        self.inner.spec.replica
-    }
-
-    #[verifier(external_body)]
-    pub fn api_resource() -> (res: ApiResource)
-        ensures
-            res@.kind == ZookeeperClusterView::kind(),
-    {
-        ApiResource::from_kube(deps_hack::kube::api::ApiResource::erase::<deps_hack::ZookeeperCluster>(&()))
-    }
-
-    // NOTE: This function assumes serde_json::to_string won't fail!
-    #[verifier(external_body)]
-    pub fn to_dynamic_object(self) -> (obj: DynamicObject)
-        ensures
-            obj@ == self@.to_dynamic_object(),
-    {
-        // TODO: this might be unnecessarily slow
-        DynamicObject::from_kube(
-            deps_hack::k8s_openapi::serde_json::from_str(&deps_hack::k8s_openapi::serde_json::to_string(&self.inner).unwrap()).unwrap()
-        )
-    }
-
-    #[verifier(external_body)]
-    pub fn from_dynamic_object(obj: DynamicObject) -> (res: Result<ZookeeperCluster, ParseDynamicObjectError>)
-        ensures
-            res.is_Ok() == ZookeeperClusterView::from_dynamic_object(obj@).is_Ok(),
-            res.is_Ok() ==> res.get_Ok_0()@ == ZookeeperClusterView::from_dynamic_object(obj@).get_Ok_0(),
-    {
-        let parse_result = obj.into_kube().try_parse::<deps_hack::ZookeeperCluster>();
-        if parse_result.is_ok() {
-            let res = ZookeeperCluster { inner: parse_result.unwrap() };
-            Result::Ok(res)
-        } else {
-            Result::Err(ParseDynamicObjectError::ExecError)
-        }
-    }
-}
-
-impl ResourceWrapper<deps_hack::ZookeeperCluster> for ZookeeperCluster {
-    #[verifier(external)]
-    fn from_kube(inner: deps_hack::ZookeeperCluster) -> ZookeeperCluster {
-        ZookeeperCluster {
-            inner: inner
-        }
-    }
-
-    #[verifier(external)]
-    fn into_kube(self) -> deps_hack::ZookeeperCluster {
-        self.inner
-    }
 }
 
 impl ZookeeperClusterView {
@@ -155,25 +81,8 @@ impl ResourceView for ZookeeperClusterView {
     proof fn from_dynamic_preserves_kind() {}
 }
 
-#[verifier(external_body)]
-pub struct ZookeeperClusterSpec {
-    inner: deps_hack::ZookeeperClusterSpec,
-}
-
 pub struct ZookeeperClusterSpecView {
     pub replica: int,
-}
-
-impl ZookeeperClusterSpec {
-    pub spec fn view(&self) -> ZookeeperClusterSpecView;
-
-    #[verifier(external_body)]
-    pub fn replica(&self) -> (replica: i32)
-        ensures
-            replica as int == self@.replica,
-    {
-        self.inner.replica
-    }
 }
 
 impl ZookeeperClusterSpecView {}

--- a/src/deps_hack/src/lib.rs
+++ b/src/deps_hack/src/lib.rs
@@ -38,7 +38,7 @@ pub struct SimpleCRSpec {
 #[kube(group = "anvil.dev", version = "v1", kind = "ZookeeperCluster")]
 #[kube(shortname = "zk", namespaced)]
 pub struct ZookeeperClusterSpec {
-    pub replica: i32,
+    pub replicas: i32,
 }
 
 #[derive(

--- a/src/zookeeper_controller.rs
+++ b/src/zookeeper_controller.rs
@@ -16,7 +16,7 @@ use builtin::*;
 use builtin_macros::*;
 
 use crate::zookeeper_controller::exec::reconciler::{ZookeeperReconcileState, ZookeeperReconciler};
-use crate::zookeeper_controller::spec::zookeepercluster::ZookeeperCluster;
+use crate::zookeeper_controller::exec::zookeepercluster::ZookeeperCluster;
 use deps_hack::anyhow::Result;
 use deps_hack::kube::CustomResourceExt;
 use deps_hack::serde_yaml;


### PR DESCRIPTION
Split the ZookeeperCluster and its ghost version into different folders and rename `replica` to `replicas`.