### PR TITLE
Simplify reasoning about schedule_controller_reconcile

### DIFF
--- a/src/kubernetes_cluster/proof/cluster.rs
+++ b/src/kubernetes_cluster/proof/cluster.rs
@@ -105,22 +105,4 @@ pub open spec fn desired_state_is<K: ResourceView, T>(cr: K) -> StatePred<State<
     }
 }
 
-pub open spec fn desired_state_exists<K: ResourceView, T>(cr: K) -> StatePred<State<K, T>>
-    recommends
-        K::kind().is_CustomResourceKind(),
-{
-    |s: State<K, T>| {
-        &&& s.resource_key_exists(cr.object_ref())
-        &&& K::from_dynamic_object(s.resource_obj_of(cr.object_ref())).is_Ok()
-    }
-}
-
-#[verifier(external_body)]
-pub proof fn lemma_always_desired_state_exists<K: ResourceView, T>(spec: TempPred<State<K, T>>, cr: K)
-    requires
-        spec.entails(always(lift_state(desired_state_is(cr)))),
-    ensures
-        spec.entails(always(lift_state(desired_state_exists(cr)))),
-{}
-
 }

--- a/src/kubernetes_cluster/proof/controller_runtime_eventual_safety.rs
+++ b/src/kubernetes_cluster/proof/controller_runtime_eventual_safety.rs
@@ -65,15 +65,9 @@ pub proof fn lemma_true_leads_to_always_the_object_in_schedule_has_spec_as<K: Re
 
     K::object_ref_is_well_formed();
 
-    lemma_always_desired_state_exists(spec, cr);
-    temp_pred_equality::<State<K, T>>(
-        lift_state(desired_state_exists(cr)), lift_state(schedule_controller_reconcile().pre(input))
+    controller_runtime_liveness::lemma_pre_leads_to_post_by_schedule_controller_reconcile_borrow_from_spec(
+        spec, input, stronger_next, desired_state_is(cr), pre, post
     );
-
-    spec_implies_pre(spec, lift_state(pre), lift_state(schedule_controller_reconcile().pre(input)));
-    use_tla_forall::<State<K, T>, ObjectRef>(spec, |key| schedule_controller_reconcile().weak_fairness(key), input);
-
-    schedule_controller_reconcile().wf1(input, spec, stronger_next, pre, post);
     leads_to_stable_temp(spec, lift_action(stronger_next), lift_state(pre), lift_state(post));
 }
 
@@ -177,13 +171,9 @@ pub proof fn lemma_true_leads_to_always_the_object_in_reconcile_has_spec_as<K: R
                     let input = cr.object_ref();
 
                     K::object_ref_is_well_formed();
-                    lemma_always_desired_state_exists(stable_spec_with_assumption, cr);
-                    temp_pred_equality::<State<K, T>>(
-                        lift_state(desired_state_exists(cr)), lift_state(schedule_controller_reconcile().pre(input))
+                    controller_runtime_liveness::lemma_pre_leads_to_post_by_schedule_controller_reconcile_borrow_from_spec(
+                        stable_spec_with_assumption, input, stronger_next, desired_state_is(cr), pre, post
                     );
-                    spec_implies_pre(stable_spec_with_assumption, lift_state(pre), lift_state(schedule_controller_reconcile().pre(input)));
-                    use_tla_forall::<State<K, T>, ObjectRef>(stable_spec_with_assumption, |key| schedule_controller_reconcile().weak_fairness(key), input);
-                    schedule_controller_reconcile().wf1(input, stable_spec_with_assumption, stronger_next, pre, post);
                     leads_to_trans_temp(stable_spec_with_assumption, lift_state(pre), lift_state(post), lift_state(the_object_in_reconcile_has_spec_as(cr)));
                 }
             );

--- a/src/kubernetes_cluster/proof/controller_runtime_eventual_safety.rs
+++ b/src/kubernetes_cluster/proof/controller_runtime_eventual_safety.rs
@@ -110,19 +110,16 @@ pub proof fn lemma_true_leads_to_always_the_object_in_reconcile_has_spec_as<K: R
         {
             let stronger_next = |s, s_prime: State<K, T>| {
                 &&& next::<K, T, ReconcilerType>()(s, s_prime)
-                &&& desired_state_is(cr)(s)
                 &&& the_object_in_schedule_has_spec_as(cr)(s)
             };
             entails_always_and_n!(
                 stable_spec_with_assumption,
                 lift_action(next::<K, T, ReconcilerType>()),
-                lift_state(desired_state_is(cr)),
                 lift_state(the_object_in_schedule_has_spec_as(cr))
             );
             temp_pred_equality(
                 lift_action(stronger_next),
                 lift_action(next::<K, T, ReconcilerType>())
-                .and(lift_state(desired_state_is(cr)))
                 .and(lift_state(the_object_in_schedule_has_spec_as(cr)))
             );
 

--- a/src/state_machine/action.rs
+++ b/src/state_machine/action.rs
@@ -64,6 +64,23 @@ impl<State, Input, Output> Action<State, Input, Output> {
         leads_to_weaken_temp::<State>(spec, always(lift_state(self.pre(input))), lift_action(self.forward(input)), always(lift_state(pre)), lift_action(self.forward(input)));
         wf1_variant_assume_temp::<State>(spec, lift_action(next), lift_action(self.forward(input)), lift_state(asm), lift_state(pre), lift_state(post));
     }
+
+    /// `wf1_borrow_from_spec` is a specialized version of temporal_logic_rules::wf1 for Action
+    pub proof fn wf1_borrow_from_spec(self, input: Input, spec: TempPred<State>, next: ActionPred<State>, c: StatePred<State>, pre: StatePred<State>, post: StatePred<State>)
+        requires
+            forall |s, s_prime: State| pre(s) && c(s) && #[trigger] next(s, s_prime) ==> pre(s_prime) || post(s_prime),
+            forall |s, s_prime: State| pre(s) && c(s) && #[trigger] next(s, s_prime) && self.forward(input)(s, s_prime) ==> post(s_prime),
+            spec.entails(always(lift_action(next))),
+            spec.entails(always((lift_state(pre).and(lift_state(c))).implies(lift_state(self.pre(input))))),
+            spec.entails(self.weak_fairness(input)),
+            spec.entails(always(lift_state(c))),
+        ensures
+            spec.entails(lift_state(pre).leads_to(lift_state(post))),
+    {
+        always_implies_preserved_by_always_temp::<State>(spec, lift_state(pre).and(lift_state(c)), lift_state(self.pre(input)));
+        leads_to_weaken_temp::<State>(spec, always(lift_state(self.pre(input))), lift_action(self.forward(input)), always(lift_state(pre).and(lift_state(c))), lift_action(self.forward(input)));
+        wf1_variant_borrow_from_spec_temp::<State>(spec, lift_action(next), lift_action(self.forward(input)), lift_state(c), lift_state(pre), lift_state(post));
+    }
 }
 
 #[is_variant]


### PR DESCRIPTION
Previously, proving wf1 for schedule_controller_reconcile is cumbersome because we need `desired_state_is` (or `desired_state_exists`) to satisfy this action's precondition, but `desired_state_is` is in the spec and cannot be directly used to satisfy the precondition when applying wf1.

This PR introduces a new lemma to "borrow" the conditions from the spec to apply wf1, which makes it simpler to reason about schedule_controller_reconcile.