### PR TITLE
Generalize lemmas on reconciled/scheduled cr objects

### DIFF
--- a/src/kubernetes_cluster/proof/cluster.rs
+++ b/src/kubernetes_cluster/proof/cluster.rs
@@ -94,4 +94,33 @@ pub proof fn lemma_any_pred_leads_to_crash_always_disabled<K: ResourceView, T, R
     leads_to_trans_temp::<State<K, T>>(spec, any_pred, true_pred(), always(lift_state(crash_disabled::<K, T>())));
 }
 
+pub open spec fn desired_state_is<K: ResourceView, T>(cr: K) -> StatePred<State<K, T>>
+    recommends
+        K::kind().is_CustomResourceKind(),
+{
+    |s: State<K, T>| {
+        &&& s.resource_key_exists(cr.object_ref())
+        &&& K::from_dynamic_object(s.resource_obj_of(cr.object_ref())).is_Ok()
+        &&& K::from_dynamic_object(s.resource_obj_of(cr.object_ref())).get_Ok_0().spec() == cr.spec()
+    }
+}
+
+pub open spec fn desired_state_exists<K: ResourceView, T>(cr: K) -> StatePred<State<K, T>>
+    recommends
+        K::kind().is_CustomResourceKind(),
+{
+    |s: State<K, T>| {
+        &&& s.resource_key_exists(cr.object_ref())
+        &&& K::from_dynamic_object(s.resource_obj_of(cr.object_ref())).is_Ok()
+    }
+}
+
+#[verifier(external_body)]
+pub proof fn lemma_always_desired_state_exists<K: ResourceView, T>(spec: TempPred<State<K, T>>, cr: K)
+    requires
+        spec.entails(always(lift_state(desired_state_is(cr)))),
+    ensures
+        spec.entails(always(lift_state(desired_state_exists(cr)))),
+{}
+
 }

--- a/src/kubernetes_cluster/proof/controller_runtime_eventual_safety.rs
+++ b/src/kubernetes_cluster/proof/controller_runtime_eventual_safety.rs
@@ -81,6 +81,8 @@ pub open spec fn the_object_in_reconcile_has_spec_as<K: ResourceView, T>(cr: K) 
     |s: State<K, T>| s.reconcile_state_contains(cr.object_ref()) ==> s.triggering_cr_of(cr.object_ref()).spec() == cr.spec()
 }
 
+// This lemma says that under the spec where []desired_state_is(cr), it will eventually reach a state where any object
+// in reconcile for cr.object_ref() has the same spec as cr.spec.
 pub proof fn lemma_true_leads_to_always_the_object_in_reconcile_has_spec_as<K: ResourceView, T, ReconcilerType: Reconciler<K, T>>(
     spec: TempPred<State<K, T>>, cr: K
 )

--- a/src/kubernetes_cluster/proof/controller_runtime_eventual_safety.rs
+++ b/src/kubernetes_cluster/proof/controller_runtime_eventual_safety.rs
@@ -1,0 +1,248 @@
+// Copyright 2022 VMware, Inc.
+// SPDX-License-Identifier: MIT
+#![allow(unused_imports)]
+use crate::kubernetes_api_objects::{common::*, resource::*};
+use crate::kubernetes_cluster::{
+    proof::{
+        cluster::*, cluster_safety, controller_runtime_liveness, kubernetes_api_safety,
+        wf1_assistant::controller_action_pre_implies_next_pre,
+    },
+    spec::{
+        cluster::*,
+        controller::common::{ControllerAction, ControllerActionInput},
+        controller::controller_runtime::{
+            continue_reconcile, end_reconcile, run_scheduled_reconcile,
+        },
+        controller::state_machine::controller,
+        message::*,
+    },
+};
+use crate::reconciler::spec::Reconciler;
+use crate::temporal_logic::defs::*;
+use crate::temporal_logic::rules::*;
+use vstd::prelude::*;
+
+verus! {
+
+pub open spec fn the_object_in_schedule_has_spec_as<K: ResourceView, T>(cr: K) -> StatePred<State<K, T>> {
+    |s: State<K, T>| s.reconcile_scheduled_for(cr.object_ref()) ==> s.reconcile_scheduled_obj_of(cr.object_ref()).spec() == cr.spec()
+}
+
+// This lemma says that under the spec where []desired_state_is(cr), it will eventually reach a state where any object
+// in schedule for cr.object_ref() has the same spec as cr.spec.
+pub proof fn lemma_true_leads_to_always_the_object_in_schedule_has_spec_as<K: ResourceView, T, ReconcilerType: Reconciler<K, T>>(
+    spec: TempPred<State<K, T>>, cr: K
+)
+    requires
+        K::kind().is_CustomResourceKind(),
+        spec.entails(always(lift_action(next::<K, T, ReconcilerType>()))),
+        spec.entails(tla_forall(|i| schedule_controller_reconcile().weak_fairness(i))),
+        spec.entails(always(lift_state(desired_state_is(cr)))),
+        spec.entails(always(lift_state(cluster_safety::each_object_in_etcd_is_well_formed()))),
+    ensures
+        spec.entails(true_pred().leads_to(always(lift_state(the_object_in_schedule_has_spec_as(cr))))),
+{
+    let pre = |s: State<K, T>| true;
+    let post = the_object_in_schedule_has_spec_as(cr);
+    let input = cr.object_ref();
+    let stronger_next = |s, s_prime: State<K, T>| {
+        &&& next::<K, T, ReconcilerType>()(s, s_prime)
+        &&& desired_state_is(cr)(s)
+        &&& cluster_safety::each_object_in_etcd_is_well_formed()(s)
+    };
+    entails_always_and_n!(
+        spec,
+        lift_action(next::<K, T, ReconcilerType>()),
+        lift_state(desired_state_is(cr)),
+        lift_state(cluster_safety::each_object_in_etcd_is_well_formed())
+    );
+    temp_pred_equality(
+        lift_action(stronger_next),
+        lift_action(next::<K, T, ReconcilerType>())
+        .and(lift_state(desired_state_is(cr)))
+        .and(lift_state(cluster_safety::each_object_in_etcd_is_well_formed()))
+    );
+
+    K::object_ref_is_well_formed();
+
+    lemma_always_desired_state_exists(spec, cr);
+    temp_pred_equality::<State<K, T>>(
+        lift_state(desired_state_exists(cr)), lift_state(schedule_controller_reconcile().pre(input))
+    );
+
+    spec_implies_pre(spec, lift_state(pre), lift_state(schedule_controller_reconcile().pre(input)));
+    use_tla_forall::<State<K, T>, ObjectRef>(spec, |key| schedule_controller_reconcile().weak_fairness(key), input);
+
+    schedule_controller_reconcile().wf1(input, spec, stronger_next, pre, post);
+    leads_to_stable_temp(spec, lift_action(stronger_next), lift_state(pre), lift_state(post));
+}
+
+pub open spec fn the_object_in_reconcile_has_spec_as<K: ResourceView, T>(cr: K) -> StatePred<State<K, T>> {
+    |s: State<K, T>| s.reconcile_state_contains(cr.object_ref()) ==> s.triggering_cr_of(cr.object_ref()).spec() == cr.spec()
+}
+
+pub proof fn lemma_true_leads_to_always_the_object_in_reconcile_has_spec_as<K: ResourceView, T, ReconcilerType: Reconciler<K, T>>(
+    spec: TempPred<State<K, T>>, cr: K
+)
+    requires
+        K::kind().is_CustomResourceKind(),
+        spec.entails(always(lift_action(next::<K, T, ReconcilerType>()))),
+        spec.entails(tla_forall(|i| controller_next::<K, T, ReconcilerType>().weak_fairness(i))),
+        spec.entails(tla_forall(|i| schedule_controller_reconcile().weak_fairness(i))),
+        spec.entails(always(lift_state(desired_state_is(cr)))),
+        spec.entails(true_pred().leads_to(lift_state(|s: State<K, T>| !s.reconcile_state_contains(cr.object_ref())))),
+        spec.entails(true_pred().leads_to(always(lift_state(the_object_in_schedule_has_spec_as(cr))))),
+    ensures
+        spec.entails(true_pred().leads_to(always(lift_state(the_object_in_reconcile_has_spec_as(cr))))),
+{
+    // We need to prepare a concrete spec which is stable because we will use unpack_conditions_from_spec later
+    let stable_spec = always(lift_action(next::<K, T, ReconcilerType>()))
+        .and(tla_forall(|i| schedule_controller_reconcile().weak_fairness(i)))
+        .and(tla_forall(|i| controller_next::<K, T, ReconcilerType>().weak_fairness(i)))
+        .and(always(lift_state(desired_state_is(cr))))
+        .and(true_pred().leads_to(lift_state(|s: State<K, T>| !s.reconcile_state_contains(cr.object_ref()))))
+        .and(true_pred().leads_to(always(lift_state(the_object_in_schedule_has_spec_as(cr)))));
+
+    let stable_spec_with_assumption = stable_spec.and(always(lift_state(the_object_in_schedule_has_spec_as(cr))));
+
+    // Let's first prove true ~> []the_object_in_reconcile_has_spec_as(cr)
+    assert_by(
+        stable_spec_with_assumption
+        .entails(
+            true_pred().leads_to(always(lift_state(the_object_in_reconcile_has_spec_as(cr))))
+        ),
+        {
+            let stronger_next = |s, s_prime: State<K, T>| {
+                &&& next::<K, T, ReconcilerType>()(s, s_prime)
+                &&& desired_state_is(cr)(s)
+                &&& the_object_in_schedule_has_spec_as(cr)(s)
+            };
+            entails_always_and_n!(
+                stable_spec_with_assumption,
+                lift_action(next::<K, T, ReconcilerType>()),
+                lift_state(desired_state_is(cr)),
+                lift_state(the_object_in_schedule_has_spec_as(cr))
+            );
+            temp_pred_equality(
+                lift_action(stronger_next),
+                lift_action(next::<K, T, ReconcilerType>())
+                .and(lift_state(desired_state_is(cr)))
+                .and(lift_state(the_object_in_schedule_has_spec_as(cr)))
+            );
+
+            // Here we split the cases by whether s.reconcile_scheduled_for(cr.object_ref()) is true
+            assert_by(
+                stable_spec_with_assumption
+                .entails(
+                    lift_state(|s: State<K, T>| {
+                        &&& !s.reconcile_state_contains(cr.object_ref())
+                        &&& s.reconcile_scheduled_for(cr.object_ref())
+                    }).leads_to(lift_state(the_object_in_reconcile_has_spec_as(cr)))
+                ),
+                {
+                    let pre = |s: State<K, T>| {
+                        &&& !s.reconcile_state_contains(cr.object_ref())
+                        &&& s.reconcile_scheduled_for(cr.object_ref())
+                    };
+                    let post = the_object_in_reconcile_has_spec_as(cr);
+                    let input = (Option::None, Option::Some(cr.object_ref()));
+
+                    K::object_ref_is_well_formed();
+                    controller_runtime_liveness::lemma_pre_leads_to_post_by_controller::<K, T, ReconcilerType>(
+                        stable_spec_with_assumption, input, stronger_next,
+                        run_scheduled_reconcile::<K, T, ReconcilerType>(), pre, post
+                    );
+                }
+            );
+
+            assert_by(
+                stable_spec_with_assumption
+                .entails(
+                    lift_state(|s: State<K, T>| {
+                        &&& !s.reconcile_state_contains(cr.object_ref())
+                        &&& !s.reconcile_scheduled_for(cr.object_ref())
+                    }).leads_to(lift_state(the_object_in_reconcile_has_spec_as(cr)))
+                ),
+                {
+                    let pre = |s: State<K, T>| {
+                        &&& !s.reconcile_state_contains(cr.object_ref())
+                        &&& !s.reconcile_scheduled_for(cr.object_ref())
+                    };
+                    let post = |s: State<K, T>| {
+                        &&& !s.reconcile_state_contains(cr.object_ref())
+                        &&& s.reconcile_scheduled_for(cr.object_ref())
+                    };
+                    let input = cr.object_ref();
+
+                    K::object_ref_is_well_formed();
+                    lemma_always_desired_state_exists(stable_spec_with_assumption, cr);
+                    temp_pred_equality::<State<K, T>>(
+                        lift_state(desired_state_exists(cr)), lift_state(schedule_controller_reconcile().pre(input))
+                    );
+                    spec_implies_pre(stable_spec_with_assumption, lift_state(pre), lift_state(schedule_controller_reconcile().pre(input)));
+                    use_tla_forall::<State<K, T>, ObjectRef>(stable_spec_with_assumption, |key| schedule_controller_reconcile().weak_fairness(key), input);
+                    schedule_controller_reconcile().wf1(input, stable_spec_with_assumption, stronger_next, pre, post);
+                    leads_to_trans_temp(stable_spec_with_assumption, lift_state(pre), lift_state(post), lift_state(the_object_in_reconcile_has_spec_as(cr)));
+                }
+            );
+
+            or_leads_to_combine_temp(
+                stable_spec_with_assumption,
+                lift_state(|s: State<K, T>| {
+                    &&& !s.reconcile_state_contains(cr.object_ref())
+                    &&& s.reconcile_scheduled_for(cr.object_ref())
+                }),
+                lift_state(|s: State<K, T>| {
+                    &&& !s.reconcile_state_contains(cr.object_ref())
+                    &&& !s.reconcile_scheduled_for(cr.object_ref())
+                }),
+                lift_state(the_object_in_reconcile_has_spec_as(cr))
+            );
+
+            temp_pred_equality(
+                lift_state(|s: State<K, T>| {
+                    &&& !s.reconcile_state_contains(cr.object_ref())
+                    &&& s.reconcile_scheduled_for(cr.object_ref())
+                }).or(lift_state(|s: State<K, T>| {
+                    &&& !s.reconcile_state_contains(cr.object_ref())
+                    &&& !s.reconcile_scheduled_for(cr.object_ref())
+                })),
+                lift_state(|s: State<K, T>| !s.reconcile_state_contains(cr.object_ref()))
+            );
+
+            leads_to_trans_temp(
+                stable_spec_with_assumption,
+                true_pred(),
+                lift_state(|s: State<K, T>| !s.reconcile_state_contains(cr.object_ref())),
+                lift_state(the_object_in_reconcile_has_spec_as(cr))
+            );
+            leads_to_stable_temp(stable_spec_with_assumption, lift_action(stronger_next), true_pred(), lift_state(the_object_in_reconcile_has_spec_as(cr)));
+        }
+    );
+
+    // By unpacking the conditions we will have: stable_spec |= []the_object_in_schedule_has_spec_as(cr) ~> []the_object_in_reconcile_has_spec_as(cr)
+    assume(valid(stable(stable_spec)));
+    unpack_conditions_from_spec(
+        stable_spec,
+        always(lift_state(the_object_in_schedule_has_spec_as(cr))),
+        true_pred(),
+        always(lift_state(the_object_in_reconcile_has_spec_as(cr)))
+    );
+    temp_pred_equality(true_pred().and(always(lift_state(the_object_in_schedule_has_spec_as::<K, T>(cr)))), always(lift_state(the_object_in_schedule_has_spec_as(cr))));
+
+    leads_to_trans_temp(stable_spec, true_pred(), always(lift_state(the_object_in_schedule_has_spec_as(cr))), always(lift_state(the_object_in_reconcile_has_spec_as(cr))));
+
+    // Because spec might be different from stable_spec, we need this extra step
+    entails_and_n!(
+        spec,
+        always(lift_action(next::<K, T, ReconcilerType>())),
+        tla_forall(|i| schedule_controller_reconcile().weak_fairness(i)),
+        tla_forall(|i| controller_next::<K, T, ReconcilerType>().weak_fairness(i)),
+        always(lift_state(desired_state_is(cr))),
+        true_pred().leads_to(lift_state(|s: State<K, T>| !s.reconcile_state_contains(cr.object_ref()))),
+        true_pred().leads_to(always(lift_state(the_object_in_schedule_has_spec_as(cr))))
+    );
+    entails_trans(spec, stable_spec, true_pred().leads_to(always(lift_state(the_object_in_reconcile_has_spec_as(cr)))));
+}
+
+}

--- a/src/kubernetes_cluster/proof/mod.rs
+++ b/src/kubernetes_cluster/proof/mod.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: MIT
 pub mod cluster;
 pub mod cluster_safety;
+pub mod controller_runtime_eventual_safety;
 pub mod controller_runtime_liveness;
 pub mod controller_runtime_safety;
 pub mod kubernetes_api_liveness;


### PR DESCRIPTION
Generalize the two lemmas lemma_true_leads_to_always_the_object_in_schedule_has_spec_as and lemma_true_leads_to_always_the_object_in_reconcile_has_spec_as and move them to controller_runtime_eventual_safety.rs.