### PR TITLE
Support config reload for rabbitmq unverified controller

### DIFF
--- a/reference-controllers/rabbitmq-controller/Cargo.lock
+++ b/reference-controllers/rabbitmq-controller/Cargo.lock
@@ -153,8 +153,11 @@ checksum = "ec837a71355b28f6556dbd569b37b3f363091c0bd4b2e735674521b4c5fd9bc5"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",
+ "js-sys",
  "num-traits",
  "serde",
+ "time",
+ "wasm-bindgen",
  "winapi",
 ]
 
@@ -425,7 +428,7 @@ checksum = "be4136b2a15dd319360be1c07d9933517ccf0be8f16bf62a3bee4f0d618df427"
 dependencies = [
  "cfg-if",
  "libc",
- "wasi",
+ "wasi 0.11.0+wasi-snapshot-preview1",
 ]
 
 [[package]]
@@ -854,7 +857,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "927a765cd3fc26206e66b296465fa9d3e5ab003e651c1b3c060e7956d96b19d2"
 dependencies = [
  "libc",
- "wasi",
+ "wasi 0.11.0+wasi-snapshot-preview1",
  "windows-sys",
 ]
 
@@ -1067,6 +1070,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "base64 0.13.1",
+ "chrono",
  "futures",
  "http",
  "hyper",
@@ -1474,6 +1478,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "time"
+version = "0.1.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b797afad3f312d1c66a56d11d0316f916356d11bd158fbc6ca6389ff6bf805a"
+dependencies = [
+ "libc",
+ "wasi 0.10.0+wasi-snapshot-preview1",
+ "winapi",
+]
+
+[[package]]
 name = "tinyvec"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1808,6 +1823,12 @@ checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
 dependencies = [
  "try-lock",
 ]
+
+[[package]]
+name = "wasi"
+version = "0.10.0+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f"
 
 [[package]]
 name = "wasi"

--- a/reference-controllers/rabbitmq-controller/Cargo.toml
+++ b/reference-controllers/rabbitmq-controller/Cargo.toml
@@ -36,3 +36,4 @@ thiserror = "1.0.29"
 tower = "0.4.12"
 hyper = "0.14"
 tokio-stream = { version = "0.1.9", features = ["net"] }
+chrono = "0.4"

--- a/reference-controllers/rabbitmq-controller/src/rabbitmqcluster_types.rs
+++ b/reference-controllers/rabbitmq-controller/src/rabbitmqcluster_types.rs
@@ -12,10 +12,24 @@ pub struct RabbitmqClusterSpec {
     pub replicas: i32,
     #[serde(rename = "image", skip_serializing_if = "Option::is_none")]
     pub image: Option<String>,
+    #[serde(rename = "rabbitmq", skip_serializing_if = "Option::is_none")]
+    pub rabbitmq_config: Option<RabbitmqClusterConfigurationSpec>,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize, JsonSchema)]
 pub struct RabbitmqClusterPersistenceSpec {
     pub storage_class_name: Option<String>,
     pub storage: Option<Quantity>,
+}
+
+#[derive(Debug, Clone, serde::Deserialize, serde::Serialize, schemars::JsonSchema)]
+pub struct RabbitmqClusterConfigurationSpec {
+    // #[serde(rename = "additionalPlugins", skip_serializing_if = "Option::is_none")]
+    // pub additional_plugins: Option<Vec<String>>,
+    #[serde(rename = "additionalConfig", skip_serializing_if = "Option::is_none")]
+    pub additional_config: Option<String>,
+    #[serde(rename = "advancedConfig", skip_serializing_if = "Option::is_none")]
+    pub advanced_config: Option<String>,
+    #[serde(rename = "envConfig", skip_serializing_if = "Option::is_none")]
+    pub env_config: Option<String>,
 }

--- a/reference-controllers/rabbitmq-controller/src/server_configmap.rs
+++ b/reference-controllers/rabbitmq-controller/src/server_configmap.rs
@@ -33,7 +33,7 @@ pub fn server_configmap_build(rabbitmq: &RabbitmqCluster) -> corev1::ConfigMap {
             ),
             (
                 "userDefinedConfiguration.conf".to_string(),
-                default_user_config(),
+                default_user_config(rabbitmq),
             ),
         ])),
         ..corev1::ConfigMap::default()
@@ -60,10 +60,17 @@ fn default_rbmq_config(rabbitmq: &RabbitmqCluster) -> String {
     default_part
 }
 
-fn default_user_config() -> String {
+fn default_user_config(rabbitmq: &RabbitmqCluster) -> String {
     let value = remove_headroom(1073741824 * 2 as i64); // 2Gi in default
-    let rabmq_part = format!("total_memory_available_override_value = {}\n", value,);
-    rabmq_part
+    let mut rmq_conf_buff = format!("total_memory_available_override_value = {}\n", value,);
+    if rabbitmq.spec.rabbitmq_config.is_some() {
+        // check if there are rabbitmq-related customized configurations
+        let rabbitmq_config = rabbitmq.spec.clone().rabbitmq_config.unwrap();
+        if rabbitmq_config.additional_config.is_some() {
+            rmq_conf_buff = rmq_conf_buff + rabbitmq_config.additional_config.unwrap().as_str();
+        }
+    }
+    rmq_conf_buff
 }
 
 fn remove_headroom(mem_limit: i64) -> i64 {

--- a/reference-controllers/rabbitmq-controller/src/statefulset.rs
+++ b/reference-controllers/rabbitmq-controller/src/statefulset.rs
@@ -338,7 +338,6 @@ fn setup_container(rabbitmq: &RabbitmqCluster) -> corev1::Container{
     if rabbitmq.spec.image.is_some() {
         image_used = rabbitmq.spec.image.clone();
     }
-    println!("image_used: {:?}", image_used);
     let setup_container = corev1::Container {
         name: "setup-container".to_string(),
         image: image_used,


### PR DESCRIPTION
Currently, timestamp are used to indicate whether the statefulset needs restarting. The ResourceVersion may be used as new indicator in next PR.