### PR TITLE
Simplify the termination and safety proof of zookeeper

### DIFF
--- a/src/controller_examples/zookeeper_controller/proof/liveness.rs
+++ b/src/controller_examples/zookeeper_controller/proof/liveness.rs
@@ -24,6 +24,7 @@ use crate::kubernetes_cluster::{
 };
 use crate::temporal_logic::{defs::*, rules::*};
 use crate::zookeeper_controller::{
+    common::*,
     proof::{common::*, safety, terminate},
     spec::{reconciler::*, zookeepercluster::*},
 };
@@ -127,11 +128,11 @@ spec fn invariants(zk: ZookeeperClusterView) -> TempPred<ClusterState> {
     .and(always(lift_state(safety::pending_msg_at_after_update_stateful_set_step_is_update_sts_req(zk.object_ref()))))
     .and(always(lift_state(safety::reconcile_init_implies_no_pending_req(zk.object_ref()))))
     .and(always(lift_state(safety::pending_req_in_flight_or_resp_in_flight_at_after_update_stateful_set_step(zk.object_ref()))))
-    .and(always(lift_state(safety::pending_req_in_flight_or_resp_in_flight_at_after_create_stateful_set_step(zk.object_ref()))))
-    .and(always(lift_state(safety::pending_req_in_flight_or_resp_in_flight_at_after_create_headless_service_step(zk.object_ref()))))
-    .and(always(lift_state(safety::pending_req_in_flight_or_resp_in_flight_at_after_create_client_service_step(zk.object_ref()))))
-    .and(always(lift_state(safety::pending_req_in_flight_or_resp_in_flight_at_after_create_admin_server_service_step(zk.object_ref()))))
-    .and(always(lift_state(safety::pending_req_in_flight_or_resp_in_flight_at_after_create_config_map_step(zk.object_ref()))))
+    .and(always(lift_state(safety::pending_req_in_flight_or_resp_in_flight_at_after_create_obj_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateStatefulSet))))
+    .and(always(lift_state(safety::pending_req_in_flight_or_resp_in_flight_at_after_create_obj_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateHeadlessService))))
+    .and(always(lift_state(safety::pending_req_in_flight_or_resp_in_flight_at_after_create_obj_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateClientService))))
+    .and(always(lift_state(safety::pending_req_in_flight_or_resp_in_flight_at_after_create_obj_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateAdminServerService))))
+    .and(always(lift_state(safety::pending_req_in_flight_or_resp_in_flight_at_after_create_obj_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateConfigMap))))
     .and(always(lift_state(safety::pending_req_in_flight_or_resp_in_flight_at_after_get_stateful_set_step(zk.object_ref()))))
 }
 
@@ -150,11 +151,11 @@ proof fn invariants_is_stable(zk: ZookeeperClusterView)
     always_p_is_stable(lift_state(safety::pending_msg_at_after_update_stateful_set_step_is_update_sts_req(zk.object_ref())));
     always_p_is_stable(lift_state(safety::reconcile_init_implies_no_pending_req(zk.object_ref())));
     always_p_is_stable(lift_state(safety::pending_req_in_flight_or_resp_in_flight_at_after_update_stateful_set_step(zk.object_ref())));
-    always_p_is_stable(lift_state(safety::pending_req_in_flight_or_resp_in_flight_at_after_create_stateful_set_step(zk.object_ref())));
-    always_p_is_stable(lift_state(safety::pending_req_in_flight_or_resp_in_flight_at_after_create_headless_service_step(zk.object_ref())));
-    always_p_is_stable(lift_state(safety::pending_req_in_flight_or_resp_in_flight_at_after_create_client_service_step(zk.object_ref())));
-    always_p_is_stable(lift_state(safety::pending_req_in_flight_or_resp_in_flight_at_after_create_admin_server_service_step(zk.object_ref())));
-    always_p_is_stable(lift_state(safety::pending_req_in_flight_or_resp_in_flight_at_after_create_config_map_step(zk.object_ref())));
+    always_p_is_stable(lift_state(safety::pending_req_in_flight_or_resp_in_flight_at_after_create_obj_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateStatefulSet)));
+    always_p_is_stable(lift_state(safety::pending_req_in_flight_or_resp_in_flight_at_after_create_obj_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateHeadlessService)));
+    always_p_is_stable(lift_state(safety::pending_req_in_flight_or_resp_in_flight_at_after_create_obj_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateClientService)));
+    always_p_is_stable(lift_state(safety::pending_req_in_flight_or_resp_in_flight_at_after_create_obj_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateAdminServerService)));
+    always_p_is_stable(lift_state(safety::pending_req_in_flight_or_resp_in_flight_at_after_create_obj_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateConfigMap)));
     always_p_is_stable(lift_state(safety::pending_req_in_flight_or_resp_in_flight_at_after_get_stateful_set_step(zk.object_ref())));
 
     stable_and_n!(
@@ -169,11 +170,11 @@ proof fn invariants_is_stable(zk: ZookeeperClusterView)
         always(lift_state(safety::pending_msg_at_after_update_stateful_set_step_is_update_sts_req(zk.object_ref()))),
         always(lift_state(safety::reconcile_init_implies_no_pending_req(zk.object_ref()))),
         always(lift_state(safety::pending_req_in_flight_or_resp_in_flight_at_after_update_stateful_set_step(zk.object_ref()))),
-        always(lift_state(safety::pending_req_in_flight_or_resp_in_flight_at_after_create_stateful_set_step(zk.object_ref()))),
-        always(lift_state(safety::pending_req_in_flight_or_resp_in_flight_at_after_create_headless_service_step(zk.object_ref()))),
-        always(lift_state(safety::pending_req_in_flight_or_resp_in_flight_at_after_create_client_service_step(zk.object_ref()))),
-        always(lift_state(safety::pending_req_in_flight_or_resp_in_flight_at_after_create_admin_server_service_step(zk.object_ref()))),
-        always(lift_state(safety::pending_req_in_flight_or_resp_in_flight_at_after_create_config_map_step(zk.object_ref()))),
+        always(lift_state(safety::pending_req_in_flight_or_resp_in_flight_at_after_create_obj_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateStatefulSet))),
+        always(lift_state(safety::pending_req_in_flight_or_resp_in_flight_at_after_create_obj_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateHeadlessService))),
+        always(lift_state(safety::pending_req_in_flight_or_resp_in_flight_at_after_create_obj_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateClientService))),
+        always(lift_state(safety::pending_req_in_flight_or_resp_in_flight_at_after_create_obj_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateAdminServerService))),
+        always(lift_state(safety::pending_req_in_flight_or_resp_in_flight_at_after_create_obj_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateConfigMap))),
         always(lift_state(safety::pending_req_in_flight_or_resp_in_flight_at_after_get_stateful_set_step(zk.object_ref())))
     );
 }
@@ -420,11 +421,11 @@ proof fn liveness_proof(zk: ZookeeperClusterView)
             safety::lemma_always_pending_msg_at_after_update_stateful_set_step_is_update_sts_req(spec, zk.object_ref());
             safety::lemma_always_reconcile_init_implies_no_pending_req(spec, zk.object_ref());
             safety::lemma_always_pending_req_in_flight_or_resp_in_flight_at_after_update_stateful_set_step(spec, zk.object_ref());
-            safety::lemma_always_pending_req_in_flight_or_resp_in_flight_at_after_create_stateful_set_step(spec, zk.object_ref());
-            safety::lemma_always_pending_req_in_flight_or_resp_in_flight_at_after_create_headless_service_step(spec, zk.object_ref());
-            safety::lemma_always_pending_req_in_flight_or_resp_in_flight_at_after_create_client_service_step(spec, zk.object_ref());
-            safety::lemma_always_pending_req_in_flight_or_resp_in_flight_at_after_create_admin_server_service_step(spec, zk.object_ref());
-            safety::lemma_always_pending_req_in_flight_or_resp_in_flight_at_after_create_config_map_step(spec, zk.object_ref());
+            safety::lemma_always_pending_req_in_flight_or_resp_in_flight_at_after_create_obj_step(spec, zk.object_ref(), ZookeeperReconcileStep::AfterCreateStatefulSet);
+            safety::lemma_always_pending_req_in_flight_or_resp_in_flight_at_after_create_obj_step(spec, zk.object_ref(), ZookeeperReconcileStep::AfterCreateHeadlessService);
+            safety::lemma_always_pending_req_in_flight_or_resp_in_flight_at_after_create_obj_step(spec, zk.object_ref(), ZookeeperReconcileStep::AfterCreateClientService);
+            safety::lemma_always_pending_req_in_flight_or_resp_in_flight_at_after_create_obj_step(spec, zk.object_ref(), ZookeeperReconcileStep::AfterCreateAdminServerService);
+            safety::lemma_always_pending_req_in_flight_or_resp_in_flight_at_after_create_obj_step(spec, zk.object_ref(), ZookeeperReconcileStep::AfterCreateConfigMap);
             safety::lemma_always_pending_req_in_flight_or_resp_in_flight_at_after_get_stateful_set_step(spec, zk.object_ref());
 
             entails_and_n!(
@@ -440,11 +441,11 @@ proof fn liveness_proof(zk: ZookeeperClusterView)
                 always(lift_state(safety::pending_msg_at_after_update_stateful_set_step_is_update_sts_req(zk.object_ref()))),
                 always(lift_state(safety::reconcile_init_implies_no_pending_req(zk.object_ref()))),
                 always(lift_state(safety::pending_req_in_flight_or_resp_in_flight_at_after_update_stateful_set_step(zk.object_ref()))),
-                always(lift_state(safety::pending_req_in_flight_or_resp_in_flight_at_after_create_stateful_set_step(zk.object_ref()))),
-                always(lift_state(safety::pending_req_in_flight_or_resp_in_flight_at_after_create_headless_service_step(zk.object_ref()))),
-                always(lift_state(safety::pending_req_in_flight_or_resp_in_flight_at_after_create_client_service_step(zk.object_ref()))),
-                always(lift_state(safety::pending_req_in_flight_or_resp_in_flight_at_after_create_admin_server_service_step(zk.object_ref()))),
-                always(lift_state(safety::pending_req_in_flight_or_resp_in_flight_at_after_create_config_map_step(zk.object_ref()))),
+                always(lift_state(safety::pending_req_in_flight_or_resp_in_flight_at_after_create_obj_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateStatefulSet))),
+                always(lift_state(safety::pending_req_in_flight_or_resp_in_flight_at_after_create_obj_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateHeadlessService))),
+                always(lift_state(safety::pending_req_in_flight_or_resp_in_flight_at_after_create_obj_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateClientService))),
+                always(lift_state(safety::pending_req_in_flight_or_resp_in_flight_at_after_create_obj_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateAdminServerService))),
+                always(lift_state(safety::pending_req_in_flight_or_resp_in_flight_at_after_create_obj_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateConfigMap))),
                 always(lift_state(safety::pending_req_in_flight_or_resp_in_flight_at_after_get_stateful_set_step(zk.object_ref())))
             );
 

--- a/src/controller_examples/zookeeper_controller/proof/liveness.rs
+++ b/src/controller_examples/zookeeper_controller/proof/liveness.rs
@@ -127,13 +127,13 @@ spec fn invariants(zk: ZookeeperClusterView) -> TempPred<ClusterState> {
     .and(always(lift_state(safety::pending_msg_at_after_create_stateful_set_step_is_create_sts_req(zk.object_ref()))))
     .and(always(lift_state(safety::pending_msg_at_after_update_stateful_set_step_is_update_sts_req(zk.object_ref()))))
     .and(always(lift_state(safety::reconcile_init_implies_no_pending_req(zk.object_ref()))))
-    .and(always(lift_state(safety::pending_req_in_flight_or_resp_in_flight_at_after_update_stateful_set_step(zk.object_ref()))))
-    .and(always(lift_state(safety::pending_req_in_flight_or_resp_in_flight_at_after_create_obj_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateStatefulSet))))
-    .and(always(lift_state(safety::pending_req_in_flight_or_resp_in_flight_at_after_create_obj_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateHeadlessService))))
-    .and(always(lift_state(safety::pending_req_in_flight_or_resp_in_flight_at_after_create_obj_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateClientService))))
-    .and(always(lift_state(safety::pending_req_in_flight_or_resp_in_flight_at_after_create_obj_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateAdminServerService))))
-    .and(always(lift_state(safety::pending_req_in_flight_or_resp_in_flight_at_after_create_obj_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateConfigMap))))
-    .and(always(lift_state(safety::pending_req_in_flight_or_resp_in_flight_at_after_get_stateful_set_step(zk.object_ref()))))
+    .and(always(lift_state(safety::pending_req_in_flight_or_resp_in_flight_at_step(zk.object_ref(), ZookeeperReconcileStep::AfterUpdateStatefulSet))))
+    .and(always(lift_state(safety::pending_req_in_flight_or_resp_in_flight_at_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateStatefulSet))))
+    .and(always(lift_state(safety::pending_req_in_flight_or_resp_in_flight_at_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateHeadlessService))))
+    .and(always(lift_state(safety::pending_req_in_flight_or_resp_in_flight_at_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateClientService))))
+    .and(always(lift_state(safety::pending_req_in_flight_or_resp_in_flight_at_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateAdminServerService))))
+    .and(always(lift_state(safety::pending_req_in_flight_or_resp_in_flight_at_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateConfigMap))))
+    .and(always(lift_state(safety::pending_req_in_flight_or_resp_in_flight_at_step(zk.object_ref(), ZookeeperReconcileStep::AfterGetStatefulSet))))
 }
 
 proof fn invariants_is_stable(zk: ZookeeperClusterView)
@@ -150,13 +150,13 @@ proof fn invariants_is_stable(zk: ZookeeperClusterView)
     always_p_is_stable(lift_state(safety::pending_msg_at_after_create_stateful_set_step_is_create_sts_req(zk.object_ref())));
     always_p_is_stable(lift_state(safety::pending_msg_at_after_update_stateful_set_step_is_update_sts_req(zk.object_ref())));
     always_p_is_stable(lift_state(safety::reconcile_init_implies_no_pending_req(zk.object_ref())));
-    always_p_is_stable(lift_state(safety::pending_req_in_flight_or_resp_in_flight_at_after_update_stateful_set_step(zk.object_ref())));
-    always_p_is_stable(lift_state(safety::pending_req_in_flight_or_resp_in_flight_at_after_create_obj_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateStatefulSet)));
-    always_p_is_stable(lift_state(safety::pending_req_in_flight_or_resp_in_flight_at_after_create_obj_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateHeadlessService)));
-    always_p_is_stable(lift_state(safety::pending_req_in_flight_or_resp_in_flight_at_after_create_obj_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateClientService)));
-    always_p_is_stable(lift_state(safety::pending_req_in_flight_or_resp_in_flight_at_after_create_obj_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateAdminServerService)));
-    always_p_is_stable(lift_state(safety::pending_req_in_flight_or_resp_in_flight_at_after_create_obj_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateConfigMap)));
-    always_p_is_stable(lift_state(safety::pending_req_in_flight_or_resp_in_flight_at_after_get_stateful_set_step(zk.object_ref())));
+    always_p_is_stable(lift_state(safety::pending_req_in_flight_or_resp_in_flight_at_step(zk.object_ref(), ZookeeperReconcileStep::AfterUpdateStatefulSet)));
+    always_p_is_stable(lift_state(safety::pending_req_in_flight_or_resp_in_flight_at_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateStatefulSet)));
+    always_p_is_stable(lift_state(safety::pending_req_in_flight_or_resp_in_flight_at_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateHeadlessService)));
+    always_p_is_stable(lift_state(safety::pending_req_in_flight_or_resp_in_flight_at_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateClientService)));
+    always_p_is_stable(lift_state(safety::pending_req_in_flight_or_resp_in_flight_at_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateAdminServerService)));
+    always_p_is_stable(lift_state(safety::pending_req_in_flight_or_resp_in_flight_at_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateConfigMap)));
+    always_p_is_stable(lift_state(safety::pending_req_in_flight_or_resp_in_flight_at_step(zk.object_ref(), ZookeeperReconcileStep::AfterGetStatefulSet)));
 
     stable_and_n!(
         always(lift_state(controller_runtime_safety::every_in_flight_msg_has_unique_id::<ZookeeperClusterView, ZookeeperReconcileState>())),
@@ -169,13 +169,13 @@ proof fn invariants_is_stable(zk: ZookeeperClusterView)
         always(lift_state(safety::pending_msg_at_after_create_stateful_set_step_is_create_sts_req(zk.object_ref()))),
         always(lift_state(safety::pending_msg_at_after_update_stateful_set_step_is_update_sts_req(zk.object_ref()))),
         always(lift_state(safety::reconcile_init_implies_no_pending_req(zk.object_ref()))),
-        always(lift_state(safety::pending_req_in_flight_or_resp_in_flight_at_after_update_stateful_set_step(zk.object_ref()))),
-        always(lift_state(safety::pending_req_in_flight_or_resp_in_flight_at_after_create_obj_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateStatefulSet))),
-        always(lift_state(safety::pending_req_in_flight_or_resp_in_flight_at_after_create_obj_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateHeadlessService))),
-        always(lift_state(safety::pending_req_in_flight_or_resp_in_flight_at_after_create_obj_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateClientService))),
-        always(lift_state(safety::pending_req_in_flight_or_resp_in_flight_at_after_create_obj_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateAdminServerService))),
-        always(lift_state(safety::pending_req_in_flight_or_resp_in_flight_at_after_create_obj_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateConfigMap))),
-        always(lift_state(safety::pending_req_in_flight_or_resp_in_flight_at_after_get_stateful_set_step(zk.object_ref())))
+        always(lift_state(safety::pending_req_in_flight_or_resp_in_flight_at_step(zk.object_ref(), ZookeeperReconcileStep::AfterUpdateStatefulSet))),
+        always(lift_state(safety::pending_req_in_flight_or_resp_in_flight_at_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateStatefulSet))),
+        always(lift_state(safety::pending_req_in_flight_or_resp_in_flight_at_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateHeadlessService))),
+        always(lift_state(safety::pending_req_in_flight_or_resp_in_flight_at_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateClientService))),
+        always(lift_state(safety::pending_req_in_flight_or_resp_in_flight_at_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateAdminServerService))),
+        always(lift_state(safety::pending_req_in_flight_or_resp_in_flight_at_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateConfigMap))),
+        always(lift_state(safety::pending_req_in_flight_or_resp_in_flight_at_step(zk.object_ref(), ZookeeperReconcileStep::AfterGetStatefulSet)))
     );
 }
 
@@ -420,13 +420,13 @@ proof fn liveness_proof(zk: ZookeeperClusterView)
             safety::lemma_always_pending_msg_at_after_create_stateful_set_step_is_create_sts_req(spec, zk.object_ref());
             safety::lemma_always_pending_msg_at_after_update_stateful_set_step_is_update_sts_req(spec, zk.object_ref());
             safety::lemma_always_reconcile_init_implies_no_pending_req(spec, zk.object_ref());
-            safety::lemma_always_pending_req_in_flight_or_resp_in_flight_at_after_update_stateful_set_step(spec, zk.object_ref());
-            safety::lemma_always_pending_req_in_flight_or_resp_in_flight_at_after_create_obj_step(spec, zk.object_ref(), ZookeeperReconcileStep::AfterCreateStatefulSet);
-            safety::lemma_always_pending_req_in_flight_or_resp_in_flight_at_after_create_obj_step(spec, zk.object_ref(), ZookeeperReconcileStep::AfterCreateHeadlessService);
-            safety::lemma_always_pending_req_in_flight_or_resp_in_flight_at_after_create_obj_step(spec, zk.object_ref(), ZookeeperReconcileStep::AfterCreateClientService);
-            safety::lemma_always_pending_req_in_flight_or_resp_in_flight_at_after_create_obj_step(spec, zk.object_ref(), ZookeeperReconcileStep::AfterCreateAdminServerService);
-            safety::lemma_always_pending_req_in_flight_or_resp_in_flight_at_after_create_obj_step(spec, zk.object_ref(), ZookeeperReconcileStep::AfterCreateConfigMap);
-            safety::lemma_always_pending_req_in_flight_or_resp_in_flight_at_after_get_stateful_set_step(spec, zk.object_ref());
+            safety::lemma_always_pending_req_in_flight_or_resp_in_flight_at_step(spec, zk.object_ref(), ZookeeperReconcileStep::AfterUpdateStatefulSet);
+            safety::lemma_always_pending_req_in_flight_or_resp_in_flight_at_step(spec, zk.object_ref(), ZookeeperReconcileStep::AfterCreateStatefulSet);
+            safety::lemma_always_pending_req_in_flight_or_resp_in_flight_at_step(spec, zk.object_ref(), ZookeeperReconcileStep::AfterCreateHeadlessService);
+            safety::lemma_always_pending_req_in_flight_or_resp_in_flight_at_step(spec, zk.object_ref(), ZookeeperReconcileStep::AfterCreateClientService);
+            safety::lemma_always_pending_req_in_flight_or_resp_in_flight_at_step(spec, zk.object_ref(), ZookeeperReconcileStep::AfterCreateAdminServerService);
+            safety::lemma_always_pending_req_in_flight_or_resp_in_flight_at_step(spec, zk.object_ref(), ZookeeperReconcileStep::AfterCreateConfigMap);
+            safety::lemma_always_pending_req_in_flight_or_resp_in_flight_at_step(spec, zk.object_ref(), ZookeeperReconcileStep::AfterGetStatefulSet);
 
             entails_and_n!(
                 spec,
@@ -440,13 +440,13 @@ proof fn liveness_proof(zk: ZookeeperClusterView)
                 always(lift_state(safety::pending_msg_at_after_create_stateful_set_step_is_create_sts_req(zk.object_ref()))),
                 always(lift_state(safety::pending_msg_at_after_update_stateful_set_step_is_update_sts_req(zk.object_ref()))),
                 always(lift_state(safety::reconcile_init_implies_no_pending_req(zk.object_ref()))),
-                always(lift_state(safety::pending_req_in_flight_or_resp_in_flight_at_after_update_stateful_set_step(zk.object_ref()))),
-                always(lift_state(safety::pending_req_in_flight_or_resp_in_flight_at_after_create_obj_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateStatefulSet))),
-                always(lift_state(safety::pending_req_in_flight_or_resp_in_flight_at_after_create_obj_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateHeadlessService))),
-                always(lift_state(safety::pending_req_in_flight_or_resp_in_flight_at_after_create_obj_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateClientService))),
-                always(lift_state(safety::pending_req_in_flight_or_resp_in_flight_at_after_create_obj_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateAdminServerService))),
-                always(lift_state(safety::pending_req_in_flight_or_resp_in_flight_at_after_create_obj_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateConfigMap))),
-                always(lift_state(safety::pending_req_in_flight_or_resp_in_flight_at_after_get_stateful_set_step(zk.object_ref())))
+                always(lift_state(safety::pending_req_in_flight_or_resp_in_flight_at_step(zk.object_ref(), ZookeeperReconcileStep::AfterUpdateStatefulSet))),
+                always(lift_state(safety::pending_req_in_flight_or_resp_in_flight_at_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateStatefulSet))),
+                always(lift_state(safety::pending_req_in_flight_or_resp_in_flight_at_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateHeadlessService))),
+                always(lift_state(safety::pending_req_in_flight_or_resp_in_flight_at_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateClientService))),
+                always(lift_state(safety::pending_req_in_flight_or_resp_in_flight_at_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateAdminServerService))),
+                always(lift_state(safety::pending_req_in_flight_or_resp_in_flight_at_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateConfigMap))),
+                always(lift_state(safety::pending_req_in_flight_or_resp_in_flight_at_step(zk.object_ref(), ZookeeperReconcileStep::AfterGetStatefulSet)))
             );
 
             simplify_predicate(spec, invariants(zk));

--- a/src/controller_examples/zookeeper_controller/proof/safety.rs
+++ b/src/controller_examples/zookeeper_controller/proof/safety.rs
@@ -380,7 +380,6 @@ pub proof fn lemma_always_at_most_one_create_sts_req_since_rest_id_is_in_flight(
     );
 }
 
-
 pub open spec fn sts_update_request_msg(key: ObjectRef) -> FnSpec(Message) -> bool {
     |msg: Message|
         msg.dst.is_KubernetesAPI()
@@ -394,105 +393,25 @@ pub open spec fn sts_update_request_msg_since(key: ObjectRef, rest_id: RestId) -
         && msg.content.get_rest_id() >= rest_id
 }
 
-pub open spec fn req_msg_is_the_in_flight_pending_req_at_after_create_admin_server_service_step(
-    key: ObjectRef, req_msg: Message
+pub open spec fn req_msg_is_the_in_flight_pending_req_at_step(
+    key: ObjectRef, step: ZookeeperReconcileStep, req_msg: Message
 ) -> StatePred<ClusterState> {
     |s: ClusterState| {
-        at_zookeeper_step(key, ZookeeperReconcileStep::AfterCreateAdminServerService)(s)
+        at_zookeeper_step(key, step)(s)
         && s.reconcile_state_of(key).pending_req_msg == Option::Some(req_msg)
         && is_controller_request(req_msg)
         && s.message_in_flight(req_msg)
     }
 }
 
-pub open spec fn req_msg_is_the_in_flight_pending_req_at_after_create_config_map_step(
-    key: ObjectRef, req_msg: Message
-) -> StatePred<ClusterState> {
-    |s: ClusterState| {
-        at_zookeeper_step(key, ZookeeperReconcileStep::AfterCreateConfigMap)(s)
-        && s.reconcile_state_of(key).pending_req_msg == Option::Some(req_msg)
-        && is_controller_request(req_msg)
-        && s.message_in_flight(req_msg)
-    }
-}
-
-pub open spec fn req_msg_is_the_in_flight_pending_req_at_after_create_client_service_step(
-    key: ObjectRef, req_msg: Message
-) -> StatePred<ClusterState> {
-    |s: ClusterState| {
-        at_zookeeper_step(key, ZookeeperReconcileStep::AfterCreateClientService)(s)
-        && s.reconcile_state_of(key).pending_req_msg == Option::Some(req_msg)
-        && is_controller_request(req_msg)
-        && s.message_in_flight(req_msg)
-    }
-}
-
-pub open spec fn req_msg_is_the_in_flight_pending_req_at_after_create_headless_service_step(
-    key: ObjectRef, req_msg: Message
-) -> StatePred<ClusterState> {
-    |s: ClusterState| {
-        at_zookeeper_step(key, ZookeeperReconcileStep::AfterCreateHeadlessService)(s)
-        && s.reconcile_state_of(key).pending_req_msg == Option::Some(req_msg)
-        && is_controller_request(req_msg)
-        && s.message_in_flight(req_msg)
-    }
-}
-
-pub open spec fn req_msg_is_the_in_flight_pending_req_at_after_create_stateful_set_step(
-    key: ObjectRef, req_msg: Message
-) -> StatePred<ClusterState> {
-    |s: ClusterState| {
-        at_zookeeper_step(key, ZookeeperReconcileStep::AfterCreateStatefulSet)(s)
-        && s.reconcile_state_of(key).pending_req_msg == Option::Some(req_msg)
-        && is_controller_request(req_msg)
-        && s.message_in_flight(req_msg)
-    }
-}
-
-pub open spec fn req_msg_is_the_in_flight_pending_req_at_after_get_stateful_set_step(
-    key: ObjectRef, req_msg: Message
-) -> StatePred<ClusterState> {
-    |s: ClusterState| {
-        at_zookeeper_step(key, ZookeeperReconcileStep::AfterGetStatefulSet)(s)
-        && s.reconcile_state_of(key).pending_req_msg == Option::Some(req_msg)
-        && is_controller_request(req_msg)
-        && s.message_in_flight(req_msg)
-    }
-}
-
-pub open spec fn req_msg_is_the_in_flight_pending_req_at_after_update_stateful_set_step(
-    key: ObjectRef, req_msg: Message
-) -> StatePred<ClusterState> {
-    |s: ClusterState| {
-        at_zookeeper_step(key, ZookeeperReconcileStep::AfterUpdateStatefulSet)(s)
-        && s.reconcile_state_of(key).pending_req_msg == Option::Some(req_msg)
-        && is_controller_request(req_msg)
-        && s.message_in_flight(req_msg)
-    }
-}
-
-pub open spec fn at_after_create_headless_service_step_and_pending_req_in_flight(
-    key: ObjectRef
+pub open spec fn resp_in_flight_matches_pending_req_at_step(
+    key: ObjectRef, step: ZookeeperReconcileStep
 ) -> StatePred<ClusterState>
     recommends
         key.kind.is_CustomResourceKind(),
 {
     |s: ClusterState| {
-        at_zookeeper_step(key, ZookeeperReconcileStep::AfterCreateHeadlessService)(s)
-        && s.reconcile_state_of(key).pending_req_msg.is_Some()
-        && is_controller_request(s.pending_req_of(key))
-        && s.message_in_flight(s.pending_req_of(key))
-    }
-}
-
-pub open spec fn at_after_create_headless_service_step_and_resp_matches_pending_req_in_flight(
-    key: ObjectRef
-) -> StatePred<ClusterState>
-    recommends
-        key.kind.is_CustomResourceKind(),
-{
-    |s: ClusterState| {
-        at_zookeeper_step(key, ZookeeperReconcileStep::AfterCreateHeadlessService)(s)
+        at_zookeeper_step(key, step)(s)
         && s.reconcile_state_of(key).pending_req_msg.is_Some()
         && is_controller_request(s.pending_req_of(key))
         && exists |resp_msg: Message| {
@@ -502,189 +421,17 @@ pub open spec fn at_after_create_headless_service_step_and_resp_matches_pending_
     }
 }
 
-pub open spec fn at_after_create_admin_server_service_step_and_pending_req_in_flight(
-    key: ObjectRef
+pub open spec fn pending_req_in_flight_at_step(
+    key: ObjectRef, step: ZookeeperReconcileStep
 ) -> StatePred<ClusterState>
     recommends
         key.kind.is_CustomResourceKind(),
 {
     |s: ClusterState| {
-        at_zookeeper_step(key, ZookeeperReconcileStep::AfterCreateAdminServerService)(s)
+        at_zookeeper_step(key, step)(s)
         && s.reconcile_state_of(key).pending_req_msg.is_Some()
         && is_controller_request(s.pending_req_of(key))
         && s.message_in_flight(s.pending_req_of(key))
-    }
-}
-
-pub open spec fn at_after_create_admin_server_service_step_and_resp_matches_pending_req_in_flight(
-    key: ObjectRef
-) -> StatePred<ClusterState>
-    recommends
-        key.kind.is_CustomResourceKind(),
-{
-    |s: ClusterState| {
-        at_zookeeper_step(key, ZookeeperReconcileStep::AfterCreateAdminServerService)(s)
-        && s.reconcile_state_of(key).pending_req_msg.is_Some()
-        && is_controller_request(s.pending_req_of(key))
-        && exists |resp_msg: Message| {
-            #[trigger] s.message_in_flight(resp_msg)
-            && resp_msg_matches_req_msg(resp_msg, s.pending_req_of(key))
-        }
-    }
-}
-
-pub open spec fn at_after_create_config_map_step_and_pending_req_in_flight(
-    key: ObjectRef
-) -> StatePred<ClusterState>
-    recommends
-        key.kind.is_CustomResourceKind(),
-{
-    |s: ClusterState| {
-        at_zookeeper_step(key, ZookeeperReconcileStep::AfterCreateConfigMap)(s)
-        && s.reconcile_state_of(key).pending_req_msg.is_Some()
-        && is_controller_request(s.pending_req_of(key))
-        && s.message_in_flight(s.pending_req_of(key))
-    }
-}
-
-pub open spec fn at_after_create_config_map_step_and_resp_matches_pending_req_in_flight(
-    key: ObjectRef
-) -> StatePred<ClusterState>
-    recommends
-        key.kind.is_CustomResourceKind(),
-{
-    |s: ClusterState| {
-        at_zookeeper_step(key, ZookeeperReconcileStep::AfterCreateConfigMap)(s)
-        && s.reconcile_state_of(key).pending_req_msg.is_Some()
-        && is_controller_request(s.pending_req_of(key))
-        && exists |resp_msg: Message| {
-            #[trigger] s.message_in_flight(resp_msg)
-            && resp_msg_matches_req_msg(resp_msg, s.pending_req_of(key))
-        }
-    }
-}
-
-pub open spec fn at_after_create_client_service_step_and_pending_req_in_flight(
-    key: ObjectRef
-) -> StatePred<ClusterState>
-    recommends
-        key.kind.is_CustomResourceKind(),
-{
-    |s: ClusterState| {
-        at_zookeeper_step(key, ZookeeperReconcileStep::AfterCreateClientService)(s)
-        && s.reconcile_state_of(key).pending_req_msg.is_Some()
-        && is_controller_request(s.pending_req_of(key))
-        && s.message_in_flight(s.pending_req_of(key))
-    }
-}
-
-pub open spec fn at_after_create_client_service_step_and_resp_matches_pending_req_in_flight(
-    key: ObjectRef
-) -> StatePred<ClusterState>
-    recommends
-        key.kind.is_CustomResourceKind(),
-{
-    |s: ClusterState| {
-        at_zookeeper_step(key, ZookeeperReconcileStep::AfterCreateClientService)(s)
-        && s.reconcile_state_of(key).pending_req_msg.is_Some()
-        && is_controller_request(s.pending_req_of(key))
-        && exists |resp_msg: Message| {
-            #[trigger] s.message_in_flight(resp_msg)
-            && resp_msg_matches_req_msg(resp_msg, s.pending_req_of(key))
-        }
-    }
-}
-
-pub open spec fn at_after_get_stateful_set_step_and_pending_req_in_flight(
-    key: ObjectRef
-) -> StatePred<ClusterState>
-    recommends
-        key.kind.is_CustomResourceKind(),
-{
-    |s: ClusterState| {
-        at_zookeeper_step(key, ZookeeperReconcileStep::AfterGetStatefulSet)(s)
-        && s.reconcile_state_of(key).pending_req_msg.is_Some()
-        && is_controller_request(s.pending_req_of(key))
-        && s.message_in_flight(s.pending_req_of(key))
-    }
-}
-
-pub open spec fn at_after_get_stateful_set_step_and_resp_matches_pending_req_in_flight(
-    key: ObjectRef
-) -> StatePred<ClusterState>
-    recommends
-        key.kind.is_CustomResourceKind(),
-{
-    |s: ClusterState| {
-        at_zookeeper_step(key, ZookeeperReconcileStep::AfterGetStatefulSet)(s)
-        && s.reconcile_state_of(key).pending_req_msg.is_Some()
-        && is_controller_request(s.pending_req_of(key))
-        && exists |resp_msg: Message| {
-            #[trigger] s.message_in_flight(resp_msg)
-            && resp_msg_matches_req_msg(resp_msg, s.pending_req_of(key))
-        }
-    }
-}
-
-pub open spec fn at_after_create_stateful_set_step_and_pending_req_in_flight(
-    key: ObjectRef
-) -> StatePred<ClusterState>
-    recommends
-        key.kind.is_CustomResourceKind(),
-{
-    |s: ClusterState| {
-        at_zookeeper_step(key, ZookeeperReconcileStep::AfterCreateStatefulSet)(s)
-        && s.reconcile_state_of(key).pending_req_msg.is_Some()
-        && is_controller_request(s.pending_req_of(key))
-        && s.message_in_flight(s.pending_req_of(key))
-    }
-}
-
-pub open spec fn at_after_create_stateful_set_step_and_resp_matches_pending_req_in_flight(
-    key: ObjectRef
-) -> StatePred<ClusterState>
-    recommends
-        key.kind.is_CustomResourceKind(),
-{
-    |s: ClusterState| {
-        at_zookeeper_step(key, ZookeeperReconcileStep::AfterCreateStatefulSet)(s)
-        && s.reconcile_state_of(key).pending_req_msg.is_Some()
-        && is_controller_request(s.pending_req_of(key))
-        && exists |resp_msg: Message| {
-            #[trigger] s.message_in_flight(resp_msg)
-            && resp_msg_matches_req_msg(resp_msg, s.pending_req_of(key))
-        }
-    }
-}
-
-pub open spec fn at_after_update_stateful_set_step_and_pending_req_in_flight(
-    key: ObjectRef
-) -> StatePred<ClusterState>
-    recommends
-        key.kind.is_CustomResourceKind(),
-{
-    |s: ClusterState| {
-        at_zookeeper_step(key, ZookeeperReconcileStep::AfterUpdateStatefulSet)(s)
-        && s.reconcile_state_of(key).pending_req_msg.is_Some()
-        && is_controller_request(s.pending_req_of(key))
-        && s.message_in_flight(s.pending_req_of(key))
-    }
-}
-
-pub open spec fn at_after_update_stateful_set_step_and_resp_matches_pending_req_in_flight(
-    key: ObjectRef
-) -> StatePred<ClusterState>
-    recommends
-        key.kind.is_CustomResourceKind(),
-{
-    |s: ClusterState| {
-        at_zookeeper_step(key, ZookeeperReconcileStep::AfterUpdateStatefulSet)(s)
-        && s.reconcile_state_of(key).pending_req_msg.is_Some()
-        && is_controller_request(s.pending_req_of(key))
-        && exists |resp_msg: Message| {
-            #[trigger] s.message_in_flight(resp_msg)
-            && resp_msg_matches_req_msg(resp_msg, s.pending_req_of(key))
-        }
     }
 }
 

--- a/src/controller_examples/zookeeper_controller/proof/terminate.rs
+++ b/src/controller_examples/zookeeper_controller/proof/terminate.rs
@@ -151,8 +151,16 @@ pub proof fn lemma_from_after_update_stateful_set_step_to_reconcile_idle(spec: T
     // 1. resp_in_flight ~> done_step
     // 2. req_in_flight ~> resp_in_flight ~> done_step
     let done_step = reconciler_reconcile_done::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>(zk.object_ref());
-    lemma_from_at_after_update_stateful_set_step_and_resp_matches_pending_req_in_flight_to_done_step(spec, zk);
-    lemma_from_at_after_update_stateful_set_step_and_pending_req_in_flight_to_done_step(spec, zk);
+    lemma_from_step_a_and_resp_matches_pending_req_in_flight_to_step_b(
+        spec, zk, ZookeeperReconcileStep::AfterUpdateStatefulSet, ZookeeperReconcileStep::Done
+    );
+    temp_pred_equality(
+        lift_state(at_zookeeper_step(zk.object_ref(), ZookeeperReconcileStep::Done)),
+        lift_state(reconciler_reconcile_done::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>(zk.object_ref()))
+    );
+    lemma_from_pending_req_in_flight_at_step_a_to_step_b(
+        spec, zk, ZookeeperReconcileStep::AfterUpdateStatefulSet, ZookeeperReconcileStep::Done
+    );
     or_leads_to_combine(spec, req_in_flight, resp_in_flight, done_step);
     temp_pred_equality::<ClusterState>(
         lift_state(req_in_flight).or(lift_state(resp_in_flight)),
@@ -213,8 +221,16 @@ pub proof fn lemma_from_after_create_stateful_set_step_to_reconcile_idle(spec: T
     // 1. resp_in_flight ~> done_step
     // 2. req_in_flight ~> resp_in_flight ~> done_step
     let done_step = reconciler_reconcile_done::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>(zk.object_ref());
-    lemma_from_at_after_create_stateful_set_step_and_resp_matches_pending_req_in_flight_to_done_step(spec, zk);
-    lemma_from_at_after_create_stateful_set_step_and_pending_req_in_flight_to_done_step(spec, zk);
+    lemma_from_step_a_and_resp_matches_pending_req_in_flight_to_step_b(
+        spec, zk, ZookeeperReconcileStep::AfterCreateStatefulSet, ZookeeperReconcileStep::Done
+    );
+    temp_pred_equality(
+        lift_state(at_zookeeper_step(zk.object_ref(), ZookeeperReconcileStep::Done)),
+        lift_state(reconciler_reconcile_done::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>(zk.object_ref()))
+    );
+    lemma_from_pending_req_in_flight_at_step_a_to_step_b(
+        spec, zk, ZookeeperReconcileStep::AfterCreateStatefulSet, ZookeeperReconcileStep::Done
+    );
     or_leads_to_combine(spec, req_in_flight, resp_in_flight, done_step);
     temp_pred_equality::<ClusterState>(
         lift_state(req_in_flight).or(lift_state(resp_in_flight)),
@@ -326,8 +342,12 @@ pub proof fn lemma_from_after_create_config_map_step_to_reconcile_idle(spec: Tem
     let resp_in_flight = resp_in_flight_matches_pending_req_at_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateConfigMap);
 
     let done_step = reconciler_reconcile_done::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>(zk.object_ref());
-    lemma_from_at_after_create_config_map_step_and_resp_matches_pending_req_in_flight_to_after_get_stateful_set_step(spec, zk);
-    lemma_from_at_after_create_config_map_step_and_pending_req_in_flight_to_after_get_stateful_set_step(spec, zk);
+    lemma_from_step_a_and_resp_matches_pending_req_in_flight_to_step_b(
+        spec, zk, ZookeeperReconcileStep::AfterCreateConfigMap, ZookeeperReconcileStep::AfterGetStatefulSet
+    );
+    lemma_from_pending_req_in_flight_at_step_a_to_step_b(
+        spec, zk, ZookeeperReconcileStep::AfterCreateConfigMap, ZookeeperReconcileStep::AfterGetStatefulSet
+    );
     or_leads_to_combine(spec, req_in_flight, resp_in_flight, at_zookeeper_step(zk.object_ref(), ZookeeperReconcileStep::AfterGetStatefulSet));
     temp_pred_equality::<ClusterState>(
         lift_state(req_in_flight).or(lift_state(resp_in_flight)),
@@ -385,8 +405,12 @@ pub proof fn lemma_from_after_create_admin_server_service_step_to_reconcile_idle
     let resp_in_flight = resp_in_flight_matches_pending_req_at_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateAdminServerService);
 
     let done_step = reconciler_reconcile_done::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>(zk.object_ref());
-    lemma_from_at_after_create_admin_server_service_step_and_resp_matches_pending_req_in_flight_to_after_create_config_map_step(spec, zk);
-    lemma_from_at_after_create_admin_server_service_step_and_pending_req_in_flight_to_after_create_config_map_step(spec, zk);
+    lemma_from_step_a_and_resp_matches_pending_req_in_flight_to_step_b(
+        spec, zk, ZookeeperReconcileStep::AfterCreateAdminServerService, ZookeeperReconcileStep::AfterCreateConfigMap
+    );
+    lemma_from_pending_req_in_flight_at_step_a_to_step_b(
+        spec, zk, ZookeeperReconcileStep::AfterCreateAdminServerService, ZookeeperReconcileStep::AfterCreateConfigMap
+    );
     or_leads_to_combine(spec, req_in_flight, resp_in_flight, at_zookeeper_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateConfigMap));
     temp_pred_equality::<ClusterState>(
         lift_state(req_in_flight).or(lift_state(resp_in_flight)),
@@ -442,13 +466,13 @@ pub proof fn lemma_from_after_create_client_service_step_to_reconcile_idle(spec:
 
     let req_in_flight = pending_req_in_flight_at_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateClientService);
     let resp_in_flight = resp_in_flight_matches_pending_req_at_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateClientService);
-    // To show after_update_sts_step ~> done_step
-    // Use or_leads_to_combine after discussing the two cases:
-    // 1. resp_in_flight ~> done_step
-    // 2. req_in_flight ~> resp_in_flight ~> done_step
-    let done_step = reconciler_reconcile_done::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>(zk.object_ref());
-    lemma_from_at_after_create_client_service_step_and_resp_matches_pending_req_in_flight_to_after_create_admin_server_service_step(spec, zk);
-    lemma_from_at_after_create_client_service_step_and_pending_req_in_flight_to_after_create_admin_server_service_step(spec, zk);
+
+    lemma_from_step_a_and_resp_matches_pending_req_in_flight_to_step_b(
+        spec, zk, ZookeeperReconcileStep::AfterCreateClientService, ZookeeperReconcileStep::AfterCreateAdminServerService
+    );
+    lemma_from_pending_req_in_flight_at_step_a_to_step_b(
+        spec, zk, ZookeeperReconcileStep::AfterCreateClientService, ZookeeperReconcileStep::AfterCreateAdminServerService
+    );
     or_leads_to_combine(spec, req_in_flight, resp_in_flight, at_zookeeper_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateAdminServerService));
     temp_pred_equality::<ClusterState>(
         lift_state(req_in_flight).or(lift_state(resp_in_flight)),
@@ -505,8 +529,12 @@ pub proof fn lemma_from_after_create_headless_service_step_to_reconcile_idle(spe
     let req_in_flight = pending_req_in_flight_at_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateHeadlessService);
     let resp_in_flight = resp_in_flight_matches_pending_req_at_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateHeadlessService);
 
-    lemma_from_at_after_create_headless_service_step_and_resp_matches_pending_req_in_flight_to_after_create_client_service_step(spec, zk);
-    lemma_from_at_after_create_headless_service_step_and_pending_req_in_flight_to_after_create_client_service_step(spec, zk);
+    lemma_from_step_a_and_resp_matches_pending_req_in_flight_to_step_b(
+        spec, zk, ZookeeperReconcileStep::AfterCreateHeadlessService, ZookeeperReconcileStep::AfterCreateClientService
+    );
+    lemma_from_pending_req_in_flight_at_step_a_to_step_b(
+        spec, zk, ZookeeperReconcileStep::AfterCreateHeadlessService, ZookeeperReconcileStep::AfterCreateClientService
+    );
     or_leads_to_combine(spec, req_in_flight, resp_in_flight, at_zookeeper_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateClientService));
     temp_pred_equality::<ClusterState>(
         lift_state(req_in_flight).or(lift_state(resp_in_flight)),
@@ -578,1054 +606,6 @@ pub proof fn lemma_from_init_step_to_reconcile_idle(spec: TempPred<ClusterState>
         lift_state(reconciler_init_and_no_pending_req::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>(zk.object_ref())),
         lift_state(at_zookeeper_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateHeadlessService)),
         lift_state(|s: ClusterState| !s.reconcile_state_contains(zk.object_ref()))
-    );
-}
-
-proof fn lemma_from_at_after_update_stateful_set_step_and_pending_req_in_flight_to_done_step(spec: TempPred<ClusterState>, zk: ZookeeperClusterView)
-    requires
-        zk.well_formed(),
-        spec.entails(always(lift_action(next::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>()))),
-        spec.entails(tla_forall(|i| kubernetes_api_next().weak_fairness(i))),
-        spec.entails(tla_forall(|i| controller_next::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>().weak_fairness(i))),
-        spec.entails(always(lift_state(crash_disabled()))),
-        spec.entails(always(lift_state(controller_runtime_safety::every_in_flight_msg_has_unique_id()))),
-        spec.entails(always(lift_state(controller_runtime_safety::each_resp_matches_at_most_one_pending_req(zk.object_ref())))),
-        spec.entails(always(lift_state(controller_runtime_safety::each_resp_if_matches_pending_req_then_no_other_resp_matches(zk.object_ref())))),
-        spec.entails(always(lift_state(reconcile_init_implies_no_pending_req(zk.object_ref())))),
-        spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_step(zk.object_ref(), ZookeeperReconcileStep::AfterUpdateStatefulSet)))),
-        spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateStatefulSet)))),
-        spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateHeadlessService)))),
-        spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateClientService)))),
-        spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateAdminServerService)))),
-        spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateConfigMap)))),
-        spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_step(zk.object_ref(), ZookeeperReconcileStep::AfterGetStatefulSet)))),
-    ensures
-        spec.entails(lift_state(pending_req_in_flight_at_step(zk.object_ref(), ZookeeperReconcileStep::AfterUpdateStatefulSet)).leads_to(lift_state(reconciler_reconcile_done::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>(zk.object_ref())))),
-{
-    let pre = pending_req_in_flight_at_step(zk.object_ref(), ZookeeperReconcileStep::AfterUpdateStatefulSet);
-    let post = reconciler_reconcile_done::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>(zk.object_ref());
-    assert forall |req_msg: Message| spec.entails(
-        lift_state(#[trigger] req_msg_is_the_in_flight_pending_req_at_step(zk.object_ref(), ZookeeperReconcileStep::AfterUpdateStatefulSet, req_msg))
-            .leads_to(lift_state(resp_in_flight_matches_pending_req_at_step(zk.object_ref(), ZookeeperReconcileStep::AfterUpdateStatefulSet)))
-    ) by {
-        let pre_1 = req_msg_is_the_in_flight_pending_req_at_step(zk.object_ref(), ZookeeperReconcileStep::AfterUpdateStatefulSet, req_msg);
-        let post_1 = resp_in_flight_matches_pending_req_at_step(zk.object_ref(), ZookeeperReconcileStep::AfterUpdateStatefulSet);
-        let stronger_next = |s, s_prime: ClusterState| {
-            &&& next::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>()(s, s_prime)
-            &&& crash_disabled()(s)
-            &&& controller_runtime_safety::every_in_flight_msg_has_unique_id()(s)
-        };
-        entails_always_and_n!(
-            spec,
-            lift_action(next::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>()),
-            lift_state(crash_disabled()),
-            lift_state(controller_runtime_safety::every_in_flight_msg_has_unique_id())
-        );
-        temp_pred_equality(
-            lift_action(stronger_next),
-            lift_action(next::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>())
-            .and(lift_state(crash_disabled()))
-            .and(lift_state(controller_runtime_safety::every_in_flight_msg_has_unique_id()))
-        );
-        let input = Option::Some(req_msg);
-        assert forall |s, s_prime: ClusterState| pre_1(s) && #[trigger] stronger_next(s, s_prime)
-        && kubernetes_api_next().forward(input)(s, s_prime) implies post_1(s_prime) by {
-            let resp_msg = transition_by_etcd(req_msg, s.kubernetes_api_state).1;
-            assert({
-                &&& s_prime.message_in_flight(resp_msg)
-                &&& resp_msg_matches_req_msg(resp_msg, req_msg)
-            });
-        };
-        lemma_pre_leads_to_post_by_kubernetes_api::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>(
-            spec, input, stronger_next, handle_request(), pre_1, post_1
-        );
-    }
-    let msg_2_temp = |msg| lift_state(req_msg_is_the_in_flight_pending_req_at_step(zk.object_ref(), ZookeeperReconcileStep::AfterUpdateStatefulSet, msg));
-    leads_to_exists_intro(
-        spec, msg_2_temp,
-        lift_state(resp_in_flight_matches_pending_req_at_step(zk.object_ref(), ZookeeperReconcileStep::AfterUpdateStatefulSet))
-    );
-    assert_by(
-        tla_exists(|msg| lift_state(req_msg_is_the_in_flight_pending_req_at_step(zk.object_ref(), ZookeeperReconcileStep::AfterUpdateStatefulSet, msg)))
-        == lift_state(pre),
-        {
-            assert forall |ex| #[trigger] lift_state(pre).satisfied_by(ex) implies
-            tla_exists(msg_2_temp).satisfied_by(ex) by {
-                let req_msg = ex.head().pending_req_of(zk.object_ref());
-                assert(msg_2_temp(req_msg).satisfied_by(ex));
-            }
-            temp_pred_equality(lift_state(pre), tla_exists(msg_2_temp));
-        }
-    );
-    lemma_from_at_after_update_stateful_set_step_and_resp_matches_pending_req_in_flight_to_done_step(spec, zk);
-    leads_to_trans_n!(
-        spec,
-        lift_state(pre),
-        lift_state(resp_in_flight_matches_pending_req_at_step(zk.object_ref(), ZookeeperReconcileStep::AfterUpdateStatefulSet)),
-        lift_state(post)
-    );
-}
-
-proof fn lemma_from_at_after_update_stateful_set_step_and_resp_matches_pending_req_in_flight_to_done_step(spec: TempPred<ClusterState>, zk: ZookeeperClusterView)
-    requires
-        zk.well_formed(),
-        spec.entails(always(lift_action(next::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>()))),
-        spec.entails(tla_forall(|i| kubernetes_api_next().weak_fairness(i))),
-        spec.entails(tla_forall(|i| controller_next::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>().weak_fairness(i))),
-        spec.entails(always(lift_state(crash_disabled()))),
-        spec.entails(always(lift_state(controller_runtime_safety::every_in_flight_msg_has_unique_id()))),
-        spec.entails(always(lift_state(controller_runtime_safety::each_resp_matches_at_most_one_pending_req(zk.object_ref())))),
-        spec.entails(always(lift_state(controller_runtime_safety::each_resp_if_matches_pending_req_then_no_other_resp_matches(zk.object_ref())))),
-        spec.entails(always(lift_state(reconcile_init_implies_no_pending_req(zk.object_ref())))),
-        spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_step(zk.object_ref(), ZookeeperReconcileStep::AfterUpdateStatefulSet)))),
-        spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateStatefulSet)))),
-        spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateHeadlessService)))),
-        spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateClientService)))),
-        spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateAdminServerService)))),
-        spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateConfigMap)))),
-        spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_step(zk.object_ref(), ZookeeperReconcileStep::AfterGetStatefulSet)))),
-    ensures
-        spec.entails(lift_state(resp_in_flight_matches_pending_req_at_step(zk.object_ref(), ZookeeperReconcileStep::AfterUpdateStatefulSet)).leads_to(lift_state(reconciler_reconcile_done::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>(zk.object_ref())))),
-{
-    let pre = resp_in_flight_matches_pending_req_at_step(zk.object_ref(), ZookeeperReconcileStep::AfterUpdateStatefulSet);
-    let post = reconciler_reconcile_done::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>(zk.object_ref());
-    let stronger_next = |s, s_prime: ClusterState| {
-        &&& next::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>()(s, s_prime)
-        &&& crash_disabled()(s)
-        &&& controller_runtime_safety::each_resp_matches_at_most_one_pending_req(zk.object_ref())(s)
-        &&& controller_runtime_safety::each_resp_if_matches_pending_req_then_no_other_resp_matches(zk.object_ref())(s)
-    };
-    entails_always_and_n!(
-        spec,
-        lift_action(next::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>()),
-        lift_state(crash_disabled()),
-        lift_state(controller_runtime_safety::each_resp_matches_at_most_one_pending_req(zk.object_ref())),
-        lift_state(controller_runtime_safety::each_resp_if_matches_pending_req_then_no_other_resp_matches(zk.object_ref()))
-    );
-    temp_pred_equality(
-        lift_action(stronger_next),
-        lift_action(next::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>())
-        .and(lift_state(crash_disabled()))
-        .and(lift_state(controller_runtime_safety::each_resp_matches_at_most_one_pending_req(zk.object_ref())))
-        .and(lift_state(controller_runtime_safety::each_resp_if_matches_pending_req_then_no_other_resp_matches(zk.object_ref())))
-    );
-    let known_resp_in_flight = |resp| lift_state(
-        |s: ClusterState| {
-            at_zookeeper_step(zk.object_ref(), ZookeeperReconcileStep::AfterUpdateStatefulSet)(s)
-            && s.reconcile_state_of(zk.object_ref()).pending_req_msg.is_Some()
-            && is_controller_request(s.pending_req_of(zk.object_ref()))
-            && s.message_in_flight(resp)
-            && resp_msg_matches_req_msg(resp, s.pending_req_of(zk.object_ref()))
-        }
-    );
-    assert forall |msg: Message| spec.entails(#[trigger] known_resp_in_flight(msg)
-        .leads_to(lift_state(post))) by {
-            let resp_in_flight_state = |s: ClusterState| {
-                at_zookeeper_step(zk.object_ref(), ZookeeperReconcileStep::AfterUpdateStatefulSet)(s)
-                && s.reconcile_state_of(zk.object_ref()).pending_req_msg.is_Some()
-                && is_controller_request(s.pending_req_of(zk.object_ref()))
-                && s.message_in_flight(msg)
-                && resp_msg_matches_req_msg(msg, s.pending_req_of(zk.object_ref()))
-            };
-            let input = (Option::Some(msg), Option::Some(zk.object_ref()));
-            lemma_pre_leads_to_post_by_controller::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>(
-                spec,
-                input,
-                stronger_next,
-                continue_reconcile::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>(),
-                resp_in_flight_state,
-                post
-            );
-    };
-    leads_to_exists_intro::<ClusterState, Message>(spec, known_resp_in_flight, lift_state(post));
-    assert_by(
-        tla_exists(known_resp_in_flight) == lift_state(pre),
-        {
-            assert forall |ex| #[trigger] lift_state(pre).satisfied_by(ex)
-            implies tla_exists(known_resp_in_flight).satisfied_by(ex) by {
-                let s = ex.head();
-                let msg = choose |resp_msg: Message| {
-                    #[trigger] s.message_in_flight(resp_msg)
-                    && resp_msg_matches_req_msg(resp_msg, s.reconcile_state_of(zk.object_ref()).pending_req_msg.get_Some_0())
-                };
-                assert(known_resp_in_flight(msg).satisfied_by(ex));
-            }
-            temp_pred_equality(tla_exists(known_resp_in_flight), lift_state(pre));
-        }
-    );
-}
-
-proof fn lemma_from_at_after_create_stateful_set_step_and_pending_req_in_flight_to_done_step(spec: TempPred<ClusterState>, zk: ZookeeperClusterView)
-    requires
-        zk.well_formed(),
-        spec.entails(always(lift_action(next::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>()))),
-        spec.entails(tla_forall(|i| kubernetes_api_next().weak_fairness(i))),
-        spec.entails(tla_forall(|i| controller_next::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>().weak_fairness(i))),
-        spec.entails(always(lift_state(crash_disabled()))),
-        spec.entails(always(lift_state(controller_runtime_safety::every_in_flight_msg_has_unique_id()))),
-        spec.entails(always(lift_state(controller_runtime_safety::each_resp_matches_at_most_one_pending_req(zk.object_ref())))),
-        spec.entails(always(lift_state(controller_runtime_safety::each_resp_if_matches_pending_req_then_no_other_resp_matches(zk.object_ref())))),
-        spec.entails(always(lift_state(reconcile_init_implies_no_pending_req(zk.object_ref())))),
-        spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_step(zk.object_ref(), ZookeeperReconcileStep::AfterUpdateStatefulSet)))),
-        spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateStatefulSet)))),
-        spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateHeadlessService)))),
-        spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateClientService)))),
-        spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateAdminServerService)))),
-        spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateConfigMap)))),
-        spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_step(zk.object_ref(), ZookeeperReconcileStep::AfterGetStatefulSet)))),
-    ensures
-        spec.entails(lift_state(pending_req_in_flight_at_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateStatefulSet)).leads_to(lift_state(reconciler_reconcile_done::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>(zk.object_ref())))),
-{
-    let pre = pending_req_in_flight_at_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateStatefulSet);
-    let post = reconciler_reconcile_done::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>(zk.object_ref());
-    assert forall |req_msg: Message| spec.entails(
-        lift_state(#[trigger] req_msg_is_the_in_flight_pending_req_at_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateStatefulSet, req_msg))
-            .leads_to(lift_state(resp_in_flight_matches_pending_req_at_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateStatefulSet)))
-    ) by {
-        let pre_1 = req_msg_is_the_in_flight_pending_req_at_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateStatefulSet, req_msg);
-        let post_1 = resp_in_flight_matches_pending_req_at_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateStatefulSet);
-        let stronger_next = |s, s_prime: ClusterState| {
-            &&& next::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>()(s, s_prime)
-            &&& crash_disabled()(s)
-            &&& controller_runtime_safety::every_in_flight_msg_has_unique_id()(s)
-        };
-        entails_always_and_n!(
-            spec,
-            lift_action(next::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>()),
-            lift_state(crash_disabled()),
-            lift_state(controller_runtime_safety::every_in_flight_msg_has_unique_id())
-        );
-        temp_pred_equality(
-            lift_action(stronger_next),
-            lift_action(next::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>())
-            .and(lift_state(crash_disabled()))
-            .and(lift_state(controller_runtime_safety::every_in_flight_msg_has_unique_id()))
-        );
-        let input = Option::Some(req_msg);
-        assert forall |s, s_prime: ClusterState| pre_1(s) && #[trigger] stronger_next(s, s_prime)
-        && kubernetes_api_next().forward(input)(s, s_prime) implies post_1(s_prime) by {
-            let resp_msg = transition_by_etcd(req_msg, s.kubernetes_api_state).1;
-            assert({
-                &&& s_prime.message_in_flight(resp_msg)
-                &&& resp_msg_matches_req_msg(resp_msg, req_msg)
-            });
-        };
-        lemma_pre_leads_to_post_by_kubernetes_api::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>(
-            spec, input, stronger_next, handle_request(), pre_1, post_1
-        );
-    }
-    let msg_2_temp = |msg| lift_state(req_msg_is_the_in_flight_pending_req_at_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateStatefulSet, msg));
-    leads_to_exists_intro(
-        spec, msg_2_temp,
-        lift_state(resp_in_flight_matches_pending_req_at_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateStatefulSet))
-    );
-    assert_by(
-        tla_exists(|msg| lift_state(req_msg_is_the_in_flight_pending_req_at_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateStatefulSet, msg)))
-        == lift_state(pre),
-        {
-            assert forall |ex| #[trigger] lift_state(pre).satisfied_by(ex) implies
-            tla_exists(msg_2_temp).satisfied_by(ex) by {
-                let req_msg = ex.head().pending_req_of(zk.object_ref());
-                assert(msg_2_temp(req_msg).satisfied_by(ex));
-            }
-            temp_pred_equality(lift_state(pre), tla_exists(msg_2_temp));
-        }
-    );
-    lemma_from_at_after_create_stateful_set_step_and_resp_matches_pending_req_in_flight_to_done_step(spec, zk);
-    leads_to_trans_n!(
-        spec,
-        lift_state(pre),
-        lift_state(resp_in_flight_matches_pending_req_at_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateStatefulSet)),
-        lift_state(post)
-    );
-}
-
-proof fn lemma_from_at_after_create_stateful_set_step_and_resp_matches_pending_req_in_flight_to_done_step(spec: TempPred<ClusterState>, zk: ZookeeperClusterView)
-    requires
-        zk.well_formed(),
-        spec.entails(always(lift_action(next::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>()))),
-        spec.entails(tla_forall(|i| kubernetes_api_next().weak_fairness(i))),
-        spec.entails(tla_forall(|i| controller_next::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>().weak_fairness(i))),
-        spec.entails(always(lift_state(crash_disabled()))),
-        spec.entails(always(lift_state(controller_runtime_safety::every_in_flight_msg_has_unique_id()))),
-        spec.entails(always(lift_state(controller_runtime_safety::each_resp_matches_at_most_one_pending_req(zk.object_ref())))),
-        spec.entails(always(lift_state(controller_runtime_safety::each_resp_if_matches_pending_req_then_no_other_resp_matches(zk.object_ref())))),
-        spec.entails(always(lift_state(reconcile_init_implies_no_pending_req(zk.object_ref())))),
-        spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_step(zk.object_ref(), ZookeeperReconcileStep::AfterUpdateStatefulSet)))),
-        spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateStatefulSet)))),
-        spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateHeadlessService)))),
-        spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateClientService)))),
-        spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateAdminServerService)))),
-        spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateConfigMap)))),
-        spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_step(zk.object_ref(), ZookeeperReconcileStep::AfterGetStatefulSet)))),
-    ensures
-        spec.entails(lift_state(resp_in_flight_matches_pending_req_at_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateStatefulSet)).leads_to(lift_state(reconciler_reconcile_done::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>(zk.object_ref())))),
-{
-    let pre = resp_in_flight_matches_pending_req_at_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateStatefulSet);
-    let post = reconciler_reconcile_done::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>(zk.object_ref());
-    let stronger_next = |s, s_prime: ClusterState| {
-        &&& next::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>()(s, s_prime)
-        &&& crash_disabled()(s)
-        &&& controller_runtime_safety::each_resp_matches_at_most_one_pending_req(zk.object_ref())(s)
-        &&& controller_runtime_safety::each_resp_if_matches_pending_req_then_no_other_resp_matches(zk.object_ref())(s)
-    };
-    entails_always_and_n!(
-        spec,
-        lift_action(next::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>()),
-        lift_state(crash_disabled()),
-        lift_state(controller_runtime_safety::each_resp_matches_at_most_one_pending_req(zk.object_ref())),
-        lift_state(controller_runtime_safety::each_resp_if_matches_pending_req_then_no_other_resp_matches(zk.object_ref()))
-    );
-    temp_pred_equality(
-        lift_action(stronger_next),
-        lift_action(next::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>())
-        .and(lift_state(crash_disabled()))
-        .and(lift_state(controller_runtime_safety::each_resp_matches_at_most_one_pending_req(zk.object_ref())))
-        .and(lift_state(controller_runtime_safety::each_resp_if_matches_pending_req_then_no_other_resp_matches(zk.object_ref())))
-    );
-    let known_resp_in_flight = |resp| lift_state(
-        |s: ClusterState| {
-            at_zookeeper_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateStatefulSet)(s)
-            && s.reconcile_state_of(zk.object_ref()).pending_req_msg.is_Some()
-            && is_controller_request(s.pending_req_of(zk.object_ref()))
-            && s.message_in_flight(resp)
-            && resp_msg_matches_req_msg(resp, s.pending_req_of(zk.object_ref()))
-        }
-    );
-    assert forall |msg: Message| spec.entails(#[trigger] known_resp_in_flight(msg)
-        .leads_to(lift_state(post))) by {
-            let resp_in_flight_state = |s: ClusterState| {
-                at_zookeeper_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateStatefulSet)(s)
-                && s.reconcile_state_of(zk.object_ref()).pending_req_msg.is_Some()
-                && is_controller_request(s.pending_req_of(zk.object_ref()))
-                && s.message_in_flight(msg)
-                && resp_msg_matches_req_msg(msg, s.pending_req_of(zk.object_ref()))
-            };
-            let input = (Option::Some(msg), Option::Some(zk.object_ref()));
-            lemma_pre_leads_to_post_by_controller::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>(
-                spec,
-                input,
-                stronger_next,
-                continue_reconcile::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>(),
-                resp_in_flight_state,
-                post
-            );
-    };
-    leads_to_exists_intro::<ClusterState, Message>(spec, known_resp_in_flight, lift_state(post));
-    assert_by(
-        tla_exists(known_resp_in_flight) == lift_state(pre),
-        {
-            assert forall |ex| #[trigger] lift_state(pre).satisfied_by(ex)
-            implies tla_exists(known_resp_in_flight).satisfied_by(ex) by {
-                let s = ex.head();
-                let msg = choose |resp_msg: Message| {
-                    #[trigger] s.message_in_flight(resp_msg)
-                    && resp_msg_matches_req_msg(resp_msg, s.reconcile_state_of(zk.object_ref()).pending_req_msg.get_Some_0())
-                };
-                assert(known_resp_in_flight(msg).satisfied_by(ex));
-            }
-            temp_pred_equality(tla_exists(known_resp_in_flight), lift_state(pre));
-        }
-    );
-}
-
-proof fn lemma_from_at_after_create_headless_service_step_and_pending_req_in_flight_to_after_create_client_service_step(spec: TempPred<ClusterState>, zk: ZookeeperClusterView)
-    requires
-        zk.well_formed(),
-        spec.entails(always(lift_action(next::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>()))),
-        spec.entails(tla_forall(|i| kubernetes_api_next().weak_fairness(i))),
-        spec.entails(tla_forall(|i| controller_next::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>().weak_fairness(i))),
-        spec.entails(always(lift_state(crash_disabled()))),
-        spec.entails(always(lift_state(controller_runtime_safety::every_in_flight_msg_has_unique_id()))),
-        spec.entails(always(lift_state(controller_runtime_safety::each_resp_matches_at_most_one_pending_req(zk.object_ref())))),
-        spec.entails(always(lift_state(controller_runtime_safety::each_resp_if_matches_pending_req_then_no_other_resp_matches(zk.object_ref())))),
-        spec.entails(always(lift_state(reconcile_init_implies_no_pending_req(zk.object_ref())))),
-        spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_step(zk.object_ref(), ZookeeperReconcileStep::AfterUpdateStatefulSet)))),
-        spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateStatefulSet)))),
-        spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateHeadlessService)))),
-        spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateClientService)))),
-        spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateAdminServerService)))),
-        spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateConfigMap)))),
-        spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_step(zk.object_ref(), ZookeeperReconcileStep::AfterGetStatefulSet)))),
-    ensures
-        spec.entails(lift_state(pending_req_in_flight_at_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateHeadlessService)).leads_to(lift_state(at_zookeeper_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateClientService)))),
-{
-    let pre = pending_req_in_flight_at_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateHeadlessService);
-    let post = at_zookeeper_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateClientService);
-    assert forall |req_msg: Message| spec.entails(
-        lift_state(#[trigger] req_msg_is_the_in_flight_pending_req_at_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateHeadlessService, req_msg))
-            .leads_to(lift_state(resp_in_flight_matches_pending_req_at_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateHeadlessService)))
-    ) by {
-        let pre_1 = req_msg_is_the_in_flight_pending_req_at_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateHeadlessService, req_msg);
-        let post_1 = resp_in_flight_matches_pending_req_at_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateHeadlessService);
-        let stronger_next = |s, s_prime: ClusterState| {
-            &&& next::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>()(s, s_prime)
-            &&& crash_disabled()(s)
-            &&& controller_runtime_safety::every_in_flight_msg_has_unique_id()(s)
-        };
-        entails_always_and_n!(
-            spec,
-            lift_action(next::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>()),
-            lift_state(crash_disabled()),
-            lift_state(controller_runtime_safety::every_in_flight_msg_has_unique_id())
-        );
-        temp_pred_equality(
-            lift_action(stronger_next),
-            lift_action(next::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>())
-            .and(lift_state(crash_disabled()))
-            .and(lift_state(controller_runtime_safety::every_in_flight_msg_has_unique_id()))
-        );
-        let input = Option::Some(req_msg);
-        assert forall |s, s_prime: ClusterState| pre_1(s) && #[trigger] stronger_next(s, s_prime)
-        && kubernetes_api_next().forward(input)(s, s_prime) implies post_1(s_prime) by {
-            let resp_msg = transition_by_etcd(req_msg, s.kubernetes_api_state).1;
-            assert({
-                &&& s_prime.message_in_flight(resp_msg)
-                &&& resp_msg_matches_req_msg(resp_msg, req_msg)
-            });
-        };
-        lemma_pre_leads_to_post_by_kubernetes_api::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>(
-            spec, input, stronger_next, handle_request(), pre_1, post_1
-        );
-    }
-    let msg_2_temp = |msg| lift_state(req_msg_is_the_in_flight_pending_req_at_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateHeadlessService, msg));
-    leads_to_exists_intro(
-        spec, msg_2_temp,
-        lift_state(resp_in_flight_matches_pending_req_at_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateHeadlessService))
-    );
-    assert_by(
-        tla_exists(|msg| lift_state(req_msg_is_the_in_flight_pending_req_at_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateHeadlessService, msg)))
-        == lift_state(pre),
-        {
-            assert forall |ex| #[trigger] lift_state(pre).satisfied_by(ex) implies
-            tla_exists(msg_2_temp).satisfied_by(ex) by {
-                let req_msg = ex.head().pending_req_of(zk.object_ref());
-                assert(msg_2_temp(req_msg).satisfied_by(ex));
-            }
-            temp_pred_equality(lift_state(pre), tla_exists(msg_2_temp));
-        }
-    );
-    lemma_from_at_after_create_headless_service_step_and_resp_matches_pending_req_in_flight_to_after_create_client_service_step(spec, zk);
-    leads_to_trans_n!(
-        spec,
-        lift_state(pre),
-        lift_state(resp_in_flight_matches_pending_req_at_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateHeadlessService)),
-        lift_state(post)
-    );
-}
-
-proof fn lemma_from_at_after_create_headless_service_step_and_resp_matches_pending_req_in_flight_to_after_create_client_service_step(spec: TempPred<ClusterState>, zk: ZookeeperClusterView)
-    requires
-        zk.well_formed(),
-        spec.entails(always(lift_action(next::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>()))),
-        spec.entails(tla_forall(|i| kubernetes_api_next().weak_fairness(i))),
-        spec.entails(tla_forall(|i| controller_next::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>().weak_fairness(i))),
-        spec.entails(always(lift_state(crash_disabled()))),
-        spec.entails(always(lift_state(controller_runtime_safety::every_in_flight_msg_has_unique_id()))),
-        spec.entails(always(lift_state(controller_runtime_safety::each_resp_matches_at_most_one_pending_req(zk.object_ref())))),
-        spec.entails(always(lift_state(controller_runtime_safety::each_resp_if_matches_pending_req_then_no_other_resp_matches(zk.object_ref())))),
-        spec.entails(always(lift_state(reconcile_init_implies_no_pending_req(zk.object_ref())))),
-        spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_step(zk.object_ref(), ZookeeperReconcileStep::AfterUpdateStatefulSet)))),
-        spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateStatefulSet)))),
-        spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateHeadlessService)))),
-        spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateClientService)))),
-        spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateAdminServerService)))),
-        spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateConfigMap)))),
-        spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_step(zk.object_ref(), ZookeeperReconcileStep::AfterGetStatefulSet)))),
-    ensures
-        spec.entails(lift_state(resp_in_flight_matches_pending_req_at_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateHeadlessService)).leads_to(lift_state(at_zookeeper_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateClientService)))),
-{
-    let pre = resp_in_flight_matches_pending_req_at_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateHeadlessService);
-    let post = at_zookeeper_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateClientService);
-    // TODO: lift stronger next to a public spec
-    let stronger_next = |s, s_prime: ClusterState| {
-        &&& next::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>()(s, s_prime)
-        &&& crash_disabled()(s)
-        &&& controller_runtime_safety::each_resp_matches_at_most_one_pending_req(zk.object_ref())(s)
-        &&& controller_runtime_safety::each_resp_if_matches_pending_req_then_no_other_resp_matches(zk.object_ref())(s)
-    };
-    entails_always_and_n!(
-        spec,
-        lift_action(next::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>()),
-        lift_state(crash_disabled()),
-        lift_state(controller_runtime_safety::each_resp_matches_at_most_one_pending_req(zk.object_ref())),
-        lift_state(controller_runtime_safety::each_resp_if_matches_pending_req_then_no_other_resp_matches(zk.object_ref()))
-    );
-    temp_pred_equality(
-        lift_action(stronger_next),
-        lift_action(next::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>())
-        .and(lift_state(crash_disabled()))
-        .and(lift_state(controller_runtime_safety::each_resp_matches_at_most_one_pending_req(zk.object_ref())))
-        .and(lift_state(controller_runtime_safety::each_resp_if_matches_pending_req_then_no_other_resp_matches(zk.object_ref())))
-    );
-    let known_resp_in_flight = |resp| lift_state(
-        |s: ClusterState| {
-            at_zookeeper_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateHeadlessService)(s)
-            && s.reconcile_state_of(zk.object_ref()).pending_req_msg.is_Some()
-            && is_controller_request(s.pending_req_of(zk.object_ref()))
-            && s.message_in_flight(resp)
-            && resp_msg_matches_req_msg(resp, s.pending_req_of(zk.object_ref()))
-        }
-    );
-    assert forall |msg: Message| spec.entails(#[trigger] known_resp_in_flight(msg)
-        .leads_to(lift_state(post))) by {
-            let resp_in_flight_state = |s: ClusterState| {
-                at_zookeeper_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateHeadlessService)(s)
-                && s.reconcile_state_of(zk.object_ref()).pending_req_msg.is_Some()
-                && is_controller_request(s.pending_req_of(zk.object_ref()))
-                && s.message_in_flight(msg)
-                && resp_msg_matches_req_msg(msg, s.pending_req_of(zk.object_ref()))
-            };
-            let input = (Option::Some(msg), Option::Some(zk.object_ref()));
-            lemma_pre_leads_to_post_by_controller::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>(
-                spec,
-                input,
-                stronger_next,
-                continue_reconcile::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>(),
-                resp_in_flight_state,
-                post
-            );
-    };
-    leads_to_exists_intro::<ClusterState, Message>(spec, known_resp_in_flight, lift_state(post));
-    assert_by(
-        tla_exists(known_resp_in_flight) == lift_state(pre),
-        {
-            assert forall |ex| #[trigger] lift_state(pre).satisfied_by(ex)
-            implies tla_exists(known_resp_in_flight).satisfied_by(ex) by {
-                let s = ex.head();
-                let msg = choose |resp_msg: Message| {
-                    #[trigger] s.message_in_flight(resp_msg)
-                    && resp_msg_matches_req_msg(resp_msg, s.reconcile_state_of(zk.object_ref()).pending_req_msg.get_Some_0())
-                };
-                assert(known_resp_in_flight(msg).satisfied_by(ex));
-            }
-            temp_pred_equality(tla_exists(known_resp_in_flight), lift_state(pre));
-        }
-    );
-}
-
-proof fn lemma_from_at_after_create_client_service_step_and_pending_req_in_flight_to_after_create_admin_server_service_step(spec: TempPred<ClusterState>, zk: ZookeeperClusterView)
-    requires
-        zk.well_formed(),
-        spec.entails(always(lift_action(next::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>()))),
-        spec.entails(tla_forall(|i| kubernetes_api_next().weak_fairness(i))),
-        spec.entails(tla_forall(|i| controller_next::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>().weak_fairness(i))),
-        spec.entails(always(lift_state(crash_disabled()))),
-        spec.entails(always(lift_state(controller_runtime_safety::every_in_flight_msg_has_unique_id()))),
-        spec.entails(always(lift_state(controller_runtime_safety::each_resp_matches_at_most_one_pending_req(zk.object_ref())))),
-        spec.entails(always(lift_state(controller_runtime_safety::each_resp_if_matches_pending_req_then_no_other_resp_matches(zk.object_ref())))),
-        spec.entails(always(lift_state(reconcile_init_implies_no_pending_req(zk.object_ref())))),
-        spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_step(zk.object_ref(), ZookeeperReconcileStep::AfterUpdateStatefulSet)))),
-        spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateStatefulSet)))),
-        spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateHeadlessService)))),
-        spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateClientService)))),
-        spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateAdminServerService)))),
-        spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateConfigMap)))),
-        spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_step(zk.object_ref(), ZookeeperReconcileStep::AfterGetStatefulSet)))),
-    ensures
-        spec.entails(lift_state(pending_req_in_flight_at_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateClientService)).leads_to(lift_state(at_zookeeper_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateAdminServerService)))),
-{
-    let pre = pending_req_in_flight_at_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateClientService);
-    let post = at_zookeeper_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateAdminServerService);
-    assert forall |req_msg: Message| spec.entails(
-        lift_state(#[trigger] req_msg_is_the_in_flight_pending_req_at_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateClientService, req_msg))
-            .leads_to(lift_state(resp_in_flight_matches_pending_req_at_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateClientService)))
-    ) by {
-        let pre_1 = req_msg_is_the_in_flight_pending_req_at_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateClientService, req_msg);
-        let post_1 = resp_in_flight_matches_pending_req_at_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateClientService);
-        let stronger_next = |s, s_prime: ClusterState| {
-            &&& next::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>()(s, s_prime)
-            &&& crash_disabled()(s)
-            &&& controller_runtime_safety::every_in_flight_msg_has_unique_id()(s)
-        };
-        entails_always_and_n!(
-            spec,
-            lift_action(next::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>()),
-            lift_state(crash_disabled()),
-            lift_state(controller_runtime_safety::every_in_flight_msg_has_unique_id())
-        );
-        temp_pred_equality(
-            lift_action(stronger_next),
-            lift_action(next::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>())
-            .and(lift_state(crash_disabled()))
-            .and(lift_state(controller_runtime_safety::every_in_flight_msg_has_unique_id()))
-        );
-        let input = Option::Some(req_msg);
-        assert forall |s, s_prime: ClusterState| pre_1(s) && #[trigger] stronger_next(s, s_prime)
-        && kubernetes_api_next().forward(input)(s, s_prime) implies post_1(s_prime) by {
-            let resp_msg = transition_by_etcd(req_msg, s.kubernetes_api_state).1;
-            assert({
-                &&& s_prime.message_in_flight(resp_msg)
-                &&& resp_msg_matches_req_msg(resp_msg, req_msg)
-            });
-        };
-        lemma_pre_leads_to_post_by_kubernetes_api::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>(
-            spec, input, stronger_next, handle_request(), pre_1, post_1
-        );
-    }
-    let msg_2_temp = |msg| lift_state(req_msg_is_the_in_flight_pending_req_at_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateClientService, msg));
-    leads_to_exists_intro(
-        spec, msg_2_temp,
-        lift_state(resp_in_flight_matches_pending_req_at_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateClientService))
-    );
-    assert_by(
-        tla_exists(|msg| lift_state(req_msg_is_the_in_flight_pending_req_at_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateClientService, msg)))
-        == lift_state(pre),
-        {
-            assert forall |ex| #[trigger] lift_state(pre).satisfied_by(ex) implies
-            tla_exists(msg_2_temp).satisfied_by(ex) by {
-                let req_msg = ex.head().pending_req_of(zk.object_ref());
-                assert(msg_2_temp(req_msg).satisfied_by(ex));
-            }
-            temp_pred_equality(lift_state(pre), tla_exists(msg_2_temp));
-        }
-    );
-    lemma_from_at_after_create_client_service_step_and_resp_matches_pending_req_in_flight_to_after_create_admin_server_service_step(spec, zk);
-    leads_to_trans_n!(
-        spec,
-        lift_state(pre),
-        lift_state(resp_in_flight_matches_pending_req_at_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateClientService)),
-        lift_state(post)
-    );
-}
-
-proof fn lemma_from_at_after_create_client_service_step_and_resp_matches_pending_req_in_flight_to_after_create_admin_server_service_step(spec: TempPred<ClusterState>, zk: ZookeeperClusterView)
-    requires
-        zk.well_formed(),
-        spec.entails(always(lift_action(next::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>()))),
-        spec.entails(tla_forall(|i| kubernetes_api_next().weak_fairness(i))),
-        spec.entails(tla_forall(|i| controller_next::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>().weak_fairness(i))),
-        spec.entails(always(lift_state(crash_disabled()))),
-        spec.entails(always(lift_state(controller_runtime_safety::every_in_flight_msg_has_unique_id()))),
-        spec.entails(always(lift_state(controller_runtime_safety::each_resp_matches_at_most_one_pending_req(zk.object_ref())))),
-        spec.entails(always(lift_state(controller_runtime_safety::each_resp_if_matches_pending_req_then_no_other_resp_matches(zk.object_ref())))),
-        spec.entails(always(lift_state(reconcile_init_implies_no_pending_req(zk.object_ref())))),
-        spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_step(zk.object_ref(), ZookeeperReconcileStep::AfterUpdateStatefulSet)))),
-        spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateStatefulSet)))),
-        spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateHeadlessService)))),
-        spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateClientService)))),
-        spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateAdminServerService)))),
-        spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateConfigMap)))),
-        spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_step(zk.object_ref(), ZookeeperReconcileStep::AfterGetStatefulSet)))),
-    ensures
-        spec.entails(lift_state(resp_in_flight_matches_pending_req_at_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateClientService)).leads_to(lift_state(at_zookeeper_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateAdminServerService)))),
-{
-    let pre = resp_in_flight_matches_pending_req_at_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateClientService);
-    let post = at_zookeeper_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateAdminServerService);
-    // TODO: lift stronger next to a public spec
-    let stronger_next = |s, s_prime: ClusterState| {
-        &&& next::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>()(s, s_prime)
-        &&& crash_disabled()(s)
-        &&& controller_runtime_safety::each_resp_matches_at_most_one_pending_req(zk.object_ref())(s)
-        &&& controller_runtime_safety::each_resp_if_matches_pending_req_then_no_other_resp_matches(zk.object_ref())(s)
-    };
-    entails_always_and_n!(
-        spec,
-        lift_action(next::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>()),
-        lift_state(crash_disabled()),
-        lift_state(controller_runtime_safety::each_resp_matches_at_most_one_pending_req(zk.object_ref())),
-        lift_state(controller_runtime_safety::each_resp_if_matches_pending_req_then_no_other_resp_matches(zk.object_ref()))
-    );
-    temp_pred_equality(
-        lift_action(stronger_next),
-        lift_action(next::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>())
-        .and(lift_state(crash_disabled()))
-        .and(lift_state(controller_runtime_safety::each_resp_matches_at_most_one_pending_req(zk.object_ref())))
-        .and(lift_state(controller_runtime_safety::each_resp_if_matches_pending_req_then_no_other_resp_matches(zk.object_ref())))
-    );
-    let known_resp_in_flight = |resp| lift_state(
-        |s: ClusterState| {
-            at_zookeeper_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateClientService)(s)
-            && s.reconcile_state_of(zk.object_ref()).pending_req_msg.is_Some()
-            && is_controller_request(s.pending_req_of(zk.object_ref()))
-            && s.message_in_flight(resp)
-            && resp_msg_matches_req_msg(resp, s.pending_req_of(zk.object_ref()))
-        }
-    );
-    assert forall |msg: Message| spec.entails(#[trigger] known_resp_in_flight(msg)
-        .leads_to(lift_state(post))) by {
-            let resp_in_flight_state = |s: ClusterState| {
-                at_zookeeper_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateClientService)(s)
-                && s.reconcile_state_of(zk.object_ref()).pending_req_msg.is_Some()
-                && is_controller_request(s.pending_req_of(zk.object_ref()))
-                && s.message_in_flight(msg)
-                && resp_msg_matches_req_msg(msg, s.pending_req_of(zk.object_ref()))
-            };
-            let input = (Option::Some(msg), Option::Some(zk.object_ref()));
-            lemma_pre_leads_to_post_by_controller::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>(
-                spec,
-                input,
-                stronger_next,
-                continue_reconcile::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>(),
-                resp_in_flight_state,
-                post
-            );
-    };
-    leads_to_exists_intro::<ClusterState, Message>(spec, known_resp_in_flight, lift_state(post));
-    assert_by(
-        tla_exists(known_resp_in_flight) == lift_state(pre),
-        {
-            assert forall |ex| #[trigger] lift_state(pre).satisfied_by(ex)
-            implies tla_exists(known_resp_in_flight).satisfied_by(ex) by {
-                let s = ex.head();
-                let msg = choose |resp_msg: Message| {
-                    #[trigger] s.message_in_flight(resp_msg)
-                    && resp_msg_matches_req_msg(resp_msg, s.reconcile_state_of(zk.object_ref()).pending_req_msg.get_Some_0())
-                };
-                assert(known_resp_in_flight(msg).satisfied_by(ex));
-            }
-            temp_pred_equality(tla_exists(known_resp_in_flight), lift_state(pre));
-        }
-    );
-}
-
-proof fn lemma_from_at_after_create_admin_server_service_step_and_resp_matches_pending_req_in_flight_to_after_create_config_map_step(spec: TempPred<ClusterState>, zk: ZookeeperClusterView)
-    requires
-        zk.well_formed(),
-        spec.entails(always(lift_action(next::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>()))),
-        spec.entails(tla_forall(|i| kubernetes_api_next().weak_fairness(i))),
-        spec.entails(tla_forall(|i| controller_next::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>().weak_fairness(i))),
-        spec.entails(always(lift_state(crash_disabled()))),
-        spec.entails(always(lift_state(controller_runtime_safety::every_in_flight_msg_has_unique_id()))),
-        spec.entails(always(lift_state(controller_runtime_safety::each_resp_matches_at_most_one_pending_req(zk.object_ref())))),
-        spec.entails(always(lift_state(controller_runtime_safety::each_resp_if_matches_pending_req_then_no_other_resp_matches(zk.object_ref())))),
-        spec.entails(always(lift_state(reconcile_init_implies_no_pending_req(zk.object_ref())))),
-        spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_step(zk.object_ref(), ZookeeperReconcileStep::AfterUpdateStatefulSet)))),
-        spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateStatefulSet)))),
-        spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateHeadlessService)))),
-        spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateClientService)))),
-        spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateAdminServerService)))),
-        spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateConfigMap)))),
-        spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_step(zk.object_ref(), ZookeeperReconcileStep::AfterGetStatefulSet)))),
-    ensures
-        spec.entails(lift_state(resp_in_flight_matches_pending_req_at_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateAdminServerService)).leads_to(lift_state(at_zookeeper_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateConfigMap)))),
-{
-    let pre = resp_in_flight_matches_pending_req_at_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateAdminServerService);
-    let post = at_zookeeper_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateConfigMap);
-    // TODO: lift stronger next to a public spec
-    let stronger_next = |s, s_prime: ClusterState| {
-        &&& next::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>()(s, s_prime)
-        &&& crash_disabled()(s)
-        &&& controller_runtime_safety::each_resp_matches_at_most_one_pending_req(zk.object_ref())(s)
-        &&& controller_runtime_safety::each_resp_if_matches_pending_req_then_no_other_resp_matches(zk.object_ref())(s)
-    };
-    entails_always_and_n!(
-        spec,
-        lift_action(next::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>()),
-        lift_state(crash_disabled()),
-        lift_state(controller_runtime_safety::each_resp_matches_at_most_one_pending_req(zk.object_ref())),
-        lift_state(controller_runtime_safety::each_resp_if_matches_pending_req_then_no_other_resp_matches(zk.object_ref()))
-    );
-    temp_pred_equality(
-        lift_action(stronger_next),
-        lift_action(next::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>())
-        .and(lift_state(crash_disabled()))
-        .and(lift_state(controller_runtime_safety::each_resp_matches_at_most_one_pending_req(zk.object_ref())))
-        .and(lift_state(controller_runtime_safety::each_resp_if_matches_pending_req_then_no_other_resp_matches(zk.object_ref())))
-    );
-    let known_resp_in_flight = |resp| lift_state(
-        |s: ClusterState| {
-            at_zookeeper_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateAdminServerService)(s)
-            && s.reconcile_state_of(zk.object_ref()).pending_req_msg.is_Some()
-            && is_controller_request(s.pending_req_of(zk.object_ref()))
-            && s.message_in_flight(resp)
-            && resp_msg_matches_req_msg(resp, s.pending_req_of(zk.object_ref()))
-        }
-    );
-    assert forall |msg: Message| spec.entails(#[trigger] known_resp_in_flight(msg)
-        .leads_to(lift_state(post))) by {
-            let resp_in_flight_state = |s: ClusterState| {
-                at_zookeeper_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateAdminServerService)(s)
-                && s.reconcile_state_of(zk.object_ref()).pending_req_msg.is_Some()
-                && is_controller_request(s.pending_req_of(zk.object_ref()))
-                && s.message_in_flight(msg)
-                && resp_msg_matches_req_msg(msg, s.pending_req_of(zk.object_ref()))
-            };
-            let input = (Option::Some(msg), Option::Some(zk.object_ref()));
-            lemma_pre_leads_to_post_by_controller::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>(
-                spec,
-                input,
-                stronger_next,
-                continue_reconcile::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>(),
-                resp_in_flight_state,
-                post
-            );
-    };
-    leads_to_exists_intro::<ClusterState, Message>(spec, known_resp_in_flight, lift_state(post));
-    assert_by(
-        tla_exists(known_resp_in_flight) == lift_state(pre),
-        {
-            assert forall |ex| #[trigger] lift_state(pre).satisfied_by(ex)
-            implies tla_exists(known_resp_in_flight).satisfied_by(ex) by {
-                let s = ex.head();
-                let msg = choose |resp_msg: Message| {
-                    #[trigger] s.message_in_flight(resp_msg)
-                    && resp_msg_matches_req_msg(resp_msg, s.reconcile_state_of(zk.object_ref()).pending_req_msg.get_Some_0())
-                };
-                assert(known_resp_in_flight(msg).satisfied_by(ex));
-            }
-            temp_pred_equality(tla_exists(known_resp_in_flight), lift_state(pre));
-        }
-    );
-}
-
-proof fn lemma_from_at_after_create_admin_server_service_step_and_pending_req_in_flight_to_after_create_config_map_step(spec: TempPred<ClusterState>, zk: ZookeeperClusterView)
-    requires
-        zk.well_formed(),
-        spec.entails(always(lift_action(next::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>()))),
-        spec.entails(tla_forall(|i| kubernetes_api_next().weak_fairness(i))),
-        spec.entails(tla_forall(|i| controller_next::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>().weak_fairness(i))),
-        spec.entails(always(lift_state(crash_disabled()))),
-        spec.entails(always(lift_state(controller_runtime_safety::every_in_flight_msg_has_unique_id()))),
-        spec.entails(always(lift_state(controller_runtime_safety::each_resp_matches_at_most_one_pending_req(zk.object_ref())))),
-        spec.entails(always(lift_state(controller_runtime_safety::each_resp_if_matches_pending_req_then_no_other_resp_matches(zk.object_ref())))),
-        spec.entails(always(lift_state(reconcile_init_implies_no_pending_req(zk.object_ref())))),
-        spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_step(zk.object_ref(), ZookeeperReconcileStep::AfterUpdateStatefulSet)))),
-        spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateStatefulSet)))),
-        spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateHeadlessService)))),
-        spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateClientService)))),
-        spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateAdminServerService)))),
-        spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateConfigMap)))),
-        spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_step(zk.object_ref(), ZookeeperReconcileStep::AfterGetStatefulSet)))),
-    ensures
-        spec.entails(lift_state(pending_req_in_flight_at_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateAdminServerService)).leads_to(lift_state(at_zookeeper_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateConfigMap)))),
-{
-    let pre = pending_req_in_flight_at_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateAdminServerService);
-    let post = at_zookeeper_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateConfigMap);
-    assert forall |req_msg: Message| spec.entails(
-        lift_state(#[trigger] req_msg_is_the_in_flight_pending_req_at_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateAdminServerService, req_msg))
-            .leads_to(lift_state(resp_in_flight_matches_pending_req_at_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateAdminServerService)))
-    ) by {
-        let pre_1 = req_msg_is_the_in_flight_pending_req_at_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateAdminServerService, req_msg);
-        let post_1 = resp_in_flight_matches_pending_req_at_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateAdminServerService);
-        let stronger_next = |s, s_prime: ClusterState| {
-            &&& next::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>()(s, s_prime)
-            &&& crash_disabled()(s)
-            &&& controller_runtime_safety::every_in_flight_msg_has_unique_id()(s)
-        };
-        entails_always_and_n!(
-            spec,
-            lift_action(next::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>()),
-            lift_state(crash_disabled()),
-            lift_state(controller_runtime_safety::every_in_flight_msg_has_unique_id())
-        );
-        temp_pred_equality(
-            lift_action(stronger_next),
-            lift_action(next::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>())
-            .and(lift_state(crash_disabled()))
-            .and(lift_state(controller_runtime_safety::every_in_flight_msg_has_unique_id()))
-        );
-        let input = Option::Some(req_msg);
-        assert forall |s, s_prime: ClusterState| pre_1(s) && #[trigger] stronger_next(s, s_prime)
-        && kubernetes_api_next().forward(input)(s, s_prime) implies post_1(s_prime) by {
-            let resp_msg = transition_by_etcd(req_msg, s.kubernetes_api_state).1;
-            assert({
-                &&& s_prime.message_in_flight(resp_msg)
-                &&& resp_msg_matches_req_msg(resp_msg, req_msg)
-            });
-        };
-        lemma_pre_leads_to_post_by_kubernetes_api::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>(
-            spec, input, stronger_next, handle_request(), pre_1, post_1
-        );
-    }
-    let msg_2_temp = |msg| lift_state(req_msg_is_the_in_flight_pending_req_at_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateAdminServerService, msg));
-    leads_to_exists_intro(
-        spec, msg_2_temp,
-        lift_state(resp_in_flight_matches_pending_req_at_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateAdminServerService))
-    );
-    assert_by(
-        tla_exists(|msg| lift_state(req_msg_is_the_in_flight_pending_req_at_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateAdminServerService, msg)))
-        == lift_state(pre),
-        {
-            assert forall |ex| #[trigger] lift_state(pre).satisfied_by(ex) implies
-            tla_exists(msg_2_temp).satisfied_by(ex) by {
-                let req_msg = ex.head().pending_req_of(zk.object_ref());
-                assert(msg_2_temp(req_msg).satisfied_by(ex));
-            }
-            temp_pred_equality(lift_state(pre), tla_exists(msg_2_temp));
-        }
-    );
-    lemma_from_at_after_create_admin_server_service_step_and_resp_matches_pending_req_in_flight_to_after_create_config_map_step(spec, zk);
-    leads_to_trans_n!(
-        spec,
-        lift_state(pre),
-        lift_state(resp_in_flight_matches_pending_req_at_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateAdminServerService)),
-        lift_state(post)
-    );
-}
-
-proof fn lemma_from_at_after_create_config_map_step_and_resp_matches_pending_req_in_flight_to_after_get_stateful_set_step(spec: TempPred<ClusterState>, zk: ZookeeperClusterView)
-    requires
-        zk.well_formed(),
-        spec.entails(always(lift_action(next::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>()))),
-        spec.entails(tla_forall(|i| kubernetes_api_next().weak_fairness(i))),
-        spec.entails(tla_forall(|i| controller_next::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>().weak_fairness(i))),
-        spec.entails(always(lift_state(crash_disabled()))),
-        spec.entails(always(lift_state(controller_runtime_safety::every_in_flight_msg_has_unique_id()))),
-        spec.entails(always(lift_state(controller_runtime_safety::each_resp_matches_at_most_one_pending_req(zk.object_ref())))),
-        spec.entails(always(lift_state(controller_runtime_safety::each_resp_if_matches_pending_req_then_no_other_resp_matches(zk.object_ref())))),
-        spec.entails(always(lift_state(reconcile_init_implies_no_pending_req(zk.object_ref())))),
-        spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_step(zk.object_ref(), ZookeeperReconcileStep::AfterUpdateStatefulSet)))),
-        spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateStatefulSet)))),
-        spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateHeadlessService)))),
-        spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateClientService)))),
-        spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateAdminServerService)))),
-        spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateConfigMap)))),
-        spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_step(zk.object_ref(), ZookeeperReconcileStep::AfterGetStatefulSet)))),
-    ensures
-        spec.entails(lift_state(resp_in_flight_matches_pending_req_at_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateConfigMap)).leads_to(lift_state(at_zookeeper_step(zk.object_ref(), ZookeeperReconcileStep::AfterGetStatefulSet)))),
-{
-    let pre = resp_in_flight_matches_pending_req_at_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateConfigMap);
-    let post = at_zookeeper_step(zk.object_ref(), ZookeeperReconcileStep::AfterGetStatefulSet);
-    // TODO: lift stronger next to a public spec
-    let stronger_next = |s, s_prime: ClusterState| {
-        &&& next::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>()(s, s_prime)
-        &&& crash_disabled()(s)
-        &&& controller_runtime_safety::each_resp_matches_at_most_one_pending_req(zk.object_ref())(s)
-        &&& controller_runtime_safety::each_resp_if_matches_pending_req_then_no_other_resp_matches(zk.object_ref())(s)
-    };
-    entails_always_and_n!(
-        spec,
-        lift_action(next::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>()),
-        lift_state(crash_disabled()),
-        lift_state(controller_runtime_safety::each_resp_matches_at_most_one_pending_req(zk.object_ref())),
-        lift_state(controller_runtime_safety::each_resp_if_matches_pending_req_then_no_other_resp_matches(zk.object_ref()))
-    );
-    temp_pred_equality(
-        lift_action(stronger_next),
-        lift_action(next::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>())
-        .and(lift_state(crash_disabled()))
-        .and(lift_state(controller_runtime_safety::each_resp_matches_at_most_one_pending_req(zk.object_ref())))
-        .and(lift_state(controller_runtime_safety::each_resp_if_matches_pending_req_then_no_other_resp_matches(zk.object_ref())))
-    );
-    let known_resp_in_flight = |resp| lift_state(
-        |s: ClusterState| {
-            at_zookeeper_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateConfigMap)(s)
-            && s.reconcile_state_of(zk.object_ref()).pending_req_msg.is_Some()
-            && is_controller_request(s.pending_req_of(zk.object_ref()))
-            && s.message_in_flight(resp)
-            && resp_msg_matches_req_msg(resp, s.pending_req_of(zk.object_ref()))
-        }
-    );
-    assert forall |msg: Message| spec.entails(#[trigger] known_resp_in_flight(msg)
-        .leads_to(lift_state(post))) by {
-            let resp_in_flight_state = |s: ClusterState| {
-                at_zookeeper_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateConfigMap)(s)
-                && s.reconcile_state_of(zk.object_ref()).pending_req_msg.is_Some()
-                && is_controller_request(s.pending_req_of(zk.object_ref()))
-                && s.message_in_flight(msg)
-                && resp_msg_matches_req_msg(msg, s.pending_req_of(zk.object_ref()))
-            };
-            let input = (Option::Some(msg), Option::Some(zk.object_ref()));
-            lemma_pre_leads_to_post_by_controller::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>(
-                spec,
-                input,
-                stronger_next,
-                continue_reconcile::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>(),
-                resp_in_flight_state,
-                post
-            );
-    };
-    leads_to_exists_intro::<ClusterState, Message>(spec, known_resp_in_flight, lift_state(post));
-    assert_by(
-        tla_exists(known_resp_in_flight) == lift_state(pre),
-        {
-            assert forall |ex| #[trigger] lift_state(pre).satisfied_by(ex)
-            implies tla_exists(known_resp_in_flight).satisfied_by(ex) by {
-                let s = ex.head();
-                let msg = choose |resp_msg: Message| {
-                    #[trigger] s.message_in_flight(resp_msg)
-                    && resp_msg_matches_req_msg(resp_msg, s.reconcile_state_of(zk.object_ref()).pending_req_msg.get_Some_0())
-                };
-                assert(known_resp_in_flight(msg).satisfied_by(ex));
-            }
-            temp_pred_equality(tla_exists(known_resp_in_flight), lift_state(pre));
-        }
-    );
-}
-
-proof fn lemma_from_at_after_create_config_map_step_and_pending_req_in_flight_to_after_get_stateful_set_step(spec: TempPred<ClusterState>, zk: ZookeeperClusterView)
-    requires
-        zk.well_formed(),
-        spec.entails(always(lift_action(next::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>()))),
-        spec.entails(tla_forall(|i| kubernetes_api_next().weak_fairness(i))),
-        spec.entails(tla_forall(|i| controller_next::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>().weak_fairness(i))),
-        spec.entails(always(lift_state(crash_disabled()))),
-        spec.entails(always(lift_state(controller_runtime_safety::every_in_flight_msg_has_unique_id()))),
-        spec.entails(always(lift_state(controller_runtime_safety::each_resp_matches_at_most_one_pending_req(zk.object_ref())))),
-        spec.entails(always(lift_state(controller_runtime_safety::each_resp_if_matches_pending_req_then_no_other_resp_matches(zk.object_ref())))),
-        spec.entails(always(lift_state(reconcile_init_implies_no_pending_req(zk.object_ref())))),
-        spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_step(zk.object_ref(), ZookeeperReconcileStep::AfterUpdateStatefulSet)))),
-        spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateStatefulSet)))),
-        spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateHeadlessService)))),
-        spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateClientService)))),
-        spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateAdminServerService)))),
-        spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateConfigMap)))),
-        spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_step(zk.object_ref(), ZookeeperReconcileStep::AfterGetStatefulSet)))),
-    ensures
-        spec.entails(lift_state(pending_req_in_flight_at_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateConfigMap)).leads_to(lift_state(at_zookeeper_step(zk.object_ref(), ZookeeperReconcileStep::AfterGetStatefulSet)))),
-{
-    let pre = pending_req_in_flight_at_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateConfigMap);
-    let post = at_zookeeper_step(zk.object_ref(), ZookeeperReconcileStep::AfterGetStatefulSet);
-    assert forall |req_msg: Message| spec.entails(
-        lift_state(#[trigger] req_msg_is_the_in_flight_pending_req_at_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateConfigMap, req_msg))
-            .leads_to(lift_state(resp_in_flight_matches_pending_req_at_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateConfigMap)))
-    ) by {
-        let pre_1 = req_msg_is_the_in_flight_pending_req_at_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateConfigMap, req_msg);
-        let post_1 = resp_in_flight_matches_pending_req_at_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateConfigMap);
-        let stronger_next = |s, s_prime: ClusterState| {
-            &&& next::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>()(s, s_prime)
-            &&& crash_disabled()(s)
-            &&& controller_runtime_safety::every_in_flight_msg_has_unique_id()(s)
-        };
-        entails_always_and_n!(
-            spec,
-            lift_action(next::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>()),
-            lift_state(crash_disabled()),
-            lift_state(controller_runtime_safety::every_in_flight_msg_has_unique_id())
-        );
-        temp_pred_equality(
-            lift_action(stronger_next),
-            lift_action(next::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>())
-            .and(lift_state(crash_disabled()))
-            .and(lift_state(controller_runtime_safety::every_in_flight_msg_has_unique_id()))
-        );
-        let input = Option::Some(req_msg);
-        assert forall |s, s_prime: ClusterState| pre_1(s) && #[trigger] stronger_next(s, s_prime)
-        && kubernetes_api_next().forward(input)(s, s_prime) implies post_1(s_prime) by {
-            let resp_msg = transition_by_etcd(req_msg, s.kubernetes_api_state).1;
-            assert({
-                &&& s_prime.message_in_flight(resp_msg)
-                &&& resp_msg_matches_req_msg(resp_msg, req_msg)
-            });
-        };
-        lemma_pre_leads_to_post_by_kubernetes_api::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>(
-            spec, input, stronger_next, handle_request(), pre_1, post_1
-        );
-    }
-    let msg_2_temp = |msg| lift_state(req_msg_is_the_in_flight_pending_req_at_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateConfigMap, msg));
-    leads_to_exists_intro(
-        spec, msg_2_temp,
-        lift_state(resp_in_flight_matches_pending_req_at_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateConfigMap))
-    );
-    assert_by(
-        tla_exists(|msg| lift_state(req_msg_is_the_in_flight_pending_req_at_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateConfigMap, msg)))
-        == lift_state(pre),
-        {
-            assert forall |ex| #[trigger] lift_state(pre).satisfied_by(ex) implies
-            tla_exists(msg_2_temp).satisfied_by(ex) by {
-                let req_msg = ex.head().pending_req_of(zk.object_ref());
-                assert(msg_2_temp(req_msg).satisfied_by(ex));
-            }
-            temp_pred_equality(lift_state(pre), tla_exists(msg_2_temp));
-        }
-    );
-    lemma_from_at_after_create_config_map_step_and_resp_matches_pending_req_in_flight_to_after_get_stateful_set_step(spec, zk);
-    leads_to_trans_n!(
-        spec,
-        lift_state(pre),
-        lift_state(resp_in_flight_matches_pending_req_at_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateConfigMap)),
-        lift_state(post)
     );
 }
 
@@ -1825,6 +805,177 @@ proof fn lemma_from_at_after_get_stateful_set_step_and_pending_req_in_flight_to_
         lift_state(pre),
         lift_state(resp_in_flight_matches_pending_req_at_step(zk.object_ref(), ZookeeperReconcileStep::AfterGetStatefulSet)),
         lift_state(post)
+    );
+}
+
+proof fn lemma_from_pending_req_in_flight_at_step_a_to_step_b(
+    spec: TempPred<ClusterState>, zk: ZookeeperClusterView, step_a: ZookeeperReconcileStep, step_b: ZookeeperReconcileStep
+)
+    requires
+        zk.well_formed(),
+        spec.entails(always(lift_action(next::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>()))),
+        spec.entails(tla_forall(|i| kubernetes_api_next().weak_fairness(i))),
+        spec.entails(tla_forall(|i| controller_next::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>().weak_fairness(i))),
+        spec.entails(always(lift_state(crash_disabled()))),
+        spec.entails(always(lift_state(controller_runtime_safety::every_in_flight_msg_has_unique_id()))),
+        spec.entails(always(lift_state(controller_runtime_safety::each_resp_matches_at_most_one_pending_req(zk.object_ref())))),
+        spec.entails(always(lift_state(controller_runtime_safety::each_resp_if_matches_pending_req_then_no_other_resp_matches(zk.object_ref())))),
+        step_a != ZookeeperReconcileStep::Done, step_a != ZookeeperReconcileStep::Error,
+        step_b != ZookeeperReconcileStep::Init,
+        forall |zk: ZookeeperClusterView, resp_o: Option<APIResponse>|
+            #[trigger] reconcile_core(zk, resp_o, ZookeeperReconcileState{ reconcile_step: step_a }).0.reconcile_step == step_b
+    ensures
+        spec.entails(lift_state(pending_req_in_flight_at_step(zk.object_ref(), step_a))
+        .leads_to(lift_state(at_zookeeper_step(zk.object_ref(), step_b)))),
+{
+    let pre = pending_req_in_flight_at_step(zk.object_ref(), step_a);
+    assert forall |req_msg: Message| spec.entails(
+        lift_state(#[trigger] req_msg_is_the_in_flight_pending_req_at_step(zk.object_ref(), step_a, req_msg))
+            .leads_to(lift_state(resp_in_flight_matches_pending_req_at_step(zk.object_ref(), step_a)))
+    ) by {
+        let pre_1 = req_msg_is_the_in_flight_pending_req_at_step(zk.object_ref(), step_a, req_msg);
+        let post_1 = resp_in_flight_matches_pending_req_at_step(zk.object_ref(), step_a);
+        let stronger_next = |s, s_prime: ClusterState| {
+            &&& next::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>()(s, s_prime)
+            &&& crash_disabled()(s)
+            &&& controller_runtime_safety::every_in_flight_msg_has_unique_id()(s)
+        };
+        entails_always_and_n!(
+            spec,
+            lift_action(next::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>()),
+            lift_state(crash_disabled()),
+            lift_state(controller_runtime_safety::every_in_flight_msg_has_unique_id())
+        );
+        temp_pred_equality(
+            lift_action(stronger_next),
+            lift_action(next::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>())
+            .and(lift_state(crash_disabled()))
+            .and(lift_state(controller_runtime_safety::every_in_flight_msg_has_unique_id()))
+        );
+        let input = Option::Some(req_msg);
+        assert forall |s, s_prime: ClusterState| pre_1(s) && #[trigger] stronger_next(s, s_prime)
+        && kubernetes_api_next().forward(input)(s, s_prime) implies post_1(s_prime) by {
+            let resp_msg = transition_by_etcd(req_msg, s.kubernetes_api_state).1;
+            assert({
+                &&& s_prime.message_in_flight(resp_msg)
+                &&& resp_msg_matches_req_msg(resp_msg, req_msg)
+            });
+        };
+        lemma_pre_leads_to_post_by_kubernetes_api::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>(
+            spec, input, stronger_next, handle_request(), pre_1, post_1
+        );
+    }
+    let msg_2_temp = |msg| lift_state(req_msg_is_the_in_flight_pending_req_at_step(zk.object_ref(), step_a, msg));
+    leads_to_exists_intro(
+        spec, msg_2_temp,
+        lift_state(resp_in_flight_matches_pending_req_at_step(zk.object_ref(), step_a))
+    );
+    assert_by(
+        tla_exists(|msg| lift_state(req_msg_is_the_in_flight_pending_req_at_step(zk.object_ref(), step_a, msg)))
+        == lift_state(pre),
+        {
+            assert forall |ex| #[trigger] lift_state(pre).satisfied_by(ex) implies
+            tla_exists(msg_2_temp).satisfied_by(ex) by {
+                let req_msg = ex.head().pending_req_of(zk.object_ref());
+                assert(msg_2_temp(req_msg).satisfied_by(ex));
+            }
+            temp_pred_equality(lift_state(pre), tla_exists(msg_2_temp));
+        }
+    );
+    lemma_from_step_a_and_resp_matches_pending_req_in_flight_to_step_b(spec, zk, step_a, step_b);
+    leads_to_trans_n!(
+        spec,
+        lift_state(pre),
+        lift_state(resp_in_flight_matches_pending_req_at_step(zk.object_ref(), step_a)),
+        lift_state(at_zookeeper_step(zk.object_ref(), step_b))
+    );
+}
+
+proof fn lemma_from_step_a_and_resp_matches_pending_req_in_flight_to_step_b(
+    spec: TempPred<ClusterState>, zk: ZookeeperClusterView, step_a: ZookeeperReconcileStep, step_b: ZookeeperReconcileStep
+)
+    requires
+        zk.well_formed(),
+        spec.entails(always(lift_action(next::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>()))),
+        spec.entails(tla_forall(|i| kubernetes_api_next().weak_fairness(i))),
+        spec.entails(tla_forall(|i| controller_next::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>().weak_fairness(i))),
+        spec.entails(always(lift_state(crash_disabled()))),
+        spec.entails(always(lift_state(controller_runtime_safety::every_in_flight_msg_has_unique_id()))),
+        spec.entails(always(lift_state(controller_runtime_safety::each_resp_matches_at_most_one_pending_req(zk.object_ref())))),
+        spec.entails(always(lift_state(controller_runtime_safety::each_resp_if_matches_pending_req_then_no_other_resp_matches(zk.object_ref())))),
+        step_a != ZookeeperReconcileStep::Done, step_a != ZookeeperReconcileStep::Error,
+        step_b != ZookeeperReconcileStep::Init,
+        forall |zk: ZookeeperClusterView, resp_o: Option<APIResponse>|
+            #[trigger] reconcile_core(zk, resp_o, ZookeeperReconcileState{ reconcile_step: step_a }).0.reconcile_step == step_b
+    ensures
+        spec.entails(lift_state(resp_in_flight_matches_pending_req_at_step(zk.object_ref(), step_a))
+        .leads_to(lift_state(at_zookeeper_step(zk.object_ref(), step_b)))),
+{
+    let pre = resp_in_flight_matches_pending_req_at_step(zk.object_ref(), step_a);
+    let post = at_zookeeper_step(zk.object_ref(), step_b);
+    let stronger_next = |s, s_prime: ClusterState| {
+        &&& next::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>()(s, s_prime)
+        &&& crash_disabled()(s)
+        &&& controller_runtime_safety::each_resp_matches_at_most_one_pending_req(zk.object_ref())(s)
+        &&& controller_runtime_safety::each_resp_if_matches_pending_req_then_no_other_resp_matches(zk.object_ref())(s)
+    };
+    entails_always_and_n!(
+        spec,
+        lift_action(next::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>()),
+        lift_state(crash_disabled()),
+        lift_state(controller_runtime_safety::each_resp_matches_at_most_one_pending_req(zk.object_ref())),
+        lift_state(controller_runtime_safety::each_resp_if_matches_pending_req_then_no_other_resp_matches(zk.object_ref()))
+    );
+    temp_pred_equality(
+        lift_action(stronger_next),
+        lift_action(next::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>())
+        .and(lift_state(crash_disabled()))
+        .and(lift_state(controller_runtime_safety::each_resp_matches_at_most_one_pending_req(zk.object_ref())))
+        .and(lift_state(controller_runtime_safety::each_resp_if_matches_pending_req_then_no_other_resp_matches(zk.object_ref())))
+    );
+    let known_resp_in_flight = |resp| lift_state(
+        |s: ClusterState| {
+            at_zookeeper_step(zk.object_ref(), step_a)(s)
+            && s.reconcile_state_of(zk.object_ref()).pending_req_msg.is_Some()
+            && is_controller_request(s.pending_req_of(zk.object_ref()))
+            && s.message_in_flight(resp)
+            && resp_msg_matches_req_msg(resp, s.pending_req_of(zk.object_ref()))
+        }
+    );
+    assert forall |msg: Message| spec.entails(#[trigger] known_resp_in_flight(msg)
+        .leads_to(lift_state(post))) by {
+            let resp_in_flight_state = |s: ClusterState| {
+                at_zookeeper_step(zk.object_ref(), step_a)(s)
+                && s.reconcile_state_of(zk.object_ref()).pending_req_msg.is_Some()
+                && is_controller_request(s.pending_req_of(zk.object_ref()))
+                && s.message_in_flight(msg)
+                && resp_msg_matches_req_msg(msg, s.pending_req_of(zk.object_ref()))
+            };
+            let input = (Option::Some(msg), Option::Some(zk.object_ref()));
+            lemma_pre_leads_to_post_by_controller::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>(
+                spec,
+                input,
+                stronger_next,
+                continue_reconcile::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>(),
+                resp_in_flight_state,
+                post
+            );
+    };
+    leads_to_exists_intro::<ClusterState, Message>(spec, known_resp_in_flight, lift_state(post));
+    assert_by(
+        tla_exists(known_resp_in_flight) == lift_state(pre),
+        {
+            assert forall |ex| #[trigger] lift_state(pre).satisfied_by(ex)
+            implies tla_exists(known_resp_in_flight).satisfied_by(ex) by {
+                let s = ex.head();
+                let msg = choose |resp_msg: Message| {
+                    #[trigger] s.message_in_flight(resp_msg)
+                    && resp_msg_matches_req_msg(resp_msg, s.reconcile_state_of(zk.object_ref()).pending_req_msg.get_Some_0())
+                };
+                assert(known_resp_in_flight(msg).satisfied_by(ex));
+            }
+            temp_pred_equality(tla_exists(known_resp_in_flight), lift_state(pre));
+        }
     );
 }
 

--- a/src/controller_examples/zookeeper_controller/proof/terminate.rs
+++ b/src/controller_examples/zookeeper_controller/proof/terminate.rs
@@ -56,11 +56,11 @@ pub proof fn reconcile_eventually_terminates(spec: TempPred<ClusterState>, zk: Z
         spec.entails(always(lift_state(controller_runtime_safety::each_resp_if_matches_pending_req_then_no_other_resp_matches(zk.object_ref())))),
         spec.entails(always(lift_state(reconcile_init_implies_no_pending_req(zk.object_ref())))),
         spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_after_update_stateful_set_step(zk.object_ref())))),
-        spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_after_create_stateful_set_step(zk.object_ref())))),
-        spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_after_create_headless_service_step(zk.object_ref())))),
-        spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_after_create_client_service_step(zk.object_ref())))),
-        spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_after_create_admin_server_service_step(zk.object_ref())))),
-        spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_after_create_config_map_step(zk.object_ref())))),
+        spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_after_create_obj_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateStatefulSet)))),
+        spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_after_create_obj_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateHeadlessService)))),
+        spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_after_create_obj_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateClientService)))),
+        spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_after_create_obj_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateAdminServerService)))),
+        spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_after_create_obj_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateConfigMap)))),
         spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_after_get_stateful_set_step(zk.object_ref())))),
     ensures
         spec.entails(
@@ -122,11 +122,11 @@ pub proof fn lemma_from_after_update_stateful_set_step_to_reconcile_idle(spec: T
         spec.entails(always(lift_state(controller_runtime_safety::each_resp_if_matches_pending_req_then_no_other_resp_matches(zk.object_ref())))),
         spec.entails(always(lift_state(reconcile_init_implies_no_pending_req(zk.object_ref())))),
         spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_after_update_stateful_set_step(zk.object_ref())))),
-        spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_after_create_stateful_set_step(zk.object_ref())))),
-        spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_after_create_headless_service_step(zk.object_ref())))),
-        spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_after_create_client_service_step(zk.object_ref())))),
-        spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_after_create_admin_server_service_step(zk.object_ref())))),
-        spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_after_create_config_map_step(zk.object_ref())))),
+        spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_after_create_obj_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateStatefulSet)))),
+        spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_after_create_obj_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateHeadlessService)))),
+        spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_after_create_obj_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateClientService)))),
+        spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_after_create_obj_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateAdminServerService)))),
+        spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_after_create_obj_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateConfigMap)))),
         spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_after_get_stateful_set_step(zk.object_ref())))),
     ensures
         spec.entails(
@@ -184,11 +184,11 @@ pub proof fn lemma_from_after_create_stateful_set_step_to_reconcile_idle(spec: T
         spec.entails(always(lift_state(controller_runtime_safety::each_resp_if_matches_pending_req_then_no_other_resp_matches(zk.object_ref())))),
         spec.entails(always(lift_state(reconcile_init_implies_no_pending_req(zk.object_ref())))),
         spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_after_update_stateful_set_step(zk.object_ref())))),
-        spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_after_create_stateful_set_step(zk.object_ref())))),
-        spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_after_create_headless_service_step(zk.object_ref())))),
-        spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_after_create_client_service_step(zk.object_ref())))),
-        spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_after_create_admin_server_service_step(zk.object_ref())))),
-        spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_after_create_config_map_step(zk.object_ref())))),
+        spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_after_create_obj_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateStatefulSet)))),
+        spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_after_create_obj_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateHeadlessService)))),
+        spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_after_create_obj_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateClientService)))),
+        spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_after_create_obj_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateAdminServerService)))),
+        spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_after_create_obj_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateConfigMap)))),
         spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_after_get_stateful_set_step(zk.object_ref())))),
     ensures
         spec.entails(
@@ -206,7 +206,7 @@ pub proof fn lemma_from_after_create_stateful_set_step_to_reconcile_idle(spec: T
             && resp_msg_matches_req_msg(resp_msg, s.pending_req_of(zk.object_ref()))
         })
     };
-    temp_pred_equality::<ClusterState>(lift_state(pending_req_in_flight_or_resp_in_flight_at_after_create_stateful_set_step(zk.object_ref())), lift_state(at_zookeeper_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateStatefulSet)).implies(lift_state(at_after_create_stateful_set_step_and_pending_req_in_flight_or_resp_in_flight)));
+    temp_pred_equality::<ClusterState>(lift_state(pending_req_in_flight_or_resp_in_flight_at_after_create_obj_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateStatefulSet)), lift_state(at_zookeeper_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateStatefulSet)).implies(lift_state(at_after_create_stateful_set_step_and_pending_req_in_flight_or_resp_in_flight)));
     implies_to_leads_to::<ClusterState>(spec, lift_state(at_zookeeper_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateStatefulSet)), lift_state(at_after_create_stateful_set_step_and_pending_req_in_flight_or_resp_in_flight));
 
     let req_in_flight = at_after_create_stateful_set_step_and_pending_req_in_flight(zk.object_ref());
@@ -246,11 +246,11 @@ pub proof fn lemma_from_after_get_stateful_set_step_to_reconcile_idle(spec: Temp
         spec.entails(always(lift_state(controller_runtime_safety::each_resp_if_matches_pending_req_then_no_other_resp_matches(zk.object_ref())))),
         spec.entails(always(lift_state(reconcile_init_implies_no_pending_req(zk.object_ref())))),
         spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_after_update_stateful_set_step(zk.object_ref())))),
-        spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_after_create_stateful_set_step(zk.object_ref())))),
-        spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_after_create_headless_service_step(zk.object_ref())))),
-        spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_after_create_client_service_step(zk.object_ref())))),
-        spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_after_create_admin_server_service_step(zk.object_ref())))),
-        spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_after_create_config_map_step(zk.object_ref())))),
+        spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_after_create_obj_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateStatefulSet)))),
+        spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_after_create_obj_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateHeadlessService)))),
+        spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_after_create_obj_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateClientService)))),
+        spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_after_create_obj_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateAdminServerService)))),
+        spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_after_create_obj_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateConfigMap)))),
         spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_after_get_stateful_set_step(zk.object_ref())))),
     ensures
         spec.entails(
@@ -300,11 +300,11 @@ pub proof fn lemma_from_after_create_config_map_step_to_reconcile_idle(spec: Tem
         spec.entails(always(lift_state(controller_runtime_safety::each_resp_if_matches_pending_req_then_no_other_resp_matches(zk.object_ref())))),
         spec.entails(always(lift_state(reconcile_init_implies_no_pending_req(zk.object_ref())))),
         spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_after_update_stateful_set_step(zk.object_ref())))),
-        spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_after_create_stateful_set_step(zk.object_ref())))),
-        spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_after_create_headless_service_step(zk.object_ref())))),
-        spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_after_create_client_service_step(zk.object_ref())))),
-        spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_after_create_admin_server_service_step(zk.object_ref())))),
-        spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_after_create_config_map_step(zk.object_ref())))),
+        spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_after_create_obj_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateStatefulSet)))),
+        spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_after_create_obj_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateHeadlessService)))),
+        spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_after_create_obj_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateClientService)))),
+        spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_after_create_obj_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateAdminServerService)))),
+        spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_after_create_obj_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateConfigMap)))),
         spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_after_get_stateful_set_step(zk.object_ref())))),
     ensures
         spec.entails(
@@ -322,7 +322,7 @@ pub proof fn lemma_from_after_create_config_map_step_to_reconcile_idle(spec: Tem
             && resp_msg_matches_req_msg(resp_msg, s.pending_req_of(zk.object_ref()))
         })
     };
-    temp_pred_equality::<ClusterState>(lift_state(pending_req_in_flight_or_resp_in_flight_at_after_create_config_map_step(zk.object_ref())), lift_state(at_zookeeper_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateConfigMap)).implies(lift_state(at_after_create_config_map_step_and_pending_req_in_flight_or_resp_in_flight)));
+    temp_pred_equality::<ClusterState>(lift_state(pending_req_in_flight_or_resp_in_flight_at_after_create_obj_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateConfigMap)), lift_state(at_zookeeper_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateConfigMap)).implies(lift_state(at_after_create_config_map_step_and_pending_req_in_flight_or_resp_in_flight)));
     implies_to_leads_to::<ClusterState>(spec, lift_state(at_zookeeper_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateConfigMap)), lift_state(at_after_create_config_map_step_and_pending_req_in_flight_or_resp_in_flight));
 
     let req_in_flight = at_after_create_config_map_step_and_pending_req_in_flight(zk.object_ref());
@@ -359,11 +359,11 @@ pub proof fn lemma_from_after_create_admin_server_service_step_to_reconcile_idle
         spec.entails(always(lift_state(controller_runtime_safety::each_resp_if_matches_pending_req_then_no_other_resp_matches(zk.object_ref())))),
         spec.entails(always(lift_state(reconcile_init_implies_no_pending_req(zk.object_ref())))),
         spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_after_update_stateful_set_step(zk.object_ref())))),
-        spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_after_create_stateful_set_step(zk.object_ref())))),
-        spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_after_create_headless_service_step(zk.object_ref())))),
-        spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_after_create_client_service_step(zk.object_ref())))),
-        spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_after_create_admin_server_service_step(zk.object_ref())))),
-        spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_after_create_config_map_step(zk.object_ref())))),
+        spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_after_create_obj_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateStatefulSet)))),
+        spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_after_create_obj_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateHeadlessService)))),
+        spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_after_create_obj_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateClientService)))),
+        spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_after_create_obj_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateAdminServerService)))),
+        spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_after_create_obj_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateConfigMap)))),
         spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_after_get_stateful_set_step(zk.object_ref())))),
     ensures
         spec.entails(
@@ -381,7 +381,7 @@ pub proof fn lemma_from_after_create_admin_server_service_step_to_reconcile_idle
             && resp_msg_matches_req_msg(resp_msg, s.pending_req_of(zk.object_ref()))
         })
     };
-    temp_pred_equality::<ClusterState>(lift_state(pending_req_in_flight_or_resp_in_flight_at_after_create_admin_server_service_step(zk.object_ref())), lift_state(at_zookeeper_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateAdminServerService)).implies(lift_state(at_after_create_admin_server_service_step_and_pending_req_in_flight_or_resp_in_flight)));
+    temp_pred_equality::<ClusterState>(lift_state(pending_req_in_flight_or_resp_in_flight_at_after_create_obj_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateAdminServerService)), lift_state(at_zookeeper_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateAdminServerService)).implies(lift_state(at_after_create_admin_server_service_step_and_pending_req_in_flight_or_resp_in_flight)));
     implies_to_leads_to::<ClusterState>(spec, lift_state(at_zookeeper_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateAdminServerService)), lift_state(at_after_create_admin_server_service_step_and_pending_req_in_flight_or_resp_in_flight));
 
     let req_in_flight = at_after_create_admin_server_service_step_and_pending_req_in_flight(zk.object_ref());
@@ -418,11 +418,11 @@ pub proof fn lemma_from_after_create_client_service_step_to_reconcile_idle(spec:
         spec.entails(always(lift_state(controller_runtime_safety::each_resp_if_matches_pending_req_then_no_other_resp_matches(zk.object_ref())))),
         spec.entails(always(lift_state(reconcile_init_implies_no_pending_req(zk.object_ref())))),
         spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_after_update_stateful_set_step(zk.object_ref())))),
-        spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_after_create_stateful_set_step(zk.object_ref())))),
-        spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_after_create_headless_service_step(zk.object_ref())))),
-        spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_after_create_client_service_step(zk.object_ref())))),
-        spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_after_create_admin_server_service_step(zk.object_ref())))),
-        spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_after_create_config_map_step(zk.object_ref())))),
+        spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_after_create_obj_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateStatefulSet)))),
+        spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_after_create_obj_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateHeadlessService)))),
+        spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_after_create_obj_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateClientService)))),
+        spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_after_create_obj_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateAdminServerService)))),
+        spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_after_create_obj_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateConfigMap)))),
         spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_after_get_stateful_set_step(zk.object_ref())))),
     ensures
         spec.entails(
@@ -440,7 +440,7 @@ pub proof fn lemma_from_after_create_client_service_step_to_reconcile_idle(spec:
             && resp_msg_matches_req_msg(resp_msg, s.pending_req_of(zk.object_ref()))
         })
     };
-    temp_pred_equality::<ClusterState>(lift_state(pending_req_in_flight_or_resp_in_flight_at_after_create_client_service_step(zk.object_ref())), lift_state(at_zookeeper_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateClientService)).implies(lift_state(at_after_create_client_service_step_and_pending_req_in_flight_or_resp_in_flight)));
+    temp_pred_equality::<ClusterState>(lift_state(pending_req_in_flight_or_resp_in_flight_at_after_create_obj_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateClientService)), lift_state(at_zookeeper_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateClientService)).implies(lift_state(at_after_create_client_service_step_and_pending_req_in_flight_or_resp_in_flight)));
     implies_to_leads_to::<ClusterState>(spec, lift_state(at_zookeeper_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateClientService)), lift_state(at_after_create_client_service_step_and_pending_req_in_flight_or_resp_in_flight));
 
     let req_in_flight = at_after_create_client_service_step_and_pending_req_in_flight(zk.object_ref());
@@ -480,11 +480,11 @@ pub proof fn lemma_from_after_create_headless_service_step_to_reconcile_idle(spe
         spec.entails(always(lift_state(controller_runtime_safety::each_resp_if_matches_pending_req_then_no_other_resp_matches(zk.object_ref())))),
         spec.entails(always(lift_state(reconcile_init_implies_no_pending_req(zk.object_ref())))),
         spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_after_update_stateful_set_step(zk.object_ref())))),
-        spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_after_create_stateful_set_step(zk.object_ref())))),
-        spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_after_create_headless_service_step(zk.object_ref())))),
-        spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_after_create_client_service_step(zk.object_ref())))),
-        spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_after_create_admin_server_service_step(zk.object_ref())))),
-        spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_after_create_config_map_step(zk.object_ref())))),
+        spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_after_create_obj_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateStatefulSet)))),
+        spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_after_create_obj_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateHeadlessService)))),
+        spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_after_create_obj_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateClientService)))),
+        spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_after_create_obj_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateAdminServerService)))),
+        spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_after_create_obj_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateConfigMap)))),
         spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_after_get_stateful_set_step(zk.object_ref())))),
     ensures
         spec.entails(
@@ -502,7 +502,7 @@ pub proof fn lemma_from_after_create_headless_service_step_to_reconcile_idle(spe
             && resp_msg_matches_req_msg(resp_msg, s.pending_req_of(zk.object_ref()))
         })
     };
-    temp_pred_equality::<ClusterState>(lift_state(pending_req_in_flight_or_resp_in_flight_at_after_create_headless_service_step(zk.object_ref())), lift_state(at_zookeeper_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateHeadlessService)).implies(lift_state(at_after_create_headless_service_step_and_pending_req_in_flight_or_resp_in_flight)));
+    temp_pred_equality::<ClusterState>(lift_state(pending_req_in_flight_or_resp_in_flight_at_after_create_obj_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateHeadlessService)), lift_state(at_zookeeper_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateHeadlessService)).implies(lift_state(at_after_create_headless_service_step_and_pending_req_in_flight_or_resp_in_flight)));
     implies_to_leads_to::<ClusterState>(spec, lift_state(at_zookeeper_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateHeadlessService)), lift_state(at_after_create_headless_service_step_and_pending_req_in_flight_or_resp_in_flight));
 
     let req_in_flight = at_after_create_headless_service_step_and_pending_req_in_flight(zk.object_ref());
@@ -538,11 +538,11 @@ pub proof fn lemma_from_init_step_to_reconcile_idle(spec: TempPred<ClusterState>
         spec.entails(always(lift_state(controller_runtime_safety::each_resp_if_matches_pending_req_then_no_other_resp_matches(zk.object_ref())))),
         spec.entails(always(lift_state(reconcile_init_implies_no_pending_req(zk.object_ref())))),
         spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_after_update_stateful_set_step(zk.object_ref())))),
-        spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_after_create_stateful_set_step(zk.object_ref())))),
-        spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_after_create_headless_service_step(zk.object_ref())))),
-        spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_after_create_client_service_step(zk.object_ref())))),
-        spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_after_create_admin_server_service_step(zk.object_ref())))),
-        spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_after_create_config_map_step(zk.object_ref())))),
+        spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_after_create_obj_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateStatefulSet)))),
+        spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_after_create_obj_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateHeadlessService)))),
+        spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_after_create_obj_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateClientService)))),
+        spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_after_create_obj_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateAdminServerService)))),
+        spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_after_create_obj_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateConfigMap)))),
         spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_after_get_stateful_set_step(zk.object_ref())))),
     ensures
         spec.entails(
@@ -596,11 +596,11 @@ proof fn lemma_from_at_after_update_stateful_set_step_and_pending_req_in_flight_
         spec.entails(always(lift_state(controller_runtime_safety::each_resp_if_matches_pending_req_then_no_other_resp_matches(zk.object_ref())))),
         spec.entails(always(lift_state(reconcile_init_implies_no_pending_req(zk.object_ref())))),
         spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_after_update_stateful_set_step(zk.object_ref())))),
-        spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_after_create_stateful_set_step(zk.object_ref())))),
-        spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_after_create_headless_service_step(zk.object_ref())))),
-        spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_after_create_client_service_step(zk.object_ref())))),
-        spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_after_create_admin_server_service_step(zk.object_ref())))),
-        spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_after_create_config_map_step(zk.object_ref())))),
+        spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_after_create_obj_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateStatefulSet)))),
+        spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_after_create_obj_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateHeadlessService)))),
+        spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_after_create_obj_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateClientService)))),
+        spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_after_create_obj_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateAdminServerService)))),
+        spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_after_create_obj_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateConfigMap)))),
         spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_after_get_stateful_set_step(zk.object_ref())))),
     ensures
         spec.entails(lift_state(at_after_update_stateful_set_step_and_pending_req_in_flight(zk.object_ref())).leads_to(lift_state(reconciler_reconcile_done::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>(zk.object_ref())))),
@@ -681,11 +681,11 @@ proof fn lemma_from_at_after_update_stateful_set_step_and_resp_matches_pending_r
         spec.entails(always(lift_state(controller_runtime_safety::each_resp_if_matches_pending_req_then_no_other_resp_matches(zk.object_ref())))),
         spec.entails(always(lift_state(reconcile_init_implies_no_pending_req(zk.object_ref())))),
         spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_after_update_stateful_set_step(zk.object_ref())))),
-        spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_after_create_stateful_set_step(zk.object_ref())))),
-        spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_after_create_headless_service_step(zk.object_ref())))),
-        spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_after_create_client_service_step(zk.object_ref())))),
-        spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_after_create_admin_server_service_step(zk.object_ref())))),
-        spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_after_create_config_map_step(zk.object_ref())))),
+        spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_after_create_obj_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateStatefulSet)))),
+        spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_after_create_obj_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateHeadlessService)))),
+        spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_after_create_obj_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateClientService)))),
+        spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_after_create_obj_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateAdminServerService)))),
+        spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_after_create_obj_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateConfigMap)))),
         spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_after_get_stateful_set_step(zk.object_ref())))),
     ensures
         spec.entails(lift_state(at_after_update_stateful_set_step_and_resp_matches_pending_req_in_flight(zk.object_ref())).leads_to(lift_state(reconciler_reconcile_done::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>(zk.object_ref())))),
@@ -770,11 +770,11 @@ proof fn lemma_from_at_after_create_stateful_set_step_and_pending_req_in_flight_
         spec.entails(always(lift_state(controller_runtime_safety::each_resp_if_matches_pending_req_then_no_other_resp_matches(zk.object_ref())))),
         spec.entails(always(lift_state(reconcile_init_implies_no_pending_req(zk.object_ref())))),
         spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_after_update_stateful_set_step(zk.object_ref())))),
-        spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_after_create_stateful_set_step(zk.object_ref())))),
-        spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_after_create_headless_service_step(zk.object_ref())))),
-        spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_after_create_client_service_step(zk.object_ref())))),
-        spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_after_create_admin_server_service_step(zk.object_ref())))),
-        spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_after_create_config_map_step(zk.object_ref())))),
+        spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_after_create_obj_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateStatefulSet)))),
+        spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_after_create_obj_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateHeadlessService)))),
+        spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_after_create_obj_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateClientService)))),
+        spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_after_create_obj_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateAdminServerService)))),
+        spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_after_create_obj_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateConfigMap)))),
         spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_after_get_stateful_set_step(zk.object_ref())))),
     ensures
         spec.entails(lift_state(at_after_create_stateful_set_step_and_pending_req_in_flight(zk.object_ref())).leads_to(lift_state(reconciler_reconcile_done::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>(zk.object_ref())))),
@@ -855,11 +855,11 @@ proof fn lemma_from_at_after_create_stateful_set_step_and_resp_matches_pending_r
         spec.entails(always(lift_state(controller_runtime_safety::each_resp_if_matches_pending_req_then_no_other_resp_matches(zk.object_ref())))),
         spec.entails(always(lift_state(reconcile_init_implies_no_pending_req(zk.object_ref())))),
         spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_after_update_stateful_set_step(zk.object_ref())))),
-        spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_after_create_stateful_set_step(zk.object_ref())))),
-        spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_after_create_headless_service_step(zk.object_ref())))),
-        spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_after_create_client_service_step(zk.object_ref())))),
-        spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_after_create_admin_server_service_step(zk.object_ref())))),
-        spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_after_create_config_map_step(zk.object_ref())))),
+        spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_after_create_obj_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateStatefulSet)))),
+        spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_after_create_obj_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateHeadlessService)))),
+        spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_after_create_obj_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateClientService)))),
+        spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_after_create_obj_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateAdminServerService)))),
+        spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_after_create_obj_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateConfigMap)))),
         spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_after_get_stateful_set_step(zk.object_ref())))),
     ensures
         spec.entails(lift_state(at_after_create_stateful_set_step_and_resp_matches_pending_req_in_flight(zk.object_ref())).leads_to(lift_state(reconciler_reconcile_done::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>(zk.object_ref())))),
@@ -944,11 +944,11 @@ proof fn lemma_from_at_after_create_headless_service_step_and_pending_req_in_fli
         spec.entails(always(lift_state(controller_runtime_safety::each_resp_if_matches_pending_req_then_no_other_resp_matches(zk.object_ref())))),
         spec.entails(always(lift_state(reconcile_init_implies_no_pending_req(zk.object_ref())))),
         spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_after_update_stateful_set_step(zk.object_ref())))),
-        spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_after_create_stateful_set_step(zk.object_ref())))),
-        spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_after_create_headless_service_step(zk.object_ref())))),
-        spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_after_create_client_service_step(zk.object_ref())))),
-        spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_after_create_admin_server_service_step(zk.object_ref())))),
-        spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_after_create_config_map_step(zk.object_ref())))),
+        spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_after_create_obj_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateStatefulSet)))),
+        spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_after_create_obj_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateHeadlessService)))),
+        spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_after_create_obj_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateClientService)))),
+        spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_after_create_obj_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateAdminServerService)))),
+        spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_after_create_obj_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateConfigMap)))),
         spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_after_get_stateful_set_step(zk.object_ref())))),
     ensures
         spec.entails(lift_state(at_after_create_headless_service_step_and_pending_req_in_flight(zk.object_ref())).leads_to(lift_state(at_zookeeper_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateClientService)))),
@@ -1029,11 +1029,11 @@ proof fn lemma_from_at_after_create_headless_service_step_and_resp_matches_pendi
         spec.entails(always(lift_state(controller_runtime_safety::each_resp_if_matches_pending_req_then_no_other_resp_matches(zk.object_ref())))),
         spec.entails(always(lift_state(reconcile_init_implies_no_pending_req(zk.object_ref())))),
         spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_after_update_stateful_set_step(zk.object_ref())))),
-        spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_after_create_stateful_set_step(zk.object_ref())))),
-        spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_after_create_headless_service_step(zk.object_ref())))),
-        spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_after_create_client_service_step(zk.object_ref())))),
-        spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_after_create_admin_server_service_step(zk.object_ref())))),
-        spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_after_create_config_map_step(zk.object_ref())))),
+        spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_after_create_obj_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateStatefulSet)))),
+        spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_after_create_obj_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateHeadlessService)))),
+        spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_after_create_obj_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateClientService)))),
+        spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_after_create_obj_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateAdminServerService)))),
+        spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_after_create_obj_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateConfigMap)))),
         spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_after_get_stateful_set_step(zk.object_ref())))),
     ensures
         spec.entails(lift_state(at_after_create_headless_service_step_and_resp_matches_pending_req_in_flight(zk.object_ref())).leads_to(lift_state(at_zookeeper_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateClientService)))),
@@ -1119,11 +1119,11 @@ proof fn lemma_from_at_after_create_client_service_step_and_pending_req_in_fligh
         spec.entails(always(lift_state(controller_runtime_safety::each_resp_if_matches_pending_req_then_no_other_resp_matches(zk.object_ref())))),
         spec.entails(always(lift_state(reconcile_init_implies_no_pending_req(zk.object_ref())))),
         spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_after_update_stateful_set_step(zk.object_ref())))),
-        spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_after_create_stateful_set_step(zk.object_ref())))),
-        spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_after_create_headless_service_step(zk.object_ref())))),
-        spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_after_create_client_service_step(zk.object_ref())))),
-        spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_after_create_admin_server_service_step(zk.object_ref())))),
-        spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_after_create_config_map_step(zk.object_ref())))),
+        spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_after_create_obj_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateStatefulSet)))),
+        spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_after_create_obj_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateHeadlessService)))),
+        spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_after_create_obj_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateClientService)))),
+        spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_after_create_obj_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateAdminServerService)))),
+        spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_after_create_obj_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateConfigMap)))),
         spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_after_get_stateful_set_step(zk.object_ref())))),
     ensures
         spec.entails(lift_state(at_after_create_client_service_step_and_pending_req_in_flight(zk.object_ref())).leads_to(lift_state(at_zookeeper_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateAdminServerService)))),
@@ -1204,11 +1204,11 @@ proof fn lemma_from_at_after_create_client_service_step_and_resp_matches_pending
         spec.entails(always(lift_state(controller_runtime_safety::each_resp_if_matches_pending_req_then_no_other_resp_matches(zk.object_ref())))),
         spec.entails(always(lift_state(reconcile_init_implies_no_pending_req(zk.object_ref())))),
         spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_after_update_stateful_set_step(zk.object_ref())))),
-        spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_after_create_stateful_set_step(zk.object_ref())))),
-        spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_after_create_headless_service_step(zk.object_ref())))),
-        spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_after_create_client_service_step(zk.object_ref())))),
-        spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_after_create_admin_server_service_step(zk.object_ref())))),
-        spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_after_create_config_map_step(zk.object_ref())))),
+        spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_after_create_obj_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateStatefulSet)))),
+        spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_after_create_obj_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateHeadlessService)))),
+        spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_after_create_obj_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateClientService)))),
+        spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_after_create_obj_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateAdminServerService)))),
+        spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_after_create_obj_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateConfigMap)))),
         spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_after_get_stateful_set_step(zk.object_ref())))),
     ensures
         spec.entails(lift_state(at_after_create_client_service_step_and_resp_matches_pending_req_in_flight(zk.object_ref())).leads_to(lift_state(at_zookeeper_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateAdminServerService)))),
@@ -1294,11 +1294,11 @@ proof fn lemma_from_at_after_create_admin_server_service_step_and_resp_matches_p
         spec.entails(always(lift_state(controller_runtime_safety::each_resp_if_matches_pending_req_then_no_other_resp_matches(zk.object_ref())))),
         spec.entails(always(lift_state(reconcile_init_implies_no_pending_req(zk.object_ref())))),
         spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_after_update_stateful_set_step(zk.object_ref())))),
-        spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_after_create_stateful_set_step(zk.object_ref())))),
-        spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_after_create_headless_service_step(zk.object_ref())))),
-        spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_after_create_client_service_step(zk.object_ref())))),
-        spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_after_create_admin_server_service_step(zk.object_ref())))),
-        spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_after_create_config_map_step(zk.object_ref())))),
+        spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_after_create_obj_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateStatefulSet)))),
+        spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_after_create_obj_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateHeadlessService)))),
+        spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_after_create_obj_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateClientService)))),
+        spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_after_create_obj_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateAdminServerService)))),
+        spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_after_create_obj_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateConfigMap)))),
         spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_after_get_stateful_set_step(zk.object_ref())))),
     ensures
         spec.entails(lift_state(at_after_create_admin_server_service_step_and_resp_matches_pending_req_in_flight(zk.object_ref())).leads_to(lift_state(at_zookeeper_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateConfigMap)))),
@@ -1384,11 +1384,11 @@ proof fn lemma_from_at_after_create_admin_server_service_step_and_pending_req_in
         spec.entails(always(lift_state(controller_runtime_safety::each_resp_if_matches_pending_req_then_no_other_resp_matches(zk.object_ref())))),
         spec.entails(always(lift_state(reconcile_init_implies_no_pending_req(zk.object_ref())))),
         spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_after_update_stateful_set_step(zk.object_ref())))),
-        spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_after_create_stateful_set_step(zk.object_ref())))),
-        spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_after_create_headless_service_step(zk.object_ref())))),
-        spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_after_create_client_service_step(zk.object_ref())))),
-        spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_after_create_admin_server_service_step(zk.object_ref())))),
-        spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_after_create_config_map_step(zk.object_ref())))),
+        spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_after_create_obj_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateStatefulSet)))),
+        spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_after_create_obj_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateHeadlessService)))),
+        spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_after_create_obj_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateClientService)))),
+        spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_after_create_obj_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateAdminServerService)))),
+        spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_after_create_obj_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateConfigMap)))),
         spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_after_get_stateful_set_step(zk.object_ref())))),
     ensures
         spec.entails(lift_state(at_after_create_admin_server_service_step_and_pending_req_in_flight(zk.object_ref())).leads_to(lift_state(at_zookeeper_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateConfigMap)))),
@@ -1469,11 +1469,11 @@ proof fn lemma_from_at_after_create_config_map_step_and_resp_matches_pending_req
         spec.entails(always(lift_state(controller_runtime_safety::each_resp_if_matches_pending_req_then_no_other_resp_matches(zk.object_ref())))),
         spec.entails(always(lift_state(reconcile_init_implies_no_pending_req(zk.object_ref())))),
         spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_after_update_stateful_set_step(zk.object_ref())))),
-        spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_after_create_stateful_set_step(zk.object_ref())))),
-        spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_after_create_headless_service_step(zk.object_ref())))),
-        spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_after_create_client_service_step(zk.object_ref())))),
-        spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_after_create_admin_server_service_step(zk.object_ref())))),
-        spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_after_create_config_map_step(zk.object_ref())))),
+        spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_after_create_obj_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateStatefulSet)))),
+        spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_after_create_obj_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateHeadlessService)))),
+        spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_after_create_obj_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateClientService)))),
+        spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_after_create_obj_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateAdminServerService)))),
+        spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_after_create_obj_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateConfigMap)))),
         spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_after_get_stateful_set_step(zk.object_ref())))),
     ensures
         spec.entails(lift_state(at_after_create_config_map_step_and_resp_matches_pending_req_in_flight(zk.object_ref())).leads_to(lift_state(at_zookeeper_step(zk.object_ref(), ZookeeperReconcileStep::AfterGetStatefulSet)))),
@@ -1559,11 +1559,11 @@ proof fn lemma_from_at_after_create_config_map_step_and_pending_req_in_flight_to
         spec.entails(always(lift_state(controller_runtime_safety::each_resp_if_matches_pending_req_then_no_other_resp_matches(zk.object_ref())))),
         spec.entails(always(lift_state(reconcile_init_implies_no_pending_req(zk.object_ref())))),
         spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_after_update_stateful_set_step(zk.object_ref())))),
-        spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_after_create_stateful_set_step(zk.object_ref())))),
-        spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_after_create_headless_service_step(zk.object_ref())))),
-        spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_after_create_client_service_step(zk.object_ref())))),
-        spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_after_create_admin_server_service_step(zk.object_ref())))),
-        spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_after_create_config_map_step(zk.object_ref())))),
+        spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_after_create_obj_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateStatefulSet)))),
+        spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_after_create_obj_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateHeadlessService)))),
+        spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_after_create_obj_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateClientService)))),
+        spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_after_create_obj_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateAdminServerService)))),
+        spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_after_create_obj_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateConfigMap)))),
         spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_after_get_stateful_set_step(zk.object_ref())))),
     ensures
         spec.entails(lift_state(at_after_create_config_map_step_and_pending_req_in_flight(zk.object_ref())).leads_to(lift_state(at_zookeeper_step(zk.object_ref(), ZookeeperReconcileStep::AfterGetStatefulSet)))),
@@ -1644,11 +1644,11 @@ proof fn lemma_from_at_after_get_stateful_set_step_and_resp_matches_pending_req_
         spec.entails(always(lift_state(controller_runtime_safety::each_resp_if_matches_pending_req_then_no_other_resp_matches(zk.object_ref())))),
         spec.entails(always(lift_state(reconcile_init_implies_no_pending_req(zk.object_ref())))),
         spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_after_update_stateful_set_step(zk.object_ref())))),
-        spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_after_create_stateful_set_step(zk.object_ref())))),
-        spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_after_create_headless_service_step(zk.object_ref())))),
-        spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_after_create_client_service_step(zk.object_ref())))),
-        spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_after_create_admin_server_service_step(zk.object_ref())))),
-        spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_after_create_config_map_step(zk.object_ref())))),
+        spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_after_create_obj_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateStatefulSet)))),
+        spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_after_create_obj_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateHeadlessService)))),
+        spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_after_create_obj_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateClientService)))),
+        spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_after_create_obj_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateAdminServerService)))),
+        spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_after_create_obj_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateConfigMap)))),
         spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_after_get_stateful_set_step(zk.object_ref())))),
     ensures
         spec.entails(lift_state(at_after_get_stateful_set_step_and_resp_matches_pending_req_in_flight(zk.object_ref())).leads_to(lift_state(|s: ClusterState| { !s.reconcile_state_contains(zk.object_ref()) }))),
@@ -1758,11 +1758,11 @@ proof fn lemma_from_at_after_get_stateful_set_step_and_pending_req_in_flight_to_
         spec.entails(always(lift_state(controller_runtime_safety::each_resp_if_matches_pending_req_then_no_other_resp_matches(zk.object_ref())))),
         spec.entails(always(lift_state(reconcile_init_implies_no_pending_req(zk.object_ref())))),
         spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_after_update_stateful_set_step(zk.object_ref())))),
-        spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_after_create_stateful_set_step(zk.object_ref())))),
-        spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_after_create_headless_service_step(zk.object_ref())))),
-        spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_after_create_client_service_step(zk.object_ref())))),
-        spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_after_create_admin_server_service_step(zk.object_ref())))),
-        spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_after_create_config_map_step(zk.object_ref())))),
+        spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_after_create_obj_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateStatefulSet)))),
+        spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_after_create_obj_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateHeadlessService)))),
+        spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_after_create_obj_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateClientService)))),
+        spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_after_create_obj_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateAdminServerService)))),
+        spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_after_create_obj_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateConfigMap)))),
         spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_after_get_stateful_set_step(zk.object_ref())))),
     ensures
         spec.entails(lift_state(at_after_get_stateful_set_step_and_pending_req_in_flight(zk.object_ref())).leads_to(lift_state(|s: ClusterState| { !s.reconcile_state_contains(zk.object_ref()) }))),

--- a/src/controller_examples/zookeeper_controller/proof/terminate.rs
+++ b/src/controller_examples/zookeeper_controller/proof/terminate.rs
@@ -144,8 +144,8 @@ pub proof fn lemma_from_after_update_stateful_set_step_to_reconcile_idle(spec: T
     temp_pred_equality::<ClusterState>(lift_state(pending_req_in_flight_or_resp_in_flight_at_step(zk.object_ref(), ZookeeperReconcileStep::AfterUpdateStatefulSet)), lift_state(at_zookeeper_step(zk.object_ref(), ZookeeperReconcileStep::AfterUpdateStatefulSet)).implies(lift_state(at_after_update_stateful_set_step_and_pending_req_in_flight_or_resp_in_flight)));
     implies_to_leads_to::<ClusterState>(spec, lift_state(at_zookeeper_step(zk.object_ref(), ZookeeperReconcileStep::AfterUpdateStatefulSet)), lift_state(at_after_update_stateful_set_step_and_pending_req_in_flight_or_resp_in_flight));
 
-    let req_in_flight = at_after_update_stateful_set_step_and_pending_req_in_flight(zk.object_ref());
-    let resp_in_flight = at_after_update_stateful_set_step_and_resp_matches_pending_req_in_flight(zk.object_ref());
+    let req_in_flight = pending_req_in_flight_at_step(zk.object_ref(), ZookeeperReconcileStep::AfterUpdateStatefulSet);
+    let resp_in_flight = resp_in_flight_matches_pending_req_at_step(zk.object_ref(), ZookeeperReconcileStep::AfterUpdateStatefulSet);
     // To show after_update_sts_step ~> done_step
     // Use or_leads_to_combine after discussing the two cases:
     // 1. resp_in_flight ~> done_step
@@ -206,8 +206,8 @@ pub proof fn lemma_from_after_create_stateful_set_step_to_reconcile_idle(spec: T
     temp_pred_equality::<ClusterState>(lift_state(pending_req_in_flight_or_resp_in_flight_at_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateStatefulSet)), lift_state(at_zookeeper_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateStatefulSet)).implies(lift_state(at_after_create_stateful_set_step_and_pending_req_in_flight_or_resp_in_flight)));
     implies_to_leads_to::<ClusterState>(spec, lift_state(at_zookeeper_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateStatefulSet)), lift_state(at_after_create_stateful_set_step_and_pending_req_in_flight_or_resp_in_flight));
 
-    let req_in_flight = at_after_create_stateful_set_step_and_pending_req_in_flight(zk.object_ref());
-    let resp_in_flight = at_after_create_stateful_set_step_and_resp_matches_pending_req_in_flight(zk.object_ref());
+    let req_in_flight = pending_req_in_flight_at_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateStatefulSet);
+    let resp_in_flight = resp_in_flight_matches_pending_req_at_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateStatefulSet);
     // To show after_update_sts_step ~> done_step
     // Use or_leads_to_combine after discussing the two cases:
     // 1. resp_in_flight ~> done_step
@@ -268,8 +268,8 @@ pub proof fn lemma_from_after_get_stateful_set_step_to_reconcile_idle(spec: Temp
     temp_pred_equality::<ClusterState>(lift_state(pending_req_in_flight_or_resp_in_flight_at_step(zk.object_ref(), ZookeeperReconcileStep::AfterGetStatefulSet)), lift_state(at_zookeeper_step(zk.object_ref(), ZookeeperReconcileStep::AfterGetStatefulSet)).implies(lift_state(at_after_get_stateful_set_step_and_pending_req_in_flight_or_resp_in_flight)));
     implies_to_leads_to::<ClusterState>(spec, lift_state(at_zookeeper_step(zk.object_ref(), ZookeeperReconcileStep::AfterGetStatefulSet)), lift_state(at_after_get_stateful_set_step_and_pending_req_in_flight_or_resp_in_flight));
 
-    let req_in_flight = at_after_get_stateful_set_step_and_pending_req_in_flight(zk.object_ref());
-    let resp_in_flight = at_after_get_stateful_set_step_and_resp_matches_pending_req_in_flight(zk.object_ref());
+    let req_in_flight = pending_req_in_flight_at_step(zk.object_ref(), ZookeeperReconcileStep::AfterGetStatefulSet);
+    let resp_in_flight = resp_in_flight_matches_pending_req_at_step(zk.object_ref(), ZookeeperReconcileStep::AfterGetStatefulSet);
 
     let done_step = reconciler_reconcile_done::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>(zk.object_ref());
     lemma_from_at_after_get_stateful_set_step_and_resp_matches_pending_req_in_flight_to_reconcile_idle(spec, zk);
@@ -322,8 +322,8 @@ pub proof fn lemma_from_after_create_config_map_step_to_reconcile_idle(spec: Tem
     temp_pred_equality::<ClusterState>(lift_state(pending_req_in_flight_or_resp_in_flight_at_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateConfigMap)), lift_state(at_zookeeper_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateConfigMap)).implies(lift_state(at_after_create_config_map_step_and_pending_req_in_flight_or_resp_in_flight)));
     implies_to_leads_to::<ClusterState>(spec, lift_state(at_zookeeper_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateConfigMap)), lift_state(at_after_create_config_map_step_and_pending_req_in_flight_or_resp_in_flight));
 
-    let req_in_flight = at_after_create_config_map_step_and_pending_req_in_flight(zk.object_ref());
-    let resp_in_flight = at_after_create_config_map_step_and_resp_matches_pending_req_in_flight(zk.object_ref());
+    let req_in_flight = pending_req_in_flight_at_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateConfigMap);
+    let resp_in_flight = resp_in_flight_matches_pending_req_at_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateConfigMap);
 
     let done_step = reconciler_reconcile_done::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>(zk.object_ref());
     lemma_from_at_after_create_config_map_step_and_resp_matches_pending_req_in_flight_to_after_get_stateful_set_step(spec, zk);
@@ -381,8 +381,8 @@ pub proof fn lemma_from_after_create_admin_server_service_step_to_reconcile_idle
     temp_pred_equality::<ClusterState>(lift_state(pending_req_in_flight_or_resp_in_flight_at_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateAdminServerService)), lift_state(at_zookeeper_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateAdminServerService)).implies(lift_state(at_after_create_admin_server_service_step_and_pending_req_in_flight_or_resp_in_flight)));
     implies_to_leads_to::<ClusterState>(spec, lift_state(at_zookeeper_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateAdminServerService)), lift_state(at_after_create_admin_server_service_step_and_pending_req_in_flight_or_resp_in_flight));
 
-    let req_in_flight = at_after_create_admin_server_service_step_and_pending_req_in_flight(zk.object_ref());
-    let resp_in_flight = at_after_create_admin_server_service_step_and_resp_matches_pending_req_in_flight(zk.object_ref());
+    let req_in_flight = pending_req_in_flight_at_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateAdminServerService);
+    let resp_in_flight = resp_in_flight_matches_pending_req_at_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateAdminServerService);
 
     let done_step = reconciler_reconcile_done::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>(zk.object_ref());
     lemma_from_at_after_create_admin_server_service_step_and_resp_matches_pending_req_in_flight_to_after_create_config_map_step(spec, zk);
@@ -440,8 +440,8 @@ pub proof fn lemma_from_after_create_client_service_step_to_reconcile_idle(spec:
     temp_pred_equality::<ClusterState>(lift_state(pending_req_in_flight_or_resp_in_flight_at_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateClientService)), lift_state(at_zookeeper_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateClientService)).implies(lift_state(at_after_create_client_service_step_and_pending_req_in_flight_or_resp_in_flight)));
     implies_to_leads_to::<ClusterState>(spec, lift_state(at_zookeeper_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateClientService)), lift_state(at_after_create_client_service_step_and_pending_req_in_flight_or_resp_in_flight));
 
-    let req_in_flight = at_after_create_client_service_step_and_pending_req_in_flight(zk.object_ref());
-    let resp_in_flight = at_after_create_client_service_step_and_resp_matches_pending_req_in_flight(zk.object_ref());
+    let req_in_flight = pending_req_in_flight_at_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateClientService);
+    let resp_in_flight = resp_in_flight_matches_pending_req_at_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateClientService);
     // To show after_update_sts_step ~> done_step
     // Use or_leads_to_combine after discussing the two cases:
     // 1. resp_in_flight ~> done_step
@@ -502,8 +502,8 @@ pub proof fn lemma_from_after_create_headless_service_step_to_reconcile_idle(spe
     temp_pred_equality::<ClusterState>(lift_state(pending_req_in_flight_or_resp_in_flight_at_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateHeadlessService)), lift_state(at_zookeeper_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateHeadlessService)).implies(lift_state(at_after_create_headless_service_step_and_pending_req_in_flight_or_resp_in_flight)));
     implies_to_leads_to::<ClusterState>(spec, lift_state(at_zookeeper_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateHeadlessService)), lift_state(at_after_create_headless_service_step_and_pending_req_in_flight_or_resp_in_flight));
 
-    let req_in_flight = at_after_create_headless_service_step_and_pending_req_in_flight(zk.object_ref());
-    let resp_in_flight = at_after_create_headless_service_step_and_resp_matches_pending_req_in_flight(zk.object_ref());
+    let req_in_flight = pending_req_in_flight_at_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateHeadlessService);
+    let resp_in_flight = resp_in_flight_matches_pending_req_at_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateHeadlessService);
 
     lemma_from_at_after_create_headless_service_step_and_resp_matches_pending_req_in_flight_to_after_create_client_service_step(spec, zk);
     lemma_from_at_after_create_headless_service_step_and_pending_req_in_flight_to_after_create_client_service_step(spec, zk);
@@ -600,16 +600,16 @@ proof fn lemma_from_at_after_update_stateful_set_step_and_pending_req_in_flight_
         spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateConfigMap)))),
         spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_step(zk.object_ref(), ZookeeperReconcileStep::AfterGetStatefulSet)))),
     ensures
-        spec.entails(lift_state(at_after_update_stateful_set_step_and_pending_req_in_flight(zk.object_ref())).leads_to(lift_state(reconciler_reconcile_done::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>(zk.object_ref())))),
+        spec.entails(lift_state(pending_req_in_flight_at_step(zk.object_ref(), ZookeeperReconcileStep::AfterUpdateStatefulSet)).leads_to(lift_state(reconciler_reconcile_done::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>(zk.object_ref())))),
 {
-    let pre = at_after_update_stateful_set_step_and_pending_req_in_flight(zk.object_ref());
+    let pre = pending_req_in_flight_at_step(zk.object_ref(), ZookeeperReconcileStep::AfterUpdateStatefulSet);
     let post = reconciler_reconcile_done::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>(zk.object_ref());
     assert forall |req_msg: Message| spec.entails(
-        lift_state(#[trigger] req_msg_is_the_in_flight_pending_req_at_after_update_stateful_set_step(zk.object_ref(), req_msg))
-            .leads_to(lift_state(at_after_update_stateful_set_step_and_resp_matches_pending_req_in_flight(zk.object_ref())))
+        lift_state(#[trigger] req_msg_is_the_in_flight_pending_req_at_step(zk.object_ref(), ZookeeperReconcileStep::AfterUpdateStatefulSet, req_msg))
+            .leads_to(lift_state(resp_in_flight_matches_pending_req_at_step(zk.object_ref(), ZookeeperReconcileStep::AfterUpdateStatefulSet)))
     ) by {
-        let pre_1 = req_msg_is_the_in_flight_pending_req_at_after_update_stateful_set_step(zk.object_ref(), req_msg);
-        let post_1 = at_after_update_stateful_set_step_and_resp_matches_pending_req_in_flight(zk.object_ref());
+        let pre_1 = req_msg_is_the_in_flight_pending_req_at_step(zk.object_ref(), ZookeeperReconcileStep::AfterUpdateStatefulSet, req_msg);
+        let post_1 = resp_in_flight_matches_pending_req_at_step(zk.object_ref(), ZookeeperReconcileStep::AfterUpdateStatefulSet);
         let stronger_next = |s, s_prime: ClusterState| {
             &&& next::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>()(s, s_prime)
             &&& crash_disabled()(s)
@@ -640,13 +640,13 @@ proof fn lemma_from_at_after_update_stateful_set_step_and_pending_req_in_flight_
             spec, input, stronger_next, handle_request(), pre_1, post_1
         );
     }
-    let msg_2_temp = |msg| lift_state(req_msg_is_the_in_flight_pending_req_at_after_update_stateful_set_step(zk.object_ref(), msg));
+    let msg_2_temp = |msg| lift_state(req_msg_is_the_in_flight_pending_req_at_step(zk.object_ref(), ZookeeperReconcileStep::AfterUpdateStatefulSet, msg));
     leads_to_exists_intro(
         spec, msg_2_temp,
-        lift_state(at_after_update_stateful_set_step_and_resp_matches_pending_req_in_flight(zk.object_ref()))
+        lift_state(resp_in_flight_matches_pending_req_at_step(zk.object_ref(), ZookeeperReconcileStep::AfterUpdateStatefulSet))
     );
     assert_by(
-        tla_exists(|msg| lift_state(req_msg_is_the_in_flight_pending_req_at_after_update_stateful_set_step(zk.object_ref(), msg)))
+        tla_exists(|msg| lift_state(req_msg_is_the_in_flight_pending_req_at_step(zk.object_ref(), ZookeeperReconcileStep::AfterUpdateStatefulSet, msg)))
         == lift_state(pre),
         {
             assert forall |ex| #[trigger] lift_state(pre).satisfied_by(ex) implies
@@ -661,7 +661,7 @@ proof fn lemma_from_at_after_update_stateful_set_step_and_pending_req_in_flight_
     leads_to_trans_n!(
         spec,
         lift_state(pre),
-        lift_state(at_after_update_stateful_set_step_and_resp_matches_pending_req_in_flight(zk.object_ref())),
+        lift_state(resp_in_flight_matches_pending_req_at_step(zk.object_ref(), ZookeeperReconcileStep::AfterUpdateStatefulSet)),
         lift_state(post)
     );
 }
@@ -685,9 +685,9 @@ proof fn lemma_from_at_after_update_stateful_set_step_and_resp_matches_pending_r
         spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateConfigMap)))),
         spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_step(zk.object_ref(), ZookeeperReconcileStep::AfterGetStatefulSet)))),
     ensures
-        spec.entails(lift_state(at_after_update_stateful_set_step_and_resp_matches_pending_req_in_flight(zk.object_ref())).leads_to(lift_state(reconciler_reconcile_done::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>(zk.object_ref())))),
+        spec.entails(lift_state(resp_in_flight_matches_pending_req_at_step(zk.object_ref(), ZookeeperReconcileStep::AfterUpdateStatefulSet)).leads_to(lift_state(reconciler_reconcile_done::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>(zk.object_ref())))),
 {
-    let pre = at_after_update_stateful_set_step_and_resp_matches_pending_req_in_flight(zk.object_ref());
+    let pre = resp_in_flight_matches_pending_req_at_step(zk.object_ref(), ZookeeperReconcileStep::AfterUpdateStatefulSet);
     let post = reconciler_reconcile_done::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>(zk.object_ref());
     let stronger_next = |s, s_prime: ClusterState| {
         &&& next::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>()(s, s_prime)
@@ -774,16 +774,16 @@ proof fn lemma_from_at_after_create_stateful_set_step_and_pending_req_in_flight_
         spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateConfigMap)))),
         spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_step(zk.object_ref(), ZookeeperReconcileStep::AfterGetStatefulSet)))),
     ensures
-        spec.entails(lift_state(at_after_create_stateful_set_step_and_pending_req_in_flight(zk.object_ref())).leads_to(lift_state(reconciler_reconcile_done::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>(zk.object_ref())))),
+        spec.entails(lift_state(pending_req_in_flight_at_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateStatefulSet)).leads_to(lift_state(reconciler_reconcile_done::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>(zk.object_ref())))),
 {
-    let pre = at_after_create_stateful_set_step_and_pending_req_in_flight(zk.object_ref());
+    let pre = pending_req_in_flight_at_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateStatefulSet);
     let post = reconciler_reconcile_done::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>(zk.object_ref());
     assert forall |req_msg: Message| spec.entails(
-        lift_state(#[trigger] req_msg_is_the_in_flight_pending_req_at_after_create_stateful_set_step(zk.object_ref(), req_msg))
-            .leads_to(lift_state(at_after_create_stateful_set_step_and_resp_matches_pending_req_in_flight(zk.object_ref())))
+        lift_state(#[trigger] req_msg_is_the_in_flight_pending_req_at_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateStatefulSet, req_msg))
+            .leads_to(lift_state(resp_in_flight_matches_pending_req_at_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateStatefulSet)))
     ) by {
-        let pre_1 = req_msg_is_the_in_flight_pending_req_at_after_create_stateful_set_step(zk.object_ref(), req_msg);
-        let post_1 = at_after_create_stateful_set_step_and_resp_matches_pending_req_in_flight(zk.object_ref());
+        let pre_1 = req_msg_is_the_in_flight_pending_req_at_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateStatefulSet, req_msg);
+        let post_1 = resp_in_flight_matches_pending_req_at_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateStatefulSet);
         let stronger_next = |s, s_prime: ClusterState| {
             &&& next::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>()(s, s_prime)
             &&& crash_disabled()(s)
@@ -814,13 +814,13 @@ proof fn lemma_from_at_after_create_stateful_set_step_and_pending_req_in_flight_
             spec, input, stronger_next, handle_request(), pre_1, post_1
         );
     }
-    let msg_2_temp = |msg| lift_state(req_msg_is_the_in_flight_pending_req_at_after_create_stateful_set_step(zk.object_ref(), msg));
+    let msg_2_temp = |msg| lift_state(req_msg_is_the_in_flight_pending_req_at_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateStatefulSet, msg));
     leads_to_exists_intro(
         spec, msg_2_temp,
-        lift_state(at_after_create_stateful_set_step_and_resp_matches_pending_req_in_flight(zk.object_ref()))
+        lift_state(resp_in_flight_matches_pending_req_at_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateStatefulSet))
     );
     assert_by(
-        tla_exists(|msg| lift_state(req_msg_is_the_in_flight_pending_req_at_after_create_stateful_set_step(zk.object_ref(), msg)))
+        tla_exists(|msg| lift_state(req_msg_is_the_in_flight_pending_req_at_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateStatefulSet, msg)))
         == lift_state(pre),
         {
             assert forall |ex| #[trigger] lift_state(pre).satisfied_by(ex) implies
@@ -835,7 +835,7 @@ proof fn lemma_from_at_after_create_stateful_set_step_and_pending_req_in_flight_
     leads_to_trans_n!(
         spec,
         lift_state(pre),
-        lift_state(at_after_create_stateful_set_step_and_resp_matches_pending_req_in_flight(zk.object_ref())),
+        lift_state(resp_in_flight_matches_pending_req_at_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateStatefulSet)),
         lift_state(post)
     );
 }
@@ -859,9 +859,9 @@ proof fn lemma_from_at_after_create_stateful_set_step_and_resp_matches_pending_r
         spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateConfigMap)))),
         spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_step(zk.object_ref(), ZookeeperReconcileStep::AfterGetStatefulSet)))),
     ensures
-        spec.entails(lift_state(at_after_create_stateful_set_step_and_resp_matches_pending_req_in_flight(zk.object_ref())).leads_to(lift_state(reconciler_reconcile_done::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>(zk.object_ref())))),
+        spec.entails(lift_state(resp_in_flight_matches_pending_req_at_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateStatefulSet)).leads_to(lift_state(reconciler_reconcile_done::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>(zk.object_ref())))),
 {
-    let pre = at_after_create_stateful_set_step_and_resp_matches_pending_req_in_flight(zk.object_ref());
+    let pre = resp_in_flight_matches_pending_req_at_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateStatefulSet);
     let post = reconciler_reconcile_done::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>(zk.object_ref());
     let stronger_next = |s, s_prime: ClusterState| {
         &&& next::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>()(s, s_prime)
@@ -948,16 +948,16 @@ proof fn lemma_from_at_after_create_headless_service_step_and_pending_req_in_fli
         spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateConfigMap)))),
         spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_step(zk.object_ref(), ZookeeperReconcileStep::AfterGetStatefulSet)))),
     ensures
-        spec.entails(lift_state(at_after_create_headless_service_step_and_pending_req_in_flight(zk.object_ref())).leads_to(lift_state(at_zookeeper_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateClientService)))),
+        spec.entails(lift_state(pending_req_in_flight_at_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateHeadlessService)).leads_to(lift_state(at_zookeeper_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateClientService)))),
 {
-    let pre = at_after_create_headless_service_step_and_pending_req_in_flight(zk.object_ref());
+    let pre = pending_req_in_flight_at_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateHeadlessService);
     let post = at_zookeeper_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateClientService);
     assert forall |req_msg: Message| spec.entails(
-        lift_state(#[trigger] req_msg_is_the_in_flight_pending_req_at_after_create_headless_service_step(zk.object_ref(), req_msg))
-            .leads_to(lift_state(at_after_create_headless_service_step_and_resp_matches_pending_req_in_flight(zk.object_ref())))
+        lift_state(#[trigger] req_msg_is_the_in_flight_pending_req_at_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateHeadlessService, req_msg))
+            .leads_to(lift_state(resp_in_flight_matches_pending_req_at_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateHeadlessService)))
     ) by {
-        let pre_1 = req_msg_is_the_in_flight_pending_req_at_after_create_headless_service_step(zk.object_ref(), req_msg);
-        let post_1 = at_after_create_headless_service_step_and_resp_matches_pending_req_in_flight(zk.object_ref());
+        let pre_1 = req_msg_is_the_in_flight_pending_req_at_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateHeadlessService, req_msg);
+        let post_1 = resp_in_flight_matches_pending_req_at_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateHeadlessService);
         let stronger_next = |s, s_prime: ClusterState| {
             &&& next::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>()(s, s_prime)
             &&& crash_disabled()(s)
@@ -988,13 +988,13 @@ proof fn lemma_from_at_after_create_headless_service_step_and_pending_req_in_fli
             spec, input, stronger_next, handle_request(), pre_1, post_1
         );
     }
-    let msg_2_temp = |msg| lift_state(req_msg_is_the_in_flight_pending_req_at_after_create_headless_service_step(zk.object_ref(), msg));
+    let msg_2_temp = |msg| lift_state(req_msg_is_the_in_flight_pending_req_at_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateHeadlessService, msg));
     leads_to_exists_intro(
         spec, msg_2_temp,
-        lift_state(at_after_create_headless_service_step_and_resp_matches_pending_req_in_flight(zk.object_ref()))
+        lift_state(resp_in_flight_matches_pending_req_at_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateHeadlessService))
     );
     assert_by(
-        tla_exists(|msg| lift_state(req_msg_is_the_in_flight_pending_req_at_after_create_headless_service_step(zk.object_ref(), msg)))
+        tla_exists(|msg| lift_state(req_msg_is_the_in_flight_pending_req_at_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateHeadlessService, msg)))
         == lift_state(pre),
         {
             assert forall |ex| #[trigger] lift_state(pre).satisfied_by(ex) implies
@@ -1009,7 +1009,7 @@ proof fn lemma_from_at_after_create_headless_service_step_and_pending_req_in_fli
     leads_to_trans_n!(
         spec,
         lift_state(pre),
-        lift_state(at_after_create_headless_service_step_and_resp_matches_pending_req_in_flight(zk.object_ref())),
+        lift_state(resp_in_flight_matches_pending_req_at_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateHeadlessService)),
         lift_state(post)
     );
 }
@@ -1033,9 +1033,9 @@ proof fn lemma_from_at_after_create_headless_service_step_and_resp_matches_pendi
         spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateConfigMap)))),
         spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_step(zk.object_ref(), ZookeeperReconcileStep::AfterGetStatefulSet)))),
     ensures
-        spec.entails(lift_state(at_after_create_headless_service_step_and_resp_matches_pending_req_in_flight(zk.object_ref())).leads_to(lift_state(at_zookeeper_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateClientService)))),
+        spec.entails(lift_state(resp_in_flight_matches_pending_req_at_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateHeadlessService)).leads_to(lift_state(at_zookeeper_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateClientService)))),
 {
-    let pre = at_after_create_headless_service_step_and_resp_matches_pending_req_in_flight(zk.object_ref());
+    let pre = resp_in_flight_matches_pending_req_at_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateHeadlessService);
     let post = at_zookeeper_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateClientService);
     // TODO: lift stronger next to a public spec
     let stronger_next = |s, s_prime: ClusterState| {
@@ -1123,16 +1123,16 @@ proof fn lemma_from_at_after_create_client_service_step_and_pending_req_in_fligh
         spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateConfigMap)))),
         spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_step(zk.object_ref(), ZookeeperReconcileStep::AfterGetStatefulSet)))),
     ensures
-        spec.entails(lift_state(at_after_create_client_service_step_and_pending_req_in_flight(zk.object_ref())).leads_to(lift_state(at_zookeeper_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateAdminServerService)))),
+        spec.entails(lift_state(pending_req_in_flight_at_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateClientService)).leads_to(lift_state(at_zookeeper_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateAdminServerService)))),
 {
-    let pre = at_after_create_client_service_step_and_pending_req_in_flight(zk.object_ref());
+    let pre = pending_req_in_flight_at_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateClientService);
     let post = at_zookeeper_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateAdminServerService);
     assert forall |req_msg: Message| spec.entails(
-        lift_state(#[trigger] req_msg_is_the_in_flight_pending_req_at_after_create_client_service_step(zk.object_ref(), req_msg))
-            .leads_to(lift_state(at_after_create_client_service_step_and_resp_matches_pending_req_in_flight(zk.object_ref())))
+        lift_state(#[trigger] req_msg_is_the_in_flight_pending_req_at_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateClientService, req_msg))
+            .leads_to(lift_state(resp_in_flight_matches_pending_req_at_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateClientService)))
     ) by {
-        let pre_1 = req_msg_is_the_in_flight_pending_req_at_after_create_client_service_step(zk.object_ref(), req_msg);
-        let post_1 = at_after_create_client_service_step_and_resp_matches_pending_req_in_flight(zk.object_ref());
+        let pre_1 = req_msg_is_the_in_flight_pending_req_at_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateClientService, req_msg);
+        let post_1 = resp_in_flight_matches_pending_req_at_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateClientService);
         let stronger_next = |s, s_prime: ClusterState| {
             &&& next::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>()(s, s_prime)
             &&& crash_disabled()(s)
@@ -1163,13 +1163,13 @@ proof fn lemma_from_at_after_create_client_service_step_and_pending_req_in_fligh
             spec, input, stronger_next, handle_request(), pre_1, post_1
         );
     }
-    let msg_2_temp = |msg| lift_state(req_msg_is_the_in_flight_pending_req_at_after_create_client_service_step(zk.object_ref(), msg));
+    let msg_2_temp = |msg| lift_state(req_msg_is_the_in_flight_pending_req_at_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateClientService, msg));
     leads_to_exists_intro(
         spec, msg_2_temp,
-        lift_state(at_after_create_client_service_step_and_resp_matches_pending_req_in_flight(zk.object_ref()))
+        lift_state(resp_in_flight_matches_pending_req_at_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateClientService))
     );
     assert_by(
-        tla_exists(|msg| lift_state(req_msg_is_the_in_flight_pending_req_at_after_create_client_service_step(zk.object_ref(), msg)))
+        tla_exists(|msg| lift_state(req_msg_is_the_in_flight_pending_req_at_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateClientService, msg)))
         == lift_state(pre),
         {
             assert forall |ex| #[trigger] lift_state(pre).satisfied_by(ex) implies
@@ -1184,7 +1184,7 @@ proof fn lemma_from_at_after_create_client_service_step_and_pending_req_in_fligh
     leads_to_trans_n!(
         spec,
         lift_state(pre),
-        lift_state(at_after_create_client_service_step_and_resp_matches_pending_req_in_flight(zk.object_ref())),
+        lift_state(resp_in_flight_matches_pending_req_at_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateClientService)),
         lift_state(post)
     );
 }
@@ -1208,9 +1208,9 @@ proof fn lemma_from_at_after_create_client_service_step_and_resp_matches_pending
         spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateConfigMap)))),
         spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_step(zk.object_ref(), ZookeeperReconcileStep::AfterGetStatefulSet)))),
     ensures
-        spec.entails(lift_state(at_after_create_client_service_step_and_resp_matches_pending_req_in_flight(zk.object_ref())).leads_to(lift_state(at_zookeeper_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateAdminServerService)))),
+        spec.entails(lift_state(resp_in_flight_matches_pending_req_at_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateClientService)).leads_to(lift_state(at_zookeeper_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateAdminServerService)))),
 {
-    let pre = at_after_create_client_service_step_and_resp_matches_pending_req_in_flight(zk.object_ref());
+    let pre = resp_in_flight_matches_pending_req_at_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateClientService);
     let post = at_zookeeper_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateAdminServerService);
     // TODO: lift stronger next to a public spec
     let stronger_next = |s, s_prime: ClusterState| {
@@ -1298,9 +1298,9 @@ proof fn lemma_from_at_after_create_admin_server_service_step_and_resp_matches_p
         spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateConfigMap)))),
         spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_step(zk.object_ref(), ZookeeperReconcileStep::AfterGetStatefulSet)))),
     ensures
-        spec.entails(lift_state(at_after_create_admin_server_service_step_and_resp_matches_pending_req_in_flight(zk.object_ref())).leads_to(lift_state(at_zookeeper_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateConfigMap)))),
+        spec.entails(lift_state(resp_in_flight_matches_pending_req_at_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateAdminServerService)).leads_to(lift_state(at_zookeeper_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateConfigMap)))),
 {
-    let pre = at_after_create_admin_server_service_step_and_resp_matches_pending_req_in_flight(zk.object_ref());
+    let pre = resp_in_flight_matches_pending_req_at_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateAdminServerService);
     let post = at_zookeeper_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateConfigMap);
     // TODO: lift stronger next to a public spec
     let stronger_next = |s, s_prime: ClusterState| {
@@ -1388,16 +1388,16 @@ proof fn lemma_from_at_after_create_admin_server_service_step_and_pending_req_in
         spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateConfigMap)))),
         spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_step(zk.object_ref(), ZookeeperReconcileStep::AfterGetStatefulSet)))),
     ensures
-        spec.entails(lift_state(at_after_create_admin_server_service_step_and_pending_req_in_flight(zk.object_ref())).leads_to(lift_state(at_zookeeper_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateConfigMap)))),
+        spec.entails(lift_state(pending_req_in_flight_at_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateAdminServerService)).leads_to(lift_state(at_zookeeper_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateConfigMap)))),
 {
-    let pre = at_after_create_admin_server_service_step_and_pending_req_in_flight(zk.object_ref());
+    let pre = pending_req_in_flight_at_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateAdminServerService);
     let post = at_zookeeper_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateConfigMap);
     assert forall |req_msg: Message| spec.entails(
-        lift_state(#[trigger] req_msg_is_the_in_flight_pending_req_at_after_create_admin_server_service_step(zk.object_ref(), req_msg))
-            .leads_to(lift_state(at_after_create_admin_server_service_step_and_resp_matches_pending_req_in_flight(zk.object_ref())))
+        lift_state(#[trigger] req_msg_is_the_in_flight_pending_req_at_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateAdminServerService, req_msg))
+            .leads_to(lift_state(resp_in_flight_matches_pending_req_at_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateAdminServerService)))
     ) by {
-        let pre_1 = req_msg_is_the_in_flight_pending_req_at_after_create_admin_server_service_step(zk.object_ref(), req_msg);
-        let post_1 = at_after_create_admin_server_service_step_and_resp_matches_pending_req_in_flight(zk.object_ref());
+        let pre_1 = req_msg_is_the_in_flight_pending_req_at_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateAdminServerService, req_msg);
+        let post_1 = resp_in_flight_matches_pending_req_at_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateAdminServerService);
         let stronger_next = |s, s_prime: ClusterState| {
             &&& next::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>()(s, s_prime)
             &&& crash_disabled()(s)
@@ -1428,13 +1428,13 @@ proof fn lemma_from_at_after_create_admin_server_service_step_and_pending_req_in
             spec, input, stronger_next, handle_request(), pre_1, post_1
         );
     }
-    let msg_2_temp = |msg| lift_state(req_msg_is_the_in_flight_pending_req_at_after_create_admin_server_service_step(zk.object_ref(), msg));
+    let msg_2_temp = |msg| lift_state(req_msg_is_the_in_flight_pending_req_at_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateAdminServerService, msg));
     leads_to_exists_intro(
         spec, msg_2_temp,
-        lift_state(at_after_create_admin_server_service_step_and_resp_matches_pending_req_in_flight(zk.object_ref()))
+        lift_state(resp_in_flight_matches_pending_req_at_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateAdminServerService))
     );
     assert_by(
-        tla_exists(|msg| lift_state(req_msg_is_the_in_flight_pending_req_at_after_create_admin_server_service_step(zk.object_ref(), msg)))
+        tla_exists(|msg| lift_state(req_msg_is_the_in_flight_pending_req_at_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateAdminServerService, msg)))
         == lift_state(pre),
         {
             assert forall |ex| #[trigger] lift_state(pre).satisfied_by(ex) implies
@@ -1449,7 +1449,7 @@ proof fn lemma_from_at_after_create_admin_server_service_step_and_pending_req_in
     leads_to_trans_n!(
         spec,
         lift_state(pre),
-        lift_state(at_after_create_admin_server_service_step_and_resp_matches_pending_req_in_flight(zk.object_ref())),
+        lift_state(resp_in_flight_matches_pending_req_at_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateAdminServerService)),
         lift_state(post)
     );
 }
@@ -1473,9 +1473,9 @@ proof fn lemma_from_at_after_create_config_map_step_and_resp_matches_pending_req
         spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateConfigMap)))),
         spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_step(zk.object_ref(), ZookeeperReconcileStep::AfterGetStatefulSet)))),
     ensures
-        spec.entails(lift_state(at_after_create_config_map_step_and_resp_matches_pending_req_in_flight(zk.object_ref())).leads_to(lift_state(at_zookeeper_step(zk.object_ref(), ZookeeperReconcileStep::AfterGetStatefulSet)))),
+        spec.entails(lift_state(resp_in_flight_matches_pending_req_at_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateConfigMap)).leads_to(lift_state(at_zookeeper_step(zk.object_ref(), ZookeeperReconcileStep::AfterGetStatefulSet)))),
 {
-    let pre = at_after_create_config_map_step_and_resp_matches_pending_req_in_flight(zk.object_ref());
+    let pre = resp_in_flight_matches_pending_req_at_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateConfigMap);
     let post = at_zookeeper_step(zk.object_ref(), ZookeeperReconcileStep::AfterGetStatefulSet);
     // TODO: lift stronger next to a public spec
     let stronger_next = |s, s_prime: ClusterState| {
@@ -1563,16 +1563,16 @@ proof fn lemma_from_at_after_create_config_map_step_and_pending_req_in_flight_to
         spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateConfigMap)))),
         spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_step(zk.object_ref(), ZookeeperReconcileStep::AfterGetStatefulSet)))),
     ensures
-        spec.entails(lift_state(at_after_create_config_map_step_and_pending_req_in_flight(zk.object_ref())).leads_to(lift_state(at_zookeeper_step(zk.object_ref(), ZookeeperReconcileStep::AfterGetStatefulSet)))),
+        spec.entails(lift_state(pending_req_in_flight_at_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateConfigMap)).leads_to(lift_state(at_zookeeper_step(zk.object_ref(), ZookeeperReconcileStep::AfterGetStatefulSet)))),
 {
-    let pre = at_after_create_config_map_step_and_pending_req_in_flight(zk.object_ref());
+    let pre = pending_req_in_flight_at_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateConfigMap);
     let post = at_zookeeper_step(zk.object_ref(), ZookeeperReconcileStep::AfterGetStatefulSet);
     assert forall |req_msg: Message| spec.entails(
-        lift_state(#[trigger] req_msg_is_the_in_flight_pending_req_at_after_create_config_map_step(zk.object_ref(), req_msg))
-            .leads_to(lift_state(at_after_create_config_map_step_and_resp_matches_pending_req_in_flight(zk.object_ref())))
+        lift_state(#[trigger] req_msg_is_the_in_flight_pending_req_at_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateConfigMap, req_msg))
+            .leads_to(lift_state(resp_in_flight_matches_pending_req_at_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateConfigMap)))
     ) by {
-        let pre_1 = req_msg_is_the_in_flight_pending_req_at_after_create_config_map_step(zk.object_ref(), req_msg);
-        let post_1 = at_after_create_config_map_step_and_resp_matches_pending_req_in_flight(zk.object_ref());
+        let pre_1 = req_msg_is_the_in_flight_pending_req_at_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateConfigMap, req_msg);
+        let post_1 = resp_in_flight_matches_pending_req_at_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateConfigMap);
         let stronger_next = |s, s_prime: ClusterState| {
             &&& next::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>()(s, s_prime)
             &&& crash_disabled()(s)
@@ -1603,13 +1603,13 @@ proof fn lemma_from_at_after_create_config_map_step_and_pending_req_in_flight_to
             spec, input, stronger_next, handle_request(), pre_1, post_1
         );
     }
-    let msg_2_temp = |msg| lift_state(req_msg_is_the_in_flight_pending_req_at_after_create_config_map_step(zk.object_ref(), msg));
+    let msg_2_temp = |msg| lift_state(req_msg_is_the_in_flight_pending_req_at_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateConfigMap, msg));
     leads_to_exists_intro(
         spec, msg_2_temp,
-        lift_state(at_after_create_config_map_step_and_resp_matches_pending_req_in_flight(zk.object_ref()))
+        lift_state(resp_in_flight_matches_pending_req_at_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateConfigMap))
     );
     assert_by(
-        tla_exists(|msg| lift_state(req_msg_is_the_in_flight_pending_req_at_after_create_config_map_step(zk.object_ref(), msg)))
+        tla_exists(|msg| lift_state(req_msg_is_the_in_flight_pending_req_at_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateConfigMap, msg)))
         == lift_state(pre),
         {
             assert forall |ex| #[trigger] lift_state(pre).satisfied_by(ex) implies
@@ -1624,7 +1624,7 @@ proof fn lemma_from_at_after_create_config_map_step_and_pending_req_in_flight_to
     leads_to_trans_n!(
         spec,
         lift_state(pre),
-        lift_state(at_after_create_config_map_step_and_resp_matches_pending_req_in_flight(zk.object_ref())),
+        lift_state(resp_in_flight_matches_pending_req_at_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateConfigMap)),
         lift_state(post)
     );
 }
@@ -1648,9 +1648,9 @@ proof fn lemma_from_at_after_get_stateful_set_step_and_resp_matches_pending_req_
         spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateConfigMap)))),
         spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_step(zk.object_ref(), ZookeeperReconcileStep::AfterGetStatefulSet)))),
     ensures
-        spec.entails(lift_state(at_after_get_stateful_set_step_and_resp_matches_pending_req_in_flight(zk.object_ref())).leads_to(lift_state(|s: ClusterState| { !s.reconcile_state_contains(zk.object_ref()) }))),
+        spec.entails(lift_state(resp_in_flight_matches_pending_req_at_step(zk.object_ref(), ZookeeperReconcileStep::AfterGetStatefulSet)).leads_to(lift_state(|s: ClusterState| { !s.reconcile_state_contains(zk.object_ref()) }))),
 {
-    let pre = at_after_get_stateful_set_step_and_resp_matches_pending_req_in_flight(zk.object_ref());
+    let pre = resp_in_flight_matches_pending_req_at_step(zk.object_ref(), ZookeeperReconcileStep::AfterGetStatefulSet);
     let post = |s: ClusterState| {
         s.reconcile_state_contains(zk.object_ref())
         && (
@@ -1762,16 +1762,16 @@ proof fn lemma_from_at_after_get_stateful_set_step_and_pending_req_in_flight_to_
         spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateConfigMap)))),
         spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_step(zk.object_ref(), ZookeeperReconcileStep::AfterGetStatefulSet)))),
     ensures
-        spec.entails(lift_state(at_after_get_stateful_set_step_and_pending_req_in_flight(zk.object_ref())).leads_to(lift_state(|s: ClusterState| { !s.reconcile_state_contains(zk.object_ref()) }))),
+        spec.entails(lift_state(pending_req_in_flight_at_step(zk.object_ref(), ZookeeperReconcileStep::AfterGetStatefulSet)).leads_to(lift_state(|s: ClusterState| { !s.reconcile_state_contains(zk.object_ref()) }))),
 {
-    let pre = at_after_get_stateful_set_step_and_pending_req_in_flight(zk.object_ref());
+    let pre = pending_req_in_flight_at_step(zk.object_ref(), ZookeeperReconcileStep::AfterGetStatefulSet);
     let post = |s: ClusterState| { !s.reconcile_state_contains(zk.object_ref()) };
     assert forall |req_msg: Message| spec.entails(
-        lift_state(#[trigger] req_msg_is_the_in_flight_pending_req_at_after_get_stateful_set_step(zk.object_ref(), req_msg))
-            .leads_to(lift_state(at_after_get_stateful_set_step_and_resp_matches_pending_req_in_flight(zk.object_ref())))
+        lift_state(#[trigger] req_msg_is_the_in_flight_pending_req_at_step(zk.object_ref(), ZookeeperReconcileStep::AfterGetStatefulSet, req_msg))
+            .leads_to(lift_state(resp_in_flight_matches_pending_req_at_step(zk.object_ref(), ZookeeperReconcileStep::AfterGetStatefulSet)))
     ) by {
-        let pre_1 = req_msg_is_the_in_flight_pending_req_at_after_get_stateful_set_step(zk.object_ref(), req_msg);
-        let post_1 = at_after_get_stateful_set_step_and_resp_matches_pending_req_in_flight(zk.object_ref());
+        let pre_1 = req_msg_is_the_in_flight_pending_req_at_step(zk.object_ref(), ZookeeperReconcileStep::AfterGetStatefulSet, req_msg);
+        let post_1 = resp_in_flight_matches_pending_req_at_step(zk.object_ref(), ZookeeperReconcileStep::AfterGetStatefulSet);
         let stronger_next = |s, s_prime: ClusterState| {
             &&& next::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>()(s, s_prime)
             &&& crash_disabled()(s)
@@ -1802,13 +1802,13 @@ proof fn lemma_from_at_after_get_stateful_set_step_and_pending_req_in_flight_to_
             spec, input, stronger_next, handle_request(), pre_1, post_1
         );
     }
-    let msg_2_temp = |msg| lift_state(req_msg_is_the_in_flight_pending_req_at_after_get_stateful_set_step(zk.object_ref(), msg));
+    let msg_2_temp = |msg| lift_state(req_msg_is_the_in_flight_pending_req_at_step(zk.object_ref(), ZookeeperReconcileStep::AfterGetStatefulSet, msg));
     leads_to_exists_intro(
         spec, msg_2_temp,
-        lift_state(at_after_get_stateful_set_step_and_resp_matches_pending_req_in_flight(zk.object_ref()))
+        lift_state(resp_in_flight_matches_pending_req_at_step(zk.object_ref(), ZookeeperReconcileStep::AfterGetStatefulSet))
     );
     assert_by(
-        tla_exists(|msg| lift_state(req_msg_is_the_in_flight_pending_req_at_after_get_stateful_set_step(zk.object_ref(), msg)))
+        tla_exists(|msg| lift_state(req_msg_is_the_in_flight_pending_req_at_step(zk.object_ref(), ZookeeperReconcileStep::AfterGetStatefulSet, msg)))
         == lift_state(pre),
         {
             assert forall |ex| #[trigger] lift_state(pre).satisfied_by(ex) implies
@@ -1823,7 +1823,7 @@ proof fn lemma_from_at_after_get_stateful_set_step_and_pending_req_in_flight_to_
     leads_to_trans_n!(
         spec,
         lift_state(pre),
-        lift_state(at_after_get_stateful_set_step_and_resp_matches_pending_req_in_flight(zk.object_ref())),
+        lift_state(resp_in_flight_matches_pending_req_at_step(zk.object_ref(), ZookeeperReconcileStep::AfterGetStatefulSet)),
         lift_state(post)
     );
 }

--- a/src/controller_examples/zookeeper_controller/proof/terminate.rs
+++ b/src/controller_examples/zookeeper_controller/proof/terminate.rs
@@ -65,38 +65,21 @@ pub proof fn reconcile_eventually_terminates(spec: TempPred<ClusterState>, zk: Z
         ),
 {
     let reconcile_idle = |s: ClusterState| { !s.reconcile_state_contains(zk.object_ref()) };
-    lemma_from_after_get_stateful_set_step_to_reconcile_idle(spec, zk);
-    lemma_from_after_create_stateful_set_step_to_reconcile_idle(spec, zk);
-    lemma_from_after_update_stateful_set_step_to_reconcile_idle(spec, zk);
+    lemma_reconcile_error_leads_to_reconcile_idle::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>(spec, zk.object_ref());
+    lemma_reconcile_done_leads_to_reconcile_idle::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>(spec, zk.object_ref());
+    temp_pred_equality(
+        lift_state(at_zookeeper_step(zk.object_ref(), ZookeeperReconcileStep::Done)),
+        lift_state(reconciler_reconcile_done::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>(zk.object_ref()))
+    );
+    lemma_from_some_step_to_next_step_to_reconcile_idle(spec, zk, ZookeeperReconcileStep::AfterUpdateStatefulSet, ZookeeperReconcileStep::Done);
+    lemma_from_some_step_to_next_step_to_reconcile_idle(spec, zk, ZookeeperReconcileStep::AfterCreateStatefulSet, ZookeeperReconcileStep::Done);
 
-    lemma_from_some_step_to_next_step(spec, zk, ZookeeperReconcileStep::AfterCreateConfigMap, ZookeeperReconcileStep::AfterGetStatefulSet);
-    leads_to_trans_temp(
-        spec,
-        lift_state(at_zookeeper_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateConfigMap)),
-        lift_state(at_zookeeper_step(zk.object_ref(), ZookeeperReconcileStep::AfterGetStatefulSet)),
-        lift_state(reconcile_idle)
-    );
-    lemma_from_some_step_to_next_step(spec, zk, ZookeeperReconcileStep::AfterCreateAdminServerService, ZookeeperReconcileStep::AfterCreateConfigMap);
-    leads_to_trans_temp(
-        spec,
-        lift_state(at_zookeeper_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateAdminServerService)),
-        lift_state(at_zookeeper_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateConfigMap)),
-        lift_state(reconcile_idle)
-    );
-    lemma_from_some_step_to_next_step(spec, zk, ZookeeperReconcileStep::AfterCreateClientService, ZookeeperReconcileStep::AfterCreateAdminServerService);
-    leads_to_trans_temp(
-        spec,
-        lift_state(at_zookeeper_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateClientService)),
-        lift_state(at_zookeeper_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateAdminServerService)),
-        lift_state(reconcile_idle)
-    );
-    lemma_from_some_step_to_next_step(spec, zk, ZookeeperReconcileStep::AfterCreateHeadlessService, ZookeeperReconcileStep::AfterCreateClientService);
-    leads_to_trans_temp(
-        spec,
-        lift_state(at_zookeeper_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateHeadlessService)),
-        lift_state(at_zookeeper_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateClientService)),
-        lift_state(reconcile_idle)
-    );
+    lemma_from_after_get_stateful_set_step_to_reconcile_idle(spec, zk);
+
+    lemma_from_some_step_to_next_step_to_reconcile_idle(spec, zk, ZookeeperReconcileStep::AfterCreateConfigMap, ZookeeperReconcileStep::AfterGetStatefulSet);
+    lemma_from_some_step_to_next_step_to_reconcile_idle(spec, zk, ZookeeperReconcileStep::AfterCreateAdminServerService, ZookeeperReconcileStep::AfterCreateConfigMap);
+    lemma_from_some_step_to_next_step_to_reconcile_idle(spec, zk, ZookeeperReconcileStep::AfterCreateClientService, ZookeeperReconcileStep::AfterCreateAdminServerService);
+    lemma_from_some_step_to_next_step_to_reconcile_idle(spec, zk, ZookeeperReconcileStep::AfterCreateHeadlessService, ZookeeperReconcileStep::AfterCreateClientService);
     lemma_from_init_step_to_next_step(spec, zk);
     leads_to_trans_temp(
         spec,
@@ -104,8 +87,6 @@ pub proof fn reconcile_eventually_terminates(spec: TempPred<ClusterState>, zk: Z
         lift_state(at_zookeeper_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateHeadlessService)),
         lift_state(reconcile_idle)
     );
-    lemma_reconcile_error_leads_to_reconcile_idle::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>(spec, zk.object_ref());
-    lemma_reconcile_done_leads_to_reconcile_idle::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>(spec, zk.object_ref());
     valid_implies_implies_leads_to(spec, lift_state(reconcile_idle), lift_state(reconcile_idle));
     temp_pred_equality(
         true_pred(),
@@ -138,132 +119,6 @@ pub proof fn reconcile_eventually_terminates(spec: TempPred<ClusterState>, zk: Z
     );
 }
 
-pub proof fn lemma_from_after_update_stateful_set_step_to_reconcile_idle(spec: TempPred<ClusterState>, zk: ZookeeperClusterView)
-    requires
-        zk.well_formed(),
-        spec.entails(always(lift_action(next::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>()))),
-        spec.entails(tla_forall(|i| kubernetes_api_next().weak_fairness(i))),
-        spec.entails(tla_forall(|i| controller_next::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>().weak_fairness(i))),
-        spec.entails(always(lift_state(crash_disabled()))),
-        spec.entails(always(lift_state(controller_runtime_safety::every_in_flight_msg_has_unique_id()))),
-        spec.entails(always(lift_state(controller_runtime_safety::each_resp_matches_at_most_one_pending_req(zk.object_ref())))),
-        spec.entails(always(lift_state(controller_runtime_safety::each_resp_if_matches_pending_req_then_no_other_resp_matches(zk.object_ref())))),
-        spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_step(zk.object_ref(), ZookeeperReconcileStep::AfterUpdateStatefulSet)))),
-    ensures
-        spec.entails(
-            lift_state(at_zookeeper_step(zk.object_ref(), ZookeeperReconcileStep::AfterUpdateStatefulSet))
-                .leads_to(lift_state(|s: ClusterState| !s.reconcile_state_contains(zk.object_ref())))
-        ),
-{
-    let at_after_update_stateful_set_step_and_pending_req_in_flight_or_resp_in_flight = |s: ClusterState| {
-        at_zookeeper_step(zk.object_ref(), ZookeeperReconcileStep::AfterUpdateStatefulSet)(s)
-        && s.reconcile_state_of(zk.object_ref()).pending_req_msg.is_Some()
-        && is_controller_request(s.pending_req_of(zk.object_ref()))
-        && (s.message_in_flight(s.pending_req_of(zk.object_ref()))
-        || exists |resp_msg: Message| {
-            #[trigger] s.message_in_flight(resp_msg)
-            && resp_msg_matches_req_msg(resp_msg, s.pending_req_of(zk.object_ref()))
-        })
-    };
-    temp_pred_equality::<ClusterState>(lift_state(pending_req_in_flight_or_resp_in_flight_at_step(zk.object_ref(), ZookeeperReconcileStep::AfterUpdateStatefulSet)), lift_state(at_zookeeper_step(zk.object_ref(), ZookeeperReconcileStep::AfterUpdateStatefulSet)).implies(lift_state(at_after_update_stateful_set_step_and_pending_req_in_flight_or_resp_in_flight)));
-    implies_to_leads_to::<ClusterState>(spec, lift_state(at_zookeeper_step(zk.object_ref(), ZookeeperReconcileStep::AfterUpdateStatefulSet)), lift_state(at_after_update_stateful_set_step_and_pending_req_in_flight_or_resp_in_flight));
-
-    let req_in_flight = pending_req_in_flight_at_step(zk.object_ref(), ZookeeperReconcileStep::AfterUpdateStatefulSet);
-    let resp_in_flight = resp_in_flight_matches_pending_req_at_step(zk.object_ref(), ZookeeperReconcileStep::AfterUpdateStatefulSet);
-    // To show after_update_sts_step ~> done_step
-    // Use or_leads_to_combine after discussing the two cases:
-    // 1. resp_in_flight ~> done_step
-    // 2. req_in_flight ~> resp_in_flight ~> done_step
-    let done_step = reconciler_reconcile_done::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>(zk.object_ref());
-    lemma_from_step_a_and_resp_matches_pending_req_in_flight_to_step_b(
-        spec, zk, ZookeeperReconcileStep::AfterUpdateStatefulSet, ZookeeperReconcileStep::Done
-    );
-    temp_pred_equality(
-        lift_state(at_zookeeper_step(zk.object_ref(), ZookeeperReconcileStep::Done)),
-        lift_state(reconciler_reconcile_done::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>(zk.object_ref()))
-    );
-    lemma_from_pending_req_in_flight_at_step_a_to_step_b(
-        spec, zk, ZookeeperReconcileStep::AfterUpdateStatefulSet, ZookeeperReconcileStep::Done
-    );
-    or_leads_to_combine(spec, req_in_flight, resp_in_flight, done_step);
-    temp_pred_equality::<ClusterState>(
-        lift_state(req_in_flight).or(lift_state(resp_in_flight)),
-        lift_state(at_after_update_stateful_set_step_and_pending_req_in_flight_or_resp_in_flight)
-    );
-
-    lemma_reconcile_done_leads_to_reconcile_idle::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>(spec, zk.object_ref());
-    leads_to_trans_n!(
-        spec,
-        lift_state(at_zookeeper_step(zk.object_ref(), ZookeeperReconcileStep::AfterUpdateStatefulSet)),
-        lift_state(at_after_update_stateful_set_step_and_pending_req_in_flight_or_resp_in_flight),
-        lift_state(done_step),
-        lift_state(|s: ClusterState| !s.reconcile_state_contains(zk.object_ref()))
-    );
-}
-
-pub proof fn lemma_from_after_create_stateful_set_step_to_reconcile_idle(spec: TempPred<ClusterState>, zk: ZookeeperClusterView)
-    requires
-        zk.well_formed(),
-        spec.entails(always(lift_action(next::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>()))),
-        spec.entails(tla_forall(|i| kubernetes_api_next().weak_fairness(i))),
-        spec.entails(tla_forall(|i| controller_next::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>().weak_fairness(i))),
-        spec.entails(always(lift_state(crash_disabled()))),
-        spec.entails(always(lift_state(controller_runtime_safety::every_in_flight_msg_has_unique_id()))),
-        spec.entails(always(lift_state(controller_runtime_safety::each_resp_matches_at_most_one_pending_req(zk.object_ref())))),
-        spec.entails(always(lift_state(controller_runtime_safety::each_resp_if_matches_pending_req_then_no_other_resp_matches(zk.object_ref())))),
-        spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateStatefulSet)))),
-    ensures
-        spec.entails(
-            lift_state(at_zookeeper_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateStatefulSet))
-                .leads_to(lift_state(|s: ClusterState| !s.reconcile_state_contains(zk.object_ref())))
-        ),
-{
-    let at_after_create_stateful_set_step_and_pending_req_in_flight_or_resp_in_flight = |s: ClusterState| {
-        at_zookeeper_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateStatefulSet)(s)
-        && s.reconcile_state_of(zk.object_ref()).pending_req_msg.is_Some()
-        && is_controller_request(s.pending_req_of(zk.object_ref()))
-        && (s.message_in_flight(s.pending_req_of(zk.object_ref()))
-        || exists |resp_msg: Message| {
-            #[trigger] s.message_in_flight(resp_msg)
-            && resp_msg_matches_req_msg(resp_msg, s.pending_req_of(zk.object_ref()))
-        })
-    };
-    temp_pred_equality::<ClusterState>(lift_state(pending_req_in_flight_or_resp_in_flight_at_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateStatefulSet)), lift_state(at_zookeeper_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateStatefulSet)).implies(lift_state(at_after_create_stateful_set_step_and_pending_req_in_flight_or_resp_in_flight)));
-    implies_to_leads_to::<ClusterState>(spec, lift_state(at_zookeeper_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateStatefulSet)), lift_state(at_after_create_stateful_set_step_and_pending_req_in_flight_or_resp_in_flight));
-
-    let req_in_flight = pending_req_in_flight_at_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateStatefulSet);
-    let resp_in_flight = resp_in_flight_matches_pending_req_at_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateStatefulSet);
-    // To show after_update_sts_step ~> done_step
-    // Use or_leads_to_combine after discussing the two cases:
-    // 1. resp_in_flight ~> done_step
-    // 2. req_in_flight ~> resp_in_flight ~> done_step
-    let done_step = reconciler_reconcile_done::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>(zk.object_ref());
-    lemma_from_step_a_and_resp_matches_pending_req_in_flight_to_step_b(
-        spec, zk, ZookeeperReconcileStep::AfterCreateStatefulSet, ZookeeperReconcileStep::Done
-    );
-    temp_pred_equality(
-        lift_state(at_zookeeper_step(zk.object_ref(), ZookeeperReconcileStep::Done)),
-        lift_state(reconciler_reconcile_done::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>(zk.object_ref()))
-    );
-    lemma_from_pending_req_in_flight_at_step_a_to_step_b(
-        spec, zk, ZookeeperReconcileStep::AfterCreateStatefulSet, ZookeeperReconcileStep::Done
-    );
-    or_leads_to_combine(spec, req_in_flight, resp_in_flight, done_step);
-    temp_pred_equality::<ClusterState>(
-        lift_state(req_in_flight).or(lift_state(resp_in_flight)),
-        lift_state(at_after_create_stateful_set_step_and_pending_req_in_flight_or_resp_in_flight)
-    );
-
-    lemma_reconcile_done_leads_to_reconcile_idle::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>(spec, zk.object_ref());
-    leads_to_trans_n!(
-        spec,
-        lift_state(at_zookeeper_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateStatefulSet)),
-        lift_state(at_after_create_stateful_set_step_and_pending_req_in_flight_or_resp_in_flight),
-        lift_state(done_step),
-        lift_state(|s: ClusterState| !s.reconcile_state_contains(zk.object_ref()))
-    );
-}
-
 pub proof fn lemma_from_after_get_stateful_set_step_to_reconcile_idle(spec: TempPred<ClusterState>, zk: ZookeeperClusterView)
     requires
         zk.well_formed(),
@@ -274,8 +129,14 @@ pub proof fn lemma_from_after_get_stateful_set_step_to_reconcile_idle(spec: Temp
         spec.entails(always(lift_state(controller_runtime_safety::every_in_flight_msg_has_unique_id()))),
         spec.entails(always(lift_state(controller_runtime_safety::each_resp_matches_at_most_one_pending_req(zk.object_ref())))),
         spec.entails(always(lift_state(controller_runtime_safety::each_resp_if_matches_pending_req_then_no_other_resp_matches(zk.object_ref())))),
-        spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_step(zk.object_ref(), ZookeeperReconcileStep::AfterUpdateStatefulSet)))),
-        spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateStatefulSet)))),
+        spec.entails(
+            lift_state(at_zookeeper_step(zk.object_ref(), ZookeeperReconcileStep::AfterUpdateStatefulSet))
+                .leads_to(lift_state(|s: ClusterState| !s.reconcile_state_contains(zk.object_ref())))
+        ),
+        spec.entails(
+            lift_state(at_zookeeper_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateStatefulSet))
+                .leads_to(lift_state(|s: ClusterState| !s.reconcile_state_contains(zk.object_ref())))
+        ),
         spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_step(zk.object_ref(),ZookeeperReconcileStep::AfterGetStatefulSet)))),
     ensures
         spec.entails(
@@ -313,7 +174,7 @@ pub proof fn lemma_from_after_get_stateful_set_step_to_reconcile_idle(spec: Temp
     );
 }
 
-pub proof fn lemma_from_some_step_to_next_step(
+pub proof fn lemma_from_some_step_to_next_step_to_reconcile_idle(
     spec: TempPred<ClusterState>, zk: ZookeeperClusterView, step: ZookeeperReconcileStep, next_step: ZookeeperReconcileStep
 )
     requires
@@ -329,11 +190,15 @@ pub proof fn lemma_from_some_step_to_next_step(
         step != ZookeeperReconcileStep::Done, step != ZookeeperReconcileStep::Error,
         next_step != ZookeeperReconcileStep::Init,
         forall |zk: ZookeeperClusterView, resp_o: Option<APIResponse>|
-            #[trigger] reconcile_core(zk, resp_o, ZookeeperReconcileState{ reconcile_step: step }).0.reconcile_step == next_step
+            #[trigger] reconcile_core(zk, resp_o, ZookeeperReconcileState{ reconcile_step: step }).0.reconcile_step == next_step,
+        spec.entails(
+            lift_state(at_zookeeper_step(zk.object_ref(), next_step))
+                .leads_to(lift_state(|s: ClusterState| !s.reconcile_state_contains(zk.object_ref())))
+        ),
     ensures
         spec.entails(
             lift_state(at_zookeeper_step(zk.object_ref(), step))
-                .leads_to(lift_state(at_zookeeper_step(zk.object_ref(), next_step)))
+                .leads_to(lift_state(|s: ClusterState| !s.reconcile_state_contains(zk.object_ref())))
         ),
 {
     let at_some_step_and_pending_req_in_flight_or_resp_in_flight = |s: ClusterState| {
@@ -360,11 +225,12 @@ pub proof fn lemma_from_some_step_to_next_step(
         lift_state(req_in_flight).or(lift_state(resp_in_flight)),
         lift_state(at_some_step_and_pending_req_in_flight_or_resp_in_flight)
     );
-    leads_to_trans_temp(
+    leads_to_trans_n!(
         spec,
         lift_state(at_zookeeper_step(zk.object_ref(), step)),
         lift_state(at_some_step_and_pending_req_in_flight_or_resp_in_flight),
-        lift_state(at_zookeeper_step(zk.object_ref(), next_step))
+        lift_state(at_zookeeper_step(zk.object_ref(), next_step)),
+        lift_state(|s: ClusterState| !s.reconcile_state_contains(zk.object_ref()))
     );
 }
 
@@ -427,8 +293,14 @@ proof fn lemma_from_at_after_get_stateful_set_step_and_resp_matches_pending_req_
         spec.entails(always(lift_state(controller_runtime_safety::every_in_flight_msg_has_unique_id()))),
         spec.entails(always(lift_state(controller_runtime_safety::each_resp_matches_at_most_one_pending_req(zk.object_ref())))),
         spec.entails(always(lift_state(controller_runtime_safety::each_resp_if_matches_pending_req_then_no_other_resp_matches(zk.object_ref())))),
-        spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_step(zk.object_ref(), ZookeeperReconcileStep::AfterUpdateStatefulSet)))),
-        spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateStatefulSet)))),
+        spec.entails(
+            lift_state(at_zookeeper_step(zk.object_ref(), ZookeeperReconcileStep::AfterUpdateStatefulSet))
+                .leads_to(lift_state(|s: ClusterState| !s.reconcile_state_contains(zk.object_ref())))
+        ),
+        spec.entails(
+            lift_state(at_zookeeper_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateStatefulSet))
+                .leads_to(lift_state(|s: ClusterState| !s.reconcile_state_contains(zk.object_ref())))
+        ),
         spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_step(zk.object_ref(), ZookeeperReconcileStep::AfterGetStatefulSet)))),
     ensures
         spec.entails(lift_state(resp_in_flight_matches_pending_req_at_step(zk.object_ref(), ZookeeperReconcileStep::AfterGetStatefulSet)).leads_to(lift_state(|s: ClusterState| { !s.reconcile_state_contains(zk.object_ref()) }))),
@@ -507,8 +379,6 @@ proof fn lemma_from_at_after_get_stateful_set_step_and_resp_matches_pending_req_
             temp_pred_equality(tla_exists(known_resp_in_flight), lift_state(pre));
         }
     );
-    lemma_from_after_update_stateful_set_step_to_reconcile_idle(spec, zk);
-    lemma_from_after_create_stateful_set_step_to_reconcile_idle(spec, zk);
     lemma_reconcile_error_leads_to_reconcile_idle::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>(spec, zk.object_ref());
     or_leads_to_combine_n!(
         spec,
@@ -536,8 +406,14 @@ proof fn lemma_from_at_after_get_stateful_set_step_and_pending_req_in_flight_to_
         spec.entails(always(lift_state(controller_runtime_safety::every_in_flight_msg_has_unique_id()))),
         spec.entails(always(lift_state(controller_runtime_safety::each_resp_matches_at_most_one_pending_req(zk.object_ref())))),
         spec.entails(always(lift_state(controller_runtime_safety::each_resp_if_matches_pending_req_then_no_other_resp_matches(zk.object_ref())))),
-        spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_step(zk.object_ref(), ZookeeperReconcileStep::AfterUpdateStatefulSet)))),
-        spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateStatefulSet)))),
+        spec.entails(
+            lift_state(at_zookeeper_step(zk.object_ref(), ZookeeperReconcileStep::AfterUpdateStatefulSet))
+                .leads_to(lift_state(|s: ClusterState| !s.reconcile_state_contains(zk.object_ref())))
+        ),
+        spec.entails(
+            lift_state(at_zookeeper_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateStatefulSet))
+                .leads_to(lift_state(|s: ClusterState| !s.reconcile_state_contains(zk.object_ref())))
+        ),
         spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_step(zk.object_ref(), ZookeeperReconcileStep::AfterGetStatefulSet)))),
     ensures
         spec.entails(lift_state(pending_req_in_flight_at_step(zk.object_ref(), ZookeeperReconcileStep::AfterGetStatefulSet)).leads_to(lift_state(|s: ClusterState| { !s.reconcile_state_contains(zk.object_ref()) }))),

--- a/src/controller_examples/zookeeper_controller/proof/terminate.rs
+++ b/src/controller_examples/zookeeper_controller/proof/terminate.rs
@@ -100,7 +100,7 @@ pub proof fn reconcile_eventually_terminates(spec: TempPred<ClusterState>, zk: Z
         .or(lift_state(at_zookeeper_step(zk.object_ref(), ZookeeperReconcileStep::AfterGetStatefulSet)))
         .or(lift_state(at_zookeeper_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateStatefulSet)))
         .or(lift_state(at_zookeeper_step(zk.object_ref(), ZookeeperReconcileStep::AfterUpdateStatefulSet)))
-        .or(lift_state(reconciler_reconcile_done::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>(zk.object_ref())))
+        .or(lift_state(at_zookeeper_step(zk.object_ref(), ZookeeperReconcileStep::Done)))
     );
     or_leads_to_combine_n!(
         spec,
@@ -114,7 +114,7 @@ pub proof fn reconcile_eventually_terminates(spec: TempPred<ClusterState>, zk: Z
         lift_state(at_zookeeper_step(zk.object_ref(), ZookeeperReconcileStep::AfterGetStatefulSet)),
         lift_state(at_zookeeper_step(zk.object_ref(), ZookeeperReconcileStep::AfterCreateStatefulSet)),
         lift_state(at_zookeeper_step(zk.object_ref(), ZookeeperReconcileStep::AfterUpdateStatefulSet)),
-        lift_state(reconciler_reconcile_done::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>(zk.object_ref()));
+        lift_state(at_zookeeper_step(zk.object_ref(), ZookeeperReconcileStep::Done));
         lift_state(reconcile_idle)
     );
 }


### PR DESCRIPTION
The general idea to simplify the proof is to find common patterns of what happens in `reconcile_core`.

The current `reconcile_core` of zookeeper controller is simple, so that I can come up with a single pattern that the controller starts from a state, reads the response, then generates a request and enters the next state.