### PR TITLE
Prove specs are stable as part of liveness proof

### DIFF
--- a/src/controller_examples/simple_controller/proof/liveness.rs
+++ b/src/controller_examples/simple_controller/proof/liveness.rs
@@ -108,7 +108,7 @@ proof fn lemma_sm_spec_entails_cr_always_exists_and_crash_always_disabled_leads_
         sm_partial_spec(simple_reconciler()).and(all_invariants(cr))
         .and(always(cr_exists(cr)).and(always(lift_state(crash_disabled::<SimpleReconcileState>())))),
         partial_spec_with_invariants_and_assumptions(cr));
-    lemma_valid_stable_sm_partial_spec_and_invariants(cr);
+    lemma_sm_partial_spec_is_stable_and_invariants(cr);
     // Step (2)
     unpack_assumption_from_spec::<State<SimpleReconcileState>>(lift_state(init(simple_reconciler())),
         sm_partial_spec(simple_reconciler()).and(all_invariants(cr)),
@@ -145,24 +145,24 @@ proof fn lemma_true_leads_to_cm_exists(cr: CustomResourceView)
 }
 
 // Step (3), prove the stability of partial_spec /\ all_invariants.
-proof fn lemma_valid_stable_sm_partial_spec_and_invariants(cr: CustomResourceView)
+proof fn lemma_sm_partial_spec_is_stable_and_invariants(cr: CustomResourceView)
     ensures
         valid(stable(sm_partial_spec(simple_reconciler()).and(all_invariants(cr)))),
 {
-    valid_stable_sm_partial_spec(simple_reconciler());
+    sm_partial_spec_is_stable(simple_reconciler());
 
-    always_p_stable::<State<SimpleReconcileState>>(
+    always_p_is_stable::<State<SimpleReconcileState>>(
         lift_state(reconcile_get_cr_done_implies_pending_req_in_flight_or_resp_in_flight(cr)));
-    always_p_stable::<State<SimpleReconcileState>>(
+    always_p_is_stable::<State<SimpleReconcileState>>(
         tla_forall(|msg| lift_state(resp_matches_at_most_one_pending_req(msg, cr.object_ref()))));
-    always_p_stable::<State<SimpleReconcileState>>(
+    always_p_is_stable::<State<SimpleReconcileState>>(
         tla_forall(|resp_msg: Message| lift_state(at_most_one_resp_matches_req(resp_msg, cr.object_ref()))));
-    always_p_stable::<State<SimpleReconcileState>>(
+    always_p_is_stable::<State<SimpleReconcileState>>(
         lift_state(reconciler_at_init_pc(cr))
             .implies(lift_state(reconciler_init_and_no_pending_req(simple_reconciler(), cr.object_ref()))));
-    always_p_stable::<State<SimpleReconcileState>>(
+    always_p_is_stable::<State<SimpleReconcileState>>(
         lift_state(every_in_flight_msg_has_lower_id_than_allocator::<SimpleReconcileState>()));
-    always_p_stable::<State<SimpleReconcileState>>(
+    always_p_is_stable::<State<SimpleReconcileState>>(
         lift_state(every_in_flight_msg_has_unique_id::<SimpleReconcileState>()));
 
     let a_to_p = |msg| lift_state(resp_matches_at_most_one_pending_req::<SimpleReconcileState>(msg, cr.object_ref()));

--- a/src/controller_examples/zookeeper_controller/proof/liveness.rs
+++ b/src/controller_examples/zookeeper_controller/proof/liveness.rs
@@ -73,11 +73,11 @@ proof fn next_with_wf_is_stable()
     ensures
         valid(stable(next_with_wf())),
 {
-    always_p_stable(lift_action(next::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>()));
-    cluster::valid_stable_tla_forall_action_weak_fairness(kubernetes_api_next::<ZookeeperClusterView, ZookeeperReconcileState>());
-    cluster::valid_stable_tla_forall_action_weak_fairness(controller_next::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>());
-    cluster::valid_stable_tla_forall_action_weak_fairness(schedule_controller_reconcile::<ZookeeperClusterView, ZookeeperReconcileState>());
-    cluster::valid_stable_action_weak_fairness(disable_crash::<ZookeeperClusterView, ZookeeperReconcileState>());
+    always_p_is_stable(lift_action(next::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>()));
+    cluster::tla_forall_action_weak_fairness_is_stable(kubernetes_api_next::<ZookeeperClusterView, ZookeeperReconcileState>());
+    cluster::tla_forall_action_weak_fairness_is_stable(controller_next::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>());
+    cluster::tla_forall_action_weak_fairness_is_stable(schedule_controller_reconcile::<ZookeeperClusterView, ZookeeperReconcileState>());
+    cluster::action_weak_fairness_is_stable(disable_crash::<ZookeeperClusterView, ZookeeperReconcileState>());
 
     stable_and_n!(
         always(lift_action(next::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>())),
@@ -101,10 +101,10 @@ proof fn assumptions_is_stable(zk: ZookeeperClusterView)
     ensures
         valid(stable(assumptions(zk))),
 {
-    always_p_stable(lift_state(crash_disabled::<ZookeeperClusterView, ZookeeperReconcileState>()));
-    always_p_stable(lift_state(cluster::desired_state_is::<ZookeeperClusterView, ZookeeperReconcileState>(zk)));
-    always_p_stable(lift_state(controller_runtime_eventual_safety::the_object_in_schedule_has_spec_as::<ZookeeperClusterView, ZookeeperReconcileState>(zk)));
-    always_p_stable(lift_state(controller_runtime_eventual_safety::the_object_in_reconcile_has_spec_as::<ZookeeperClusterView, ZookeeperReconcileState>(zk)));
+    always_p_is_stable(lift_state(crash_disabled::<ZookeeperClusterView, ZookeeperReconcileState>()));
+    always_p_is_stable(lift_state(cluster::desired_state_is::<ZookeeperClusterView, ZookeeperReconcileState>(zk)));
+    always_p_is_stable(lift_state(controller_runtime_eventual_safety::the_object_in_schedule_has_spec_as::<ZookeeperClusterView, ZookeeperReconcileState>(zk)));
+    always_p_is_stable(lift_state(controller_runtime_eventual_safety::the_object_in_reconcile_has_spec_as::<ZookeeperClusterView, ZookeeperReconcileState>(zk)));
 
     stable_and_n!(
         always(lift_state(crash_disabled::<ZookeeperClusterView, ZookeeperReconcileState>())),
@@ -139,15 +139,15 @@ proof fn invariants_is_stable(zk: ZookeeperClusterView)
     ensures
         valid(stable(invariants(zk))),
 {
-    always_p_stable(lift_state(controller_runtime_safety::every_in_flight_msg_has_unique_id::<ZookeeperClusterView, ZookeeperReconcileState>()));
-    always_p_stable(lift_state(controller_runtime_safety::each_resp_matches_at_most_one_pending_req::<ZookeeperClusterView, ZookeeperReconcileState>(zk.object_ref())));
-    always_p_stable(lift_state(controller_runtime_safety::each_resp_if_matches_pending_req_then_no_other_resp_matches::<ZookeeperClusterView, ZookeeperReconcileState>(zk.object_ref())));
-    always_p_stable(lift_state(controller_runtime_safety::every_in_flight_msg_has_lower_id_than_allocator::<ZookeeperClusterView, ZookeeperReconcileState>()));
-    always_p_stable(lift_state(cluster_safety::each_object_in_etcd_is_well_formed::<ZookeeperClusterView, ZookeeperReconcileState>()));
-    always_p_stable(lift_state(cluster_safety::each_scheduled_key_is_consistent_with_its_object::<ZookeeperClusterView, ZookeeperReconcileState>()));
-    always_p_stable(lift_state(cluster_safety::each_key_in_reconcile_is_consistent_with_its_object::<ZookeeperClusterView, ZookeeperReconcileState>()));
-    always_p_stable(lift_state(safety::pending_msg_at_after_create_stateful_set_step_is_create_sts_req(zk.object_ref())));
-    always_p_stable(lift_state(safety::pending_msg_at_after_update_stateful_set_step_is_update_sts_req(zk.object_ref())));
+    always_p_is_stable(lift_state(controller_runtime_safety::every_in_flight_msg_has_unique_id::<ZookeeperClusterView, ZookeeperReconcileState>()));
+    always_p_is_stable(lift_state(controller_runtime_safety::each_resp_matches_at_most_one_pending_req::<ZookeeperClusterView, ZookeeperReconcileState>(zk.object_ref())));
+    always_p_is_stable(lift_state(controller_runtime_safety::each_resp_if_matches_pending_req_then_no_other_resp_matches::<ZookeeperClusterView, ZookeeperReconcileState>(zk.object_ref())));
+    always_p_is_stable(lift_state(controller_runtime_safety::every_in_flight_msg_has_lower_id_than_allocator::<ZookeeperClusterView, ZookeeperReconcileState>()));
+    always_p_is_stable(lift_state(cluster_safety::each_object_in_etcd_is_well_formed::<ZookeeperClusterView, ZookeeperReconcileState>()));
+    always_p_is_stable(lift_state(cluster_safety::each_scheduled_key_is_consistent_with_its_object::<ZookeeperClusterView, ZookeeperReconcileState>()));
+    always_p_is_stable(lift_state(cluster_safety::each_key_in_reconcile_is_consistent_with_its_object::<ZookeeperClusterView, ZookeeperReconcileState>()));
+    always_p_is_stable(lift_state(safety::pending_msg_at_after_create_stateful_set_step_is_create_sts_req(zk.object_ref())));
+    always_p_is_stable(lift_state(safety::pending_msg_at_after_update_stateful_set_step_is_update_sts_req(zk.object_ref())));
 
     stable_and_n!(
         always(lift_state(controller_runtime_safety::every_in_flight_msg_has_unique_id::<ZookeeperClusterView, ZookeeperReconcileState>())),
@@ -178,11 +178,11 @@ proof fn invariants_since_rest_id_is_stable(zk: ZookeeperClusterView, rest_id: R
     ensures
         valid(stable(invariants_since_rest_id(zk, rest_id))),
 {
-    always_p_stable(lift_state(rest_id_counter_is_no_smaller_than::<ZookeeperClusterView, ZookeeperReconcileState>(rest_id)));
-    always_p_stable(lift_state(safety::at_most_one_create_sts_req_since_rest_id_is_in_flight(zk.object_ref(), rest_id)));
-    always_p_stable(lift_state(safety::at_most_one_update_sts_req_since_rest_id_is_in_flight(zk.object_ref(), rest_id)));
-    always_p_stable(lift_state(safety::no_delete_sts_req_since_rest_id_is_in_flight(zk.object_ref(), rest_id)));
-    always_p_stable(lift_state(safety::every_update_sts_req_since_rest_id_does_the_same(zk, rest_id)));
+    always_p_is_stable(lift_state(rest_id_counter_is_no_smaller_than::<ZookeeperClusterView, ZookeeperReconcileState>(rest_id)));
+    always_p_is_stable(lift_state(safety::at_most_one_create_sts_req_since_rest_id_is_in_flight(zk.object_ref(), rest_id)));
+    always_p_is_stable(lift_state(safety::at_most_one_update_sts_req_since_rest_id_is_in_flight(zk.object_ref(), rest_id)));
+    always_p_is_stable(lift_state(safety::no_delete_sts_req_since_rest_id_is_in_flight(zk.object_ref(), rest_id)));
+    always_p_is_stable(lift_state(safety::every_update_sts_req_since_rest_id_does_the_same(zk, rest_id)));
 
     stable_and_n!(
         always(lift_state(rest_id_counter_is_no_smaller_than(rest_id))),
@@ -203,7 +203,7 @@ proof fn invariants_led_to_by_rest_id_is_stable(zk: ZookeeperClusterView, rest_i
     ensures
         valid(stable(invariants_led_to_by_rest_id(zk, rest_id))),
 {
-    always_p_stable(lift_state(kubernetes_api_liveness::no_req_before_rest_id_is_in_flight::<ZookeeperClusterView, ZookeeperReconcileState>(rest_id)));
+    always_p_is_stable(lift_state(kubernetes_api_liveness::no_req_before_rest_id_is_in_flight::<ZookeeperClusterView, ZookeeperReconcileState>(rest_id)));
 }
 
 proof fn liveness_proof(zk: ZookeeperClusterView)
@@ -292,8 +292,8 @@ proof fn liveness_proof(zk: ZookeeperClusterView)
                 {
                     next_with_wf_is_stable();
                     invariants_is_stable(zk);
-                    always_p_stable(lift_state(cluster::desired_state_is::<ZookeeperClusterView, ZookeeperReconcileState>(zk)));
-                    always_p_stable(lift_state(crash_disabled::<ZookeeperClusterView, ZookeeperReconcileState>()));
+                    always_p_is_stable(lift_state(cluster::desired_state_is::<ZookeeperClusterView, ZookeeperReconcileState>(zk)));
+                    always_p_is_stable(lift_state(crash_disabled::<ZookeeperClusterView, ZookeeperReconcileState>()));
 
                     stable_and_n!(
                         next_with_wf(),
@@ -338,7 +338,7 @@ proof fn liveness_proof(zk: ZookeeperClusterView)
                 {
                     next_with_wf_is_stable();
                     invariants_is_stable(zk);
-                    always_p_stable(lift_state(cluster::desired_state_is::<ZookeeperClusterView, ZookeeperReconcileState>(zk)));
+                    always_p_is_stable(lift_state(cluster::desired_state_is::<ZookeeperClusterView, ZookeeperReconcileState>(zk)));
 
                     stable_and_n!(
                         next_with_wf(),

--- a/src/controller_examples/zookeeper_controller/proof/liveness.rs
+++ b/src/controller_examples/zookeeper_controller/proof/liveness.rs
@@ -148,6 +148,14 @@ proof fn invariants_is_stable(zk: ZookeeperClusterView)
     always_p_is_stable(lift_state(cluster_safety::each_key_in_reconcile_is_consistent_with_its_object::<ZookeeperClusterView, ZookeeperReconcileState>()));
     always_p_is_stable(lift_state(safety::pending_msg_at_after_create_stateful_set_step_is_create_sts_req(zk.object_ref())));
     always_p_is_stable(lift_state(safety::pending_msg_at_after_update_stateful_set_step_is_update_sts_req(zk.object_ref())));
+    always_p_is_stable(lift_state(safety::reconcile_init_implies_no_pending_req(zk.object_ref())));
+    always_p_is_stable(lift_state(safety::pending_req_in_flight_or_resp_in_flight_at_after_update_stateful_set_step(zk.object_ref())));
+    always_p_is_stable(lift_state(safety::pending_req_in_flight_or_resp_in_flight_at_after_create_stateful_set_step(zk.object_ref())));
+    always_p_is_stable(lift_state(safety::pending_req_in_flight_or_resp_in_flight_at_after_create_headless_service_step(zk.object_ref())));
+    always_p_is_stable(lift_state(safety::pending_req_in_flight_or_resp_in_flight_at_after_create_client_service_step(zk.object_ref())));
+    always_p_is_stable(lift_state(safety::pending_req_in_flight_or_resp_in_flight_at_after_create_admin_server_service_step(zk.object_ref())));
+    always_p_is_stable(lift_state(safety::pending_req_in_flight_or_resp_in_flight_at_after_create_config_map_step(zk.object_ref())));
+    always_p_is_stable(lift_state(safety::pending_req_in_flight_or_resp_in_flight_at_after_get_stateful_set_step(zk.object_ref())));
 
     stable_and_n!(
         always(lift_state(controller_runtime_safety::every_in_flight_msg_has_unique_id::<ZookeeperClusterView, ZookeeperReconcileState>())),
@@ -158,7 +166,15 @@ proof fn invariants_is_stable(zk: ZookeeperClusterView)
         always(lift_state(cluster_safety::each_scheduled_key_is_consistent_with_its_object::<ZookeeperClusterView, ZookeeperReconcileState>())),
         always(lift_state(cluster_safety::each_key_in_reconcile_is_consistent_with_its_object::<ZookeeperClusterView, ZookeeperReconcileState>())),
         always(lift_state(safety::pending_msg_at_after_create_stateful_set_step_is_create_sts_req(zk.object_ref()))),
-        always(lift_state(safety::pending_msg_at_after_update_stateful_set_step_is_update_sts_req(zk.object_ref())))
+        always(lift_state(safety::pending_msg_at_after_update_stateful_set_step_is_update_sts_req(zk.object_ref()))),
+        always(lift_state(safety::reconcile_init_implies_no_pending_req(zk.object_ref()))),
+        always(lift_state(safety::pending_req_in_flight_or_resp_in_flight_at_after_update_stateful_set_step(zk.object_ref()))),
+        always(lift_state(safety::pending_req_in_flight_or_resp_in_flight_at_after_create_stateful_set_step(zk.object_ref()))),
+        always(lift_state(safety::pending_req_in_flight_or_resp_in_flight_at_after_create_headless_service_step(zk.object_ref()))),
+        always(lift_state(safety::pending_req_in_flight_or_resp_in_flight_at_after_create_client_service_step(zk.object_ref()))),
+        always(lift_state(safety::pending_req_in_flight_or_resp_in_flight_at_after_create_admin_server_service_step(zk.object_ref()))),
+        always(lift_state(safety::pending_req_in_flight_or_resp_in_flight_at_after_create_config_map_step(zk.object_ref()))),
+        always(lift_state(safety::pending_req_in_flight_or_resp_in_flight_at_after_get_stateful_set_step(zk.object_ref())))
     );
 }
 

--- a/src/controller_examples/zookeeper_controller/proof/liveness.rs
+++ b/src/controller_examples/zookeeper_controller/proof/liveness.rs
@@ -69,6 +69,25 @@ spec fn next_with_wf() -> TempPred<ClusterState> {
     .and(disable_crash().weak_fairness(()))
 }
 
+proof fn next_with_wf_is_stable()
+    ensures
+        valid(stable(next_with_wf())),
+{
+    always_p_stable(lift_action(next::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>()));
+    cluster::valid_stable_tla_forall_action_weak_fairness(kubernetes_api_next::<ZookeeperClusterView, ZookeeperReconcileState>());
+    cluster::valid_stable_tla_forall_action_weak_fairness(controller_next::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>());
+    cluster::valid_stable_tla_forall_action_weak_fairness(schedule_controller_reconcile::<ZookeeperClusterView, ZookeeperReconcileState>());
+    cluster::valid_stable_action_weak_fairness(disable_crash::<ZookeeperClusterView, ZookeeperReconcileState>());
+
+    stable_and_n!(
+        always(lift_action(next::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>())),
+        tla_forall(|input| kubernetes_api_next::<ZookeeperClusterView, ZookeeperReconcileState>().weak_fairness(input)),
+        tla_forall(|input| controller_next::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>().weak_fairness(input)),
+        tla_forall(|input| schedule_controller_reconcile().weak_fairness(input)),
+        disable_crash().weak_fairness(())
+    );
+}
+
 // All assumptions that makes liveness possible, such as controller crash no longer happens,
 // the cr's spec always remains unchanged, and so on.
 spec fn assumptions(zk: ZookeeperClusterView) -> TempPred<ClusterState> {
@@ -76,6 +95,23 @@ spec fn assumptions(zk: ZookeeperClusterView) -> TempPred<ClusterState> {
     .and(always(lift_state(cluster::desired_state_is(zk))))
     .and(always(lift_state(controller_runtime_eventual_safety::the_object_in_schedule_has_spec_as(zk))))
     .and(always(lift_state(controller_runtime_eventual_safety::the_object_in_reconcile_has_spec_as(zk))))
+}
+
+proof fn assumptions_is_stable(zk: ZookeeperClusterView)
+    ensures
+        valid(stable(assumptions(zk))),
+{
+    always_p_stable(lift_state(crash_disabled::<ZookeeperClusterView, ZookeeperReconcileState>()));
+    always_p_stable(lift_state(cluster::desired_state_is::<ZookeeperClusterView, ZookeeperReconcileState>(zk)));
+    always_p_stable(lift_state(controller_runtime_eventual_safety::the_object_in_schedule_has_spec_as::<ZookeeperClusterView, ZookeeperReconcileState>(zk)));
+    always_p_stable(lift_state(controller_runtime_eventual_safety::the_object_in_reconcile_has_spec_as::<ZookeeperClusterView, ZookeeperReconcileState>(zk)));
+
+    stable_and_n!(
+        always(lift_state(crash_disabled::<ZookeeperClusterView, ZookeeperReconcileState>())),
+        always(lift_state(cluster::desired_state_is::<ZookeeperClusterView, ZookeeperReconcileState>(zk))),
+        always(lift_state(controller_runtime_eventual_safety::the_object_in_schedule_has_spec_as::<ZookeeperClusterView, ZookeeperReconcileState>(zk))),
+        always(lift_state(controller_runtime_eventual_safety::the_object_in_reconcile_has_spec_as::<ZookeeperClusterView, ZookeeperReconcileState>(zk)))
+    );
 }
 
 // The safety invariants that are required to prove liveness.
@@ -99,6 +135,33 @@ spec fn invariants(zk: ZookeeperClusterView) -> TempPred<ClusterState> {
     .and(always(lift_state(safety::pending_req_in_flight_or_resp_in_flight_at_after_get_stateful_set_step(zk.object_ref()))))
 }
 
+proof fn invariants_is_stable(zk: ZookeeperClusterView)
+    ensures
+        valid(stable(invariants(zk))),
+{
+    always_p_stable(lift_state(controller_runtime_safety::every_in_flight_msg_has_unique_id::<ZookeeperClusterView, ZookeeperReconcileState>()));
+    always_p_stable(lift_state(controller_runtime_safety::each_resp_matches_at_most_one_pending_req::<ZookeeperClusterView, ZookeeperReconcileState>(zk.object_ref())));
+    always_p_stable(lift_state(controller_runtime_safety::each_resp_if_matches_pending_req_then_no_other_resp_matches::<ZookeeperClusterView, ZookeeperReconcileState>(zk.object_ref())));
+    always_p_stable(lift_state(controller_runtime_safety::every_in_flight_msg_has_lower_id_than_allocator::<ZookeeperClusterView, ZookeeperReconcileState>()));
+    always_p_stable(lift_state(cluster_safety::each_object_in_etcd_is_well_formed::<ZookeeperClusterView, ZookeeperReconcileState>()));
+    always_p_stable(lift_state(cluster_safety::each_scheduled_key_is_consistent_with_its_object::<ZookeeperClusterView, ZookeeperReconcileState>()));
+    always_p_stable(lift_state(cluster_safety::each_key_in_reconcile_is_consistent_with_its_object::<ZookeeperClusterView, ZookeeperReconcileState>()));
+    always_p_stable(lift_state(safety::pending_msg_at_after_create_stateful_set_step_is_create_sts_req(zk.object_ref())));
+    always_p_stable(lift_state(safety::pending_msg_at_after_update_stateful_set_step_is_update_sts_req(zk.object_ref())));
+
+    stable_and_n!(
+        always(lift_state(controller_runtime_safety::every_in_flight_msg_has_unique_id::<ZookeeperClusterView, ZookeeperReconcileState>())),
+        always(lift_state(controller_runtime_safety::each_resp_matches_at_most_one_pending_req::<ZookeeperClusterView, ZookeeperReconcileState>(zk.object_ref()))),
+        always(lift_state(controller_runtime_safety::each_resp_if_matches_pending_req_then_no_other_resp_matches::<ZookeeperClusterView, ZookeeperReconcileState>(zk.object_ref()))),
+        always(lift_state(controller_runtime_safety::every_in_flight_msg_has_lower_id_than_allocator::<ZookeeperClusterView, ZookeeperReconcileState>())),
+        always(lift_state(cluster_safety::each_object_in_etcd_is_well_formed::<ZookeeperClusterView, ZookeeperReconcileState>())),
+        always(lift_state(cluster_safety::each_scheduled_key_is_consistent_with_its_object::<ZookeeperClusterView, ZookeeperReconcileState>())),
+        always(lift_state(cluster_safety::each_key_in_reconcile_is_consistent_with_its_object::<ZookeeperClusterView, ZookeeperReconcileState>())),
+        always(lift_state(safety::pending_msg_at_after_create_stateful_set_step_is_create_sts_req(zk.object_ref()))),
+        always(lift_state(safety::pending_msg_at_after_update_stateful_set_step_is_update_sts_req(zk.object_ref())))
+    );
+}
+
 // Some other invariants requires to prove liveness.
 // Note that different from the above invariants, these do not hold for the entire execution from init.
 // They only hold since some point (e.g., when the rest id counter is the same as rest_id).
@@ -111,10 +174,36 @@ spec fn invariants_since_rest_id(zk: ZookeeperClusterView, rest_id: RestId) -> T
     .and(always(lift_state(safety::every_update_sts_req_since_rest_id_does_the_same(zk, rest_id))))
 }
 
+proof fn invariants_since_rest_id_is_stable(zk: ZookeeperClusterView, rest_id: RestId)
+    ensures
+        valid(stable(invariants_since_rest_id(zk, rest_id))),
+{
+    always_p_stable(lift_state(rest_id_counter_is_no_smaller_than::<ZookeeperClusterView, ZookeeperReconcileState>(rest_id)));
+    always_p_stable(lift_state(safety::at_most_one_create_sts_req_since_rest_id_is_in_flight(zk.object_ref(), rest_id)));
+    always_p_stable(lift_state(safety::at_most_one_update_sts_req_since_rest_id_is_in_flight(zk.object_ref(), rest_id)));
+    always_p_stable(lift_state(safety::no_delete_sts_req_since_rest_id_is_in_flight(zk.object_ref(), rest_id)));
+    always_p_stable(lift_state(safety::every_update_sts_req_since_rest_id_does_the_same(zk, rest_id)));
+
+    stable_and_n!(
+        always(lift_state(rest_id_counter_is_no_smaller_than(rest_id))),
+        always(lift_state(safety::at_most_one_create_sts_req_since_rest_id_is_in_flight(zk.object_ref(), rest_id))),
+        always(lift_state(safety::at_most_one_update_sts_req_since_rest_id_is_in_flight(zk.object_ref(), rest_id))),
+        always(lift_state(safety::no_delete_sts_req_since_rest_id_is_in_flight(zk.object_ref(), rest_id))),
+        always(lift_state(safety::every_update_sts_req_since_rest_id_does_the_same(zk, rest_id)))
+    );
+}
+
 // This invariant is also used to prove liveness.
 // Different from above, it only holds after some time since the rest id counter is the same as rest_id.
 spec fn invariants_led_to_by_rest_id(zk: ZookeeperClusterView, rest_id: RestId) -> TempPred<ClusterState> {
     always(lift_state(kubernetes_api_liveness::no_req_before_rest_id_is_in_flight(rest_id)))
+}
+
+proof fn invariants_led_to_by_rest_id_is_stable(zk: ZookeeperClusterView, rest_id: RestId)
+    ensures
+        valid(stable(invariants_led_to_by_rest_id(zk, rest_id))),
+{
+    always_p_stable(lift_state(kubernetes_api_liveness::no_req_before_rest_id_is_in_flight::<ZookeeperClusterView, ZookeeperReconcileState>(rest_id)));
 }
 
 proof fn liveness_proof(zk: ZookeeperClusterView)
@@ -137,7 +226,20 @@ proof fn liveness_proof(zk: ZookeeperClusterView)
             assert forall |rest_id|
             spec.entails(#[trigger] idle_and_rest_id_is(rest_id).leads_to(always(lift_state(current_state_matches(zk))))) by {
                 lemma_true_leads_to_always_current_state_matches_zk_from_idle_with_rest_id(zk, rest_id);
-                assume(valid(stable(spec)));
+                assert_by(
+                    valid(stable(spec)),
+                    {
+                        next_with_wf_is_stable();
+                        invariants_is_stable(zk);
+                        assumptions_is_stable(zk);
+
+                        stable_and_n!(
+                            next_with_wf(),
+                            invariants(zk),
+                            assumptions(zk)
+                        );
+                    }
+                );
                 temp_pred_equality(
                     lift_state(rest_id_counter_is(rest_id))
                     .and(lift_state(|s: ClusterState| !s.reconcile_state_contains(zk.object_ref())))
@@ -185,7 +287,22 @@ proof fn liveness_proof(zk: ZookeeperClusterView)
                 next_with_wf().and(invariants(zk)).and(assumptions(zk)),
                 next_with_wf().and(invariants(zk)).and(always(lift_state(cluster::desired_state_is(zk)))).and(always(lift_state(crash_disabled()))).and(other_assumptions)
             );
-            assume(valid(stable(spec)));
+            assert_by(
+                valid(stable(spec)),
+                {
+                    next_with_wf_is_stable();
+                    invariants_is_stable(zk);
+                    always_p_stable(lift_state(cluster::desired_state_is::<ZookeeperClusterView, ZookeeperReconcileState>(zk)));
+                    always_p_stable(lift_state(crash_disabled::<ZookeeperClusterView, ZookeeperReconcileState>()));
+
+                    stable_and_n!(
+                        next_with_wf(),
+                        invariants(zk),
+                        always(lift_state(cluster::desired_state_is::<ZookeeperClusterView, ZookeeperReconcileState>(zk))),
+                        always(lift_state(crash_disabled::<ZookeeperClusterView, ZookeeperReconcileState>()))
+                    );
+                }
+            );
             unpack_conditions_from_spec(spec, other_assumptions, true_pred(), always(lift_state(current_state_matches(zk))));
             temp_pred_equality(true_pred().and(other_assumptions), other_assumptions);
 
@@ -216,7 +333,20 @@ proof fn liveness_proof(zk: ZookeeperClusterView)
         ),
         {
             let spec = next_with_wf().and(invariants(zk)).and(always(lift_state(cluster::desired_state_is(zk))));
-            assume(valid(stable(spec)));
+            assert_by(
+                valid(stable(spec)),
+                {
+                    next_with_wf_is_stable();
+                    invariants_is_stable(zk);
+                    always_p_stable(lift_state(cluster::desired_state_is::<ZookeeperClusterView, ZookeeperReconcileState>(zk)));
+
+                    stable_and_n!(
+                        next_with_wf(),
+                        invariants(zk),
+                        always(lift_state(cluster::desired_state_is::<ZookeeperClusterView, ZookeeperReconcileState>(zk)))
+                    );
+                }
+            );
             unpack_conditions_from_spec(spec, always(lift_state(crash_disabled())), true_pred(), always(lift_state(current_state_matches(zk))));
             temp_pred_equality(true_pred().and(always(lift_state(crash_disabled()))), always(lift_state(crash_disabled::<ZookeeperClusterView, ZookeeperReconcileState>())));
 
@@ -235,7 +365,15 @@ proof fn liveness_proof(zk: ZookeeperClusterView)
         {
             let spec = next_with_wf().and(invariants(zk));
             let assumption = always(lift_state(cluster::desired_state_is(zk)));
-            assume(valid(stable(spec)));
+            assert_by(
+                valid(stable(spec)),
+                {
+                    next_with_wf_is_stable();
+                    invariants_is_stable(zk);
+
+                    stable_and_n!(next_with_wf(), invariants(zk));
+                }
+            );
             unpack_conditions_from_spec(spec, assumption, true_pred(), always(lift_state(current_state_matches(zk))));
             temp_pred_equality(true_pred().and(assumption), assumption);
         }
@@ -328,7 +466,17 @@ proof fn lemma_true_leads_to_always_current_state_matches_zk_from_idle_with_rest
         ),
         {
             lemma_true_leads_to_always_current_state_matches_zk_under_eventual_invariants(zk, rest_id);
-            assume(valid(stable(stable_spec.and(invariants_since_rest_id(zk, rest_id)))));
+            assert_by(
+                valid(stable(stable_spec.and(invariants_since_rest_id(zk, rest_id)))),
+                {
+                    next_with_wf_is_stable();
+                    invariants_is_stable(zk);
+                    assumptions_is_stable(zk);
+                    invariants_since_rest_id_is_stable(zk, rest_id);
+
+                    stable_and_n!(next_with_wf(), invariants(zk), assumptions(zk), invariants_since_rest_id(zk, rest_id));
+                }
+            );
             unpack_conditions_from_spec(
                 stable_spec.and(invariants_since_rest_id(zk, rest_id)),
                 invariants_led_to_by_rest_id(zk, rest_id),

--- a/src/kubernetes_cluster/proof/cluster.rs
+++ b/src/kubernetes_cluster/proof/cluster.rs
@@ -26,7 +26,7 @@ use vstd::prelude::*;
 verus! {
 
 /// Prove weak_fairness is stable.
-proof fn valid_stable_action_weak_fairness<K: ResourceView, T, Output>(action: Action<State<K, T>, (), Output>)
+pub proof fn valid_stable_action_weak_fairness<K: ResourceView, T, Output>(action: Action<State<K, T>, (), Output>)
     ensures
         valid(stable(action.weak_fairness(()))),
 {
@@ -35,7 +35,7 @@ proof fn valid_stable_action_weak_fairness<K: ResourceView, T, Output>(action: A
 }
 
 /// Prove weak_fairness for all input is stable.
-proof fn valid_stable_tla_forall_action_weak_fairness<K: ResourceView, T, Input, Output>(
+pub proof fn valid_stable_tla_forall_action_weak_fairness<K: ResourceView, T, Input, Output>(
     action: Action<State<K, T>, Input, Output>
 )
     ensures

--- a/src/kubernetes_cluster/proof/cluster.rs
+++ b/src/kubernetes_cluster/proof/cluster.rs
@@ -26,16 +26,16 @@ use vstd::prelude::*;
 verus! {
 
 /// Prove weak_fairness is stable.
-pub proof fn valid_stable_action_weak_fairness<K: ResourceView, T, Output>(action: Action<State<K, T>, (), Output>)
+pub proof fn action_weak_fairness_is_stable<K: ResourceView, T, Output>(action: Action<State<K, T>, (), Output>)
     ensures
         valid(stable(action.weak_fairness(()))),
 {
     let split_always = always(lift_state(action.pre(()))).implies(eventually(lift_action(action.forward(()))));
-    always_p_stable::<State<K, T>>(split_always);
+    always_p_is_stable::<State<K, T>>(split_always);
 }
 
 /// Prove weak_fairness for all input is stable.
-pub proof fn valid_stable_tla_forall_action_weak_fairness<K: ResourceView, T, Input, Output>(
+pub proof fn tla_forall_action_weak_fairness_is_stable<K: ResourceView, T, Input, Output>(
     action: Action<State<K, T>, Input, Output>
 )
     ensures
@@ -43,19 +43,19 @@ pub proof fn valid_stable_tla_forall_action_weak_fairness<K: ResourceView, T, In
 {
     let split_always = |input| always(lift_state(action.pre(input))).implies(eventually(lift_action(action.forward(input))));
     tla_forall_always_equality_variant::<State<K, T>, Input>(|input| action.weak_fairness(input), split_always);
-    always_p_stable::<State<K, T>>(tla_forall(split_always));
+    always_p_is_stable::<State<K, T>>(tla_forall(split_always));
 }
 
 /// Prove partial_spec is stable.
-pub proof fn valid_stable_sm_partial_spec<K: ResourceView, T, ReconcilerType: Reconciler<K, T>>()
+pub proof fn sm_partial_spec_is_stable<K: ResourceView, T, ReconcilerType: Reconciler<K, T>>()
     ensures
         valid(stable(sm_partial_spec::<K, T, ReconcilerType>())),
 {
-    always_p_stable::<State<K, T>>(lift_action(next::<K, T, ReconcilerType>()));
-    valid_stable_tla_forall_action_weak_fairness::<K, T, Option<Message>, ()>(kubernetes_api_next());
-    valid_stable_tla_forall_action_weak_fairness::<K, T, (Option<Message>, Option<ObjectRef>), ()>(controller_next::<K, T, ReconcilerType>());
-    valid_stable_tla_forall_action_weak_fairness::<K, T, ObjectRef, ()>(schedule_controller_reconcile());
-    valid_stable_action_weak_fairness::<K, T, ()>(disable_crash());
+    always_p_is_stable::<State<K, T>>(lift_action(next::<K, T, ReconcilerType>()));
+    tla_forall_action_weak_fairness_is_stable::<K, T, Option<Message>, ()>(kubernetes_api_next());
+    tla_forall_action_weak_fairness_is_stable::<K, T, (Option<Message>, Option<ObjectRef>), ()>(controller_next::<K, T, ReconcilerType>());
+    tla_forall_action_weak_fairness_is_stable::<K, T, ObjectRef, ()>(schedule_controller_reconcile());
+    action_weak_fairness_is_stable::<K, T, ()>(disable_crash());
 
     stable_and_n!(
         always(lift_action(next::<K, T, ReconcilerType>())),

--- a/src/kubernetes_cluster/proof/controller_runtime_eventual_safety.rs
+++ b/src/kubernetes_cluster/proof/controller_runtime_eventual_safety.rs
@@ -213,12 +213,12 @@ pub proof fn lemma_true_leads_to_always_the_object_in_reconcile_has_spec_as<K: R
     assert_by(
         valid(stable(stable_spec)),
         {
-            always_p_stable(lift_action(next::<K, T, ReconcilerType>()));
-            valid_stable_tla_forall_action_weak_fairness(schedule_controller_reconcile::<K, T>());
-            valid_stable_tla_forall_action_weak_fairness(controller_next::<K, T, ReconcilerType>());
-            always_p_stable(lift_state(desired_state_is::<K, T>(cr)));
-            p_leads_to_q_stable(true_pred(), lift_state(|s: State<K, T>| !s.reconcile_state_contains(cr.object_ref())));
-            p_leads_to_q_stable(true_pred(), always(lift_state(the_object_in_schedule_has_spec_as::<K, T>(cr))));
+            always_p_is_stable(lift_action(next::<K, T, ReconcilerType>()));
+            tla_forall_action_weak_fairness_is_stable(schedule_controller_reconcile::<K, T>());
+            tla_forall_action_weak_fairness_is_stable(controller_next::<K, T, ReconcilerType>());
+            always_p_is_stable(lift_state(desired_state_is::<K, T>(cr)));
+            p_leads_to_q_is_stable(true_pred(), lift_state(|s: State<K, T>| !s.reconcile_state_contains(cr.object_ref())));
+            p_leads_to_q_is_stable(true_pred(), always(lift_state(the_object_in_schedule_has_spec_as::<K, T>(cr))));
 
             stable_and_n!(
                 always(lift_action(next::<K, T, ReconcilerType>())),

--- a/src/kubernetes_cluster/proof/controller_runtime_eventual_safety.rs
+++ b/src/kubernetes_cluster/proof/controller_runtime_eventual_safety.rs
@@ -210,7 +210,26 @@ pub proof fn lemma_true_leads_to_always_the_object_in_reconcile_has_spec_as<K: R
     );
 
     // By unpacking the conditions we will have: stable_spec |= []the_object_in_schedule_has_spec_as(cr) ~> []the_object_in_reconcile_has_spec_as(cr)
-    assume(valid(stable(stable_spec)));
+    assert_by(
+        valid(stable(stable_spec)),
+        {
+            always_p_stable(lift_action(next::<K, T, ReconcilerType>()));
+            valid_stable_tla_forall_action_weak_fairness(schedule_controller_reconcile::<K, T>());
+            valid_stable_tla_forall_action_weak_fairness(controller_next::<K, T, ReconcilerType>());
+            always_p_stable(lift_state(desired_state_is::<K, T>(cr)));
+            p_leads_to_q_stable(true_pred(), lift_state(|s: State<K, T>| !s.reconcile_state_contains(cr.object_ref())));
+            p_leads_to_q_stable(true_pred(), always(lift_state(the_object_in_schedule_has_spec_as::<K, T>(cr))));
+
+            stable_and_n!(
+                always(lift_action(next::<K, T, ReconcilerType>())),
+                tla_forall(|input| schedule_controller_reconcile().weak_fairness(input)),
+                tla_forall(|input| controller_next::<K, T, ReconcilerType>().weak_fairness(input)),
+                always(lift_state(desired_state_is::<K, T>(cr))),
+                true_pred().leads_to(lift_state(|s: State<K, T>| !s.reconcile_state_contains(cr.object_ref()))),
+                true_pred().leads_to(always(lift_state(the_object_in_schedule_has_spec_as(cr))))
+            );
+        }
+    );
     unpack_conditions_from_spec(
         stable_spec,
         always(lift_state(the_object_in_schedule_has_spec_as(cr))),

--- a/src/temporal_logic/rules.rs
+++ b/src/temporal_logic/rules.rs
@@ -1066,7 +1066,7 @@ pub proof fn entails_and_different_temp<T>(spec1: TempPred<T>, spec2: TempPred<T
 /// An always predicate is stable.
 /// post:
 ///     |= stable(always(p))
-pub proof fn always_p_stable<T>(p: TempPred<T>)
+pub proof fn always_p_is_stable<T>(p: TempPred<T>)
     ensures
         valid(stable(always(p))),
 {
@@ -1080,11 +1080,11 @@ pub proof fn always_p_stable<T>(p: TempPred<T>)
 /// A leads-to predicate is stable.
 /// post:
 ///     |= stable(p ~> q)
-pub proof fn p_leads_to_q_stable<T>(p: TempPred<T>, q: TempPred<T>)
+pub proof fn p_leads_to_q_is_stable<T>(p: TempPred<T>, q: TempPred<T>)
     ensures
         valid(stable(p.leads_to(q))),
 {
-    always_p_stable(p.implies(eventually(q)));
+    always_p_is_stable(p.implies(eventually(q)));
 }
 
 /// p and q is stable if both p and q are stable.

--- a/src/temporal_logic/rules.rs
+++ b/src/temporal_logic/rules.rs
@@ -1077,6 +1077,16 @@ pub proof fn always_p_stable<T>(p: TempPred<T>)
     }
 }
 
+/// A leads-to predicate is stable.
+/// post:
+///     |= stable(p ~> q)
+pub proof fn p_leads_to_q_stable<T>(p: TempPred<T>, q: TempPred<T>)
+    ensures
+        valid(stable(p.leads_to(q))),
+{
+    always_p_stable(p.implies(eventually(q)));
+}
+
 /// p and q is stable if both p and q are stable.
 /// pre:
 ///     |= stable(p)


### PR DESCRIPTION
Finish the stable proofs (which were left as assumed in the liveness proof). Also rename related lemmas to the form of `x_is_stable`.

In future work, some lemmas/predicates can be made more generic to avoid redundancy.