### PR TITLE
Remove the next_state != init preconditions for some lemmas

### DIFF
--- a/src/controller_examples/zookeeper_controller/proof/liveness.rs
+++ b/src/controller_examples/zookeeper_controller/proof/liveness.rs
@@ -952,7 +952,7 @@ proof fn lemma_from_pending_req_in_flight_at_some_step_to_pending_req_in_flight_
         spec.entails(always(lift_state(controller_runtime_safety::every_in_flight_msg_has_unique_id()))),
         spec.entails(always(lift_state(controller_runtime_safety::each_resp_matches_at_most_one_pending_req(zk.object_ref())))),
         step != ZookeeperReconcileStep::Error, step != ZookeeperReconcileStep::Done,
-        next_step != ZookeeperReconcileStep::Init,
+        // next_step != ZookeeperReconcileStep::Init,
         forall |zk_1: ZookeeperClusterView, resp_o: Option<APIResponse>|
             #[trigger] reconcile_core(zk_1, resp_o, ZookeeperReconcileState{ reconcile_step: step }).0.reconcile_step == next_step
             && reconcile_core(zk, resp_o, ZookeeperReconcileState{ reconcile_step: step }).1.is_Some()
@@ -1183,7 +1183,7 @@ proof fn lemma_from_resp_in_flight_at_some_step_to_pending_req_in_flight_at_next
         spec.entails(always(lift_state(busy_disabled()))),
         spec.entails(always(lift_state(controller_runtime_safety::each_resp_matches_at_most_one_pending_req(zk.object_ref())))),
         step != ZookeeperReconcileStep::Done, step != ZookeeperReconcileStep::Error,
-        result_step != ZookeeperReconcileStep::Init,
+        // result_step != ZookeeperReconcileStep::Init,
         // This forall zk_1 constraint is used because the cr passed to reconcile_core is not necessarily zk here.
         // We only know that zk_1.object_ref() == zk.object_ref() && zk_1.spec == zk.spec.
         forall |zk_1: ZookeeperClusterView, resp_o: Option<APIResponse>|

--- a/src/kubernetes_cluster/proof/controller_runtime_liveness.rs
+++ b/src/kubernetes_cluster/proof/controller_runtime_liveness.rs
@@ -358,7 +358,7 @@ pub proof fn lemma_from_pending_req_in_flight_at_some_state_to_next_state<K: Res
         spec.entails(always(lift_state(controller_runtime_safety::each_resp_matches_at_most_one_pending_req(cr.object_ref())))),
         spec.entails(always(lift_state(controller_runtime_safety::each_resp_if_matches_pending_req_then_no_other_resp_matches(cr.object_ref())))),
         !ReconcilerType::reconcile_error(state), !ReconcilerType::reconcile_done(state),
-        next_state != ReconcilerType::reconcile_init_state(),
+        // next_state != ReconcilerType::reconcile_init_state(),
         forall |cr_1: K, resp_o: Option<APIResponse>|
             #[trigger] ReconcilerType::reconcile_core(cr_1, resp_o, state).0 == next_state,
     ensures
@@ -446,7 +446,7 @@ pub proof fn lemma_from_in_flight_resp_matches_pending_req_at_some_state_to_next
         spec.entails(always(lift_state(controller_runtime_safety::each_resp_matches_at_most_one_pending_req(cr.object_ref())))),
         spec.entails(always(lift_state(controller_runtime_safety::each_resp_if_matches_pending_req_then_no_other_resp_matches(cr.object_ref())))),
         !ReconcilerType::reconcile_error(state), !ReconcilerType::reconcile_done(state),
-        next_state != ReconcilerType::reconcile_init_state(),
+        // next_state != ReconcilerType::reconcile_init_state(),
         forall |cr_1: K, resp_o: Option<APIResponse>|
             #[trigger] ReconcilerType::reconcile_core(cr_1, resp_o, state).0 == next_state,
     ensures
@@ -533,7 +533,7 @@ pub proof fn lemma_from_some_state_to_next_state_to_reconcile_idle<K: ResourceVi
         spec.entails(always(lift_state(controller_runtime_safety::each_resp_if_matches_pending_req_then_no_other_resp_matches(cr.object_ref())))),
         spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_reconcile_state(cr.object_ref(), state)))),
         !ReconcilerType::reconcile_error(state), !ReconcilerType::reconcile_done(state),
-        next_state != ReconcilerType::reconcile_init_state(),
+        // next_state != ReconcilerType::reconcile_init_state(),
         forall |cr_1: K, resp_o: Option<APIResponse>|
             #[trigger] ReconcilerType::reconcile_core(cr_1, resp_o, state).0 == next_state,
         spec.entails(


### PR DESCRIPTION
Previously, I add `next_state != init` to the preconditions of some lemmas for disabling the `run_scheduled_reconcile` action. Now I find this is really not needed because the state before `~>` requires that the reconcile already starts.