### PR TITLE
Support k8s busy action and fix the liveness proof after that

### DIFF
--- a/src/controller_examples/zookeeper_controller/proof/safety.rs
+++ b/src/controller_examples/zookeeper_controller/proof/safety.rs
@@ -566,7 +566,7 @@ pub proof fn lemma_always_pending_req_in_flight_or_resp_in_flight_at_step(
                 }
                 Step::KubernetesBusy(input) => {
                     if input == Option::Some(s.pending_req_of(key)) {
-                        let resp_msg = form_matched_resp_msg(s.pending_req_of(key), Result::Err(APIError::ServerBusy));
+                        let resp_msg = form_matched_resp_msg(s.pending_req_of(key), Result::Err(APIError::ServerTimeout));
                         assert(s_prime.message_in_flight(resp_msg));
                     } else {
                         if !s.message_in_flight(s.pending_req_of(key)) {

--- a/src/controller_examples/zookeeper_controller/proof/terminate.rs
+++ b/src/controller_examples/zookeeper_controller/proof/terminate.rs
@@ -48,6 +48,7 @@ pub proof fn reconcile_eventually_terminates(spec: TempPred<ClusterState>, zk: Z
         spec.entails(tla_forall(|i| kubernetes_api_next().weak_fairness(i))),
         spec.entails(tla_forall(|i| controller_next::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>().weak_fairness(i))),
         spec.entails(always(lift_state(crash_disabled()))),
+        spec.entails(always(lift_state(busy_disabled()))),
         spec.entails(always(lift_state(controller_runtime_safety::every_in_flight_msg_has_unique_id()))),
         spec.entails(always(lift_state(controller_runtime_safety::each_resp_matches_at_most_one_pending_req(zk.object_ref())))),
         spec.entails(always(lift_state(controller_runtime_safety::each_resp_if_matches_pending_req_then_no_other_resp_matches(zk.object_ref())))),
@@ -126,6 +127,7 @@ pub proof fn lemma_from_after_get_stateful_set_step_to_reconcile_idle(spec: Temp
         spec.entails(tla_forall(|i| kubernetes_api_next().weak_fairness(i))),
         spec.entails(tla_forall(|i| controller_next::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>().weak_fairness(i))),
         spec.entails(always(lift_state(crash_disabled()))),
+        spec.entails(always(lift_state(busy_disabled()))),
         spec.entails(always(lift_state(controller_runtime_safety::every_in_flight_msg_has_unique_id()))),
         spec.entails(always(lift_state(controller_runtime_safety::each_resp_matches_at_most_one_pending_req(zk.object_ref())))),
         spec.entails(always(lift_state(controller_runtime_safety::each_resp_if_matches_pending_req_then_no_other_resp_matches(zk.object_ref())))),
@@ -183,6 +185,7 @@ pub proof fn lemma_from_some_step_to_next_step_to_reconcile_idle(
         spec.entails(tla_forall(|i| kubernetes_api_next().weak_fairness(i))),
         spec.entails(tla_forall(|i| controller_next::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>().weak_fairness(i))),
         spec.entails(always(lift_state(crash_disabled()))),
+        spec.entails(always(lift_state(busy_disabled()))),
         spec.entails(always(lift_state(controller_runtime_safety::every_in_flight_msg_has_unique_id()))),
         spec.entails(always(lift_state(controller_runtime_safety::each_resp_matches_at_most_one_pending_req(zk.object_ref())))),
         spec.entails(always(lift_state(controller_runtime_safety::each_resp_if_matches_pending_req_then_no_other_resp_matches(zk.object_ref())))),
@@ -405,6 +408,7 @@ proof fn lemma_from_at_after_get_stateful_set_step_and_pending_req_in_flight_to_
         spec.entails(tla_forall(|i| kubernetes_api_next().weak_fairness(i))),
         spec.entails(tla_forall(|i| controller_next::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>().weak_fairness(i))),
         spec.entails(always(lift_state(crash_disabled()))),
+        spec.entails(always(lift_state(busy_disabled()))),
         spec.entails(always(lift_state(controller_runtime_safety::every_in_flight_msg_has_unique_id()))),
         spec.entails(always(lift_state(controller_runtime_safety::each_resp_matches_at_most_one_pending_req(zk.object_ref())))),
         spec.entails(always(lift_state(controller_runtime_safety::each_resp_if_matches_pending_req_then_no_other_resp_matches(zk.object_ref())))),
@@ -434,18 +438,21 @@ proof fn lemma_from_at_after_get_stateful_set_step_and_pending_req_in_flight_to_
         let stronger_next = |s, s_prime: ClusterState| {
             &&& next::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>()(s, s_prime)
             &&& crash_disabled()(s)
+            &&& busy_disabled()(s)
             &&& controller_runtime_safety::every_in_flight_msg_has_unique_id()(s)
         };
         entails_always_and_n!(
             spec,
             lift_action(next::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>()),
             lift_state(crash_disabled()),
+            lift_state(busy_disabled()),
             lift_state(controller_runtime_safety::every_in_flight_msg_has_unique_id())
         );
         temp_pred_equality(
             lift_action(stronger_next),
             lift_action(next::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>())
             .and(lift_state(crash_disabled()))
+            .and(lift_state(busy_disabled()))
             .and(lift_state(controller_runtime_safety::every_in_flight_msg_has_unique_id()))
         );
         let input = Option::Some(req_msg);
@@ -496,6 +503,7 @@ proof fn lemma_from_pending_req_in_flight_at_step_a_to_step_b(
         spec.entails(tla_forall(|i| kubernetes_api_next().weak_fairness(i))),
         spec.entails(tla_forall(|i| controller_next::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>().weak_fairness(i))),
         spec.entails(always(lift_state(crash_disabled()))),
+        spec.entails(always(lift_state(busy_disabled()))),
         spec.entails(always(lift_state(controller_runtime_safety::every_in_flight_msg_has_unique_id()))),
         spec.entails(always(lift_state(controller_runtime_safety::each_resp_matches_at_most_one_pending_req(zk.object_ref())))),
         spec.entails(always(lift_state(controller_runtime_safety::each_resp_if_matches_pending_req_then_no_other_resp_matches(zk.object_ref())))),
@@ -519,18 +527,21 @@ proof fn lemma_from_pending_req_in_flight_at_step_a_to_step_b(
         let stronger_next = |s, s_prime: ClusterState| {
             &&& next::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>()(s, s_prime)
             &&& crash_disabled()(s)
+            &&& busy_disabled()(s)
             &&& controller_runtime_safety::every_in_flight_msg_has_unique_id()(s)
         };
         entails_always_and_n!(
             spec,
             lift_action(next::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>()),
             lift_state(crash_disabled()),
+            lift_state(busy_disabled()),
             lift_state(controller_runtime_safety::every_in_flight_msg_has_unique_id())
         );
         temp_pred_equality(
             lift_action(stronger_next),
             lift_action(next::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>())
             .and(lift_state(crash_disabled()))
+            .and(lift_state(busy_disabled()))
             .and(lift_state(controller_runtime_safety::every_in_flight_msg_has_unique_id()))
         );
         let input = Option::Some(req_msg);

--- a/src/kubernetes_api_objects/error.rs
+++ b/src/kubernetes_api_objects/error.rs
@@ -16,7 +16,7 @@ pub enum APIError {
     ObjectNotFound,
     ObjectAlreadyExists,
     NotSupported,
-    ServerBusy,
+    ServerTimeout,
     Other
 }
 
@@ -30,7 +30,7 @@ impl std::fmt::Debug for APIError {
             APIError::ObjectNotFound => write!(f, "ObjectNotFound"),
             APIError::ObjectAlreadyExists => write!(f, "ObjectAlreadyExists"),
             APIError::NotSupported => write!(f, "NotSupported"),
-            APIError::ServerBusy => write!(f, "ServerBusy"),
+            APIError::ServerTimeout => write!(f, "ServerTimeout"),
             APIError::Other => write!(f, "Other"),
         }
     }

--- a/src/kubernetes_api_objects/error.rs
+++ b/src/kubernetes_api_objects/error.rs
@@ -16,6 +16,7 @@ pub enum APIError {
     ObjectNotFound,
     ObjectAlreadyExists,
     NotSupported,
+    ServerBusy,
     Other
 }
 
@@ -29,6 +30,7 @@ impl std::fmt::Debug for APIError {
             APIError::ObjectNotFound => write!(f, "ObjectNotFound"),
             APIError::ObjectAlreadyExists => write!(f, "ObjectAlreadyExists"),
             APIError::NotSupported => write!(f, "NotSupported"),
+            APIError::ServerBusy => write!(f, "ServerBusy"),
             APIError::Other => write!(f, "Other"),
         }
     }

--- a/src/kubernetes_cluster/proof/cluster.rs
+++ b/src/kubernetes_cluster/proof/cluster.rs
@@ -82,6 +82,20 @@ pub proof fn lemma_true_leads_to_crash_always_disabled<K: ResourceView, T, Recon
     leads_to_stable_temp::<State<K, T>>(spec, lift_action(next::<K, T, ReconcilerType>()), true_pred(), lift_state(crash_disabled::<K, T>()));
 }
 
+pub proof fn lemma_true_leads_to_busy_always_disabled<K: ResourceView, T, ReconcilerType: Reconciler<K, T>>(
+    spec: TempPred<State<K, T>>,
+)
+    requires
+        spec.entails(always(lift_action(next::<K, T, ReconcilerType>()))),
+        spec.entails(disable_busy().weak_fairness(())),
+    ensures
+        spec.entails(true_pred().leads_to(always(lift_state(busy_disabled::<K, T>())))),
+{
+    let true_state = |s: State<K, T>| true;
+    disable_busy().wf1((), spec, next::<K, T, ReconcilerType>(), true_state, busy_disabled::<K, T>());
+    leads_to_stable_temp::<State<K, T>>(spec, lift_action(next::<K, T, ReconcilerType>()), true_pred(), lift_state(busy_disabled::<K, T>()));
+}
+
 pub proof fn lemma_any_pred_leads_to_crash_always_disabled<K: ResourceView, T, ReconcilerType: Reconciler<K, T>>(
     spec: TempPred<State<K, T>>, any_pred: TempPred<State<K, T>>
 )

--- a/src/kubernetes_cluster/proof/cluster.rs
+++ b/src/kubernetes_cluster/proof/cluster.rs
@@ -56,13 +56,15 @@ pub proof fn sm_partial_spec_is_stable<K: ResourceView, T, ReconcilerType: Recon
     tla_forall_action_weak_fairness_is_stable::<K, T, (Option<Message>, Option<ObjectRef>), ()>(controller_next::<K, T, ReconcilerType>());
     tla_forall_action_weak_fairness_is_stable::<K, T, ObjectRef, ()>(schedule_controller_reconcile());
     action_weak_fairness_is_stable::<K, T, ()>(disable_crash());
+    action_weak_fairness_is_stable::<K, T, ()>(disable_busy());
 
     stable_and_n!(
         always(lift_action(next::<K, T, ReconcilerType>())),
         tla_forall(|input| kubernetes_api_next().weak_fairness(input)),
         tla_forall(|input| controller_next::<K, T, ReconcilerType>().weak_fairness(input)),
         tla_forall(|input| schedule_controller_reconcile().weak_fairness(input)),
-        disable_crash().weak_fairness(())
+        disable_crash().weak_fairness(()),
+        disable_busy().weak_fairness(())
     );
 }
 

--- a/src/kubernetes_cluster/proof/kubernetes_api_liveness.rs
+++ b/src/kubernetes_cluster/proof/kubernetes_api_liveness.rs
@@ -101,7 +101,7 @@ pub proof fn lemma_get_req_leads_to_some_resp
             },
             Step::KubernetesBusy(input) => {
                 if input.get_Some_0() == msg {
-                    let resp = form_matched_resp_msg(msg, Result::Err(APIError::ServerBusy));
+                    let resp = form_matched_resp_msg(msg, Result::Err(APIError::ServerTimeout));
                     assert(s_prime.message_in_flight(resp));
                     assert(resp_msg_matches_req_msg(resp, msg));
                     assert(post(s_prime));
@@ -160,7 +160,7 @@ pub proof fn lemma_get_req_leads_to_ok_or_err_resp
     };
     let stronger_next = |s, s_prime: State<K, T>| {
         next::<K, T, ReconcilerType>()(s, s_prime)
-        && !s.k8s_maybe_busy
+        && !s.busy_enabled
     };
     strengthen_next::<State<K, T>>(spec, next::<K, T, ReconcilerType>(), busy_disabled(), stronger_next);
     lemma_pre_leads_to_post_by_kubernetes_api::<K, T, ReconcilerType>(spec, Option::Some(msg), stronger_next, handle_request(), pre, post);
@@ -210,7 +210,7 @@ pub proof fn lemma_create_req_leads_to_res_exists
         );
     let stronger_next = |s, s_prime: State<K, T>| {
         next::<K, T, ReconcilerType>()(s, s_prime)
-        && !s.k8s_maybe_busy
+        && !s.busy_enabled
     };
     strengthen_next::<State<K, T>>(spec, next::<K, T, ReconcilerType>(), busy_disabled(), stronger_next);
     lemma_pre_leads_to_post_by_kubernetes_api::<K, T, ReconcilerType>(spec, Option::Some(msg), stronger_next, handle_request(), pre, post);
@@ -244,7 +244,7 @@ pub proof fn lemma_delete_req_leads_to_res_not_exists
     };
     let stronger_next = |s, s_prime: State<K, T>| {
         next::<K, T, ReconcilerType>()(s, s_prime)
-        && !s.k8s_maybe_busy
+        && !s.busy_enabled
     };
     strengthen_next::<State<K, T>>(spec, next::<K, T, ReconcilerType>(), busy_disabled(), stronger_next);
     lemma_pre_leads_to_post_by_kubernetes_api::<K, T, ReconcilerType>(spec, Option::Some(msg), stronger_next, handle_request(), pre, post);
@@ -534,7 +534,7 @@ proof fn pending_requests_num_decreases<K: ResourceView, T, ReconcilerType: Reco
     let stronger_next = |s, s_prime: State<K, T>| {
         &&& next::<K, T, ReconcilerType>()(s, s_prime)
         &&& s.rest_id_counter_is_no_smaller_than(rest_id)
-        &&& !s.k8s_maybe_busy
+        &&& !s.busy_enabled
     };
     entails_always_and_n!(
         spec,

--- a/src/kubernetes_cluster/spec/cluster.rs
+++ b/src/kubernetes_cluster/spec/cluster.rs
@@ -1,7 +1,7 @@
 // Copyright 2022 VMware, Inc.
 // SPDX-License-Identifier: MIT
 #![allow(unused_imports)]
-use crate::kubernetes_api_objects::{api_method::*, common::*, dynamic::*, resource::*};
+use crate::kubernetes_api_objects::{api_method::*, common::*, dynamic::*, error::*, resource::*};
 use crate::kubernetes_cluster::spec::{
     client::{client, ClientActionInput, ClientState},
     controller::{
@@ -21,7 +21,7 @@ use crate::kubernetes_cluster::spec::{
 use crate::reconciler::spec::Reconciler;
 use crate::state_machine::{action::*, state_machine::*};
 use crate::temporal_logic::defs::*;
-use vstd::prelude::*;
+use vstd::{multiset::*, prelude::*};
 
 verus! {
 
@@ -32,6 +32,7 @@ pub struct State<K: ResourceView, T> {
     pub network_state: NetworkState,
     pub rest_id_allocator: RestIdAllocator,
     pub crash_enabled: bool,
+    pub k8s_maybe_busy: bool,
 }
 
 impl<K: ResourceView, T> State<K, T> {
@@ -106,6 +107,7 @@ pub open spec fn init<K: ResourceView, T, ReconcilerType: Reconciler<K ,T>>() ->
         &&& (client::<K>().init)(s.client_state)
         &&& (network().init)(s.network_state)
         &&& s.crash_enabled
+        &&& s.k8s_maybe_busy
     }
 }
 
@@ -250,6 +252,50 @@ pub open spec fn disable_crash<K: ResourceView, T>() -> Action<State<K, T>, (), 
     }
 }
 
+pub open spec fn make_kubernetes_api_busy<K: ResourceView, T>() -> Action<State<K, T>, Option<Message>, ()> {
+    let network_result = |input: Option<Message>, s: State<K, T>| {
+        let req_msg = input.get_Some_0();
+        let resp = form_matched_resp_msg(req_msg, Result::Err(APIError::ServerBusy));
+        let msg_ops = MessageOps {
+            recv: input,
+            send: Multiset::singleton(resp),
+        };
+        let result = network().next_result(msg_ops, s.network_state);
+        result
+    };
+    Action {
+        precondition: |input: Option<Message>, s: State<K, T>| {
+            &&& s.k8s_maybe_busy
+            &&& input.is_Some()
+            &&& input.get_Some_0().content.is_APIRequest()
+            &&& network_result(input, s).is_Enabled()
+        },
+        transition: |input: Option<Message>, s: State<K, T>| {
+            (State {
+                network_state: network_result(input, s).get_Enabled_0(),
+                ..s
+            }, ())
+        }
+    }
+}
+
+/// This action disallows the kubernetes api to be busy from this point.
+/// This is used to constraint the crash behavior for liveness proof:
+/// the controller eventually stops rejecting requests.
+pub open spec fn disable_busy<K: ResourceView, T>() -> Action<State<K, T>, (), ()> {
+    Action {
+        precondition: |input:(), s: State<K, T>| {
+            true
+        },
+        transition: |input: (), s: State<K, T>| {
+            (State {
+                k8s_maybe_busy: false,
+                ..s
+            }, ())
+        }
+    }
+}
+
 pub open spec fn client_next<K: ResourceView, T>() -> Action<State<K, T>, (Option<Message>, K), ()> {
     let result = |input: (Option<Message>, K), s: State<K, T>| {
         let host_result = client().next_result(
@@ -300,6 +346,8 @@ pub enum Step<K> {
     ScheduleControllerReconcileStep(ObjectRef),
     RestartController(),
     DisableCrash(),
+    KubernetesBusy(Option<Message>),
+    DisableBusy(),
     StutterStep(),
 }
 
@@ -312,6 +360,8 @@ pub open spec fn next_step<K: ResourceView, T, ReconcilerType: Reconciler<K, T>>
         Step::ScheduleControllerReconcileStep(input) => schedule_controller_reconcile().forward(input)(s, s_prime),
         Step::RestartController() => restart_controller().forward(())(s, s_prime),
         Step::DisableCrash() => disable_crash().forward(())(s, s_prime),
+        Step::KubernetesBusy(input) => make_kubernetes_api_busy().forward(input)(s, s_prime),
+        Step::DisableBusy() => disable_busy().forward(())(s, s_prime),
         Step::StutterStep() => stutter().forward(())(s, s_prime),
     }
 }
@@ -336,6 +386,7 @@ pub open spec fn sm_partial_spec<K: ResourceView, T, ReconcilerType: Reconciler<
     .and(tla_forall(|input| controller_next::<K, T, ReconcilerType>().weak_fairness(input)))
     .and(tla_forall(|input| schedule_controller_reconcile().weak_fairness(input)))
     .and(disable_crash().weak_fairness(()))
+    .and(disable_busy().weak_fairness(()))
 }
 
 pub open spec fn kubernetes_api_action_pre<K: ResourceView, T>(action: KubernetesAPIAction, input: Option<Message>) -> StatePred<State<K, T>> {
@@ -378,6 +429,10 @@ pub open spec fn controller_action_pre<K: ResourceView, T, ReconcilerType: Recon
 
 pub open spec fn crash_disabled<K: ResourceView, T>() -> StatePred<State<K, T>> {
     |s: State<K, T>| !s.crash_enabled
+}
+
+pub open spec fn busy_disabled<K: ResourceView, T>() -> StatePred<State<K, T>> {
+    |s: State<K, T>| !s.k8s_maybe_busy
 }
 
 pub open spec fn rest_id_counter_is<K: ResourceView, T>(rest_id: nat) -> StatePred<State<K, T>> {

--- a/src/kubernetes_cluster/spec/message.rs
+++ b/src/kubernetes_cluster/spec/message.rs
@@ -241,6 +241,18 @@ pub open spec fn resp_msg_matches_req_msg(resp_msg: Message, req_msg: Message) -
     }
 }
 
+pub open spec fn form_matched_resp_msg(req_msg: Message, result: Result<DynamicObjectView, APIError>) -> Message
+    recommends req_msg.content.is_APIRequest(),
+{
+    match req_msg.content.get_APIRequest_0() {
+        APIRequest::GetRequest(_) => form_get_resp_msg(req_msg, result),
+        APIRequest::ListRequest(_) => form_list_resp_msg(req_msg, Result::Err(APIError::Invalid)),
+        APIRequest::CreateRequest(_) => form_create_resp_msg(req_msg, result),
+        APIRequest::DeleteRequest(_) => form_delete_resp_msg(req_msg, result),
+        APIRequest::UpdateRequest(_) => form_update_resp_msg(req_msg, result),
+    }
+}
+
 pub open spec fn form_msg(src: HostId, dst: HostId, msg_content: MessageContent) -> Message {
     Message{
         src: src,


### PR DESCRIPTION
In this PR, we add a new action to the state machine that supports kubernetes to stay busy and reject the received request (send an error response).