### PR TITLE
Support upgrade for unverified rabbitmq controller

### DIFF
--- a/reference-controllers/rabbitmq-controller/src/main.rs
+++ b/reference-controllers/rabbitmq-controller/src/main.rs
@@ -91,12 +91,15 @@ async fn reconcile_stateful_set(rabbitmq: &RabbitmqCluster, client: Client) -> R
             spec: sts.spec,
             ..old_sts
         };
-        // Scale up or no change
-        sts_api
-            .replace(sts_name, &PostParams::default(), &updated_sts)
-            .await
-            .map_err(Error::ReconcileStatefulSetFailed)?;
-
+        if updated_sts.spec.as_ref().unwrap().replicas.unwrap()
+            >= old_sts.spec.as_ref().unwrap().replicas.unwrap()
+        {
+            // Only scale up is supported.
+            sts_api
+                .replace(sts_name, &PostParams::default(), &updated_sts)
+                .await
+                .map_err(Error::ReconcileStatefulSetFailed)?;
+        }
         Ok(())
     } else {
         info!("Create statefulset: {}", sts_name);

--- a/reference-controllers/rabbitmq-controller/src/server_configmap.rs
+++ b/reference-controllers/rabbitmq-controller/src/server_configmap.rs
@@ -32,7 +32,7 @@ pub fn server_configmap_build(rabbitmq: &RabbitmqCluster) -> corev1::ConfigMap {
                 default_rbmq_config(rabbitmq),
             ),
             (
-                "userDefineConfiguration.conf".to_string(),
+                "userDefinedConfiguration.conf".to_string(),
                 default_user_config(),
             ),
         ])),

--- a/reference-controllers/rabbitmq-controller/src/statefulset.rs
+++ b/reference-controllers/rabbitmq-controller/src/statefulset.rs
@@ -119,8 +119,8 @@ fn pod_template_spec(rabbitmq: &RabbitmqCluster) -> corev1::PodTemplateSpec{
                                         ..corev1::KeyToPath::default()
                                     },
                                     corev1::KeyToPath{
-                                        key: "userDefineConfiguration.conf".to_string(),
-                                        path: "userDefineConfiguration.conf".to_string(),
+                                        key: "userDefinedConfiguration.conf".to_string(),
+                                        path: "userDefinedConfiguration.conf".to_string(),
                                         ..corev1::KeyToPath::default()
                                     }
                                 ]),
@@ -225,7 +225,10 @@ fn pod_template_spec(rabbitmq: &RabbitmqCluster) -> corev1::PodTemplateSpec{
         },
     ];
 
-    let image_used = Some(String::from("rabbitmq:3.11.10-management"));
+    let mut image_used = Some(String::from("rabbitmq:3.11.10-management"));
+    if rabbitmq.spec.image.is_some() {
+        image_used = rabbitmq.spec.image.clone();
+    }
 
     let rabbitmq_uid = 999 as i64;
     let pod_template_spec = corev1::PodTemplateSpec{
@@ -321,7 +324,7 @@ fn pod_template_spec(rabbitmq: &RabbitmqCluster) -> corev1::PodTemplateSpec{
     pod_template_spec
 }
 
-fn setup_container(_rabbitmq: &RabbitmqCluster) -> corev1::Container{
+fn setup_container(rabbitmq: &RabbitmqCluster) -> corev1::Container{
     let cpu_request = "100m".to_string();
     let mem_request = "500Mi".to_string();
     let command = vec![
@@ -331,7 +334,11 @@ fn setup_container(_rabbitmq: &RabbitmqCluster) -> corev1::Container{
 
     ];
 
-    let image_used = Some(String::from("rabbitmq:3.11.10-management"));
+    let mut image_used = Some(String::from("rabbitmq:3.11.10-management"));
+    if rabbitmq.spec.image.is_some() {
+        image_used = rabbitmq.spec.image.clone();
+    }
+    println!("image_used: {:?}", image_used);
     let setup_container = corev1::Container {
         name: "setup-container".to_string(),
         image: image_used,


### PR DESCRIPTION
Support upgrade for unverified rabbitmq controller. Details are shown in #175 .
Add code to update StatefulSet.spec.replicas and StatefulSet.spec.image.
The replicas field is based on rabbitmq.spec.replicas and the image field is based on rabbitmq.spec.image.