### PR TITLE
Translate kube error to Verus-friendly type by `reason`, instead of `code`

### DIFF
--- a/src/shim_layer/mod.rs
+++ b/src/shim_layer/mod.rs
@@ -236,15 +236,21 @@ pub struct Data {
 /// kube_error_to_ghost translates the API error from kube-rs APIs
 /// to the form that can be processed by reconcile_core.
 
-// TODO: revisit the translation; the current implementation is too coarse grained.
+// TODO: match more error types.
 #[verifier(external)]
 pub fn kube_error_to_ghost(error: &deps_hack::kube::Error) -> APIError {
     match error {
         deps_hack::kube::Error::Api(error_resp) => {
-            if error_resp.code == 404 {
+            if &error_resp.reason == "NotFound" {
                 APIError::ObjectNotFound
-            } else if error_resp.code == 403 {
+            } else if &error_resp.reason == "AlreadyExists" {
                 APIError::ObjectAlreadyExists
+            } else if &error_resp.reason == "BadRequest" {
+                APIError::BadRequest
+            } else if &error_resp.reason == "Conflict" {
+                APIError::Conflict
+            } else if &error_resp.reason == "Invalid" {
+                APIError::Invalid
             } else {
                 APIError::Other
             }


### PR DESCRIPTION
Previously we translate the kube error types to APIError (an enum that represents different kinds of errors k8s might return) by checking its `code`. This PR changes it by checking `reason`, which is more straightforward and robust.