### PR TITLE
Implement spec() for K8s object types

### DIFF
--- a/src/controller_examples/rabbitmq_controller/spec/rabbitmqcluster.rs
+++ b/src/controller_examples/rabbitmq_controller/spec/rabbitmqcluster.rs
@@ -35,6 +35,8 @@ impl RabbitmqClusterView {
 }
 
 impl ResourceView for RabbitmqClusterView {
+    type Spec = RabbitmqClusterSpecView;
+
     open spec fn metadata(self) -> ObjectMetaView {
         self.metadata
     }
@@ -52,6 +54,10 @@ impl ResourceView for RabbitmqClusterView {
     }
 
     proof fn object_ref_is_well_formed() {}
+
+    open spec fn spec(self) -> RabbitmqClusterSpecView {
+        self.spec
+    }
 
     open spec fn to_dynamic_object(self) -> DynamicObjectView {
         DynamicObjectView {

--- a/src/controller_examples/simple_controller/spec/custom_resource.rs
+++ b/src/controller_examples/simple_controller/spec/custom_resource.rs
@@ -111,6 +111,8 @@ impl CustomResourceView {
 }
 
 impl ResourceView for CustomResourceView {
+    type Spec = CustomResourceSpecView;
+
     open spec fn metadata(self) -> ObjectMetaView {
         self.metadata
     }
@@ -135,6 +137,10 @@ impl ResourceView for CustomResourceView {
             metadata: self.metadata,
             spec: CustomResourceView::marshal_spec(self.spec),
         }
+    }
+
+    open spec fn spec(self) -> CustomResourceSpecView {
+        self.spec
     }
 
     open spec fn from_dynamic_object(obj: DynamicObjectView) -> Result<CustomResourceView, ParseDynamicObjectError> {

--- a/src/controller_examples/zookeeper_controller/spec/zookeepercluster.rs
+++ b/src/controller_examples/zookeeper_controller/spec/zookeepercluster.rs
@@ -33,6 +33,8 @@ impl ZookeeperClusterView {
 }
 
 impl ResourceView for ZookeeperClusterView {
+    type Spec = ZookeeperClusterSpecView;
+
     open spec fn metadata(self) -> ObjectMetaView {
         self.metadata
     }
@@ -50,6 +52,10 @@ impl ResourceView for ZookeeperClusterView {
     }
 
     proof fn object_ref_is_well_formed() {}
+
+    open spec fn spec(self) -> ZookeeperClusterSpecView {
+        self.spec
+    }
 
     open spec fn to_dynamic_object(self) -> DynamicObjectView {
         DynamicObjectView {

--- a/src/kubernetes_api_objects/config_map.rs
+++ b/src/kubernetes_api_objects/config_map.rs
@@ -179,6 +179,8 @@ impl ConfigMapView {
 }
 
 impl ResourceView for ConfigMapView {
+    type Spec = ConfigMapSpecView;
+
     open spec fn metadata(self) -> ObjectMetaView {
         self.metadata
     }
@@ -196,6 +198,10 @@ impl ResourceView for ConfigMapView {
     }
 
     proof fn object_ref_is_well_formed() {}
+
+    open spec fn spec(self) -> ConfigMapSpecView {
+        (self.data, ())
+    }
 
     open spec fn to_dynamic_object(self) -> DynamicObjectView {
         DynamicObjectView {

--- a/src/kubernetes_api_objects/persistent_volume_claim.rs
+++ b/src/kubernetes_api_objects/persistent_volume_claim.rs
@@ -216,6 +216,8 @@ impl PersistentVolumeClaimView {
 }
 
 impl ResourceView for PersistentVolumeClaimView {
+    type Spec = Option<PersistentVolumeClaimSpecView>;
+
     open spec fn metadata(self) -> ObjectMetaView {
         self.metadata
     }
@@ -233,6 +235,10 @@ impl ResourceView for PersistentVolumeClaimView {
     }
 
     proof fn object_ref_is_well_formed() {}
+
+    open spec fn spec(self) -> Option<PersistentVolumeClaimSpecView> {
+        self.spec
+    }
 
     open spec fn to_dynamic_object(self) -> DynamicObjectView {
         DynamicObjectView {

--- a/src/kubernetes_api_objects/pod.rs
+++ b/src/kubernetes_api_objects/pod.rs
@@ -911,6 +911,8 @@ impl PodView {
 }
 
 impl ResourceView for PodView {
+    type Spec = Option<PodSpecView>;
+
     open spec fn metadata(self) -> ObjectMetaView {
         self.metadata
     }
@@ -928,6 +930,10 @@ impl ResourceView for PodView {
     }
 
     proof fn object_ref_is_well_formed() {}
+
+    open spec fn spec(self) -> Option<PodSpecView> {
+        self.spec
+    }
 
     open spec fn to_dynamic_object(self) -> DynamicObjectView {
         DynamicObjectView {

--- a/src/kubernetes_api_objects/resource.rs
+++ b/src/kubernetes_api_objects/resource.rs
@@ -22,6 +22,8 @@ pub trait ResourceWrapper<T>: Sized {
 
 /// This trait defines the methods that each ghost type of Kubernetes resource object should implement
 pub trait ResourceView: Sized {
+    type Spec;
+
     /// Get the metadata of the object
 
     open spec fn metadata(self) -> ObjectMetaView;
@@ -44,6 +46,10 @@ pub trait ResourceView: Sized {
                     name: o.metadata().name.get_Some_0(),
                     namespace: o.metadata().namespace.get_Some_0(),
                 });
+
+    /// Get the spec of the object
+
+    open spec fn spec(self) -> Self::Spec;
 
     /// Convert the object to a dynamic object
 

--- a/src/kubernetes_api_objects/role.rs
+++ b/src/kubernetes_api_objects/role.rs
@@ -203,6 +203,8 @@ impl RoleView {
 }
 
 impl ResourceView for RoleView {
+    type Spec = RoleSpecView;
+
     open spec fn metadata(self) -> ObjectMetaView {
         self.metadata
     }
@@ -220,6 +222,10 @@ impl ResourceView for RoleView {
     }
 
     proof fn object_ref_is_well_formed() {}
+
+    open spec fn spec(self) -> RoleSpecView {
+        (self.policy_rules, ())
+    }
 
     open spec fn to_dynamic_object(self) -> DynamicObjectView {
         DynamicObjectView {

--- a/src/kubernetes_api_objects/role_binding.rs
+++ b/src/kubernetes_api_objects/role_binding.rs
@@ -269,6 +269,8 @@ impl RoleBindingView {
 }
 
 impl ResourceView for RoleBindingView {
+    type Spec = RoleBindingSpecView;
+
     open spec fn metadata(self) -> ObjectMetaView {
         self.metadata
     }
@@ -286,6 +288,10 @@ impl ResourceView for RoleBindingView {
     }
 
     proof fn object_ref_is_well_formed() {}
+
+    open spec fn spec(self) -> RoleBindingSpecView {
+        (self.role_ref, self.subjects)
+    }
 
     open spec fn to_dynamic_object(self) -> DynamicObjectView {
         DynamicObjectView {

--- a/src/kubernetes_api_objects/secret.rs
+++ b/src/kubernetes_api_objects/secret.rs
@@ -188,6 +188,8 @@ impl SecretView {
 }
 
 impl ResourceView for SecretView {
+    type Spec = SecretSpecView;
+
     open spec fn metadata(self) -> ObjectMetaView {
         self.metadata
     }
@@ -202,6 +204,10 @@ impl ResourceView for SecretView {
             name: self.metadata.name.get_Some_0(),
             namespace: self.metadata.namespace.get_Some_0(),
         }
+    }
+
+    open spec fn spec(self) -> SecretSpecView {
+        (self.data, self.type_)
     }
 
     proof fn object_ref_is_well_formed() {}

--- a/src/kubernetes_api_objects/service.rs
+++ b/src/kubernetes_api_objects/service.rs
@@ -274,6 +274,8 @@ impl ServiceView {
 }
 
 impl ResourceView for ServiceView {
+    type Spec = Option<ServiceSpecView>;
+
     open spec fn metadata(self) -> ObjectMetaView {
         self.metadata
     }
@@ -291,6 +293,10 @@ impl ResourceView for ServiceView {
     }
 
     proof fn object_ref_is_well_formed() {}
+
+    open spec fn spec(self) -> Option<ServiceSpecView> {
+        self.spec
+    }
 
     open spec fn to_dynamic_object(self) -> DynamicObjectView {
         DynamicObjectView {

--- a/src/kubernetes_api_objects/stateful_set.rs
+++ b/src/kubernetes_api_objects/stateful_set.rs
@@ -271,6 +271,8 @@ impl StatefulSetView {
 }
 
 impl ResourceView for StatefulSetView {
+    type Spec = Option<StatefulSetSpecView>;
+
     open spec fn metadata(self) -> ObjectMetaView {
         self.metadata
     }
@@ -288,6 +290,10 @@ impl ResourceView for StatefulSetView {
     }
 
     proof fn object_ref_is_well_formed() {}
+
+    open spec fn spec(self) -> Option<StatefulSetSpecView> {
+        self.spec
+    }
 
     open spec fn to_dynamic_object(self) -> DynamicObjectView {
         DynamicObjectView {


### PR DESCRIPTION
The `spec()` is a trait method of ResourceView trait. This is mainly used to expose the spec content of a K8s object in the Anvil built in lemmas where we don't know the concrete type of a ResourceView object.