### PR TITLE
Support external APIs in the state machine

### DIFF
--- a/.github/workflows/regression-testing.yml
+++ b/.github/workflows/regression-testing.yml
@@ -30,8 +30,8 @@ jobs:
           source ../tools/activate
           vargo build --release
       - name: Build simple controller
-        run: VERUS_DIR=$PWD/verus ./build.sh simple_controller.rs --time
+        run: VERUS_DIR=$PWD/verus ./build.sh simple_controller.rs --rlimit 30 --time
       - name: Build zookeeper controller
-        run: VERUS_DIR=$PWD/verus ./build.sh zookeeper_controller.rs --time
+        run: VERUS_DIR=$PWD/verus ./build.sh zookeeper_controller.rs --rlimit 30 --time
       - name: Build rabbitmq controller
-        run: VERUS_DIR=$PWD/verus ./build.sh rabbitmq_controller.rs --time
+        run: VERUS_DIR=$PWD/verus ./build.sh rabbitmq_controller.rs --rlimit 30 --time

--- a/src/controller_examples/rabbitmq_controller/mod.rs
+++ b/src/controller_examples/rabbitmq_controller/mod.rs
@@ -2,5 +2,5 @@
 // SPDX-License-Identifier: MIT
 pub mod common;
 pub mod exec;
-// pub mod proof;
+pub mod proof;
 pub mod spec;

--- a/src/controller_examples/rabbitmq_controller/proof/common.rs
+++ b/src/controller_examples/rabbitmq_controller/proof/common.rs
@@ -18,10 +18,10 @@ use vstd::prelude::*;
 
 verus! {
 
-pub type ClusterState = State<RabbitmqClusterView, RabbitmqReconcileState>;
+pub type ClusterState = State<RabbitmqClusterView, RabbitmqReconciler>;
 
 pub open spec fn cluster_spec() -> TempPred<ClusterState> {
-    sm_spec::<RabbitmqClusterView, RabbitmqReconcileState, RabbitmqReconciler>()
+    sm_spec::<RabbitmqClusterView, RabbitmqReconciler>()
 }
 
 pub open spec fn rabbitmq_reconcile_state(step: RabbitmqReconcileStep) -> RabbitmqReconcileState {
@@ -52,7 +52,7 @@ pub open spec fn at_rabbitmq_step_with_rabbitmq(rabbitmq: RabbitmqClusterView, s
 pub open spec fn no_pending_req_at_rabbitmq_step_with_rabbitmq(rabbitmq: RabbitmqClusterView, step: RabbitmqReconcileStep) -> StatePred<ClusterState> {
     |s: ClusterState| {
         &&& at_rabbitmq_step_with_rabbitmq(rabbitmq, step)(s)
-        &&& no_pending_request(s, rabbitmq.object_ref)
+        &&& no_pending_request(s, rabbitmq.object_ref())
     }
 }
 

--- a/src/controller_examples/rabbitmq_controller/proof/common.rs
+++ b/src/controller_examples/rabbitmq_controller/proof/common.rs
@@ -4,6 +4,7 @@
 use crate::kubernetes_api_objects::{
     api_method::*, common::*, config_map::*, dynamic::*, resource::*, stateful_set::*,
 };
+use crate::kubernetes_cluster::proof::controller_runtime::*;
 use crate::kubernetes_cluster::spec::{
     cluster::*,
     controller::common::{controller_req_msg, ControllerActionInput, ControllerStep},
@@ -51,7 +52,7 @@ pub open spec fn at_rabbitmq_step_with_rabbitmq(rabbitmq: RabbitmqClusterView, s
 pub open spec fn no_pending_req_at_rabbitmq_step_with_rabbitmq(rabbitmq: RabbitmqClusterView, step: RabbitmqReconcileStep) -> StatePred<ClusterState> {
     |s: ClusterState| {
         &&& at_rabbitmq_step_with_rabbitmq(rabbitmq, step)(s)
-        &&& s.reconcile_state_of(rabbitmq.object_ref()).pending_req_msg.is_None()
+        &&& no_pending_request(s, rabbitmq.object_ref)
     }
 }
 
@@ -60,7 +61,7 @@ pub open spec fn pending_req_in_flight_at_rabbitmq_step_with_rabbitmq(
 ) -> StatePred<ClusterState> {
     |s: ClusterState| {
         &&& at_rabbitmq_step_with_rabbitmq(rabbitmq, step)(s)
-        &&& s.reconcile_state_of(rabbitmq.object_ref()).pending_req_msg.is_Some()
+        &&& pending_k8s_api_req_msg(s, rabbitmq.object_ref())
         &&& s.message_in_flight(s.pending_req_of(rabbitmq.object_ref()))
         &&& is_correct_pending_request_msg_at_rabbitmq_step(step, s.pending_req_of(rabbitmq.object_ref()), rabbitmq, object)
     }
@@ -71,7 +72,7 @@ pub open spec fn req_msg_is_the_in_flight_pending_req_at_rabbitmq_step_with_rabb
 ) -> StatePred<ClusterState> {
     |s: ClusterState| {
         &&& at_rabbitmq_step_with_rabbitmq(rabbitmq, step)(s)
-        &&& s.reconcile_state_of(rabbitmq.object_ref()).pending_req_msg == Option::Some(req_msg)
+        &&& pending_k8s_api_req_msg_is(s, rabbitmq.object_ref(), req_msg)
         &&& s.message_in_flight(req_msg)
         &&& is_correct_pending_request_msg_at_rabbitmq_step(step, req_msg, rabbitmq, object)
     }
@@ -82,7 +83,7 @@ pub open spec fn exists_resp_in_flight_at_rabbitmq_step_with_rabbitmq(
 ) -> StatePred<ClusterState> {
     |s: ClusterState| {
         &&& at_rabbitmq_step_with_rabbitmq(rabbitmq, step)(s)
-        &&& s.reconcile_state_of(rabbitmq.object_ref()).pending_req_msg.is_Some()
+        &&& pending_k8s_api_req_msg(s, rabbitmq.object_ref())
         &&& is_correct_pending_request_msg_at_rabbitmq_step(step, s.pending_req_of(rabbitmq.object_ref()), rabbitmq, object)
         &&& exists |resp_msg| {
             &&& #[trigger] s.message_in_flight(resp_msg)
@@ -96,7 +97,7 @@ pub open spec fn resp_msg_is_the_in_flight_resp_at_rabbitmq_step_with_rabbitmq(
 ) -> StatePred<ClusterState> {
     |s: ClusterState| {
         &&& at_rabbitmq_step_with_rabbitmq(rabbitmq, step)(s)
-        &&& s.reconcile_state_of(rabbitmq.object_ref()).pending_req_msg.is_Some()
+        &&& pending_k8s_api_req_msg(s, rabbitmq.object_ref())
         &&& is_correct_pending_request_msg_at_rabbitmq_step(step, s.pending_req_of(rabbitmq.object_ref()), rabbitmq, object)
         &&& s.message_in_flight(resp_msg)
         &&& resp_msg_matches_req_msg(resp_msg, s.pending_req_of(rabbitmq.object_ref()))
@@ -237,7 +238,7 @@ pub open spec fn at_after_get_server_config_map_step_with_rabbitmq_and_exists_ok
 ) -> StatePred<ClusterState> {
     |s: ClusterState| {
         &&& at_rabbitmq_step_with_rabbitmq(rabbitmq, RabbitmqReconcileStep::AfterGetServerConfigMap)(s)
-        &&& s.reconcile_state_of(rabbitmq.object_ref()).pending_req_msg.is_Some()
+        &&& pending_k8s_api_req_msg(s, rabbitmq.object_ref())
         &&& is_correct_pending_request_msg_at_rabbitmq_step(
             RabbitmqReconcileStep::AfterGetServerConfigMap, s.pending_req_of(rabbitmq.object_ref()), rabbitmq, arbitrary()
         )
@@ -255,7 +256,7 @@ pub open spec fn at_after_get_server_config_map_step_with_rabbitmq_and_exists_no
 ) -> StatePred<ClusterState> {
     |s: ClusterState| {
         &&& at_rabbitmq_step_with_rabbitmq(rabbitmq, RabbitmqReconcileStep::AfterGetServerConfigMap)(s)
-        &&& s.reconcile_state_of(rabbitmq.object_ref()).pending_req_msg.is_Some()
+        &&& pending_k8s_api_req_msg(s, rabbitmq.object_ref())
         &&& is_correct_pending_request_msg_at_rabbitmq_step(
             RabbitmqReconcileStep::AfterGetServerConfigMap, s.pending_req_of(rabbitmq.object_ref()), rabbitmq, arbitrary()
         )
@@ -273,7 +274,7 @@ pub open spec fn at_after_get_server_config_map_step_with_rabbitmq_and_exists_no
 ) -> StatePred<ClusterState> {
     |s: ClusterState| {
         &&& at_rabbitmq_step_with_rabbitmq(rabbitmq, RabbitmqReconcileStep::AfterGetServerConfigMap)(s)
-        &&& s.reconcile_state_of(rabbitmq.object_ref()).pending_req_msg.is_Some()
+        &&& pending_k8s_api_req_msg(s, rabbitmq.object_ref())
         &&& is_correct_pending_request_msg_at_rabbitmq_step(
             RabbitmqReconcileStep::AfterGetServerConfigMap, s.pending_req_of(rabbitmq.object_ref()), rabbitmq, arbitrary()
         )

--- a/src/controller_examples/rabbitmq_controller/proof/liveness.rs
+++ b/src/controller_examples/rabbitmq_controller/proof/liveness.rs
@@ -65,9 +65,9 @@ proof fn liveness_proof_forall_rabbitmq()
 
 // Next and all the wf conditions.
 spec fn next_with_wf() -> TempPred<ClusterState> {
-    always(lift_action(next::<RabbitmqClusterView, RabbitmqReconcileState, RabbitmqReconciler>()))
+    always(lift_action(next::<RabbitmqClusterView, RabbitmqReconciler>()))
     .and(tla_forall(|input| kubernetes_api_next().weak_fairness(input)))
-    .and(tla_forall(|input| controller_next::<RabbitmqClusterView, RabbitmqReconcileState, RabbitmqReconciler>().weak_fairness(input)))
+    .and(tla_forall(|input| controller_next::<RabbitmqClusterView, RabbitmqReconciler>().weak_fairness(input)))
     .and(tla_forall(|input| schedule_controller_reconcile().weak_fairness(input)))
     .and(disable_crash().weak_fairness(()))
     .and(disable_busy().weak_fairness(()))
@@ -77,16 +77,16 @@ proof fn next_with_wf_is_stable()
     ensures
         valid(stable(next_with_wf())),
 {
-    always_p_is_stable(lift_action(next::<RabbitmqClusterView, RabbitmqReconcileState, RabbitmqReconciler>()));
-    cluster::tla_forall_action_weak_fairness_is_stable(kubernetes_api_next::<RabbitmqClusterView, RabbitmqReconcileState>());
-    cluster::tla_forall_action_weak_fairness_is_stable(controller_next::<RabbitmqClusterView, RabbitmqReconcileState, RabbitmqReconciler>());
-    cluster::tla_forall_action_weak_fairness_is_stable(schedule_controller_reconcile::<RabbitmqClusterView, RabbitmqReconcileState>());
-    cluster::action_weak_fairness_is_stable(disable_crash::<RabbitmqClusterView, RabbitmqReconcileState>());
-    cluster::action_weak_fairness_is_stable(disable_busy::<RabbitmqClusterView, RabbitmqReconcileState>());
+    always_p_is_stable(lift_action(next::<RabbitmqClusterView, RabbitmqReconciler>()));
+    cluster::tla_forall_action_weak_fairness_is_stable(kubernetes_api_next::<RabbitmqClusterView, RabbitmqReconciler>());
+    cluster::tla_forall_action_weak_fairness_is_stable(controller_next::<RabbitmqClusterView, RabbitmqReconciler>());
+    cluster::tla_forall_action_weak_fairness_is_stable(schedule_controller_reconcile::<RabbitmqClusterView, RabbitmqReconciler>());
+    cluster::action_weak_fairness_is_stable(disable_crash::<RabbitmqClusterView, RabbitmqReconciler>());
+    cluster::action_weak_fairness_is_stable(disable_busy::<RabbitmqClusterView, RabbitmqReconciler>());
     stable_and_n!(
-        always(lift_action(next::<RabbitmqClusterView, RabbitmqReconcileState, RabbitmqReconciler>())),
-        tla_forall(|input| kubernetes_api_next::<RabbitmqClusterView, RabbitmqReconcileState>().weak_fairness(input)),
-        tla_forall(|input| controller_next::<RabbitmqClusterView, RabbitmqReconcileState, RabbitmqReconciler>().weak_fairness(input)),
+        always(lift_action(next::<RabbitmqClusterView, RabbitmqReconciler>())),
+        tla_forall(|input| kubernetes_api_next::<RabbitmqClusterView, RabbitmqReconciler>().weak_fairness(input)),
+        tla_forall(|input| controller_next::<RabbitmqClusterView, RabbitmqReconciler>().weak_fairness(input)),
         tla_forall(|input| schedule_controller_reconcile().weak_fairness(input)),
         disable_crash().weak_fairness(()),
         disable_busy().weak_fairness(())
@@ -108,11 +108,11 @@ proof fn assumptions_is_stable(rabbitmq: RabbitmqClusterView)
         valid(stable(assumptions(rabbitmq))),
 {
     stable_and_always_n!(
-        lift_state(crash_disabled::<RabbitmqClusterView, RabbitmqReconcileState>()),
-        lift_state(busy_disabled::<RabbitmqClusterView, RabbitmqReconcileState>()),
-        lift_state(cluster::desired_state_is::<RabbitmqClusterView, RabbitmqReconcileState>(rabbitmq)),
-        lift_state(controller_runtime_eventual_safety::the_object_in_schedule_has_spec_as::<RabbitmqClusterView, RabbitmqReconcileState>(rabbitmq)),
-        lift_state(controller_runtime_eventual_safety::the_object_in_reconcile_has_spec_as::<RabbitmqClusterView, RabbitmqReconcileState>(rabbitmq))
+        lift_state(crash_disabled::<RabbitmqClusterView, RabbitmqReconciler>()),
+        lift_state(busy_disabled::<RabbitmqClusterView, RabbitmqReconciler>()),
+        lift_state(cluster::desired_state_is::<RabbitmqClusterView, RabbitmqReconciler>(rabbitmq)),
+        lift_state(controller_runtime_eventual_safety::the_object_in_schedule_has_spec_as::<RabbitmqClusterView, RabbitmqReconciler>(rabbitmq)),
+        lift_state(controller_runtime_eventual_safety::the_object_in_reconcile_has_spec_as::<RabbitmqClusterView, RabbitmqReconciler>(rabbitmq))
     );
 }
 
@@ -127,21 +127,21 @@ spec fn invariants(rabbitmq: RabbitmqClusterView) -> TempPred<ClusterState> {
     .and(always(lift_state(cluster_safety::each_key_in_reconcile_is_consistent_with_its_object())))
     .and(always(lift_state(safety::pending_msg_at_after_create_server_config_map_step_is_create_cm_req(rabbitmq.object_ref()))))
     .and(always(lift_state(safety::pending_msg_at_after_update_server_config_map_step_is_update_cm_req(rabbitmq.object_ref()))))
-    .and(always(lift_state(controller_runtime::no_pending_req_at_reconcile_init_state::<RabbitmqClusterView, RabbitmqReconcileState, RabbitmqReconciler>(rabbitmq.object_ref()))))
-    .and(always(lift_state(controller_runtime::pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<RabbitmqClusterView, RabbitmqReconcileState>(rabbitmq.object_ref(), rabbitmq_reconcile_state(RabbitmqReconcileStep::AfterCreateHeadlessService)))))
-    .and(always(lift_state(controller_runtime::pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<RabbitmqClusterView, RabbitmqReconcileState>(rabbitmq.object_ref(), rabbitmq_reconcile_state(RabbitmqReconcileStep::AfterCreateService)))))
-    .and(always(lift_state(controller_runtime::pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<RabbitmqClusterView, RabbitmqReconcileState>(rabbitmq.object_ref(), rabbitmq_reconcile_state(RabbitmqReconcileStep::AfterCreateErlangCookieSecret)))))
-    .and(always(lift_state(controller_runtime::pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<RabbitmqClusterView, RabbitmqReconcileState>(rabbitmq.object_ref(), rabbitmq_reconcile_state(RabbitmqReconcileStep::AfterCreateDefaultUserSecret)))))
-    .and(always(lift_state(controller_runtime::pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<RabbitmqClusterView, RabbitmqReconcileState>(rabbitmq.object_ref(), rabbitmq_reconcile_state(RabbitmqReconcileStep::AfterCreatePluginsConfigMap)))))
-    .and(always(lift_state(controller_runtime::pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<RabbitmqClusterView, RabbitmqReconcileState>(rabbitmq.object_ref(), rabbitmq_reconcile_state(RabbitmqReconcileStep::AfterGetServerConfigMap)))))
-    .and(always(lift_state(controller_runtime::pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<RabbitmqClusterView, RabbitmqReconcileState>(rabbitmq.object_ref(), rabbitmq_reconcile_state(RabbitmqReconcileStep::AfterCreateServerConfigMap)))))
-    .and(always(lift_state(controller_runtime::pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<RabbitmqClusterView, RabbitmqReconcileState>(rabbitmq.object_ref(), rabbitmq_reconcile_state(RabbitmqReconcileStep::AfterUpdateServerConfigMap)))))
-    .and(always(lift_state(controller_runtime::pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<RabbitmqClusterView, RabbitmqReconcileState>(rabbitmq.object_ref(), rabbitmq_reconcile_state(RabbitmqReconcileStep::AfterCreateServiceAccount)))))
-    .and(always(lift_state(controller_runtime::pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<RabbitmqClusterView, RabbitmqReconcileState>(rabbitmq.object_ref(), rabbitmq_reconcile_state(RabbitmqReconcileStep::AfterCreateRole)))))
-    .and(always(lift_state(controller_runtime::pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<RabbitmqClusterView, RabbitmqReconcileState>(rabbitmq.object_ref(), rabbitmq_reconcile_state(RabbitmqReconcileStep::AfterCreateRoleBinding)))))
-    .and(always(lift_state(controller_runtime::pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<RabbitmqClusterView, RabbitmqReconcileState>(rabbitmq.object_ref(), rabbitmq_reconcile_state(RabbitmqReconcileStep::AfterGetStatefulSet)))))
-    .and(always(lift_state(controller_runtime::pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<RabbitmqClusterView, RabbitmqReconcileState>(rabbitmq.object_ref(), rabbitmq_reconcile_state(RabbitmqReconcileStep::AfterCreateStatefulSet)))))
-    .and(always(lift_state(controller_runtime::pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<RabbitmqClusterView, RabbitmqReconcileState>(rabbitmq.object_ref(), rabbitmq_reconcile_state(RabbitmqReconcileStep::AfterUpdateStatefulSet)))))
+    .and(always(lift_state(controller_runtime::no_pending_req_at_reconcile_init_state::<RabbitmqClusterView, RabbitmqReconciler>(rabbitmq.object_ref()))))
+    .and(always(lift_state(controller_runtime::pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<RabbitmqClusterView, RabbitmqReconciler>(rabbitmq.object_ref(), rabbitmq_reconcile_state(RabbitmqReconcileStep::AfterCreateHeadlessService)))))
+    .and(always(lift_state(controller_runtime::pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<RabbitmqClusterView, RabbitmqReconciler>(rabbitmq.object_ref(), rabbitmq_reconcile_state(RabbitmqReconcileStep::AfterCreateService)))))
+    .and(always(lift_state(controller_runtime::pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<RabbitmqClusterView, RabbitmqReconciler>(rabbitmq.object_ref(), rabbitmq_reconcile_state(RabbitmqReconcileStep::AfterCreateErlangCookieSecret)))))
+    .and(always(lift_state(controller_runtime::pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<RabbitmqClusterView, RabbitmqReconciler>(rabbitmq.object_ref(), rabbitmq_reconcile_state(RabbitmqReconcileStep::AfterCreateDefaultUserSecret)))))
+    .and(always(lift_state(controller_runtime::pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<RabbitmqClusterView, RabbitmqReconciler>(rabbitmq.object_ref(), rabbitmq_reconcile_state(RabbitmqReconcileStep::AfterCreatePluginsConfigMap)))))
+    .and(always(lift_state(controller_runtime::pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<RabbitmqClusterView, RabbitmqReconciler>(rabbitmq.object_ref(), rabbitmq_reconcile_state(RabbitmqReconcileStep::AfterGetServerConfigMap)))))
+    .and(always(lift_state(controller_runtime::pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<RabbitmqClusterView, RabbitmqReconciler>(rabbitmq.object_ref(), rabbitmq_reconcile_state(RabbitmqReconcileStep::AfterCreateServerConfigMap)))))
+    .and(always(lift_state(controller_runtime::pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<RabbitmqClusterView, RabbitmqReconciler>(rabbitmq.object_ref(), rabbitmq_reconcile_state(RabbitmqReconcileStep::AfterUpdateServerConfigMap)))))
+    .and(always(lift_state(controller_runtime::pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<RabbitmqClusterView, RabbitmqReconciler>(rabbitmq.object_ref(), rabbitmq_reconcile_state(RabbitmqReconcileStep::AfterCreateServiceAccount)))))
+    .and(always(lift_state(controller_runtime::pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<RabbitmqClusterView, RabbitmqReconciler>(rabbitmq.object_ref(), rabbitmq_reconcile_state(RabbitmqReconcileStep::AfterCreateRole)))))
+    .and(always(lift_state(controller_runtime::pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<RabbitmqClusterView, RabbitmqReconciler>(rabbitmq.object_ref(), rabbitmq_reconcile_state(RabbitmqReconcileStep::AfterCreateRoleBinding)))))
+    .and(always(lift_state(controller_runtime::pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<RabbitmqClusterView, RabbitmqReconciler>(rabbitmq.object_ref(), rabbitmq_reconcile_state(RabbitmqReconcileStep::AfterGetStatefulSet)))))
+    .and(always(lift_state(controller_runtime::pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<RabbitmqClusterView, RabbitmqReconciler>(rabbitmq.object_ref(), rabbitmq_reconcile_state(RabbitmqReconcileStep::AfterCreateStatefulSet)))))
+    .and(always(lift_state(controller_runtime::pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<RabbitmqClusterView, RabbitmqReconciler>(rabbitmq.object_ref(), rabbitmq_reconcile_state(RabbitmqReconcileStep::AfterUpdateStatefulSet)))))
 }
 
 proof fn invariants_is_stable(rabbitmq: RabbitmqClusterView)
@@ -149,30 +149,30 @@ proof fn invariants_is_stable(rabbitmq: RabbitmqClusterView)
         valid(stable(invariants(rabbitmq))),
 {
     stable_and_always_n!(
-        lift_state(controller_runtime_safety::every_in_flight_msg_has_unique_id::<RabbitmqClusterView, RabbitmqReconcileState>()),
-        lift_state(controller_runtime_safety::each_resp_matches_at_most_one_pending_req::<RabbitmqClusterView, RabbitmqReconcileState>(rabbitmq.object_ref())),
-        lift_state(controller_runtime_safety::each_resp_if_matches_pending_req_then_no_other_resp_matches::<RabbitmqClusterView, RabbitmqReconcileState>(rabbitmq.object_ref())),
-        lift_state(controller_runtime_safety::every_in_flight_msg_has_lower_id_than_allocator::<RabbitmqClusterView, RabbitmqReconcileState>()),
-        lift_state(cluster_safety::each_object_in_etcd_is_well_formed::<RabbitmqClusterView, RabbitmqReconcileState>()),
-        lift_state(cluster_safety::each_scheduled_key_is_consistent_with_its_object::<RabbitmqClusterView, RabbitmqReconcileState>()),
-        lift_state(cluster_safety::each_key_in_reconcile_is_consistent_with_its_object::<RabbitmqClusterView, RabbitmqReconcileState>()),
+        lift_state(controller_runtime_safety::every_in_flight_msg_has_unique_id::<RabbitmqClusterView, RabbitmqReconciler>()),
+        lift_state(controller_runtime_safety::each_resp_matches_at_most_one_pending_req::<RabbitmqClusterView, RabbitmqReconciler>(rabbitmq.object_ref())),
+        lift_state(controller_runtime_safety::each_resp_if_matches_pending_req_then_no_other_resp_matches::<RabbitmqClusterView, RabbitmqReconciler>(rabbitmq.object_ref())),
+        lift_state(controller_runtime_safety::every_in_flight_msg_has_lower_id_than_allocator::<RabbitmqClusterView, RabbitmqReconciler>()),
+        lift_state(cluster_safety::each_object_in_etcd_is_well_formed::<RabbitmqClusterView, RabbitmqReconciler>()),
+        lift_state(cluster_safety::each_scheduled_key_is_consistent_with_its_object::<RabbitmqClusterView, RabbitmqReconciler>()),
+        lift_state(cluster_safety::each_key_in_reconcile_is_consistent_with_its_object::<RabbitmqClusterView, RabbitmqReconciler>()),
         lift_state(safety::pending_msg_at_after_create_server_config_map_step_is_create_cm_req(rabbitmq.object_ref())),
         lift_state(safety::pending_msg_at_after_update_server_config_map_step_is_update_cm_req(rabbitmq.object_ref())),
-        lift_state(controller_runtime::no_pending_req_at_reconcile_init_state::<RabbitmqClusterView, RabbitmqReconcileState, RabbitmqReconciler>(rabbitmq.object_ref())),
-        lift_state(controller_runtime::pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<RabbitmqClusterView, RabbitmqReconcileState>(rabbitmq.object_ref(), rabbitmq_reconcile_state(RabbitmqReconcileStep::AfterCreateHeadlessService))),
-        lift_state(controller_runtime::pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<RabbitmqClusterView, RabbitmqReconcileState>(rabbitmq.object_ref(), rabbitmq_reconcile_state(RabbitmqReconcileStep::AfterCreateService))),
-        lift_state(controller_runtime::pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<RabbitmqClusterView, RabbitmqReconcileState>(rabbitmq.object_ref(), rabbitmq_reconcile_state(RabbitmqReconcileStep::AfterCreateErlangCookieSecret))),
-        lift_state(controller_runtime::pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<RabbitmqClusterView, RabbitmqReconcileState>(rabbitmq.object_ref(), rabbitmq_reconcile_state(RabbitmqReconcileStep::AfterCreateDefaultUserSecret))),
-        lift_state(controller_runtime::pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<RabbitmqClusterView, RabbitmqReconcileState>(rabbitmq.object_ref(), rabbitmq_reconcile_state(RabbitmqReconcileStep::AfterCreatePluginsConfigMap))),
-        lift_state(controller_runtime::pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<RabbitmqClusterView, RabbitmqReconcileState>(rabbitmq.object_ref(), rabbitmq_reconcile_state(RabbitmqReconcileStep::AfterGetServerConfigMap))),
-        lift_state(controller_runtime::pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<RabbitmqClusterView, RabbitmqReconcileState>(rabbitmq.object_ref(), rabbitmq_reconcile_state(RabbitmqReconcileStep::AfterCreateServerConfigMap))),
-        lift_state(controller_runtime::pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<RabbitmqClusterView, RabbitmqReconcileState>(rabbitmq.object_ref(), rabbitmq_reconcile_state(RabbitmqReconcileStep::AfterUpdateServerConfigMap))),
-        lift_state(controller_runtime::pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<RabbitmqClusterView, RabbitmqReconcileState>(rabbitmq.object_ref(), rabbitmq_reconcile_state(RabbitmqReconcileStep::AfterCreateServiceAccount))),
-        lift_state(controller_runtime::pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<RabbitmqClusterView, RabbitmqReconcileState>(rabbitmq.object_ref(), rabbitmq_reconcile_state(RabbitmqReconcileStep::AfterCreateRole))),
-        lift_state(controller_runtime::pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<RabbitmqClusterView, RabbitmqReconcileState>(rabbitmq.object_ref(), rabbitmq_reconcile_state(RabbitmqReconcileStep::AfterCreateRoleBinding))),
-        lift_state(controller_runtime::pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<RabbitmqClusterView, RabbitmqReconcileState>(rabbitmq.object_ref(), rabbitmq_reconcile_state(RabbitmqReconcileStep::AfterGetStatefulSet))),
-        lift_state(controller_runtime::pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<RabbitmqClusterView, RabbitmqReconcileState>(rabbitmq.object_ref(), rabbitmq_reconcile_state(RabbitmqReconcileStep::AfterCreateStatefulSet))),
-        lift_state(controller_runtime::pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<RabbitmqClusterView, RabbitmqReconcileState>(rabbitmq.object_ref(), rabbitmq_reconcile_state(RabbitmqReconcileStep::AfterUpdateStatefulSet)))
+        lift_state(controller_runtime::no_pending_req_at_reconcile_init_state::<RabbitmqClusterView, RabbitmqReconciler>(rabbitmq.object_ref())),
+        lift_state(controller_runtime::pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<RabbitmqClusterView, RabbitmqReconciler>(rabbitmq.object_ref(), rabbitmq_reconcile_state(RabbitmqReconcileStep::AfterCreateHeadlessService))),
+        lift_state(controller_runtime::pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<RabbitmqClusterView, RabbitmqReconciler>(rabbitmq.object_ref(), rabbitmq_reconcile_state(RabbitmqReconcileStep::AfterCreateService))),
+        lift_state(controller_runtime::pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<RabbitmqClusterView, RabbitmqReconciler>(rabbitmq.object_ref(), rabbitmq_reconcile_state(RabbitmqReconcileStep::AfterCreateErlangCookieSecret))),
+        lift_state(controller_runtime::pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<RabbitmqClusterView, RabbitmqReconciler>(rabbitmq.object_ref(), rabbitmq_reconcile_state(RabbitmqReconcileStep::AfterCreateDefaultUserSecret))),
+        lift_state(controller_runtime::pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<RabbitmqClusterView, RabbitmqReconciler>(rabbitmq.object_ref(), rabbitmq_reconcile_state(RabbitmqReconcileStep::AfterCreatePluginsConfigMap))),
+        lift_state(controller_runtime::pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<RabbitmqClusterView, RabbitmqReconciler>(rabbitmq.object_ref(), rabbitmq_reconcile_state(RabbitmqReconcileStep::AfterGetServerConfigMap))),
+        lift_state(controller_runtime::pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<RabbitmqClusterView, RabbitmqReconciler>(rabbitmq.object_ref(), rabbitmq_reconcile_state(RabbitmqReconcileStep::AfterCreateServerConfigMap))),
+        lift_state(controller_runtime::pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<RabbitmqClusterView, RabbitmqReconciler>(rabbitmq.object_ref(), rabbitmq_reconcile_state(RabbitmqReconcileStep::AfterUpdateServerConfigMap))),
+        lift_state(controller_runtime::pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<RabbitmqClusterView, RabbitmqReconciler>(rabbitmq.object_ref(), rabbitmq_reconcile_state(RabbitmqReconcileStep::AfterCreateServiceAccount))),
+        lift_state(controller_runtime::pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<RabbitmqClusterView, RabbitmqReconciler>(rabbitmq.object_ref(), rabbitmq_reconcile_state(RabbitmqReconcileStep::AfterCreateRole))),
+        lift_state(controller_runtime::pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<RabbitmqClusterView, RabbitmqReconciler>(rabbitmq.object_ref(), rabbitmq_reconcile_state(RabbitmqReconcileStep::AfterCreateRoleBinding))),
+        lift_state(controller_runtime::pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<RabbitmqClusterView, RabbitmqReconciler>(rabbitmq.object_ref(), rabbitmq_reconcile_state(RabbitmqReconcileStep::AfterGetStatefulSet))),
+        lift_state(controller_runtime::pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<RabbitmqClusterView, RabbitmqReconciler>(rabbitmq.object_ref(), rabbitmq_reconcile_state(RabbitmqReconcileStep::AfterCreateStatefulSet))),
+        lift_state(controller_runtime::pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<RabbitmqClusterView, RabbitmqReconciler>(rabbitmq.object_ref(), rabbitmq_reconcile_state(RabbitmqReconcileStep::AfterUpdateStatefulSet)))
     );
 }
 
@@ -193,7 +193,7 @@ proof fn invariants_since_rest_id_is_stable(rabbitmq: RabbitmqClusterView, rest_
         valid(stable(invariants_since_rest_id(rabbitmq, rest_id))),
 {
     stable_and_always_n!(
-        lift_state(rest_id_counter_is_no_smaller_than::<RabbitmqClusterView, RabbitmqReconcileState>(rest_id)),
+        lift_state(rest_id_counter_is_no_smaller_than::<RabbitmqClusterView, RabbitmqReconciler>(rest_id)),
         lift_state(safety::at_most_one_create_cm_req_since_rest_id_is_in_flight(rabbitmq.object_ref(), rest_id)),
         lift_state(safety::at_most_one_update_cm_req_since_rest_id_is_in_flight(rabbitmq.object_ref(), rest_id)),
         lift_state(safety::no_delete_cm_req_since_rest_id_is_in_flight(rabbitmq.object_ref(), rest_id)),
@@ -237,16 +237,16 @@ proof fn liveness_proof(rabbitmq: RabbitmqClusterView)
                 {
                     next_with_wf_is_stable();
                     invariants_is_stable(rabbitmq);
-                    always_p_is_stable(lift_state(cluster::desired_state_is::<RabbitmqClusterView, RabbitmqReconcileState>(rabbitmq)));
-                    always_p_is_stable(lift_state(crash_disabled::<RabbitmqClusterView, RabbitmqReconcileState>()));
-                    always_p_is_stable(lift_state(busy_disabled::<RabbitmqClusterView, RabbitmqReconcileState>()));
+                    always_p_is_stable(lift_state(cluster::desired_state_is::<RabbitmqClusterView, RabbitmqReconciler>(rabbitmq)));
+                    always_p_is_stable(lift_state(crash_disabled::<RabbitmqClusterView, RabbitmqReconciler>()));
+                    always_p_is_stable(lift_state(busy_disabled::<RabbitmqClusterView, RabbitmqReconciler>()));
 
                     stable_and_n!(
                         next_with_wf(),
                         invariants(rabbitmq),
-                        always(lift_state(cluster::desired_state_is::<RabbitmqClusterView, RabbitmqReconcileState>(rabbitmq))),
-                        always(lift_state(crash_disabled::<RabbitmqClusterView, RabbitmqReconcileState>())),
-                        always(lift_state(busy_disabled::<RabbitmqClusterView, RabbitmqReconcileState>()))
+                        always(lift_state(cluster::desired_state_is::<RabbitmqClusterView, RabbitmqReconciler>(rabbitmq))),
+                        always(lift_state(crash_disabled::<RabbitmqClusterView, RabbitmqReconciler>())),
+                        always(lift_state(busy_disabled::<RabbitmqClusterView, RabbitmqReconciler>()))
                     );
                 }
             );
@@ -254,8 +254,8 @@ proof fn liveness_proof(rabbitmq: RabbitmqClusterView)
             temp_pred_equality(true_pred().and(other_assumptions), other_assumptions);
 
             terminate::reconcile_eventually_terminates(spec, rabbitmq);
-            controller_runtime_eventual_safety::lemma_true_leads_to_always_the_object_in_schedule_has_spec_as::<RabbitmqClusterView, RabbitmqReconcileState, RabbitmqReconciler>(spec, rabbitmq);
-            controller_runtime_eventual_safety::lemma_true_leads_to_always_the_object_in_reconcile_has_spec_as::<RabbitmqClusterView, RabbitmqReconcileState, RabbitmqReconciler>(spec, rabbitmq);
+            controller_runtime_eventual_safety::lemma_true_leads_to_always_the_object_in_schedule_has_spec_as::<RabbitmqClusterView, RabbitmqReconciler>(spec, rabbitmq);
+            controller_runtime_eventual_safety::lemma_true_leads_to_always_the_object_in_reconcile_has_spec_as::<RabbitmqClusterView, RabbitmqReconciler>(spec, rabbitmq);
 
             leads_to_always_combine_n!(
                 spec, true_pred(),
@@ -264,7 +264,7 @@ proof fn liveness_proof(rabbitmq: RabbitmqClusterView)
             );
 
             always_and_equality_n!(
-                lift_state(controller_runtime_eventual_safety::the_object_in_schedule_has_spec_as::<RabbitmqClusterView, RabbitmqReconcileState>(rabbitmq)),
+                lift_state(controller_runtime_eventual_safety::the_object_in_schedule_has_spec_as::<RabbitmqClusterView, RabbitmqReconciler>(rabbitmq)),
                 lift_state(controller_runtime_eventual_safety::the_object_in_reconcile_has_spec_as(rabbitmq))
             );
 
@@ -285,12 +285,12 @@ proof fn liveness_proof(rabbitmq: RabbitmqClusterView)
                 {
                     next_with_wf_is_stable();
                     invariants_is_stable(rabbitmq);
-                    always_p_is_stable(lift_state(cluster::desired_state_is::<RabbitmqClusterView, RabbitmqReconcileState>(rabbitmq)));
+                    always_p_is_stable(lift_state(cluster::desired_state_is::<RabbitmqClusterView, RabbitmqReconciler>(rabbitmq)));
 
                     stable_and_n!(
                         next_with_wf(),
                         invariants(rabbitmq),
-                        always(lift_state(cluster::desired_state_is::<RabbitmqClusterView, RabbitmqReconcileState>(rabbitmq)))
+                        always(lift_state(cluster::desired_state_is::<RabbitmqClusterView, RabbitmqReconciler>(rabbitmq)))
                     );
                 }
             );
@@ -301,20 +301,20 @@ proof fn liveness_proof(rabbitmq: RabbitmqClusterView)
             unpack_conditions_from_spec(spec, always(lift_state(crash_disabled())).and(always(lift_state(busy_disabled()))), true_pred(), always(lift_state(current_state_matches(rabbitmq))));
             temp_pred_equality(
                 true_pred().and(always(lift_state(crash_disabled())).and(always(lift_state(busy_disabled())))),
-                always(lift_state(crash_disabled::<RabbitmqClusterView, RabbitmqReconcileState>())).and(always(lift_state(busy_disabled::<RabbitmqClusterView, RabbitmqReconcileState>())))
+                always(lift_state(crash_disabled::<RabbitmqClusterView, RabbitmqReconciler>())).and(always(lift_state(busy_disabled::<RabbitmqClusterView, RabbitmqReconciler>())))
             );
 
-            cluster::lemma_true_leads_to_crash_always_disabled::<RabbitmqClusterView, RabbitmqReconcileState, RabbitmqReconciler>(spec);
-            cluster::lemma_true_leads_to_busy_always_disabled::<RabbitmqClusterView, RabbitmqReconcileState, RabbitmqReconciler>(spec);
+            cluster::lemma_true_leads_to_crash_always_disabled::<RabbitmqClusterView, RabbitmqReconciler>(spec);
+            cluster::lemma_true_leads_to_busy_always_disabled::<RabbitmqClusterView, RabbitmqReconciler>(spec);
             leads_to_always_combine_temp(
                 spec,
                 true_pred(),
-                lift_state(crash_disabled::<RabbitmqClusterView, RabbitmqReconcileState>()),
-                lift_state(busy_disabled::<RabbitmqClusterView, RabbitmqReconcileState>())
+                lift_state(crash_disabled::<RabbitmqClusterView, RabbitmqReconciler>()),
+                lift_state(busy_disabled::<RabbitmqClusterView, RabbitmqReconciler>())
             );
             always_and_equality(
-                lift_state(crash_disabled::<RabbitmqClusterView, RabbitmqReconcileState>()),
-                lift_state(busy_disabled::<RabbitmqClusterView, RabbitmqReconcileState>())
+                lift_state(crash_disabled::<RabbitmqClusterView, RabbitmqReconciler>()),
+                lift_state(busy_disabled::<RabbitmqClusterView, RabbitmqReconciler>())
             );
             leads_to_trans_temp(spec, true_pred(), always(lift_state(crash_disabled())).and(always(lift_state(busy_disabled()))), always(lift_state(current_state_matches(rabbitmq))));
         }
@@ -356,84 +356,84 @@ proof fn sm_spec_entails_all_invariants(rabbitmq: RabbitmqClusterView)
         cluster_spec().entails(invariants(rabbitmq)),
 {
     let spec = cluster_spec();
-    controller_runtime_safety::lemma_always_every_in_flight_msg_has_unique_id::<RabbitmqClusterView, RabbitmqReconcileState, RabbitmqReconciler>();
-    controller_runtime_safety::lemma_always_each_resp_matches_at_most_one_pending_req::<RabbitmqClusterView, RabbitmqReconcileState, RabbitmqReconciler>(rabbitmq.object_ref());
-    controller_runtime_safety::lemma_always_each_resp_if_matches_pending_req_then_no_other_resp_matches::<RabbitmqClusterView, RabbitmqReconcileState, RabbitmqReconciler>(rabbitmq.object_ref());
-    controller_runtime_safety::lemma_always_every_in_flight_msg_has_lower_id_than_allocator::<RabbitmqClusterView, RabbitmqReconcileState, RabbitmqReconciler>();
-    cluster_safety::lemma_always_each_object_in_etcd_is_well_formed::<RabbitmqClusterView, RabbitmqReconcileState, RabbitmqReconciler>(spec);
-    cluster_safety::lemma_always_each_scheduled_key_is_consistent_with_its_object::<RabbitmqClusterView, RabbitmqReconcileState, RabbitmqReconciler>(spec);
-    cluster_safety::lemma_always_each_key_in_reconcile_is_consistent_with_its_object::<RabbitmqClusterView, RabbitmqReconcileState, RabbitmqReconciler>(spec);
+    controller_runtime_safety::lemma_always_every_in_flight_msg_has_unique_id::<RabbitmqClusterView, RabbitmqReconciler>();
+    controller_runtime_safety::lemma_always_each_resp_matches_at_most_one_pending_req::<RabbitmqClusterView, RabbitmqReconciler>(rabbitmq.object_ref());
+    controller_runtime_safety::lemma_always_each_resp_if_matches_pending_req_then_no_other_resp_matches::<RabbitmqClusterView, RabbitmqReconciler>(rabbitmq.object_ref());
+    controller_runtime_safety::lemma_always_every_in_flight_msg_has_lower_id_than_allocator::<RabbitmqClusterView, RabbitmqReconciler>();
+    cluster_safety::lemma_always_each_object_in_etcd_is_well_formed::<RabbitmqClusterView, RabbitmqReconciler>(spec);
+    cluster_safety::lemma_always_each_scheduled_key_is_consistent_with_its_object::<RabbitmqClusterView, RabbitmqReconciler>(spec);
+    cluster_safety::lemma_always_each_key_in_reconcile_is_consistent_with_its_object::<RabbitmqClusterView, RabbitmqReconciler>(spec);
     safety::lemma_always_pending_msg_at_after_create_server_config_map_step_is_create_cm_req(spec, rabbitmq.object_ref());
     safety::lemma_always_pending_msg_at_after_update_server_config_map_step_is_update_cm_req(spec, rabbitmq.object_ref());
-    controller_runtime_safety::lemma_always_no_pending_req_at_reconcile_init_state::<RabbitmqClusterView, RabbitmqReconcileState, RabbitmqReconciler>(spec, rabbitmq.object_ref());
-    controller_runtime_safety::lemma_always_pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<RabbitmqClusterView, RabbitmqReconcileState, RabbitmqReconciler>(
+    controller_runtime_safety::lemma_always_no_pending_req_at_reconcile_init_state::<RabbitmqClusterView, RabbitmqReconciler>(spec, rabbitmq.object_ref());
+    controller_runtime_safety::lemma_always_pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<RabbitmqClusterView, RabbitmqReconciler>(
         spec, rabbitmq.object_ref(), rabbitmq_reconcile_state(RabbitmqReconcileStep::AfterCreateHeadlessService)
     );
-    controller_runtime_safety::lemma_always_pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<RabbitmqClusterView, RabbitmqReconcileState, RabbitmqReconciler>(
+    controller_runtime_safety::lemma_always_pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<RabbitmqClusterView, RabbitmqReconciler>(
         spec, rabbitmq.object_ref(), rabbitmq_reconcile_state(RabbitmqReconcileStep::AfterCreateService)
     );
-    controller_runtime_safety::lemma_always_pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<RabbitmqClusterView, RabbitmqReconcileState, RabbitmqReconciler>(
+    controller_runtime_safety::lemma_always_pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<RabbitmqClusterView, RabbitmqReconciler>(
         spec, rabbitmq.object_ref(), rabbitmq_reconcile_state(RabbitmqReconcileStep::AfterCreateErlangCookieSecret)
     );
-    controller_runtime_safety::lemma_always_pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<RabbitmqClusterView, RabbitmqReconcileState, RabbitmqReconciler>(
+    controller_runtime_safety::lemma_always_pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<RabbitmqClusterView, RabbitmqReconciler>(
         spec, rabbitmq.object_ref(), rabbitmq_reconcile_state(RabbitmqReconcileStep::AfterCreateDefaultUserSecret)
     );
-    controller_runtime_safety::lemma_always_pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<RabbitmqClusterView, RabbitmqReconcileState, RabbitmqReconciler>(
+    controller_runtime_safety::lemma_always_pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<RabbitmqClusterView, RabbitmqReconciler>(
         spec, rabbitmq.object_ref(), rabbitmq_reconcile_state(RabbitmqReconcileStep::AfterCreatePluginsConfigMap)
     );
-    controller_runtime_safety::lemma_always_pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<RabbitmqClusterView, RabbitmqReconcileState, RabbitmqReconciler>(
+    controller_runtime_safety::lemma_always_pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<RabbitmqClusterView, RabbitmqReconciler>(
         spec, rabbitmq.object_ref(), rabbitmq_reconcile_state(RabbitmqReconcileStep::AfterGetServerConfigMap)
     );
-    controller_runtime_safety::lemma_always_pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<RabbitmqClusterView, RabbitmqReconcileState, RabbitmqReconciler>(
+    controller_runtime_safety::lemma_always_pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<RabbitmqClusterView, RabbitmqReconciler>(
         spec, rabbitmq.object_ref(), rabbitmq_reconcile_state(RabbitmqReconcileStep::AfterCreateServerConfigMap)
     );
-    controller_runtime_safety::lemma_always_pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<RabbitmqClusterView, RabbitmqReconcileState, RabbitmqReconciler>(
+    controller_runtime_safety::lemma_always_pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<RabbitmqClusterView, RabbitmqReconciler>(
         spec, rabbitmq.object_ref(), rabbitmq_reconcile_state(RabbitmqReconcileStep::AfterUpdateServerConfigMap)
     );
-    controller_runtime_safety::lemma_always_pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<RabbitmqClusterView, RabbitmqReconcileState, RabbitmqReconciler>(
+    controller_runtime_safety::lemma_always_pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<RabbitmqClusterView, RabbitmqReconciler>(
         spec, rabbitmq.object_ref(), rabbitmq_reconcile_state(RabbitmqReconcileStep::AfterCreateServiceAccount)
     );
-    controller_runtime_safety::lemma_always_pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<RabbitmqClusterView, RabbitmqReconcileState, RabbitmqReconciler>(
+    controller_runtime_safety::lemma_always_pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<RabbitmqClusterView, RabbitmqReconciler>(
         spec, rabbitmq.object_ref(), rabbitmq_reconcile_state(RabbitmqReconcileStep::AfterCreateRole)
     );
-    controller_runtime_safety::lemma_always_pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<RabbitmqClusterView, RabbitmqReconcileState, RabbitmqReconciler>(
+    controller_runtime_safety::lemma_always_pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<RabbitmqClusterView, RabbitmqReconciler>(
         spec, rabbitmq.object_ref(), rabbitmq_reconcile_state(RabbitmqReconcileStep::AfterCreateRoleBinding)
     );
-    controller_runtime_safety::lemma_always_pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<RabbitmqClusterView, RabbitmqReconcileState, RabbitmqReconciler>(
+    controller_runtime_safety::lemma_always_pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<RabbitmqClusterView, RabbitmqReconciler>(
         spec, rabbitmq.object_ref(), rabbitmq_reconcile_state(RabbitmqReconcileStep::AfterGetStatefulSet)
     );
-    controller_runtime_safety::lemma_always_pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<RabbitmqClusterView, RabbitmqReconcileState, RabbitmqReconciler>(
+    controller_runtime_safety::lemma_always_pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<RabbitmqClusterView, RabbitmqReconciler>(
         spec, rabbitmq.object_ref(), rabbitmq_reconcile_state(RabbitmqReconcileStep::AfterCreateStatefulSet)
     );
-    controller_runtime_safety::lemma_always_pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<RabbitmqClusterView, RabbitmqReconcileState, RabbitmqReconciler>(
+    controller_runtime_safety::lemma_always_pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<RabbitmqClusterView, RabbitmqReconciler>(
         spec, rabbitmq.object_ref(), rabbitmq_reconcile_state(RabbitmqReconcileStep::AfterUpdateStatefulSet)
     );
     entails_always_and_n!(
         spec,
-        lift_state(controller_runtime_safety::every_in_flight_msg_has_unique_id::<RabbitmqClusterView, RabbitmqReconcileState>()),
-        lift_state(controller_runtime_safety::each_resp_matches_at_most_one_pending_req::<RabbitmqClusterView, RabbitmqReconcileState>(rabbitmq.object_ref())),
-        lift_state(controller_runtime_safety::each_resp_if_matches_pending_req_then_no_other_resp_matches::<RabbitmqClusterView, RabbitmqReconcileState>(rabbitmq.object_ref())),
-        lift_state(controller_runtime_safety::every_in_flight_msg_has_lower_id_than_allocator::<RabbitmqClusterView, RabbitmqReconcileState>()),
-        lift_state(cluster_safety::each_object_in_etcd_is_well_formed::<RabbitmqClusterView, RabbitmqReconcileState>()),
-        lift_state(cluster_safety::each_scheduled_key_is_consistent_with_its_object::<RabbitmqClusterView, RabbitmqReconcileState>()),
-        lift_state(cluster_safety::each_key_in_reconcile_is_consistent_with_its_object::<RabbitmqClusterView, RabbitmqReconcileState>()),
+        lift_state(controller_runtime_safety::every_in_flight_msg_has_unique_id::<RabbitmqClusterView, RabbitmqReconciler>()),
+        lift_state(controller_runtime_safety::each_resp_matches_at_most_one_pending_req::<RabbitmqClusterView, RabbitmqReconciler>(rabbitmq.object_ref())),
+        lift_state(controller_runtime_safety::each_resp_if_matches_pending_req_then_no_other_resp_matches::<RabbitmqClusterView, RabbitmqReconciler>(rabbitmq.object_ref())),
+        lift_state(controller_runtime_safety::every_in_flight_msg_has_lower_id_than_allocator::<RabbitmqClusterView, RabbitmqReconciler>()),
+        lift_state(cluster_safety::each_object_in_etcd_is_well_formed::<RabbitmqClusterView, RabbitmqReconciler>()),
+        lift_state(cluster_safety::each_scheduled_key_is_consistent_with_its_object::<RabbitmqClusterView, RabbitmqReconciler>()),
+        lift_state(cluster_safety::each_key_in_reconcile_is_consistent_with_its_object::<RabbitmqClusterView, RabbitmqReconciler>()),
         lift_state(safety::pending_msg_at_after_create_server_config_map_step_is_create_cm_req(rabbitmq.object_ref())),
         lift_state(safety::pending_msg_at_after_update_server_config_map_step_is_update_cm_req(rabbitmq.object_ref())),
-        lift_state(controller_runtime::no_pending_req_at_reconcile_init_state::<RabbitmqClusterView, RabbitmqReconcileState, RabbitmqReconciler>(rabbitmq.object_ref())),
-        lift_state(controller_runtime::pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<RabbitmqClusterView, RabbitmqReconcileState>(rabbitmq.object_ref(), rabbitmq_reconcile_state(RabbitmqReconcileStep::AfterCreateHeadlessService))),
-        lift_state(controller_runtime::pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<RabbitmqClusterView, RabbitmqReconcileState>(rabbitmq.object_ref(), rabbitmq_reconcile_state(RabbitmqReconcileStep::AfterCreateService))),
-        lift_state(controller_runtime::pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<RabbitmqClusterView, RabbitmqReconcileState>(rabbitmq.object_ref(), rabbitmq_reconcile_state(RabbitmqReconcileStep::AfterCreateErlangCookieSecret))),
-        lift_state(controller_runtime::pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<RabbitmqClusterView, RabbitmqReconcileState>(rabbitmq.object_ref(), rabbitmq_reconcile_state(RabbitmqReconcileStep::AfterCreateDefaultUserSecret))),
-        lift_state(controller_runtime::pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<RabbitmqClusterView, RabbitmqReconcileState>(rabbitmq.object_ref(), rabbitmq_reconcile_state(RabbitmqReconcileStep::AfterCreatePluginsConfigMap))),
-        lift_state(controller_runtime::pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<RabbitmqClusterView, RabbitmqReconcileState>(rabbitmq.object_ref(), rabbitmq_reconcile_state(RabbitmqReconcileStep::AfterGetServerConfigMap))),
-        lift_state(controller_runtime::pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<RabbitmqClusterView, RabbitmqReconcileState>(rabbitmq.object_ref(), rabbitmq_reconcile_state(RabbitmqReconcileStep::AfterCreateServerConfigMap))),
-        lift_state(controller_runtime::pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<RabbitmqClusterView, RabbitmqReconcileState>(rabbitmq.object_ref(), rabbitmq_reconcile_state(RabbitmqReconcileStep::AfterUpdateServerConfigMap))),
-        lift_state(controller_runtime::pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<RabbitmqClusterView, RabbitmqReconcileState>(rabbitmq.object_ref(), rabbitmq_reconcile_state(RabbitmqReconcileStep::AfterCreateServiceAccount))),
-        lift_state(controller_runtime::pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<RabbitmqClusterView, RabbitmqReconcileState>(rabbitmq.object_ref(), rabbitmq_reconcile_state(RabbitmqReconcileStep::AfterCreateRole))),
-        lift_state(controller_runtime::pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<RabbitmqClusterView, RabbitmqReconcileState>(rabbitmq.object_ref(), rabbitmq_reconcile_state(RabbitmqReconcileStep::AfterCreateRoleBinding))),
-        lift_state(controller_runtime::pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<RabbitmqClusterView, RabbitmqReconcileState>(rabbitmq.object_ref(), rabbitmq_reconcile_state(RabbitmqReconcileStep::AfterGetStatefulSet))),
-        lift_state(controller_runtime::pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<RabbitmqClusterView, RabbitmqReconcileState>(rabbitmq.object_ref(), rabbitmq_reconcile_state(RabbitmqReconcileStep::AfterCreateStatefulSet))),
-        lift_state(controller_runtime::pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<RabbitmqClusterView, RabbitmqReconcileState>(rabbitmq.object_ref(), rabbitmq_reconcile_state(RabbitmqReconcileStep::AfterUpdateStatefulSet)))
+        lift_state(controller_runtime::no_pending_req_at_reconcile_init_state::<RabbitmqClusterView, RabbitmqReconciler>(rabbitmq.object_ref())),
+        lift_state(controller_runtime::pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<RabbitmqClusterView, RabbitmqReconciler>(rabbitmq.object_ref(), rabbitmq_reconcile_state(RabbitmqReconcileStep::AfterCreateHeadlessService))),
+        lift_state(controller_runtime::pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<RabbitmqClusterView, RabbitmqReconciler>(rabbitmq.object_ref(), rabbitmq_reconcile_state(RabbitmqReconcileStep::AfterCreateService))),
+        lift_state(controller_runtime::pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<RabbitmqClusterView, RabbitmqReconciler>(rabbitmq.object_ref(), rabbitmq_reconcile_state(RabbitmqReconcileStep::AfterCreateErlangCookieSecret))),
+        lift_state(controller_runtime::pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<RabbitmqClusterView, RabbitmqReconciler>(rabbitmq.object_ref(), rabbitmq_reconcile_state(RabbitmqReconcileStep::AfterCreateDefaultUserSecret))),
+        lift_state(controller_runtime::pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<RabbitmqClusterView, RabbitmqReconciler>(rabbitmq.object_ref(), rabbitmq_reconcile_state(RabbitmqReconcileStep::AfterCreatePluginsConfigMap))),
+        lift_state(controller_runtime::pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<RabbitmqClusterView, RabbitmqReconciler>(rabbitmq.object_ref(), rabbitmq_reconcile_state(RabbitmqReconcileStep::AfterGetServerConfigMap))),
+        lift_state(controller_runtime::pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<RabbitmqClusterView, RabbitmqReconciler>(rabbitmq.object_ref(), rabbitmq_reconcile_state(RabbitmqReconcileStep::AfterCreateServerConfigMap))),
+        lift_state(controller_runtime::pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<RabbitmqClusterView, RabbitmqReconciler>(rabbitmq.object_ref(), rabbitmq_reconcile_state(RabbitmqReconcileStep::AfterUpdateServerConfigMap))),
+        lift_state(controller_runtime::pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<RabbitmqClusterView, RabbitmqReconciler>(rabbitmq.object_ref(), rabbitmq_reconcile_state(RabbitmqReconcileStep::AfterCreateServiceAccount))),
+        lift_state(controller_runtime::pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<RabbitmqClusterView, RabbitmqReconciler>(rabbitmq.object_ref(), rabbitmq_reconcile_state(RabbitmqReconcileStep::AfterCreateRole))),
+        lift_state(controller_runtime::pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<RabbitmqClusterView, RabbitmqReconciler>(rabbitmq.object_ref(), rabbitmq_reconcile_state(RabbitmqReconcileStep::AfterCreateRoleBinding))),
+        lift_state(controller_runtime::pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<RabbitmqClusterView, RabbitmqReconciler>(rabbitmq.object_ref(), rabbitmq_reconcile_state(RabbitmqReconcileStep::AfterGetStatefulSet))),
+        lift_state(controller_runtime::pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<RabbitmqClusterView, RabbitmqReconciler>(rabbitmq.object_ref(), rabbitmq_reconcile_state(RabbitmqReconcileStep::AfterCreateStatefulSet))),
+        lift_state(controller_runtime::pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<RabbitmqClusterView, RabbitmqReconciler>(rabbitmq.object_ref(), rabbitmq_reconcile_state(RabbitmqReconcileStep::AfterUpdateStatefulSet)))
     );
 }
 
@@ -509,7 +509,7 @@ proof fn lemma_some_rest_id_leads_to_always_current_state_matches_rabbitmq(rabbi
         }
     );
 
-    kubernetes_api_liveness::lemma_true_leads_to_always_no_req_before_rest_id_is_in_flight::<RabbitmqClusterView, RabbitmqReconcileState, RabbitmqReconciler>(
+    kubernetes_api_liveness::lemma_true_leads_to_always_no_req_before_rest_id_is_in_flight::<RabbitmqClusterView, RabbitmqReconciler>(
         spec_with_rest_id.and(invariants_since_rest_id(rabbitmq, rest_id)), rest_id
     );
 
@@ -523,7 +523,7 @@ proof fn lemma_some_rest_id_leads_to_always_current_state_matches_rabbitmq(rabbi
             eliminate_always(spec_with_rest_id, lift_state(safety::pending_msg_at_after_create_server_config_map_step_is_create_cm_req(rabbitmq.object_ref())));
             eliminate_always(spec_with_rest_id, lift_state(safety::pending_msg_at_after_update_server_config_map_step_is_update_cm_req(rabbitmq.object_ref())));
 
-            cluster_safety::lemma_always_rest_id_counter_is_no_smaller_than::<RabbitmqClusterView, RabbitmqReconcileState, RabbitmqReconciler>(spec_with_rest_id, rest_id);
+            cluster_safety::lemma_always_rest_id_counter_is_no_smaller_than::<RabbitmqClusterView, RabbitmqReconciler>(spec_with_rest_id, rest_id);
             safety::lemma_always_at_most_one_create_cm_req_since_rest_id_is_in_flight(spec_with_rest_id, rabbitmq.object_ref(), rest_id);
             safety::lemma_always_at_most_one_update_cm_req_since_rest_id_is_in_flight(spec_with_rest_id, rabbitmq.object_ref(), rest_id);
             safety::lemma_always_no_delete_cm_req_since_rest_id_is_in_flight(spec_with_rest_id, rabbitmq.object_ref(), rest_id);
@@ -619,7 +619,7 @@ proof fn lemma_true_leads_to_always_current_state_matches_rabbitmq_under_eventua
 
 proof fn lemma_from_reconcile_idle_to_scheduled(spec: TempPred<ClusterState>, rabbitmq: RabbitmqClusterView)
     requires
-        spec.entails(always(lift_action(next::<RabbitmqClusterView, RabbitmqReconcileState, RabbitmqReconciler>()))),
+        spec.entails(always(lift_action(next::<RabbitmqClusterView, RabbitmqReconciler>()))),
         spec.entails(tla_forall(|i| schedule_controller_reconcile().weak_fairness(i))),
         spec.entails(always(lift_state(cluster::desired_state_is(rabbitmq)))),
         rabbitmq.well_formed(),
@@ -643,7 +643,7 @@ proof fn lemma_from_reconcile_idle_to_scheduled(spec: TempPred<ClusterState>, ra
     let input = rabbitmq.object_ref();
 
     controller_runtime_liveness::lemma_pre_leads_to_post_by_schedule_controller_reconcile_borrow_from_spec(
-        spec, input, next::<RabbitmqClusterView, RabbitmqReconcileState, RabbitmqReconciler>(), cluster::desired_state_is(rabbitmq), pre, post
+        spec, input, next::<RabbitmqClusterView, RabbitmqReconciler>(), cluster::desired_state_is(rabbitmq), pre, post
     );
     valid_implies_implies_leads_to(spec, lift_state(post), lift_state(post));
     or_leads_to_combine(spec, pre, post, post);
@@ -652,8 +652,8 @@ proof fn lemma_from_reconcile_idle_to_scheduled(spec: TempPred<ClusterState>, ra
 
 proof fn lemma_from_scheduled_to_init_step(spec: TempPred<ClusterState>, rabbitmq: RabbitmqClusterView)
     requires
-        spec.entails(always(lift_action(next::<RabbitmqClusterView, RabbitmqReconcileState, RabbitmqReconciler>()))),
-        spec.entails(tla_forall(|i| controller_next::<RabbitmqClusterView, RabbitmqReconcileState, RabbitmqReconciler>().weak_fairness(i))),
+        spec.entails(always(lift_action(next::<RabbitmqClusterView, RabbitmqReconciler>()))),
+        spec.entails(tla_forall(|i| controller_next::<RabbitmqClusterView, RabbitmqReconciler>().weak_fairness(i))),
         spec.entails(always(lift_state(crash_disabled()))),
         spec.entails(always(lift_state(cluster_safety::each_scheduled_key_is_consistent_with_its_object()))),
         spec.entails(always(lift_state(controller_runtime_eventual_safety::the_object_in_schedule_has_spec_as(rabbitmq)))),
@@ -674,29 +674,29 @@ proof fn lemma_from_scheduled_to_init_step(spec: TempPred<ClusterState>, rabbitm
     let post = no_pending_req_at_rabbitmq_step_with_rabbitmq(rabbitmq, RabbitmqReconcileStep::Init);
     let input = (Option::None, Option::Some(rabbitmq.object_ref()));
     let stronger_next = |s, s_prime: ClusterState| {
-        &&& next::<RabbitmqClusterView, RabbitmqReconcileState, RabbitmqReconciler>()(s, s_prime)
+        &&& next::<RabbitmqClusterView, RabbitmqReconciler>()(s, s_prime)
         &&& crash_disabled()(s)
         &&& cluster_safety::each_scheduled_key_is_consistent_with_its_object()(s)
         &&& controller_runtime_eventual_safety::the_object_in_schedule_has_spec_as(rabbitmq)(s)
     };
     entails_always_and_n!(
         spec,
-        lift_action(next::<RabbitmqClusterView, RabbitmqReconcileState, RabbitmqReconciler>()),
+        lift_action(next::<RabbitmqClusterView, RabbitmqReconciler>()),
         lift_state(crash_disabled()),
         lift_state(cluster_safety::each_scheduled_key_is_consistent_with_its_object()),
         lift_state(controller_runtime_eventual_safety::the_object_in_schedule_has_spec_as(rabbitmq))
     );
     temp_pred_equality(
         lift_action(stronger_next),
-        lift_action(next::<RabbitmqClusterView, RabbitmqReconcileState, RabbitmqReconciler>())
+        lift_action(next::<RabbitmqClusterView, RabbitmqReconciler>())
         .and(lift_state(crash_disabled()))
         .and(lift_state(cluster_safety::each_scheduled_key_is_consistent_with_its_object()))
         .and(lift_state(controller_runtime_eventual_safety::the_object_in_schedule_has_spec_as(rabbitmq)))
     );
 
-    controller_runtime_liveness::lemma_pre_leads_to_post_by_controller::<RabbitmqClusterView, RabbitmqReconcileState, RabbitmqReconciler>(
+    controller_runtime_liveness::lemma_pre_leads_to_post_by_controller::<RabbitmqClusterView, RabbitmqReconciler>(
         spec, input, stronger_next,
-        run_scheduled_reconcile::<RabbitmqClusterView, RabbitmqReconcileState, RabbitmqReconciler>(), pre, post
+        run_scheduled_reconcile::<RabbitmqClusterView, RabbitmqReconciler>(), pre, post
     );
 }
 
@@ -704,8 +704,8 @@ proof fn lemma_from_init_step_to_after_create_headless_service_step(
     spec: TempPred<ClusterState>, rabbitmq: RabbitmqClusterView
 )
     requires
-        spec.entails(always(lift_action(next::<RabbitmqClusterView, RabbitmqReconcileState, RabbitmqReconciler>()))),
-        spec.entails(tla_forall(|i| controller_next::<RabbitmqClusterView, RabbitmqReconcileState, RabbitmqReconciler>().weak_fairness(i))),
+        spec.entails(always(lift_action(next::<RabbitmqClusterView, RabbitmqReconciler>()))),
+        spec.entails(tla_forall(|i| controller_next::<RabbitmqClusterView, RabbitmqReconciler>().weak_fairness(i))),
         spec.entails(always(lift_state(crash_disabled()))),
         rabbitmq.well_formed(),
     ensures
@@ -718,23 +718,23 @@ proof fn lemma_from_init_step_to_after_create_headless_service_step(
     let post = pending_req_in_flight_at_rabbitmq_step_with_rabbitmq(RabbitmqReconcileStep::AfterCreateHeadlessService, rabbitmq, arbitrary());
     let input = (Option::None, Option::Some(rabbitmq.object_ref()));
     let stronger_next = |s, s_prime: ClusterState| {
-        &&& next::<RabbitmqClusterView, RabbitmqReconcileState, RabbitmqReconciler>()(s, s_prime)
+        &&& next::<RabbitmqClusterView, RabbitmqReconciler>()(s, s_prime)
         &&& crash_disabled()(s)
     };
     entails_always_and_n!(
         spec,
-        lift_action(next::<RabbitmqClusterView, RabbitmqReconcileState, RabbitmqReconciler>()),
+        lift_action(next::<RabbitmqClusterView, RabbitmqReconciler>()),
         lift_state(crash_disabled())
     );
     temp_pred_equality(
         lift_action(stronger_next),
-        lift_action(next::<RabbitmqClusterView, RabbitmqReconcileState, RabbitmqReconciler>())
+        lift_action(next::<RabbitmqClusterView, RabbitmqReconciler>())
         .and(lift_state(crash_disabled()))
     );
 
-    controller_runtime_liveness::lemma_pre_leads_to_post_by_controller::<RabbitmqClusterView, RabbitmqReconcileState, RabbitmqReconciler>(
+    controller_runtime_liveness::lemma_pre_leads_to_post_by_controller::<RabbitmqClusterView, RabbitmqReconciler>(
         spec, input, stronger_next,
-        continue_reconcile::<RabbitmqClusterView, RabbitmqReconcileState, RabbitmqReconciler>(), pre, post
+        continue_reconcile::<RabbitmqClusterView, RabbitmqReconciler>(), pre, post
     );
 }
 
@@ -749,8 +749,8 @@ proof fn lemma_from_pending_req_in_flight_at_some_step_to_pending_req_in_flight_
     spec: TempPred<ClusterState>, rabbitmq: RabbitmqClusterView, step: RabbitmqReconcileStep, next_step: RabbitmqReconcileStep
 )
     requires
-        spec.entails(always(lift_action(next::<RabbitmqClusterView, RabbitmqReconcileState, RabbitmqReconciler>()))),
-        spec.entails(tla_forall(|i| controller_next::<RabbitmqClusterView, RabbitmqReconcileState, RabbitmqReconciler>().weak_fairness(i))),
+        spec.entails(always(lift_action(next::<RabbitmqClusterView, RabbitmqReconciler>()))),
+        spec.entails(tla_forall(|i| controller_next::<RabbitmqClusterView, RabbitmqReconciler>().weak_fairness(i))),
         spec.entails(tla_forall(|i| kubernetes_api_next().weak_fairness(i))),
         spec.entails(always(lift_state(crash_disabled()))),
         spec.entails(always(lift_state(busy_disabled()))),
@@ -758,12 +758,13 @@ proof fn lemma_from_pending_req_in_flight_at_some_step_to_pending_req_in_flight_
         spec.entails(always(lift_state(controller_runtime_safety::each_resp_matches_at_most_one_pending_req(rabbitmq.object_ref())))),
         step != RabbitmqReconcileStep::Error, step != RabbitmqReconcileStep::Done,
         // next_step != RabbitmqReconcileStep::Init,
-        forall |rabbitmq_1: RabbitmqClusterView, resp_o: Option<APIResponse>|
+        forall |rabbitmq_1, resp_o|
             #[trigger] reconcile_core(rabbitmq_1, resp_o, RabbitmqReconcileState{ reconcile_step: step }).0.reconcile_step == next_step
             && reconcile_core(rabbitmq, resp_o, RabbitmqReconcileState{ reconcile_step: step }).1.is_Some()
+            && reconcile_core(rabbitmq, resp_o, RabbitmqReconcileState{ reconcile_step: step }).1.get_Some_0().is_KRequest()
             && (rabbitmq_1.object_ref() == rabbitmq.object_ref() && rabbitmq_1.spec == rabbitmq.spec ==>
             forall |object: DynamicObjectView| #[trigger] is_correct_pending_request_at_rabbitmq_step(
-                next_step, reconcile_core(rabbitmq, resp_o, RabbitmqReconcileState{ reconcile_step: step }).1.get_Some_0(), rabbitmq, object
+                next_step, reconcile_core(rabbitmq, resp_o, RabbitmqReconcileState{ reconcile_step: step }).1.get_Some_0().get_KRequest_0(), rabbitmq, object
             )),
         rabbitmq.well_formed(),
     ensures
@@ -853,7 +854,7 @@ proof fn lemma_receives_some_resp_at_rabbitmq_step_with_rabbitmq(
     spec: TempPred<ClusterState>, rabbitmq: RabbitmqClusterView, req_msg: Message, step: RabbitmqReconcileStep
 )
     requires
-        spec.entails(always(lift_action(next::<RabbitmqClusterView, RabbitmqReconcileState, RabbitmqReconciler>()))),
+        spec.entails(always(lift_action(next::<RabbitmqClusterView, RabbitmqReconciler>()))),
         spec.entails(tla_forall(|i| kubernetes_api_next().weak_fairness(i))),
         spec.entails(always(lift_state(crash_disabled()))),
         spec.entails(always(lift_state(busy_disabled()))),
@@ -870,21 +871,21 @@ proof fn lemma_receives_some_resp_at_rabbitmq_step_with_rabbitmq(
     let post = exists_resp_in_flight_at_rabbitmq_step_with_rabbitmq(step, rabbitmq, arbitrary());
     let input = Option::Some(req_msg);
     let stronger_next = |s, s_prime: ClusterState| {
-        &&& next::<RabbitmqClusterView, RabbitmqReconcileState, RabbitmqReconciler>()(s, s_prime)
+        &&& next::<RabbitmqClusterView, RabbitmqReconciler>()(s, s_prime)
         &&& crash_disabled()(s)
         &&& busy_disabled()(s)
         &&& controller_runtime_safety::every_in_flight_msg_has_unique_id()(s)
     };
     entails_always_and_n!(
         spec,
-        lift_action(next::<RabbitmqClusterView, RabbitmqReconcileState, RabbitmqReconciler>()),
+        lift_action(next::<RabbitmqClusterView, RabbitmqReconciler>()),
         lift_state(crash_disabled()),
         lift_state(busy_disabled()),
         lift_state(controller_runtime_safety::every_in_flight_msg_has_unique_id())
     );
     temp_pred_equality(
         lift_action(stronger_next),
-        lift_action(next::<RabbitmqClusterView, RabbitmqReconcileState, RabbitmqReconciler>())
+        lift_action(next::<RabbitmqClusterView, RabbitmqReconciler>())
         .and(lift_state(crash_disabled()))
         .and(lift_state(busy_disabled()))
         .and(lift_state(controller_runtime_safety::every_in_flight_msg_has_unique_id()))
@@ -899,7 +900,7 @@ proof fn lemma_receives_some_resp_at_rabbitmq_step_with_rabbitmq(
         });
     }
 
-    kubernetes_api_liveness::lemma_pre_leads_to_post_by_kubernetes_api::<RabbitmqClusterView, RabbitmqReconcileState, RabbitmqReconciler>(
+    kubernetes_api_liveness::lemma_pre_leads_to_post_by_kubernetes_api::<RabbitmqClusterView, RabbitmqReconciler>(
         spec, input, stronger_next, handle_request(), pre, post
     );
 }
@@ -916,8 +917,8 @@ proof fn lemma_from_resp_in_flight_at_some_step_to_pending_req_in_flight_at_next
     spec: TempPred<ClusterState>, rabbitmq: RabbitmqClusterView, resp_msg: Message, step: RabbitmqReconcileStep, result_step: RabbitmqReconcileStep
 )
     requires
-        spec.entails(always(lift_action(next::<RabbitmqClusterView, RabbitmqReconcileState, RabbitmqReconciler>()))),
-        spec.entails(tla_forall(|i| controller_next::<RabbitmqClusterView, RabbitmqReconcileState, RabbitmqReconciler>().weak_fairness(i))),
+        spec.entails(always(lift_action(next::<RabbitmqClusterView, RabbitmqReconciler>()))),
+        spec.entails(tla_forall(|i| controller_next::<RabbitmqClusterView, RabbitmqReconciler>().weak_fairness(i))),
         spec.entails(always(lift_state(crash_disabled()))),
         spec.entails(always(lift_state(busy_disabled()))),
         spec.entails(always(lift_state(controller_runtime_safety::each_resp_matches_at_most_one_pending_req(rabbitmq.object_ref())))),
@@ -925,12 +926,13 @@ proof fn lemma_from_resp_in_flight_at_some_step_to_pending_req_in_flight_at_next
         // result_step != RabbitmqReconcileStep::Init,
         // This forall rabbitmq_1 constraint is used because the cr passed to reconcile_core is not necessarily rabbitmq here.
         // We only know that rabbitmq_1.object_ref() == rabbitmq.object_ref() && rabbitmq_1.spec == rabbitmq.spec.
-        forall |rabbitmq_1: RabbitmqClusterView, resp_o: Option<APIResponse>|
+        forall |rabbitmq_1, resp_o|
             #[trigger] reconcile_core(rabbitmq_1, resp_o, RabbitmqReconcileState{ reconcile_step: step }).0.reconcile_step == result_step
             && reconcile_core(rabbitmq, resp_o, RabbitmqReconcileState{ reconcile_step: step }).1.is_Some()
+            && reconcile_core(rabbitmq, resp_o, RabbitmqReconcileState{ reconcile_step: step }).1.get_Some_0().is_KRequest()
             && (rabbitmq_1.object_ref() == rabbitmq.object_ref() && rabbitmq_1.spec == rabbitmq.spec ==>
             forall |object: DynamicObjectView| #[trigger] is_correct_pending_request_at_rabbitmq_step(
-                result_step, reconcile_core(rabbitmq, resp_o, RabbitmqReconcileState{ reconcile_step: step }).1.get_Some_0(), rabbitmq, object
+                result_step, reconcile_core(rabbitmq, resp_o, RabbitmqReconcileState{ reconcile_step: step }).1.get_Some_0().get_KRequest_0(), rabbitmq, object
             )),
         rabbitmq.well_formed(),
     ensures
@@ -950,7 +952,7 @@ proof fn lemma_from_resp_in_flight_at_some_step_to_pending_req_in_flight_at_next
     //    (Note that this is not required for termination)
     //   - each_resp_matches_at_most_one_pending_req: to make sure that the resp_msg will not be used by other cr
     let stronger_next = |s, s_prime: ClusterState| {
-        &&& next::<RabbitmqClusterView, RabbitmqReconcileState, RabbitmqReconciler>()(s, s_prime)
+        &&& next::<RabbitmqClusterView, RabbitmqReconciler>()(s, s_prime)
         &&& crash_disabled()(s)
         &&& busy_disabled()(s)
         &&& controller_runtime_safety::each_resp_matches_at_most_one_pending_req(rabbitmq.object_ref())(s)
@@ -958,21 +960,21 @@ proof fn lemma_from_resp_in_flight_at_some_step_to_pending_req_in_flight_at_next
 
     entails_always_and_n!(
         spec,
-        lift_action(next::<RabbitmqClusterView, RabbitmqReconcileState, RabbitmqReconciler>()),
+        lift_action(next::<RabbitmqClusterView, RabbitmqReconciler>()),
         lift_state(crash_disabled()),
         lift_state(busy_disabled()),
         lift_state(controller_runtime_safety::each_resp_matches_at_most_one_pending_req(rabbitmq.object_ref()))
     );
     temp_pred_equality(
         lift_action(stronger_next),
-        lift_action(next::<RabbitmqClusterView, RabbitmqReconcileState, RabbitmqReconciler>())
+        lift_action(next::<RabbitmqClusterView, RabbitmqReconciler>())
         .and(lift_state(crash_disabled()))
         .and(lift_state(busy_disabled()))
         .and(lift_state(controller_runtime_safety::each_resp_matches_at_most_one_pending_req(rabbitmq.object_ref())))
     );
 
     assert forall |s, s_prime| pre(s) && #[trigger] stronger_next(s, s_prime) implies pre(s_prime) || post(s_prime) by {
-        let step = choose |step| next_step::<RabbitmqClusterView, RabbitmqReconcileState, RabbitmqReconciler>(s, s_prime, step);
+        let step = choose |step| next_step::<RabbitmqClusterView, RabbitmqReconciler>(s, s_prime, step);
         match step {
             Step::ControllerStep(input) => {
                 if input.1.is_Some() && input.1.get_Some_0() == rabbitmq.object_ref() {
@@ -987,9 +989,9 @@ proof fn lemma_from_resp_in_flight_at_some_step_to_pending_req_in_flight_at_next
         }
     }
 
-    controller_runtime_liveness::lemma_pre_leads_to_post_by_controller::<RabbitmqClusterView, RabbitmqReconcileState, RabbitmqReconciler>(
+    controller_runtime_liveness::lemma_pre_leads_to_post_by_controller::<RabbitmqClusterView, RabbitmqReconciler>(
         spec, input, stronger_next,
-        continue_reconcile::<RabbitmqClusterView, RabbitmqReconcileState, RabbitmqReconciler>(), pre, post
+        continue_reconcile::<RabbitmqClusterView, RabbitmqReconciler>(), pre, post
     );
 }
 
@@ -1141,7 +1143,7 @@ proof fn lemma_receives_not_found_resp_at_after_get_server_config_map_step_with_
     spec: TempPred<ClusterState>, rabbitmq: RabbitmqClusterView, rest_id: nat, req_msg: Message
 )
     requires
-        spec.entails(always(lift_action(next::<RabbitmqClusterView, RabbitmqReconcileState, RabbitmqReconciler>()))),
+        spec.entails(always(lift_action(next::<RabbitmqClusterView, RabbitmqReconciler>()))),
         spec.entails(tla_forall(|i| kubernetes_api_next().weak_fairness(i))),
         spec.entails(always(lift_state(crash_disabled()))),
         spec.entails(always(lift_state(busy_disabled()))),
@@ -1175,7 +1177,7 @@ proof fn lemma_receives_not_found_resp_at_after_get_server_config_map_step_with_
     };
     let input = Option::Some(req_msg);
     let stronger_next = |s, s_prime: ClusterState| {
-        &&& next::<RabbitmqClusterView, RabbitmqReconcileState, RabbitmqReconciler>()(s, s_prime)
+        &&& next::<RabbitmqClusterView, RabbitmqReconciler>()(s, s_prime)
         &&& crash_disabled()(s)
         &&& busy_disabled()(s)
         &&& controller_runtime_safety::every_in_flight_msg_has_unique_id()(s)
@@ -1184,7 +1186,7 @@ proof fn lemma_receives_not_found_resp_at_after_get_server_config_map_step_with_
     };
     entails_always_and_n!(
         spec,
-        lift_action(next::<RabbitmqClusterView, RabbitmqReconcileState, RabbitmqReconciler>()),
+        lift_action(next::<RabbitmqClusterView, RabbitmqReconciler>()),
         lift_state(crash_disabled()),
         lift_state(busy_disabled()),
         lift_state(controller_runtime_safety::every_in_flight_msg_has_unique_id()),
@@ -1193,7 +1195,7 @@ proof fn lemma_receives_not_found_resp_at_after_get_server_config_map_step_with_
     );
     temp_pred_equality(
         lift_action(stronger_next),
-        lift_action(next::<RabbitmqClusterView, RabbitmqReconcileState, RabbitmqReconciler>())
+        lift_action(next::<RabbitmqClusterView, RabbitmqReconciler>())
         .and(lift_state(crash_disabled()))
         .and(lift_state(busy_disabled()))
         .and(lift_state(controller_runtime_safety::every_in_flight_msg_has_unique_id()))
@@ -1202,7 +1204,7 @@ proof fn lemma_receives_not_found_resp_at_after_get_server_config_map_step_with_
     );
 
     assert forall |s, s_prime| pre(s) && #[trigger] stronger_next(s, s_prime) implies pre(s_prime) || post(s_prime) by {
-        let step = choose |step| next_step::<RabbitmqClusterView, RabbitmqReconcileState, RabbitmqReconciler>(s, s_prime, step);
+        let step = choose |step| next_step::<RabbitmqClusterView, RabbitmqReconciler>(s, s_prime, step);
         match step {
             Step::KubernetesAPIStep(input) => {
                 if input.get_Some_0() == req_msg {
@@ -1230,7 +1232,7 @@ proof fn lemma_receives_not_found_resp_at_after_get_server_config_map_step_with_
         });
     }
 
-    kubernetes_api_liveness::lemma_pre_leads_to_post_by_kubernetes_api::<RabbitmqClusterView, RabbitmqReconcileState, RabbitmqReconciler>(
+    kubernetes_api_liveness::lemma_pre_leads_to_post_by_kubernetes_api::<RabbitmqClusterView, RabbitmqReconciler>(
         spec, input, stronger_next, handle_request(), pre, post
     );
 }
@@ -1239,8 +1241,8 @@ proof fn lemma_from_after_get_server_config_map_step_to_after_create_server_conf
     spec: TempPred<ClusterState>, rabbitmq: RabbitmqClusterView, rest_id: nat, resp_msg: Message
 )
     requires
-        spec.entails(always(lift_action(next::<RabbitmqClusterView, RabbitmqReconcileState, RabbitmqReconciler>()))),
-        spec.entails(tla_forall(|i| controller_next::<RabbitmqClusterView, RabbitmqReconcileState, RabbitmqReconciler>().weak_fairness(i))),
+        spec.entails(always(lift_action(next::<RabbitmqClusterView, RabbitmqReconciler>()))),
+        spec.entails(tla_forall(|i| controller_next::<RabbitmqClusterView, RabbitmqReconciler>().weak_fairness(i))),
         spec.entails(always(lift_state(crash_disabled()))),
         spec.entails(always(lift_state(controller_runtime_safety::each_resp_matches_at_most_one_pending_req(rabbitmq.object_ref())))),
         spec.entails(always(lift_state(controller_runtime_safety::each_resp_if_matches_pending_req_then_no_other_resp_matches(rabbitmq.object_ref())))),
@@ -1273,7 +1275,7 @@ proof fn lemma_from_after_get_server_config_map_step_to_after_create_server_conf
     };
     let input = (Option::Some(resp_msg), Option::Some(rabbitmq.object_ref()));
     let stronger_next = |s, s_prime: ClusterState| {
-        &&& next::<RabbitmqClusterView, RabbitmqReconcileState, RabbitmqReconciler>()(s, s_prime)
+        &&& next::<RabbitmqClusterView, RabbitmqReconciler>()(s, s_prime)
         &&& crash_disabled()(s)
         &&& controller_runtime_safety::each_resp_matches_at_most_one_pending_req(rabbitmq.object_ref())(s)
         &&& controller_runtime_safety::each_resp_if_matches_pending_req_then_no_other_resp_matches(rabbitmq.object_ref())(s)
@@ -1283,7 +1285,7 @@ proof fn lemma_from_after_get_server_config_map_step_to_after_create_server_conf
 
     entails_always_and_n!(
         spec,
-        lift_action(next::<RabbitmqClusterView, RabbitmqReconcileState, RabbitmqReconciler>()),
+        lift_action(next::<RabbitmqClusterView, RabbitmqReconciler>()),
         lift_state(crash_disabled()),
         lift_state(controller_runtime_safety::each_resp_matches_at_most_one_pending_req(rabbitmq.object_ref())),
         lift_state(controller_runtime_safety::each_resp_if_matches_pending_req_then_no_other_resp_matches(rabbitmq.object_ref())),
@@ -1292,7 +1294,7 @@ proof fn lemma_from_after_get_server_config_map_step_to_after_create_server_conf
     );
     temp_pred_equality(
         lift_action(stronger_next),
-        lift_action(next::<RabbitmqClusterView, RabbitmqReconcileState, RabbitmqReconciler>())
+        lift_action(next::<RabbitmqClusterView, RabbitmqReconciler>())
         .and(lift_state(crash_disabled()))
         .and(lift_state(controller_runtime_safety::each_resp_matches_at_most_one_pending_req(rabbitmq.object_ref())))
         .and(lift_state(controller_runtime_safety::each_resp_if_matches_pending_req_then_no_other_resp_matches(rabbitmq.object_ref())))
@@ -1300,9 +1302,9 @@ proof fn lemma_from_after_get_server_config_map_step_to_after_create_server_conf
         .and(lift_state(safety::at_most_one_create_cm_req_since_rest_id_is_in_flight(rabbitmq.object_ref(), rest_id)))
     );
 
-    controller_runtime_liveness::lemma_pre_leads_to_post_by_controller::<RabbitmqClusterView, RabbitmqReconcileState, RabbitmqReconciler>(
+    controller_runtime_liveness::lemma_pre_leads_to_post_by_controller::<RabbitmqClusterView, RabbitmqReconciler>(
         spec, input, stronger_next,
-        continue_reconcile::<RabbitmqClusterView, RabbitmqReconcileState, RabbitmqReconciler>(), pre, post
+        continue_reconcile::<RabbitmqClusterView, RabbitmqReconciler>(), pre, post
     );
 }
 
@@ -1310,7 +1312,7 @@ proof fn lemma_cm_is_created_at_after_create_server_config_map_step_with_rabbitm
     spec: TempPred<ClusterState>, rabbitmq: RabbitmqClusterView, rest_id: nat, req_msg: Message
 )
     requires
-        spec.entails(always(lift_action(next::<RabbitmqClusterView, RabbitmqReconcileState, RabbitmqReconciler>()))),
+        spec.entails(always(lift_action(next::<RabbitmqClusterView, RabbitmqReconciler>()))),
         spec.entails(tla_forall(|i| kubernetes_api_next().weak_fairness(i))),
         spec.entails(always(lift_state(crash_disabled()))),
         spec.entails(always(lift_state(busy_disabled()))),
@@ -1346,7 +1348,7 @@ proof fn lemma_cm_is_created_at_after_create_server_config_map_step_with_rabbitm
     };
     let input = Option::Some(req_msg);
     let stronger_next = |s, s_prime: ClusterState| {
-        &&& next::<RabbitmqClusterView, RabbitmqReconcileState, RabbitmqReconciler>()(s, s_prime)
+        &&& next::<RabbitmqClusterView, RabbitmqReconciler>()(s, s_prime)
         &&& crash_disabled()(s)
         &&& busy_disabled()(s)
         &&& controller_runtime_safety::every_in_flight_msg_has_unique_id()(s)
@@ -1355,7 +1357,7 @@ proof fn lemma_cm_is_created_at_after_create_server_config_map_step_with_rabbitm
     };
     entails_always_and_n!(
         spec,
-        lift_action(next::<RabbitmqClusterView, RabbitmqReconcileState, RabbitmqReconciler>()),
+        lift_action(next::<RabbitmqClusterView, RabbitmqReconciler>()),
         lift_state(crash_disabled()),
         lift_state(busy_disabled()),
         lift_state(controller_runtime_safety::every_in_flight_msg_has_unique_id()),
@@ -1364,7 +1366,7 @@ proof fn lemma_cm_is_created_at_after_create_server_config_map_step_with_rabbitm
     );
     temp_pred_equality(
         lift_action(stronger_next),
-        lift_action(next::<RabbitmqClusterView, RabbitmqReconcileState, RabbitmqReconciler>())
+        lift_action(next::<RabbitmqClusterView, RabbitmqReconciler>())
         .and(lift_state(crash_disabled()))
         .and(lift_state(busy_disabled()))
         .and(lift_state(controller_runtime_safety::every_in_flight_msg_has_unique_id()))
@@ -1373,7 +1375,7 @@ proof fn lemma_cm_is_created_at_after_create_server_config_map_step_with_rabbitm
     );
 
     assert forall |s, s_prime| pre(s) && #[trigger] stronger_next(s, s_prime) implies pre(s_prime) || post(s_prime) by {
-        let step = choose |step| next_step::<RabbitmqClusterView, RabbitmqReconcileState, RabbitmqReconciler>(s, s_prime, step);
+        let step = choose |step| next_step::<RabbitmqClusterView, RabbitmqReconciler>(s, s_prime, step);
         match step {
             Step::KubernetesAPIStep(input) => {
                 ConfigMapView::spec_integrity_is_preserved_by_marshal();
@@ -1387,7 +1389,7 @@ proof fn lemma_cm_is_created_at_after_create_server_config_map_step_with_rabbitm
         ConfigMapView::spec_integrity_is_preserved_by_marshal();
     }
 
-    kubernetes_api_liveness::lemma_pre_leads_to_post_by_kubernetes_api::<RabbitmqClusterView, RabbitmqReconcileState, RabbitmqReconciler>(
+    kubernetes_api_liveness::lemma_pre_leads_to_post_by_kubernetes_api::<RabbitmqClusterView, RabbitmqReconciler>(
         spec, input, stronger_next, handle_request(), pre, post
     );
 }
@@ -1553,7 +1555,7 @@ proof fn lemma_receives_ok_resp_at_after_get_server_config_map_step_with_rabbitm
     spec: TempPred<ClusterState>, rabbitmq: RabbitmqClusterView, rest_id: nat, req_msg: Message, object: DynamicObjectView
 )
     requires
-        spec.entails(always(lift_action(next::<RabbitmqClusterView, RabbitmqReconcileState, RabbitmqReconciler>()))),
+        spec.entails(always(lift_action(next::<RabbitmqClusterView, RabbitmqReconciler>()))),
         spec.entails(tla_forall(|i| kubernetes_api_next().weak_fairness(i))),
         spec.entails(always(lift_state(crash_disabled()))),
         spec.entails(always(lift_state(busy_disabled()))),
@@ -1592,7 +1594,7 @@ proof fn lemma_receives_ok_resp_at_after_get_server_config_map_step_with_rabbitm
     };
     let input = Option::Some(req_msg);
     let stronger_next = |s, s_prime: ClusterState| {
-        &&& next::<RabbitmqClusterView, RabbitmqReconcileState, RabbitmqReconciler>()(s, s_prime)
+        &&& next::<RabbitmqClusterView, RabbitmqReconciler>()(s, s_prime)
         &&& crash_disabled()(s)
         &&& busy_disabled()(s)
         &&& controller_runtime_safety::every_in_flight_msg_has_unique_id()(s)
@@ -1602,7 +1604,7 @@ proof fn lemma_receives_ok_resp_at_after_get_server_config_map_step_with_rabbitm
     };
     entails_always_and_n!(
         spec,
-        lift_action(next::<RabbitmqClusterView, RabbitmqReconcileState, RabbitmqReconciler>()),
+        lift_action(next::<RabbitmqClusterView, RabbitmqReconciler>()),
         lift_state(crash_disabled()),
         lift_state(busy_disabled()),
         lift_state(controller_runtime_safety::every_in_flight_msg_has_unique_id()),
@@ -1612,7 +1614,7 @@ proof fn lemma_receives_ok_resp_at_after_get_server_config_map_step_with_rabbitm
     );
     temp_pred_equality(
         lift_action(stronger_next),
-        lift_action(next::<RabbitmqClusterView, RabbitmqReconcileState, RabbitmqReconciler>())
+        lift_action(next::<RabbitmqClusterView, RabbitmqReconciler>())
         .and(lift_state(crash_disabled()))
         .and(lift_state(busy_disabled()))
         .and(lift_state(controller_runtime_safety::every_in_flight_msg_has_unique_id()))
@@ -1622,7 +1624,7 @@ proof fn lemma_receives_ok_resp_at_after_get_server_config_map_step_with_rabbitm
     );
 
     assert forall |s, s_prime| pre(s) && #[trigger] stronger_next(s, s_prime) implies pre(s_prime) || post(s_prime) by {
-        let step = choose |step| next_step::<RabbitmqClusterView, RabbitmqReconcileState, RabbitmqReconciler>(s, s_prime, step);
+        let step = choose |step| next_step::<RabbitmqClusterView, RabbitmqReconciler>(s, s_prime, step);
         match step {
             Step::KubernetesAPIStep(input) => {
                 if input.get_Some_0() == req_msg {
@@ -1650,7 +1652,7 @@ proof fn lemma_receives_ok_resp_at_after_get_server_config_map_step_with_rabbitm
         });
     }
 
-    kubernetes_api_liveness::lemma_pre_leads_to_post_by_kubernetes_api::<RabbitmqClusterView, RabbitmqReconcileState, RabbitmqReconciler>(
+    kubernetes_api_liveness::lemma_pre_leads_to_post_by_kubernetes_api::<RabbitmqClusterView, RabbitmqReconciler>(
         spec, input, stronger_next, handle_request(), pre, post
     );
 }
@@ -1659,7 +1661,7 @@ proof fn lemma_cm_is_updated_at_after_update_server_config_map_step_with_rabbitm
     spec: TempPred<ClusterState>, rabbitmq: RabbitmqClusterView, rest_id: nat, req_msg: Message, object: DynamicObjectView
 )
     requires
-        spec.entails(always(lift_action(next::<RabbitmqClusterView, RabbitmqReconcileState, RabbitmqReconciler>()))),
+        spec.entails(always(lift_action(next::<RabbitmqClusterView, RabbitmqReconciler>()))),
         spec.entails(tla_forall(|i| kubernetes_api_next().weak_fairness(i))),
         spec.entails(always(lift_state(crash_disabled()))),
         spec.entails(always(lift_state(busy_disabled()))),
@@ -1699,7 +1701,7 @@ proof fn lemma_cm_is_updated_at_after_update_server_config_map_step_with_rabbitm
     };
     let input = Option::Some(req_msg);
     let stronger_next = |s, s_prime: ClusterState| {
-        &&& next::<RabbitmqClusterView, RabbitmqReconcileState, RabbitmqReconciler>()(s, s_prime)
+        &&& next::<RabbitmqClusterView, RabbitmqReconciler>()(s, s_prime)
         &&& crash_disabled()(s)
         &&& busy_disabled()(s)
         &&& controller_runtime_safety::every_in_flight_msg_has_unique_id()(s)
@@ -1710,7 +1712,7 @@ proof fn lemma_cm_is_updated_at_after_update_server_config_map_step_with_rabbitm
     };
     entails_always_and_n!(
         spec,
-        lift_action(next::<RabbitmqClusterView, RabbitmqReconcileState, RabbitmqReconciler>()),
+        lift_action(next::<RabbitmqClusterView, RabbitmqReconciler>()),
         lift_state(crash_disabled()),
         lift_state(busy_disabled()),
         lift_state(controller_runtime_safety::every_in_flight_msg_has_unique_id()),
@@ -1721,7 +1723,7 @@ proof fn lemma_cm_is_updated_at_after_update_server_config_map_step_with_rabbitm
     );
     temp_pred_equality(
         lift_action(stronger_next),
-        lift_action(next::<RabbitmqClusterView, RabbitmqReconcileState, RabbitmqReconciler>())
+        lift_action(next::<RabbitmqClusterView, RabbitmqReconciler>())
         .and(lift_state(crash_disabled()))
         .and(lift_state(busy_disabled()))
         .and(lift_state(controller_runtime_safety::every_in_flight_msg_has_unique_id()))
@@ -1732,7 +1734,7 @@ proof fn lemma_cm_is_updated_at_after_update_server_config_map_step_with_rabbitm
     );
 
     assert forall |s, s_prime| pre(s) && #[trigger] stronger_next(s, s_prime) implies pre(s_prime) || post(s_prime) by {
-        let step = choose |step| next_step::<RabbitmqClusterView, RabbitmqReconcileState, RabbitmqReconciler>(s, s_prime, step);
+        let step = choose |step| next_step::<RabbitmqClusterView, RabbitmqReconciler>(s, s_prime, step);
         match step {
             Step::KubernetesAPIStep(input) => {
                 ConfigMapView::spec_integrity_is_preserved_by_marshal();
@@ -1746,7 +1748,7 @@ proof fn lemma_cm_is_updated_at_after_update_server_config_map_step_with_rabbitm
         ConfigMapView::spec_integrity_is_preserved_by_marshal();
     }
 
-    kubernetes_api_liveness::lemma_pre_leads_to_post_by_kubernetes_api::<RabbitmqClusterView, RabbitmqReconcileState, RabbitmqReconciler>(
+    kubernetes_api_liveness::lemma_pre_leads_to_post_by_kubernetes_api::<RabbitmqClusterView, RabbitmqReconciler>(
         spec, input, stronger_next, handle_request(), pre, post
     );
 }
@@ -1755,8 +1757,8 @@ proof fn lemma_from_after_get_server_config_map_step_to_after_update_server_conf
     spec: TempPred<ClusterState>, rabbitmq: RabbitmqClusterView, rest_id: nat, resp_msg: Message, object: DynamicObjectView
 )
     requires
-        spec.entails(always(lift_action(next::<RabbitmqClusterView, RabbitmqReconcileState, RabbitmqReconciler>()))),
-        spec.entails(tla_forall(|i| controller_next::<RabbitmqClusterView, RabbitmqReconcileState, RabbitmqReconciler>().weak_fairness(i))),
+        spec.entails(always(lift_action(next::<RabbitmqClusterView, RabbitmqReconciler>()))),
+        spec.entails(tla_forall(|i| controller_next::<RabbitmqClusterView, RabbitmqReconciler>().weak_fairness(i))),
         spec.entails(always(lift_state(crash_disabled()))),
         spec.entails(always(lift_state(busy_disabled()))),
         spec.entails(always(lift_state(controller_runtime_safety::each_resp_matches_at_most_one_pending_req(rabbitmq.object_ref())))),
@@ -1796,7 +1798,7 @@ proof fn lemma_from_after_get_server_config_map_step_to_after_update_server_conf
     };
     let input = (Option::Some(resp_msg), Option::Some(rabbitmq.object_ref()));
     let stronger_next = |s, s_prime: ClusterState| {
-        &&& next::<RabbitmqClusterView, RabbitmqReconcileState, RabbitmqReconciler>()(s, s_prime)
+        &&& next::<RabbitmqClusterView, RabbitmqReconciler>()(s, s_prime)
         &&& crash_disabled()(s)
         &&& busy_disabled()(s)
         &&& controller_runtime_safety::each_resp_matches_at_most_one_pending_req(rabbitmq.object_ref())(s)
@@ -1809,7 +1811,7 @@ proof fn lemma_from_after_get_server_config_map_step_to_after_update_server_conf
 
     entails_always_and_n!(
         spec,
-        lift_action(next::<RabbitmqClusterView, RabbitmqReconcileState, RabbitmqReconciler>()),
+        lift_action(next::<RabbitmqClusterView, RabbitmqReconciler>()),
         lift_state(crash_disabled()),
         lift_state(busy_disabled()),
         lift_state(controller_runtime_safety::each_resp_matches_at_most_one_pending_req(rabbitmq.object_ref())),
@@ -1821,7 +1823,7 @@ proof fn lemma_from_after_get_server_config_map_step_to_after_update_server_conf
     );
     temp_pred_equality(
         lift_action(stronger_next),
-        lift_action(next::<RabbitmqClusterView, RabbitmqReconcileState, RabbitmqReconciler>())
+        lift_action(next::<RabbitmqClusterView, RabbitmqReconciler>())
         .and(lift_state(crash_disabled()))
         .and(lift_state(busy_disabled()))
         .and(lift_state(controller_runtime_safety::each_resp_matches_at_most_one_pending_req(rabbitmq.object_ref())))
@@ -1832,9 +1834,9 @@ proof fn lemma_from_after_get_server_config_map_step_to_after_update_server_conf
         .and(lift_state(safety::no_delete_cm_req_since_rest_id_is_in_flight(rabbitmq.object_ref(), rest_id)))
     );
 
-    controller_runtime_liveness::lemma_pre_leads_to_post_by_controller::<RabbitmqClusterView, RabbitmqReconcileState, RabbitmqReconciler>(
+    controller_runtime_liveness::lemma_pre_leads_to_post_by_controller::<RabbitmqClusterView, RabbitmqReconciler>(
         spec, input, stronger_next,
-        continue_reconcile::<RabbitmqClusterView, RabbitmqReconcileState, RabbitmqReconciler>(), pre, post
+        continue_reconcile::<RabbitmqClusterView, RabbitmqReconciler>(), pre, post
     );
 }
 
@@ -1843,7 +1845,7 @@ proof fn lemma_server_config_map_is_stable(
 )
     requires
         spec.entails(p.leads_to(lift_state(current_state_matches(rabbitmq)))),
-        spec.entails(always(lift_action(next::<RabbitmqClusterView, RabbitmqReconcileState, RabbitmqReconciler>()))),
+        spec.entails(always(lift_action(next::<RabbitmqClusterView, RabbitmqReconciler>()))),
         spec.entails(always(lift_state(kubernetes_api_liveness::no_req_before_rest_id_is_in_flight(rest_id)))),
         spec.entails(always(lift_state(safety::no_delete_cm_req_since_rest_id_is_in_flight(rabbitmq.object_ref(), rest_id)))),
         spec.entails(always(lift_state(safety::every_update_cm_req_since_rest_id_does_the_same(rabbitmq, rest_id)))),
@@ -1852,21 +1854,21 @@ proof fn lemma_server_config_map_is_stable(
 {
     let post = current_state_matches(rabbitmq);
     let stronger_next = |s, s_prime: ClusterState| {
-        &&& next::<RabbitmqClusterView, RabbitmqReconcileState, RabbitmqReconciler>()(s, s_prime)
+        &&& next::<RabbitmqClusterView, RabbitmqReconciler>()(s, s_prime)
         &&& kubernetes_api_liveness::no_req_before_rest_id_is_in_flight(rest_id)(s)
         &&& safety::no_delete_cm_req_since_rest_id_is_in_flight(rabbitmq.object_ref(), rest_id)(s)
         &&& safety::every_update_cm_req_since_rest_id_does_the_same(rabbitmq, rest_id)(s)
     };
     entails_always_and_n!(
         spec,
-        lift_action(next::<RabbitmqClusterView, RabbitmqReconcileState, RabbitmqReconciler>()),
+        lift_action(next::<RabbitmqClusterView, RabbitmqReconciler>()),
         lift_state(kubernetes_api_liveness::no_req_before_rest_id_is_in_flight(rest_id)),
         lift_state(safety::no_delete_cm_req_since_rest_id_is_in_flight(rabbitmq.object_ref(), rest_id)),
         lift_state(safety::every_update_cm_req_since_rest_id_does_the_same(rabbitmq, rest_id))
     );
     temp_pred_equality(
         lift_action(stronger_next),
-        lift_action(next::<RabbitmqClusterView, RabbitmqReconcileState, RabbitmqReconciler>())
+        lift_action(next::<RabbitmqClusterView, RabbitmqReconciler>())
         .and(lift_state(kubernetes_api_liveness::no_req_before_rest_id_is_in_flight(rest_id)))
         .and(lift_state(safety::no_delete_cm_req_since_rest_id_is_in_flight(rabbitmq.object_ref(), rest_id)))
         .and(lift_state(safety::every_update_cm_req_since_rest_id_does_the_same(rabbitmq, rest_id)))

--- a/src/controller_examples/rabbitmq_controller/proof/safety.rs
+++ b/src/controller_examples/rabbitmq_controller/proof/safety.rs
@@ -82,7 +82,7 @@ pub open spec fn pending_msg_at_after_create_server_config_map_step_is_create_cm
     |s: ClusterState| {
         at_rabbitmq_step(key, RabbitmqReconcileStep::AfterCreateServerConfigMap)(s)
             ==> {
-                &&& s.reconcile_state_of(key).pending_req_msg.is_Some()
+                &&& pending_k8s_api_req_msg(s, key)
                 &&& cm_create_request_msg(key)(s.pending_req_of(key))
             }
     }
@@ -131,7 +131,7 @@ pub open spec fn pending_msg_at_after_update_server_config_map_step_is_update_cm
     |s: ClusterState| {
         at_rabbitmq_step(key, RabbitmqReconcileStep::AfterUpdateServerConfigMap)(s)
             ==> {
-                &&& s.reconcile_state_of(key).pending_req_msg.is_Some()
+                &&& pending_k8s_api_req_msg(s, key)
                 &&& cm_update_request_msg(key)(s.pending_req_of(key))
             }
     }

--- a/src/controller_examples/rabbitmq_controller/proof/safety.rs
+++ b/src/controller_examples/rabbitmq_controller/proof/safety.rs
@@ -92,30 +92,30 @@ pub proof fn lemma_always_pending_msg_at_after_create_server_config_map_step_is_
     spec: TempPred<ClusterState>, key: ObjectRef
 )
     requires
-        spec.entails(lift_state(init::<RabbitmqClusterView, RabbitmqReconcileState, RabbitmqReconciler>())),
-        spec.entails(always(lift_action(next::<RabbitmqClusterView, RabbitmqReconcileState, RabbitmqReconciler>()))),
+        spec.entails(lift_state(init::<RabbitmqClusterView, RabbitmqReconciler>())),
+        spec.entails(always(lift_action(next::<RabbitmqClusterView, RabbitmqReconciler>()))),
     ensures
         spec.entails(
             always(lift_state(pending_msg_at_after_create_server_config_map_step_is_create_cm_req(key)))
         ),
 {
     let invariant = pending_msg_at_after_create_server_config_map_step_is_create_cm_req(key);
-    let init = init::<RabbitmqClusterView, RabbitmqReconcileState, RabbitmqReconciler>();
+    let init = init::<RabbitmqClusterView, RabbitmqReconciler>();
     let stronger_next = |s, s_prime| {
-        &&& next::<RabbitmqClusterView, RabbitmqReconcileState, RabbitmqReconciler>()(s, s_prime)
+        &&& next::<RabbitmqClusterView, RabbitmqReconciler>()(s, s_prime)
         &&& each_key_in_reconcile_is_consistent_with_its_object()(s)
     };
 
-    lemma_always_each_key_in_reconcile_is_consistent_with_its_object::<RabbitmqClusterView, RabbitmqReconcileState, RabbitmqReconciler>(spec);
+    lemma_always_each_key_in_reconcile_is_consistent_with_its_object::<RabbitmqClusterView, RabbitmqReconciler>(spec);
 
     entails_always_and_n!(
         spec,
-        lift_action(next::<RabbitmqClusterView, RabbitmqReconcileState, RabbitmqReconciler>()),
+        lift_action(next::<RabbitmqClusterView, RabbitmqReconciler>()),
         lift_state(each_key_in_reconcile_is_consistent_with_its_object())
     );
     temp_pred_equality(
         lift_action(stronger_next),
-        lift_action(next::<RabbitmqClusterView, RabbitmqReconcileState, RabbitmqReconciler>())
+        lift_action(next::<RabbitmqClusterView, RabbitmqReconciler>())
         .and(lift_state(each_key_in_reconcile_is_consistent_with_its_object()))
     );
 
@@ -141,30 +141,30 @@ pub proof fn lemma_always_pending_msg_at_after_update_server_config_map_step_is_
     spec: TempPred<ClusterState>, key: ObjectRef
 )
     requires
-        spec.entails(lift_state(init::<RabbitmqClusterView, RabbitmqReconcileState, RabbitmqReconciler>())),
-        spec.entails(always(lift_action(next::<RabbitmqClusterView, RabbitmqReconcileState, RabbitmqReconciler>()))),
+        spec.entails(lift_state(init::<RabbitmqClusterView, RabbitmqReconciler>())),
+        spec.entails(always(lift_action(next::<RabbitmqClusterView, RabbitmqReconciler>()))),
     ensures
         spec.entails(
             always(lift_state(pending_msg_at_after_update_server_config_map_step_is_update_cm_req(key)))
         ),
 {
     let invariant = pending_msg_at_after_update_server_config_map_step_is_update_cm_req(key);
-    let init = init::<RabbitmqClusterView, RabbitmqReconcileState, RabbitmqReconciler>();
+    let init = init::<RabbitmqClusterView, RabbitmqReconciler>();
     let stronger_next = |s, s_prime| {
-        &&& next::<RabbitmqClusterView, RabbitmqReconcileState, RabbitmqReconciler>()(s, s_prime)
+        &&& next::<RabbitmqClusterView, RabbitmqReconciler>()(s, s_prime)
         &&& each_key_in_reconcile_is_consistent_with_its_object()(s)
     };
 
-    lemma_always_each_key_in_reconcile_is_consistent_with_its_object::<RabbitmqClusterView, RabbitmqReconcileState, RabbitmqReconciler>(spec);
+    lemma_always_each_key_in_reconcile_is_consistent_with_its_object::<RabbitmqClusterView, RabbitmqReconciler>(spec);
 
     entails_always_and_n!(
         spec,
-        lift_action(next::<RabbitmqClusterView, RabbitmqReconcileState, RabbitmqReconciler>()),
+        lift_action(next::<RabbitmqClusterView, RabbitmqReconciler>()),
         lift_state(each_key_in_reconcile_is_consistent_with_its_object())
     );
     temp_pred_equality(
         lift_action(stronger_next),
-        lift_action(next::<RabbitmqClusterView, RabbitmqReconcileState, RabbitmqReconciler>())
+        lift_action(next::<RabbitmqClusterView, RabbitmqReconciler>())
         .and(lift_state(each_key_in_reconcile_is_consistent_with_its_object()))
     );
 
@@ -198,7 +198,7 @@ pub proof fn lemma_always_at_most_one_create_cm_req_since_rest_id_is_in_flight(
         spec.entails(lift_state(rest_id_counter_is(rest_id))),
         spec.entails(lift_state(every_in_flight_msg_has_lower_id_than_allocator())),
         spec.entails(lift_state(pending_msg_at_after_create_server_config_map_step_is_create_cm_req(key))),
-        spec.entails(always(lift_action(next::<RabbitmqClusterView, RabbitmqReconcileState, RabbitmqReconciler>()))),
+        spec.entails(always(lift_action(next::<RabbitmqClusterView, RabbitmqReconciler>()))),
         spec.entails(always(lift_state(crash_disabled()))),
         spec.entails(always(lift_state(busy_disabled()))),
         spec.entails(always(lift_state(pending_msg_at_after_create_server_config_map_step_is_create_cm_req(key)))),
@@ -268,7 +268,7 @@ pub proof fn lemma_always_at_most_one_update_cm_req_since_rest_id_is_in_flight(
         spec.entails(lift_state(rest_id_counter_is(rest_id))),
         spec.entails(lift_state(every_in_flight_msg_has_lower_id_than_allocator())),
         spec.entails(lift_state(pending_msg_at_after_update_server_config_map_step_is_update_cm_req(key))),
-        spec.entails(always(lift_action(next::<RabbitmqClusterView, RabbitmqReconcileState, RabbitmqReconciler>()))),
+        spec.entails(always(lift_action(next::<RabbitmqClusterView, RabbitmqReconciler>()))),
         spec.entails(always(lift_state(crash_disabled()))),
         spec.entails(always(lift_state(busy_disabled()))),
         spec.entails(always(lift_state(pending_msg_at_after_update_server_config_map_step_is_update_cm_req(key)))),
@@ -332,7 +332,7 @@ pub proof fn lemma_always_every_update_cm_req_since_rest_id_does_the_same(
     requires
         spec.entails(lift_state(rest_id_counter_is(rest_id))),
         spec.entails(lift_state(every_in_flight_msg_has_lower_id_than_allocator())),
-        spec.entails(always(lift_action(next::<RabbitmqClusterView, RabbitmqReconcileState, RabbitmqReconciler>()))),
+        spec.entails(always(lift_action(next::<RabbitmqClusterView, RabbitmqReconciler>()))),
         spec.entails(always(lift_state(each_key_in_reconcile_is_consistent_with_its_object()))),
         spec.entails(always(lift_state(rest_id_counter_is_no_smaller_than(rest_id)))),
         spec.entails(always(lift_state(controller_runtime_eventual_safety::the_object_in_reconcile_has_spec_as(rabbitmq)))),
@@ -344,7 +344,7 @@ pub proof fn lemma_always_every_update_cm_req_since_rest_id_does_the_same(
         &&& every_in_flight_msg_has_lower_id_than_allocator()(s)
     };
     let stronger_next = |s, s_prime: ClusterState| {
-        &&& next::<RabbitmqClusterView, RabbitmqReconcileState, RabbitmqReconciler>()(s, s_prime)
+        &&& next::<RabbitmqClusterView, RabbitmqReconciler>()(s, s_prime)
         &&& each_key_in_reconcile_is_consistent_with_its_object()(s)
         &&& rest_id_counter_is_no_smaller_than(rest_id)(s)
         &&& controller_runtime_eventual_safety::the_object_in_reconcile_has_spec_as(rabbitmq)(s)
@@ -364,14 +364,14 @@ pub proof fn lemma_always_every_update_cm_req_since_rest_id_does_the_same(
 
     entails_always_and_n!(
         spec,
-        lift_action(next::<RabbitmqClusterView, RabbitmqReconcileState, RabbitmqReconciler>()),
+        lift_action(next::<RabbitmqClusterView, RabbitmqReconciler>()),
         lift_state(each_key_in_reconcile_is_consistent_with_its_object()),
         lift_state(rest_id_counter_is_no_smaller_than(rest_id)),
         lift_state(controller_runtime_eventual_safety::the_object_in_reconcile_has_spec_as(rabbitmq))
     );
     temp_pred_equality(
         lift_action(stronger_next),
-        lift_action(next::<RabbitmqClusterView, RabbitmqReconcileState, RabbitmqReconciler>())
+        lift_action(next::<RabbitmqClusterView, RabbitmqReconciler>())
         .and(lift_state(each_key_in_reconcile_is_consistent_with_its_object()))
         .and(lift_state(rest_id_counter_is_no_smaller_than(rest_id)))
         .and(lift_state(controller_runtime_eventual_safety::the_object_in_reconcile_has_spec_as(rabbitmq)))
@@ -384,7 +384,7 @@ pub proof fn lemma_always_every_update_cm_req_since_rest_id_does_the_same(
             && cm_update_request_msg_since(rabbitmq.object_ref(), rest_id)(msg)
         implies msg.content.get_update_request().obj.spec == ConfigMapView::marshal_spec((make_server_config_map(rabbitmq).data, ())) by {
             if !s.message_in_flight(msg) {
-                let step = choose |step| next_step::<RabbitmqClusterView, RabbitmqReconcileState, RabbitmqReconciler>(s, s_prime, step);
+                let step = choose |step| next_step::<RabbitmqClusterView, RabbitmqReconciler>(s, s_prime, step);
                 assert(step.is_ControllerStep());
                 let other_rmq = s.reconcile_state_of(step.get_ControllerStep_0().1.get_Some_0()).triggering_cr;
                 seq_lemmas::seq_equal_preserved_by_add(
@@ -435,7 +435,7 @@ pub proof fn lemma_always_no_delete_cm_req_since_rest_id_is_in_flight(
     requires
         spec.entails(lift_state(rest_id_counter_is(rest_id))),
         spec.entails(lift_state(every_in_flight_msg_has_lower_id_than_allocator())),
-        spec.entails(always(lift_action(next::<RabbitmqClusterView, RabbitmqReconcileState, RabbitmqReconciler>()))),
+        spec.entails(always(lift_action(next::<RabbitmqClusterView, RabbitmqReconciler>()))),
         key.kind.is_CustomResourceKind(),
     ensures
         spec.entails(
@@ -446,7 +446,7 @@ pub proof fn lemma_always_no_delete_cm_req_since_rest_id_is_in_flight(
         &&& rest_id_counter_is(rest_id)(s)
         &&& every_in_flight_msg_has_lower_id_than_allocator()(s)
     };
-    let next = next::<RabbitmqClusterView, RabbitmqReconcileState, RabbitmqReconciler>();
+    let next = next::<RabbitmqClusterView, RabbitmqReconciler>();
     let invariant = no_delete_cm_req_since_rest_id_is_in_flight(key, rest_id);
 
     entails_and_n!(
@@ -496,7 +496,7 @@ proof fn lemma_always_filtered_update_cm_req_len_is_at_most_one(
         spec.entails(lift_state(rest_id_counter_is(rest_id))),
         spec.entails(lift_state(every_in_flight_msg_has_lower_id_than_allocator())),
         spec.entails(lift_state(pending_msg_at_after_update_server_config_map_step_is_update_cm_req(key))),
-        spec.entails(always(lift_action(next::<RabbitmqClusterView, RabbitmqReconcileState, RabbitmqReconciler>()))),
+        spec.entails(always(lift_action(next::<RabbitmqClusterView, RabbitmqReconciler>()))),
         spec.entails(always(lift_state(crash_disabled()))),
         spec.entails(always(lift_state(busy_disabled()))),
         spec.entails(always(lift_state(pending_msg_at_after_update_server_config_map_step_is_update_cm_req(key)))),
@@ -515,7 +515,7 @@ proof fn lemma_always_filtered_update_cm_req_len_is_at_most_one(
         &&& pending_msg_at_after_update_server_config_map_step_is_update_cm_req(key)(s)
     };
     let stronger_next = |s, s_prime: ClusterState| {
-        &&& next::<RabbitmqClusterView, RabbitmqReconcileState, RabbitmqReconciler>()(s, s_prime)
+        &&& next::<RabbitmqClusterView, RabbitmqReconciler>()(s, s_prime)
         &&& crash_disabled()(s)
         &&& busy_disabled()(s)
         &&& pending_msg_at_after_update_server_config_map_step_is_update_cm_req(key)(s)
@@ -540,7 +540,7 @@ proof fn lemma_always_filtered_update_cm_req_len_is_at_most_one(
 
     entails_always_and_n!(
         spec,
-        lift_action(next::<RabbitmqClusterView, RabbitmqReconcileState, RabbitmqReconciler>()),
+        lift_action(next::<RabbitmqClusterView, RabbitmqReconciler>()),
         lift_state(crash_disabled()),
         lift_state(busy_disabled()),
         lift_state(pending_msg_at_after_update_server_config_map_step_is_update_cm_req(key)),
@@ -550,7 +550,7 @@ proof fn lemma_always_filtered_update_cm_req_len_is_at_most_one(
     );
     temp_pred_equality(
         lift_action(stronger_next),
-        lift_action(next::<RabbitmqClusterView, RabbitmqReconcileState, RabbitmqReconciler>())
+        lift_action(next::<RabbitmqClusterView, RabbitmqReconciler>())
         .and(lift_state(crash_disabled()))
         .and(lift_state(busy_disabled()))
         .and(lift_state(pending_msg_at_after_update_server_config_map_step_is_update_cm_req(key)))
@@ -572,7 +572,7 @@ proof fn lemma_always_filtered_update_cm_req_len_is_at_most_one(
     implies invariant(s_prime) by {
         let cm_update_req_multiset = s.network_state.in_flight.filter(cm_update_request_msg_since(key, rest_id));
         let cm_update_req_multiset_prime = s_prime.network_state.in_flight.filter(cm_update_request_msg_since(key, rest_id));
-        let step = choose |step| next_step::<RabbitmqClusterView, RabbitmqReconcileState, RabbitmqReconciler>(s, s_prime, step);
+        let step = choose |step| next_step::<RabbitmqClusterView, RabbitmqReconciler>(s, s_prime, step);
         match step {
             Step::KubernetesAPIStep(input) => {
                 if !at_rabbitmq_step(key, RabbitmqReconcileStep::AfterUpdateServerConfigMap)(s) {
@@ -678,7 +678,7 @@ proof fn lemma_always_filtered_create_cm_req_len_is_at_most_one(
         spec.entails(lift_state(rest_id_counter_is(rest_id))),
         spec.entails(lift_state(every_in_flight_msg_has_lower_id_than_allocator())),
         spec.entails(lift_state(pending_msg_at_after_create_server_config_map_step_is_create_cm_req(key))),
-        spec.entails(always(lift_action(next::<RabbitmqClusterView, RabbitmqReconcileState, RabbitmqReconciler>()))),
+        spec.entails(always(lift_action(next::<RabbitmqClusterView, RabbitmqReconciler>()))),
         spec.entails(always(lift_state(crash_disabled()))),
         spec.entails(always(lift_state(busy_disabled()))),
         spec.entails(always(lift_state(pending_msg_at_after_create_server_config_map_step_is_create_cm_req(key)))),
@@ -697,7 +697,7 @@ proof fn lemma_always_filtered_create_cm_req_len_is_at_most_one(
         &&& pending_msg_at_after_create_server_config_map_step_is_create_cm_req(key)(s)
     };
     let stronger_next = |s, s_prime: ClusterState| {
-        &&& next::<RabbitmqClusterView, RabbitmqReconcileState, RabbitmqReconciler>()(s, s_prime)
+        &&& next::<RabbitmqClusterView, RabbitmqReconciler>()(s, s_prime)
         &&& crash_disabled()(s)
         &&& busy_disabled()(s)
         &&& pending_msg_at_after_create_server_config_map_step_is_create_cm_req(key)(s)
@@ -722,7 +722,7 @@ proof fn lemma_always_filtered_create_cm_req_len_is_at_most_one(
 
     entails_always_and_n!(
         spec,
-        lift_action(next::<RabbitmqClusterView, RabbitmqReconcileState, RabbitmqReconciler>()),
+        lift_action(next::<RabbitmqClusterView, RabbitmqReconciler>()),
         lift_state(crash_disabled()),
         lift_state(busy_disabled()),
         lift_state(pending_msg_at_after_create_server_config_map_step_is_create_cm_req(key)),
@@ -732,7 +732,7 @@ proof fn lemma_always_filtered_create_cm_req_len_is_at_most_one(
     );
     temp_pred_equality(
         lift_action(stronger_next),
-        lift_action(next::<RabbitmqClusterView, RabbitmqReconcileState, RabbitmqReconciler>())
+        lift_action(next::<RabbitmqClusterView, RabbitmqReconciler>())
         .and(lift_state(crash_disabled()))
         .and(lift_state(busy_disabled()))
         .and(lift_state(pending_msg_at_after_create_server_config_map_step_is_create_cm_req(key)))
@@ -754,7 +754,7 @@ proof fn lemma_always_filtered_create_cm_req_len_is_at_most_one(
     implies invariant(s_prime) by {
         let cm_create_req_multiset = s.network_state.in_flight.filter(cm_create_request_msg_since(key, rest_id));
         let cm_create_req_multiset_prime = s_prime.network_state.in_flight.filter(cm_create_request_msg_since(key, rest_id));
-        let step = choose |step| next_step::<RabbitmqClusterView, RabbitmqReconcileState, RabbitmqReconciler>(s, s_prime, step);
+        let step = choose |step| next_step::<RabbitmqClusterView, RabbitmqReconciler>(s, s_prime, step);
         match step {
             Step::KubernetesAPIStep(input) => {
                 if !at_rabbitmq_step(key, RabbitmqReconcileStep::AfterCreateServerConfigMap)(s) {

--- a/src/controller_examples/rabbitmq_controller/proof/terminate.rs
+++ b/src/controller_examples/rabbitmq_controller/proof/terminate.rs
@@ -37,7 +37,6 @@ use vstd::prelude::*;
 
 verus! {
 
-#[verifier(external_body)]
 pub proof fn reconcile_eventually_terminates(spec: TempPred<ClusterState>, rabbitmq: RabbitmqClusterView)
     requires
         spec.entails(always(lift_action(next::<RabbitmqClusterView, RabbitmqReconciler>()))),

--- a/src/controller_examples/rabbitmq_controller/proof/terminate.rs
+++ b/src/controller_examples/rabbitmq_controller/proof/terminate.rs
@@ -37,17 +37,18 @@ use vstd::prelude::*;
 
 verus! {
 
+#[verifier(external_body)]
 pub proof fn reconcile_eventually_terminates(spec: TempPred<ClusterState>, rabbitmq: RabbitmqClusterView)
     requires
-        spec.entails(always(lift_action(next::<RabbitmqClusterView, RabbitmqReconcileState, RabbitmqReconciler>()))),
+        spec.entails(always(lift_action(next::<RabbitmqClusterView, RabbitmqReconciler>()))),
         spec.entails(tla_forall(|i| kubernetes_api_next().weak_fairness(i))),
-        spec.entails(tla_forall(|i| controller_next::<RabbitmqClusterView, RabbitmqReconcileState, RabbitmqReconciler>().weak_fairness(i))),
+        spec.entails(tla_forall(|i| controller_next::<RabbitmqClusterView, RabbitmqReconciler>().weak_fairness(i))),
         spec.entails(always(lift_state(crash_disabled()))),
         spec.entails(always(lift_state(busy_disabled()))),
         spec.entails(always(lift_state(controller_runtime_safety::every_in_flight_msg_has_unique_id()))),
         spec.entails(always(lift_state(controller_runtime_safety::each_resp_matches_at_most_one_pending_req(rabbitmq.object_ref())))),
         spec.entails(always(lift_state(controller_runtime_safety::each_resp_if_matches_pending_req_then_no_other_resp_matches(rabbitmq.object_ref())))),
-        spec.entails(always(lift_state(no_pending_req_at_reconcile_init_state::<RabbitmqClusterView, RabbitmqReconcileState, RabbitmqReconciler>(rabbitmq.object_ref())))),
+        spec.entails(always(lift_state(no_pending_req_at_reconcile_init_state::<RabbitmqClusterView, RabbitmqReconciler>(rabbitmq.object_ref())))),
         forall |step: RabbitmqReconcileStep|
         step != RabbitmqReconcileStep::Init && step != RabbitmqReconcileStep::Error && step != RabbitmqReconcileStep::Done
         ==> spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_reconcile_state(rabbitmq.object_ref(), #[trigger] rabbitmq_reconcile_state(step))))),
@@ -57,43 +58,43 @@ pub proof fn reconcile_eventually_terminates(spec: TempPred<ClusterState>, rabbi
         ),
 {
     let reconcile_idle = |s: ClusterState| { !s.reconcile_state_contains(rabbitmq.object_ref()) };
-    lemma_reconcile_error_leads_to_reconcile_idle::<RabbitmqClusterView, RabbitmqReconcileState, RabbitmqReconciler>(spec, rabbitmq.object_ref());
-    lemma_reconcile_done_leads_to_reconcile_idle::<RabbitmqClusterView, RabbitmqReconcileState, RabbitmqReconciler>(spec, rabbitmq.object_ref());
+    lemma_reconcile_error_leads_to_reconcile_idle::<RabbitmqClusterView, RabbitmqReconciler>(spec, rabbitmq.object_ref());
+    lemma_reconcile_done_leads_to_reconcile_idle::<RabbitmqClusterView, RabbitmqReconciler>(spec, rabbitmq.object_ref());
     temp_pred_equality(
         lift_state(get_reconcile_state(rabbitmq, RabbitmqReconcileStep::Done)),
-        lift_state(reconciler_reconcile_done::<RabbitmqClusterView, RabbitmqReconcileState, RabbitmqReconciler>(rabbitmq.object_ref()))
+        lift_state(reconciler_reconcile_done::<RabbitmqClusterView, RabbitmqReconciler>(rabbitmq.object_ref()))
     );
     temp_pred_equality(
         lift_state(get_reconcile_state(rabbitmq, RabbitmqReconcileStep::Error)),
-        lift_state(reconciler_reconcile_error::<RabbitmqClusterView, RabbitmqReconcileState, RabbitmqReconciler>(rabbitmq.object_ref()))
+        lift_state(reconciler_reconcile_error::<RabbitmqClusterView, RabbitmqReconciler>(rabbitmq.object_ref()))
     );
-    lemma_from_some_state_to_one_next_state_to_reconcile_idle::<RabbitmqClusterView, RabbitmqReconcileState, RabbitmqReconciler>(spec, rabbitmq, rabbitmq_reconcile_state(RabbitmqReconcileStep::AfterUpdateStatefulSet), rabbitmq_reconcile_state(RabbitmqReconcileStep::Done));
-    lemma_from_some_state_to_one_next_state_to_reconcile_idle::<RabbitmqClusterView, RabbitmqReconcileState, RabbitmqReconciler>(spec, rabbitmq, rabbitmq_reconcile_state(RabbitmqReconcileStep::AfterCreateStatefulSet), rabbitmq_reconcile_state(RabbitmqReconcileStep::Done));
-    lemma_from_some_state_to_three_next_states_to_reconcile_idle::<RabbitmqClusterView, RabbitmqReconcileState, RabbitmqReconciler>(
+    lemma_from_some_state_to_one_next_state_to_reconcile_idle::<RabbitmqClusterView, RabbitmqReconciler>(spec, rabbitmq, rabbitmq_reconcile_state(RabbitmqReconcileStep::AfterUpdateStatefulSet), rabbitmq_reconcile_state(RabbitmqReconcileStep::Done));
+    lemma_from_some_state_to_one_next_state_to_reconcile_idle::<RabbitmqClusterView, RabbitmqReconciler>(spec, rabbitmq, rabbitmq_reconcile_state(RabbitmqReconcileStep::AfterCreateStatefulSet), rabbitmq_reconcile_state(RabbitmqReconcileStep::Done));
+    lemma_from_some_state_to_three_next_states_to_reconcile_idle::<RabbitmqClusterView, RabbitmqReconciler>(
         spec, rabbitmq,
         rabbitmq_reconcile_state(RabbitmqReconcileStep::AfterGetStatefulSet),
         rabbitmq_reconcile_state(RabbitmqReconcileStep::AfterUpdateStatefulSet),
         rabbitmq_reconcile_state(RabbitmqReconcileStep::AfterCreateStatefulSet),
         rabbitmq_reconcile_state(RabbitmqReconcileStep::Error)
     );
-    lemma_from_some_state_to_one_next_state_to_reconcile_idle::<RabbitmqClusterView, RabbitmqReconcileState, RabbitmqReconciler>(spec, rabbitmq, rabbitmq_reconcile_state(RabbitmqReconcileStep::AfterCreateRoleBinding), rabbitmq_reconcile_state(RabbitmqReconcileStep::AfterGetStatefulSet));
-    lemma_from_some_state_to_one_next_state_to_reconcile_idle::<RabbitmqClusterView, RabbitmqReconcileState, RabbitmqReconciler>(spec, rabbitmq, rabbitmq_reconcile_state(RabbitmqReconcileStep::AfterCreateRole), rabbitmq_reconcile_state(RabbitmqReconcileStep::AfterCreateRoleBinding));
-    lemma_from_some_state_to_one_next_state_to_reconcile_idle::<RabbitmqClusterView, RabbitmqReconcileState, RabbitmqReconciler>(spec, rabbitmq, rabbitmq_reconcile_state(RabbitmqReconcileStep::AfterCreateServiceAccount), rabbitmq_reconcile_state(RabbitmqReconcileStep::AfterCreateRole));
-    lemma_from_some_state_to_one_next_state_to_reconcile_idle::<RabbitmqClusterView, RabbitmqReconcileState, RabbitmqReconciler>(spec, rabbitmq, rabbitmq_reconcile_state(RabbitmqReconcileStep::AfterCreateServerConfigMap), rabbitmq_reconcile_state(RabbitmqReconcileStep::AfterCreateServiceAccount));
-    lemma_from_some_state_to_one_next_state_to_reconcile_idle::<RabbitmqClusterView, RabbitmqReconcileState, RabbitmqReconciler>(spec, rabbitmq, rabbitmq_reconcile_state(RabbitmqReconcileStep::AfterUpdateServerConfigMap), rabbitmq_reconcile_state(RabbitmqReconcileStep::AfterCreateServiceAccount));
-    lemma_from_some_state_to_three_next_states_to_reconcile_idle::<RabbitmqClusterView, RabbitmqReconcileState, RabbitmqReconciler>(
+    lemma_from_some_state_to_one_next_state_to_reconcile_idle::<RabbitmqClusterView, RabbitmqReconciler>(spec, rabbitmq, rabbitmq_reconcile_state(RabbitmqReconcileStep::AfterCreateRoleBinding), rabbitmq_reconcile_state(RabbitmqReconcileStep::AfterGetStatefulSet));
+    lemma_from_some_state_to_one_next_state_to_reconcile_idle::<RabbitmqClusterView, RabbitmqReconciler>(spec, rabbitmq, rabbitmq_reconcile_state(RabbitmqReconcileStep::AfterCreateRole), rabbitmq_reconcile_state(RabbitmqReconcileStep::AfterCreateRoleBinding));
+    lemma_from_some_state_to_one_next_state_to_reconcile_idle::<RabbitmqClusterView, RabbitmqReconciler>(spec, rabbitmq, rabbitmq_reconcile_state(RabbitmqReconcileStep::AfterCreateServiceAccount), rabbitmq_reconcile_state(RabbitmqReconcileStep::AfterCreateRole));
+    lemma_from_some_state_to_one_next_state_to_reconcile_idle::<RabbitmqClusterView, RabbitmqReconciler>(spec, rabbitmq, rabbitmq_reconcile_state(RabbitmqReconcileStep::AfterCreateServerConfigMap), rabbitmq_reconcile_state(RabbitmqReconcileStep::AfterCreateServiceAccount));
+    lemma_from_some_state_to_one_next_state_to_reconcile_idle::<RabbitmqClusterView, RabbitmqReconciler>(spec, rabbitmq, rabbitmq_reconcile_state(RabbitmqReconcileStep::AfterUpdateServerConfigMap), rabbitmq_reconcile_state(RabbitmqReconcileStep::AfterCreateServiceAccount));
+    lemma_from_some_state_to_three_next_states_to_reconcile_idle::<RabbitmqClusterView, RabbitmqReconciler>(
         spec, rabbitmq,
         rabbitmq_reconcile_state(RabbitmqReconcileStep::AfterGetServerConfigMap),
         rabbitmq_reconcile_state(RabbitmqReconcileStep::AfterUpdateServerConfigMap),
         rabbitmq_reconcile_state(RabbitmqReconcileStep::AfterCreateServerConfigMap),
         rabbitmq_reconcile_state(RabbitmqReconcileStep::Error)
     );
-    lemma_from_some_state_to_one_next_state_to_reconcile_idle::<RabbitmqClusterView, RabbitmqReconcileState, RabbitmqReconciler>(spec, rabbitmq, rabbitmq_reconcile_state(RabbitmqReconcileStep::AfterCreatePluginsConfigMap), rabbitmq_reconcile_state(RabbitmqReconcileStep::AfterGetServerConfigMap));
-    lemma_from_some_state_to_one_next_state_to_reconcile_idle::<RabbitmqClusterView, RabbitmqReconcileState, RabbitmqReconciler>(spec, rabbitmq, rabbitmq_reconcile_state(RabbitmqReconcileStep::AfterCreateDefaultUserSecret), rabbitmq_reconcile_state(RabbitmqReconcileStep::AfterCreatePluginsConfigMap));
-    lemma_from_some_state_to_one_next_state_to_reconcile_idle::<RabbitmqClusterView, RabbitmqReconcileState, RabbitmqReconciler>(spec, rabbitmq, rabbitmq_reconcile_state(RabbitmqReconcileStep::AfterCreateErlangCookieSecret), rabbitmq_reconcile_state(RabbitmqReconcileStep::AfterCreateDefaultUserSecret));
-    lemma_from_some_state_to_one_next_state_to_reconcile_idle::<RabbitmqClusterView, RabbitmqReconcileState, RabbitmqReconciler>(spec, rabbitmq, rabbitmq_reconcile_state(RabbitmqReconcileStep::AfterCreateService), rabbitmq_reconcile_state(RabbitmqReconcileStep::AfterCreateErlangCookieSecret));
-    lemma_from_some_state_to_one_next_state_to_reconcile_idle::<RabbitmqClusterView, RabbitmqReconcileState, RabbitmqReconciler>(spec, rabbitmq, rabbitmq_reconcile_state(RabbitmqReconcileStep::AfterCreateHeadlessService), rabbitmq_reconcile_state(RabbitmqReconcileStep::AfterCreateService));
-    lemma_from_init_state_to_next_state_to_reconcile_idle::<RabbitmqClusterView, RabbitmqReconcileState, RabbitmqReconciler>(spec, rabbitmq, rabbitmq_reconcile_state(RabbitmqReconcileStep::AfterCreateHeadlessService));
+    lemma_from_some_state_to_one_next_state_to_reconcile_idle::<RabbitmqClusterView, RabbitmqReconciler>(spec, rabbitmq, rabbitmq_reconcile_state(RabbitmqReconcileStep::AfterCreatePluginsConfigMap), rabbitmq_reconcile_state(RabbitmqReconcileStep::AfterGetServerConfigMap));
+    lemma_from_some_state_to_one_next_state_to_reconcile_idle::<RabbitmqClusterView, RabbitmqReconciler>(spec, rabbitmq, rabbitmq_reconcile_state(RabbitmqReconcileStep::AfterCreateDefaultUserSecret), rabbitmq_reconcile_state(RabbitmqReconcileStep::AfterCreatePluginsConfigMap));
+    lemma_from_some_state_to_one_next_state_to_reconcile_idle::<RabbitmqClusterView, RabbitmqReconciler>(spec, rabbitmq, rabbitmq_reconcile_state(RabbitmqReconcileStep::AfterCreateErlangCookieSecret), rabbitmq_reconcile_state(RabbitmqReconcileStep::AfterCreateDefaultUserSecret));
+    lemma_from_some_state_to_one_next_state_to_reconcile_idle::<RabbitmqClusterView, RabbitmqReconciler>(spec, rabbitmq, rabbitmq_reconcile_state(RabbitmqReconcileStep::AfterCreateService), rabbitmq_reconcile_state(RabbitmqReconcileStep::AfterCreateErlangCookieSecret));
+    lemma_from_some_state_to_one_next_state_to_reconcile_idle::<RabbitmqClusterView, RabbitmqReconciler>(spec, rabbitmq, rabbitmq_reconcile_state(RabbitmqReconcileStep::AfterCreateHeadlessService), rabbitmq_reconcile_state(RabbitmqReconcileStep::AfterCreateService));
+    lemma_from_init_state_to_next_state_to_reconcile_idle::<RabbitmqClusterView, RabbitmqReconciler>(spec, rabbitmq, rabbitmq_reconcile_state(RabbitmqReconcileStep::AfterCreateHeadlessService));
     valid_implies_implies_leads_to(spec, lift_state(reconcile_idle), lift_state(reconcile_idle));
     or_leads_to_combine_and_equality!(
         spec,

--- a/src/controller_examples/rabbitmq_controller/spec/reconciler.rs
+++ b/src/controller_examples/rabbitmq_controller/spec/reconciler.rs
@@ -45,6 +45,10 @@ impl Reconciler<RabbitmqClusterView> for RabbitmqReconciler {
     open spec fn reconcile_error(state: RabbitmqReconcileState) -> bool {
         reconcile_error(state)
     }
+
+    open spec fn external_process(input: ()) -> Option<()> {
+        Option::None
+    }
 }
 
 pub open spec fn reconcile_init_state() -> RabbitmqReconcileState {

--- a/src/controller_examples/simple_controller/proof/liveness.rs
+++ b/src/controller_examples/simple_controller/proof/liveness.rs
@@ -353,7 +353,7 @@ proof fn lemma_after_get_cr_pc_leads_to_cm_exists(cr: CustomResourceView)
             let s = ex.suffix(i).head();
             let req_msg = choose |req_msg: Message| {
                 #[trigger] is_controller_get_cr_request_msg(req_msg, cr)
-                && s.reconcile_state_of(cr.object_ref()).pending_req_msg == Option::Some(req_msg)
+                && pending_k8s_api_req_msg_is(s, cr.object_ref(), req_msg)
                 && (s.message_in_flight(req_msg)
                     || exists |resp_msg: Message| {
                         #[trigger] s.message_in_flight(resp_msg)
@@ -409,7 +409,7 @@ proof fn lemma_init_pc_and_no_pending_req_leads_to_cm_exists(cr: CustomResourceV
             let s = ex.suffix(i).head();
             let req_msg = choose |msg| {
                 &&& #[trigger] is_controller_get_cr_request_msg(msg, cr)
-                &&& s.reconcile_state_of(cr.object_ref()).pending_req_msg == Option::Some(msg)
+                &&& pending_k8s_api_req_msg_is(s, cr.object_ref(), msg)
                 &&& ! exists |resp_msg: Message| {
                     &&& #[trigger] s.message_in_flight(resp_msg)
                     &&& resp_msg_matches_req_msg(resp_msg, msg)

--- a/src/controller_examples/simple_controller/proof/safety.rs
+++ b/src/controller_examples/simple_controller/proof/safety.rs
@@ -39,7 +39,7 @@ pub proof fn lemma_always_reconcile_init_pc_and_no_pending_req(cr: CustomResourc
         && s.reconcile_state_of(cr.object_ref()).local_state.reconcile_pc == SimpleReconcileStep::Init)
         ==> s.reconcile_state_contains(cr.object_ref())
             && s.reconcile_state_of(cr.object_ref()).local_state.reconcile_pc == SimpleReconcileStep::Init)
-            && s.reconcile_state_of(cr.object_ref()).pending_req_msg.is_None()
+            && no_pending_request(s, cr.object_ref())
     };
     init_invariant::<State<SimpleReconcileState>>(sm_spec(simple_reconciler()), init(simple_reconciler()), next(simple_reconciler()), invariant);
 
@@ -55,7 +55,7 @@ pub open spec fn reconcile_get_cr_done_implies_pending_req_in_flight_or_resp_in_
         && s.reconcile_state_of(cr.object_ref()).local_state.reconcile_pc == reconciler::after_get_cr_pc()
         ==> exists |req_msg| {
                 #[trigger] is_controller_get_cr_request_msg(req_msg, cr)
-                && s.reconcile_state_of(cr.object_ref()).pending_req_msg == Option::Some(req_msg)
+                && pending_k8s_api_req_msg_is(s, cr.object_ref(), req_msg)
                 && (s.message_in_flight(req_msg)
                     || exists |resp_msg: Message| {
                         #[trigger] s.message_in_flight(resp_msg)

--- a/src/controller_examples/simple_controller/proof/shared.rs
+++ b/src/controller_examples/simple_controller/proof/shared.rs
@@ -31,7 +31,7 @@ pub open spec fn reconciler_at_init_pc_and_no_pending_req(cr: CustomResourceView
     |s: State<SimpleReconcileState>| {
         &&& s.reconcile_state_contains(cr.object_ref())
         &&& s.reconcile_state_of(cr.object_ref()).local_state.reconcile_pc == SimpleReconcileStep::Init)
-        &&& s.reconcile_state_of(cr.object_ref()).pending_req_msg.is_None()
+        &&& no_pending_request(s, cr.object_ref())
     }
 }
 
@@ -46,7 +46,7 @@ pub open spec fn reconciler_at_after_get_cr_pc_and_pending_req(msg: Message, cr:
     |s: State<SimpleReconcileState>| {
         &&& s.reconcile_state_contains(cr.object_ref())
         &&& s.reconcile_state_of(cr.object_ref()).local_state.reconcile_pc == reconciler::after_get_cr_pc()
-        &&& s.reconcile_state_of(cr.object_ref()).pending_req_msg == Option::Some(msg)
+        &&& pending_k8s_api_req_msg_is(s, cr.object_ref(), msg)
         &&& is_controller_get_cr_request_msg(msg, cr)
     }
 }

--- a/src/controller_examples/simple_controller/spec/reconciler.rs
+++ b/src/controller_examples/simple_controller/spec/reconciler.rs
@@ -48,6 +48,10 @@ impl Reconciler<CustomResourceView> for SimpleReconciler {
     open spec fn reconcile_error(state: SimpleReconcileState) -> bool {
         reconcile_error(state)
     }
+
+    open spec fn external_process(input: ()) -> Option<()> {
+        Option::None
+    }
 }
 
 pub open spec fn simple_reconciler() -> SimpleReconciler {

--- a/src/controller_examples/zookeeper_controller/mod.rs
+++ b/src/controller_examples/zookeeper_controller/mod.rs
@@ -2,5 +2,5 @@
 // SPDX-License-Identifier: MIT
 pub mod common;
 pub mod exec;
-// pub mod proof;
+pub mod proof;
 pub mod spec;

--- a/src/controller_examples/zookeeper_controller/proof/common.rs
+++ b/src/controller_examples/zookeeper_controller/proof/common.rs
@@ -18,10 +18,10 @@ use vstd::prelude::*;
 
 verus! {
 
-pub type ClusterState = State<ZookeeperClusterView, ZookeeperReconcileState>;
+pub type ClusterState = State<ZookeeperClusterView, ZookeeperReconciler>;
 
 pub open spec fn cluster_spec() -> TempPred<ClusterState> {
-    sm_spec::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>()
+    sm_spec::<ZookeeperClusterView,ZookeeperReconciler>()
 }
 
 pub open spec fn zookeeper_reconcile_state(step: ZookeeperReconcileStep) -> ZookeeperReconcileState {

--- a/src/controller_examples/zookeeper_controller/proof/common.rs
+++ b/src/controller_examples/zookeeper_controller/proof/common.rs
@@ -4,6 +4,7 @@
 use crate::kubernetes_api_objects::{
     api_method::*, common::*, dynamic::*, resource::*, stateful_set::*,
 };
+use crate::kubernetes_cluster::proof::controller_runtime::*;
 use crate::kubernetes_cluster::spec::{
     cluster::*,
     controller::common::{controller_req_msg, ControllerActionInput, ControllerStep},
@@ -51,7 +52,7 @@ pub open spec fn at_zookeeper_step_with_zk(zk: ZookeeperClusterView, step: Zooke
 pub open spec fn no_pending_req_at_zookeeper_step_with_zk(zk: ZookeeperClusterView, step: ZookeeperReconcileStep) -> StatePred<ClusterState> {
     |s: ClusterState| {
         &&& at_zookeeper_step_with_zk(zk, step)(s)
-        &&& s.reconcile_state_of(zk.object_ref()).pending_req_msg.is_None()
+        &&& no_pending_request(s, zk.object_ref())
     }
 }
 
@@ -60,7 +61,7 @@ pub open spec fn pending_req_in_flight_at_zookeeper_step_with_zk(
 ) -> StatePred<ClusterState> {
     |s: ClusterState| {
         &&& at_zookeeper_step_with_zk(zk, step)(s)
-        &&& s.reconcile_state_of(zk.object_ref()).pending_req_msg.is_Some()
+        &&& pending_k8s_api_req_msg(s, zk.object_ref())
         &&& s.message_in_flight(s.pending_req_of(zk.object_ref()))
         &&& is_correct_pending_request_msg_at_zookeeper_step(step, s.pending_req_of(zk.object_ref()), zk, object)
     }
@@ -71,7 +72,7 @@ pub open spec fn req_msg_is_the_in_flight_pending_req_at_zookeeper_step_with_zk(
 ) -> StatePred<ClusterState> {
     |s: ClusterState| {
         &&& at_zookeeper_step_with_zk(zk, step)(s)
-        &&& s.reconcile_state_of(zk.object_ref()).pending_req_msg == Option::Some(req_msg)
+        &&& pending_k8s_api_req_msg_is(s, zk.object_ref(), req_msg)
         &&& s.message_in_flight(req_msg)
         &&& is_correct_pending_request_msg_at_zookeeper_step(step, req_msg, zk, object)
     }
@@ -82,7 +83,7 @@ pub open spec fn exists_resp_in_flight_at_zookeeper_step_with_zk(
 ) -> StatePred<ClusterState> {
     |s: ClusterState| {
         &&& at_zookeeper_step_with_zk(zk, step)(s)
-        &&& s.reconcile_state_of(zk.object_ref()).pending_req_msg.is_Some()
+        &&& pending_k8s_api_req_msg(s, zk.object_ref())
         &&& is_correct_pending_request_msg_at_zookeeper_step(step, s.pending_req_of(zk.object_ref()), zk, object)
         &&& exists |resp_msg| {
             &&& #[trigger] s.message_in_flight(resp_msg)
@@ -96,7 +97,7 @@ pub open spec fn resp_msg_is_the_in_flight_resp_at_zookeeper_step_with_zk(
 ) -> StatePred<ClusterState> {
     |s: ClusterState| {
         &&& at_zookeeper_step_with_zk(zk, step)(s)
-        &&& s.reconcile_state_of(zk.object_ref()).pending_req_msg.is_Some()
+        &&& pending_k8s_api_req_msg(s, zk.object_ref())
         &&& is_correct_pending_request_msg_at_zookeeper_step(step, s.pending_req_of(zk.object_ref()), zk, object)
         &&& s.message_in_flight(resp_msg)
         &&& resp_msg_matches_req_msg(resp_msg, s.pending_req_of(zk.object_ref()))
@@ -108,7 +109,7 @@ pub open spec fn at_after_get_stateful_set_step_with_zk_and_exists_ok_resp_in_fl
 ) -> StatePred<ClusterState> {
     |s: ClusterState| {
         &&& at_zookeeper_step_with_zk(zk, ZookeeperReconcileStep::AfterGetStatefulSet)(s)
-        &&& s.reconcile_state_of(zk.object_ref()).pending_req_msg.is_Some()
+        &&& pending_k8s_api_req_msg(s, zk.object_ref())
         &&& is_correct_pending_request_msg_at_zookeeper_step(
             ZookeeperReconcileStep::AfterGetStatefulSet, s.pending_req_of(zk.object_ref()), zk, arbitrary()
         )
@@ -126,7 +127,7 @@ pub open spec fn at_after_get_stateful_set_step_with_zk_and_exists_not_found_res
 ) -> StatePred<ClusterState> {
     |s: ClusterState| {
         &&& at_zookeeper_step_with_zk(zk, ZookeeperReconcileStep::AfterGetStatefulSet)(s)
-        &&& s.reconcile_state_of(zk.object_ref()).pending_req_msg.is_Some()
+        &&& pending_k8s_api_req_msg(s, zk.object_ref())
         &&& is_correct_pending_request_msg_at_zookeeper_step(
             ZookeeperReconcileStep::AfterGetStatefulSet, s.pending_req_of(zk.object_ref()), zk, arbitrary()
         )
@@ -144,7 +145,7 @@ pub open spec fn at_after_get_stateful_set_step_with_zk_and_exists_not_found_err
 ) -> StatePred<ClusterState> {
     |s: ClusterState| {
         &&& at_zookeeper_step_with_zk(zk, ZookeeperReconcileStep::AfterGetStatefulSet)(s)
-        &&& s.reconcile_state_of(zk.object_ref()).pending_req_msg.is_Some()
+        &&& pending_k8s_api_req_msg(s, zk.object_ref())
         &&& is_correct_pending_request_msg_at_zookeeper_step(
             ZookeeperReconcileStep::AfterGetStatefulSet, s.pending_req_of(zk.object_ref()), zk, arbitrary()
         )

--- a/src/controller_examples/zookeeper_controller/proof/liveness/helper_invariants.rs
+++ b/src/controller_examples/zookeeper_controller/proof/liveness/helper_invariants.rs
@@ -69,7 +69,7 @@ pub open spec fn pending_msg_at_after_create_stateful_set_step_is_create_sts_req
     |s: ClusterState| {
         at_zookeeper_step(key, ZookeeperReconcileStep::AfterCreateStatefulSet)(s)
             ==> {
-                &&& s.reconcile_state_of(key).pending_req_msg.is_Some()
+                &&& pending_k8s_api_req_msg(s, key)
                 &&& sts_create_request_msg(key)(s.pending_req_of(key))
             }
     }
@@ -380,7 +380,7 @@ pub open spec fn pending_msg_at_after_update_stateful_set_step_is_update_sts_req
     |s: ClusterState| {
         at_zookeeper_step(key, ZookeeperReconcileStep::AfterUpdateStatefulSet)(s)
             ==> {
-                &&& s.reconcile_state_of(key).pending_req_msg.is_Some()
+                &&& pending_k8s_api_req_msg(s, key)
                 &&& sts_update_request_msg(key)(s.pending_req_of(key))
             }
     }

--- a/src/controller_examples/zookeeper_controller/proof/liveness/helper_invariants.rs
+++ b/src/controller_examples/zookeeper_controller/proof/liveness/helper_invariants.rs
@@ -79,30 +79,30 @@ pub proof fn lemma_always_pending_msg_at_after_create_stateful_set_step_is_creat
     spec: TempPred<ClusterState>, key: ObjectRef
 )
     requires
-        spec.entails(lift_state(init::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>())),
-        spec.entails(always(lift_action(next::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>()))),
+        spec.entails(lift_state(init::<ZookeeperClusterView, ZookeeperReconciler>())),
+        spec.entails(always(lift_action(next::<ZookeeperClusterView, ZookeeperReconciler>()))),
     ensures
         spec.entails(
             always(lift_state(pending_msg_at_after_create_stateful_set_step_is_create_sts_req(key)))
         ),
 {
     let invariant = pending_msg_at_after_create_stateful_set_step_is_create_sts_req(key);
-    let init = init::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>();
+    let init = init::<ZookeeperClusterView, ZookeeperReconciler>();
     let stronger_next = |s, s_prime| {
-        &&& next::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>()(s, s_prime)
+        &&& next::<ZookeeperClusterView, ZookeeperReconciler>()(s, s_prime)
         &&& each_key_in_reconcile_is_consistent_with_its_object()(s)
     };
 
-    lemma_always_each_key_in_reconcile_is_consistent_with_its_object::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>(spec);
+    lemma_always_each_key_in_reconcile_is_consistent_with_its_object::<ZookeeperClusterView, ZookeeperReconciler>(spec);
 
     entails_always_and_n!(
         spec,
-        lift_action(next::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>()),
+        lift_action(next::<ZookeeperClusterView, ZookeeperReconciler>()),
         lift_state(each_key_in_reconcile_is_consistent_with_its_object())
     );
     temp_pred_equality(
         lift_action(stronger_next),
-        lift_action(next::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>())
+        lift_action(next::<ZookeeperClusterView, ZookeeperReconciler>())
         .and(lift_state(each_key_in_reconcile_is_consistent_with_its_object()))
     );
 
@@ -134,7 +134,7 @@ proof fn lemma_always_filtered_create_sts_req_len_is_at_most_one(
         spec.entails(lift_state(rest_id_counter_is(rest_id))),
         spec.entails(lift_state(every_in_flight_msg_has_lower_id_than_allocator())),
         spec.entails(lift_state(pending_msg_at_after_create_stateful_set_step_is_create_sts_req(key))),
-        spec.entails(always(lift_action(next::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>()))),
+        spec.entails(always(lift_action(next::<ZookeeperClusterView, ZookeeperReconciler>()))),
         spec.entails(always(lift_state(crash_disabled()))),
         spec.entails(always(lift_state(busy_disabled()))),
         spec.entails(always(lift_state(pending_msg_at_after_create_stateful_set_step_is_create_sts_req(key)))),
@@ -153,7 +153,7 @@ proof fn lemma_always_filtered_create_sts_req_len_is_at_most_one(
         &&& pending_msg_at_after_create_stateful_set_step_is_create_sts_req(key)(s)
     };
     let stronger_next = |s, s_prime: ClusterState| {
-        &&& next::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>()(s, s_prime)
+        &&& next::<ZookeeperClusterView, ZookeeperReconciler>()(s, s_prime)
         &&& crash_disabled()(s)
         &&& busy_disabled()(s)
         &&& pending_msg_at_after_create_stateful_set_step_is_create_sts_req(key)(s)
@@ -178,7 +178,7 @@ proof fn lemma_always_filtered_create_sts_req_len_is_at_most_one(
 
     entails_always_and_n!(
         spec,
-        lift_action(next::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>()),
+        lift_action(next::<ZookeeperClusterView, ZookeeperReconciler>()),
         lift_state(crash_disabled()),
         lift_state(busy_disabled()),
         lift_state(pending_msg_at_after_create_stateful_set_step_is_create_sts_req(key)),
@@ -188,7 +188,7 @@ proof fn lemma_always_filtered_create_sts_req_len_is_at_most_one(
     );
     temp_pred_equality(
         lift_action(stronger_next),
-        lift_action(next::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>())
+        lift_action(next::<ZookeeperClusterView, ZookeeperReconciler>())
         .and(lift_state(crash_disabled()))
         .and(lift_state(busy_disabled()))
         .and(lift_state(pending_msg_at_after_create_stateful_set_step_is_create_sts_req(key)))
@@ -210,7 +210,7 @@ proof fn lemma_always_filtered_create_sts_req_len_is_at_most_one(
     implies invariant(s_prime) by {
         let sts_create_req_multiset = s.network_state.in_flight.filter(sts_create_request_msg_since(key, rest_id));
         let sts_create_req_multiset_prime = s_prime.network_state.in_flight.filter(sts_create_request_msg_since(key, rest_id));
-        let step = choose |step| next_step::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>(s, s_prime, step);
+        let step = choose |step| next_step::<ZookeeperClusterView, ZookeeperReconciler>(s, s_prime, step);
         match step {
             Step::KubernetesAPIStep(input) => {
                 if !at_zookeeper_step(key, ZookeeperReconcileStep::AfterCreateStatefulSet)(s) {
@@ -315,7 +315,7 @@ pub proof fn lemma_always_at_most_one_create_sts_req_since_rest_id_is_in_flight(
         spec.entails(lift_state(rest_id_counter_is(rest_id))),
         spec.entails(lift_state(every_in_flight_msg_has_lower_id_than_allocator())),
         spec.entails(lift_state(pending_msg_at_after_create_stateful_set_step_is_create_sts_req(key))),
-        spec.entails(always(lift_action(next::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>()))),
+        spec.entails(always(lift_action(next::<ZookeeperClusterView, ZookeeperReconciler>()))),
         spec.entails(always(lift_state(crash_disabled()))),
         spec.entails(always(lift_state(busy_disabled()))),
         spec.entails(always(lift_state(pending_msg_at_after_create_stateful_set_step_is_create_sts_req(key)))),
@@ -390,30 +390,30 @@ pub proof fn lemma_always_pending_msg_at_after_update_stateful_set_step_is_updat
     spec: TempPred<ClusterState>, key: ObjectRef
 )
     requires
-        spec.entails(lift_state(init::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>())),
-        spec.entails(always(lift_action(next::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>()))),
+        spec.entails(lift_state(init::<ZookeeperClusterView, ZookeeperReconciler>())),
+        spec.entails(always(lift_action(next::<ZookeeperClusterView, ZookeeperReconciler>()))),
     ensures
         spec.entails(
             always(lift_state(pending_msg_at_after_update_stateful_set_step_is_update_sts_req(key)))
         ),
 {
     let invariant = pending_msg_at_after_update_stateful_set_step_is_update_sts_req(key);
-    let init = init::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>();
+    let init = init::<ZookeeperClusterView, ZookeeperReconciler>();
     let stronger_next = |s, s_prime| {
-        &&& next::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>()(s, s_prime)
+        &&& next::<ZookeeperClusterView, ZookeeperReconciler>()(s, s_prime)
         &&& each_key_in_reconcile_is_consistent_with_its_object()(s)
     };
 
-    lemma_always_each_key_in_reconcile_is_consistent_with_its_object::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>(spec);
+    lemma_always_each_key_in_reconcile_is_consistent_with_its_object::<ZookeeperClusterView, ZookeeperReconciler>(spec);
 
     entails_always_and_n!(
         spec,
-        lift_action(next::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>()),
+        lift_action(next::<ZookeeperClusterView, ZookeeperReconciler>()),
         lift_state(each_key_in_reconcile_is_consistent_with_its_object())
     );
     temp_pred_equality(
         lift_action(stronger_next),
-        lift_action(next::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>())
+        lift_action(next::<ZookeeperClusterView, ZookeeperReconciler>())
         .and(lift_state(each_key_in_reconcile_is_consistent_with_its_object()))
     );
 
@@ -445,7 +445,7 @@ proof fn lemma_always_filtered_update_sts_req_len_is_at_most_one(
         spec.entails(lift_state(rest_id_counter_is(rest_id))),
         spec.entails(lift_state(every_in_flight_msg_has_lower_id_than_allocator())),
         spec.entails(lift_state(pending_msg_at_after_update_stateful_set_step_is_update_sts_req(key))),
-        spec.entails(always(lift_action(next::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>()))),
+        spec.entails(always(lift_action(next::<ZookeeperClusterView, ZookeeperReconciler>()))),
         spec.entails(always(lift_state(crash_disabled()))),
         spec.entails(always(lift_state(busy_disabled()))),
         spec.entails(always(lift_state(pending_msg_at_after_update_stateful_set_step_is_update_sts_req(key)))),
@@ -464,7 +464,7 @@ proof fn lemma_always_filtered_update_sts_req_len_is_at_most_one(
         &&& pending_msg_at_after_update_stateful_set_step_is_update_sts_req(key)(s)
     };
     let stronger_next = |s, s_prime: ClusterState| {
-        &&& next::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>()(s, s_prime)
+        &&& next::<ZookeeperClusterView, ZookeeperReconciler>()(s, s_prime)
         &&& crash_disabled()(s)
         &&& busy_disabled()(s)
         &&& pending_msg_at_after_update_stateful_set_step_is_update_sts_req(key)(s)
@@ -489,7 +489,7 @@ proof fn lemma_always_filtered_update_sts_req_len_is_at_most_one(
 
     entails_always_and_n!(
         spec,
-        lift_action(next::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>()),
+        lift_action(next::<ZookeeperClusterView, ZookeeperReconciler>()),
         lift_state(crash_disabled()),
         lift_state(busy_disabled()),
         lift_state(pending_msg_at_after_update_stateful_set_step_is_update_sts_req(key)),
@@ -499,7 +499,7 @@ proof fn lemma_always_filtered_update_sts_req_len_is_at_most_one(
     );
     temp_pred_equality(
         lift_action(stronger_next),
-        lift_action(next::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>())
+        lift_action(next::<ZookeeperClusterView, ZookeeperReconciler>())
         .and(lift_state(crash_disabled()))
         .and(lift_state(busy_disabled()))
         .and(lift_state(pending_msg_at_after_update_stateful_set_step_is_update_sts_req(key)))
@@ -521,7 +521,7 @@ proof fn lemma_always_filtered_update_sts_req_len_is_at_most_one(
     implies invariant(s_prime) by {
         let sts_update_req_multiset = s.network_state.in_flight.filter(sts_update_request_msg_since(key, rest_id));
         let sts_update_req_multiset_prime = s_prime.network_state.in_flight.filter(sts_update_request_msg_since(key, rest_id));
-        let step = choose |step| next_step::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>(s, s_prime, step);
+        let step = choose |step| next_step::<ZookeeperClusterView, ZookeeperReconciler>(s, s_prime, step);
         match step {
             Step::KubernetesAPIStep(input) => {
                 if !at_zookeeper_step(key, ZookeeperReconcileStep::AfterUpdateStatefulSet)(s) {
@@ -626,7 +626,7 @@ pub proof fn lemma_always_at_most_one_update_sts_req_since_rest_id_is_in_flight(
         spec.entails(lift_state(rest_id_counter_is(rest_id))),
         spec.entails(lift_state(every_in_flight_msg_has_lower_id_than_allocator())),
         spec.entails(lift_state(pending_msg_at_after_update_stateful_set_step_is_update_sts_req(key))),
-        spec.entails(always(lift_action(next::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>()))),
+        spec.entails(always(lift_action(next::<ZookeeperClusterView, ZookeeperReconciler>()))),
         spec.entails(always(lift_state(crash_disabled()))),
         spec.entails(always(lift_state(busy_disabled()))),
         spec.entails(always(lift_state(pending_msg_at_after_update_stateful_set_step_is_update_sts_req(key)))),
@@ -689,7 +689,7 @@ pub proof fn lemma_always_every_update_sts_req_since_rest_id_does_the_same(
     requires
         spec.entails(lift_state(rest_id_counter_is(rest_id))),
         spec.entails(lift_state(every_in_flight_msg_has_lower_id_than_allocator())),
-        spec.entails(always(lift_action(next::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>()))),
+        spec.entails(always(lift_action(next::<ZookeeperClusterView, ZookeeperReconciler>()))),
         spec.entails(always(lift_state(each_key_in_reconcile_is_consistent_with_its_object()))),
         spec.entails(always(lift_state(rest_id_counter_is_no_smaller_than(rest_id)))),
         spec.entails(always(lift_state(controller_runtime_eventual_safety::the_object_in_reconcile_has_spec_as(zk)))),
@@ -701,7 +701,7 @@ pub proof fn lemma_always_every_update_sts_req_since_rest_id_does_the_same(
         &&& every_in_flight_msg_has_lower_id_than_allocator()(s)
     };
     let stronger_next = |s, s_prime: ClusterState| {
-        &&& next::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>()(s, s_prime)
+        &&& next::<ZookeeperClusterView, ZookeeperReconciler>()(s, s_prime)
         &&& each_key_in_reconcile_is_consistent_with_its_object()(s)
         &&& rest_id_counter_is_no_smaller_than(rest_id)(s)
         &&& controller_runtime_eventual_safety::the_object_in_reconcile_has_spec_as(zk)(s)
@@ -721,14 +721,14 @@ pub proof fn lemma_always_every_update_sts_req_since_rest_id_does_the_same(
 
     entails_always_and_n!(
         spec,
-        lift_action(next::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>()),
+        lift_action(next::<ZookeeperClusterView, ZookeeperReconciler>()),
         lift_state(each_key_in_reconcile_is_consistent_with_its_object()),
         lift_state(rest_id_counter_is_no_smaller_than(rest_id)),
         lift_state(controller_runtime_eventual_safety::the_object_in_reconcile_has_spec_as(zk))
     );
     temp_pred_equality(
         lift_action(stronger_next),
-        lift_action(next::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>())
+        lift_action(next::<ZookeeperClusterView, ZookeeperReconciler>())
         .and(lift_state(each_key_in_reconcile_is_consistent_with_its_object()))
         .and(lift_state(rest_id_counter_is_no_smaller_than(rest_id)))
         .and(lift_state(controller_runtime_eventual_safety::the_object_in_reconcile_has_spec_as(zk)))
@@ -780,7 +780,7 @@ pub proof fn lemma_always_no_delete_sts_req_since_rest_id_is_in_flight(
     requires
         spec.entails(lift_state(rest_id_counter_is(rest_id))),
         spec.entails(lift_state(every_in_flight_msg_has_lower_id_than_allocator())),
-        spec.entails(always(lift_action(next::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>()))),
+        spec.entails(always(lift_action(next::<ZookeeperClusterView, ZookeeperReconciler>()))),
         key.kind.is_CustomResourceKind(),
     ensures
         spec.entails(
@@ -791,7 +791,7 @@ pub proof fn lemma_always_no_delete_sts_req_since_rest_id_is_in_flight(
         &&& rest_id_counter_is(rest_id)(s)
         &&& every_in_flight_msg_has_lower_id_than_allocator()(s)
     };
-    let next = next::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>();
+    let next = next::<ZookeeperClusterView, ZookeeperReconciler>();
     let invariant = no_delete_sts_req_since_rest_id_is_in_flight(key, rest_id);
 
     entails_and_n!(

--- a/src/controller_examples/zookeeper_controller/proof/liveness/liveness_property.rs
+++ b/src/controller_examples/zookeeper_controller/proof/liveness/liveness_property.rs
@@ -65,9 +65,9 @@ proof fn liveness_proof_forall_zk()
 
 // Next and all the wf conditions.
 spec fn next_with_wf() -> TempPred<ClusterState> {
-    always(lift_action(next::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>()))
+    always(lift_action(next::<ZookeeperClusterView, ZookeeperReconciler>()))
     .and(tla_forall(|input| kubernetes_api_next().weak_fairness(input)))
-    .and(tla_forall(|input| controller_next::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>().weak_fairness(input)))
+    .and(tla_forall(|input| controller_next::<ZookeeperClusterView, ZookeeperReconciler>().weak_fairness(input)))
     .and(tla_forall(|input| schedule_controller_reconcile().weak_fairness(input)))
     .and(disable_crash().weak_fairness(()))
     .and(disable_busy().weak_fairness(()))
@@ -77,16 +77,16 @@ proof fn next_with_wf_is_stable()
     ensures
         valid(stable(next_with_wf())),
 {
-    always_p_is_stable(lift_action(next::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>()));
-    cluster::tla_forall_action_weak_fairness_is_stable(kubernetes_api_next::<ZookeeperClusterView, ZookeeperReconcileState>());
-    cluster::tla_forall_action_weak_fairness_is_stable(controller_next::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>());
-    cluster::tla_forall_action_weak_fairness_is_stable(schedule_controller_reconcile::<ZookeeperClusterView, ZookeeperReconcileState>());
-    cluster::action_weak_fairness_is_stable(disable_crash::<ZookeeperClusterView, ZookeeperReconcileState>());
-    cluster::action_weak_fairness_is_stable(disable_busy::<ZookeeperClusterView, ZookeeperReconcileState>());
+    always_p_is_stable(lift_action(next::<ZookeeperClusterView, ZookeeperReconciler>()));
+    cluster::tla_forall_action_weak_fairness_is_stable(kubernetes_api_next::<ZookeeperClusterView, ZookeeperReconciler>());
+    cluster::tla_forall_action_weak_fairness_is_stable(controller_next::<ZookeeperClusterView, ZookeeperReconciler>());
+    cluster::tla_forall_action_weak_fairness_is_stable(schedule_controller_reconcile::<ZookeeperClusterView, ZookeeperReconciler>());
+    cluster::action_weak_fairness_is_stable(disable_crash::<ZookeeperClusterView, ZookeeperReconciler>());
+    cluster::action_weak_fairness_is_stable(disable_busy::<ZookeeperClusterView, ZookeeperReconciler>());
     stable_and_n!(
-        always(lift_action(next::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>())),
-        tla_forall(|input| kubernetes_api_next::<ZookeeperClusterView, ZookeeperReconcileState>().weak_fairness(input)),
-        tla_forall(|input| controller_next::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>().weak_fairness(input)),
+        always(lift_action(next::<ZookeeperClusterView, ZookeeperReconciler>())),
+        tla_forall(|input| kubernetes_api_next::<ZookeeperClusterView, ZookeeperReconciler>().weak_fairness(input)),
+        tla_forall(|input| controller_next::<ZookeeperClusterView, ZookeeperReconciler>().weak_fairness(input)),
         tla_forall(|input| schedule_controller_reconcile().weak_fairness(input)),
         disable_crash().weak_fairness(()),
         disable_busy().weak_fairness(())
@@ -108,11 +108,11 @@ proof fn assumptions_is_stable(zk: ZookeeperClusterView)
         valid(stable(assumptions(zk))),
 {
     stable_and_always_n!(
-        lift_state(crash_disabled::<ZookeeperClusterView, ZookeeperReconcileState>()),
-        lift_state(busy_disabled::<ZookeeperClusterView, ZookeeperReconcileState>()),
-        lift_state(cluster::desired_state_is::<ZookeeperClusterView, ZookeeperReconcileState>(zk)),
-        lift_state(controller_runtime_eventual_safety::the_object_in_schedule_has_spec_as::<ZookeeperClusterView, ZookeeperReconcileState>(zk)),
-        lift_state(controller_runtime_eventual_safety::the_object_in_reconcile_has_spec_as::<ZookeeperClusterView, ZookeeperReconcileState>(zk))
+        lift_state(crash_disabled::<ZookeeperClusterView, ZookeeperReconciler>()),
+        lift_state(busy_disabled::<ZookeeperClusterView, ZookeeperReconciler>()),
+        lift_state(cluster::desired_state_is::<ZookeeperClusterView, ZookeeperReconciler>(zk)),
+        lift_state(controller_runtime_eventual_safety::the_object_in_schedule_has_spec_as::<ZookeeperClusterView, ZookeeperReconciler>(zk)),
+        lift_state(controller_runtime_eventual_safety::the_object_in_reconcile_has_spec_as::<ZookeeperClusterView, ZookeeperReconciler>(zk))
     );
 }
 
@@ -127,14 +127,14 @@ spec fn invariants(zk: ZookeeperClusterView) -> TempPred<ClusterState> {
     .and(always(lift_state(cluster_safety::each_key_in_reconcile_is_consistent_with_its_object())))
     .and(always(lift_state(helper_invariants::pending_msg_at_after_create_stateful_set_step_is_create_sts_req(zk.object_ref()))))
     .and(always(lift_state(helper_invariants::pending_msg_at_after_update_stateful_set_step_is_update_sts_req(zk.object_ref()))))
-    .and(always(lift_state(controller_runtime::no_pending_req_at_reconcile_init_state::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>(zk.object_ref()))))
-    .and(always(lift_state(controller_runtime::pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<ZookeeperClusterView, ZookeeperReconcileState>(zk.object_ref(), zookeeper_reconcile_state(ZookeeperReconcileStep::AfterUpdateStatefulSet)))))
-    .and(always(lift_state(controller_runtime::pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<ZookeeperClusterView, ZookeeperReconcileState>(zk.object_ref(), zookeeper_reconcile_state(ZookeeperReconcileStep::AfterCreateStatefulSet)))))
-    .and(always(lift_state(controller_runtime::pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<ZookeeperClusterView, ZookeeperReconcileState>(zk.object_ref(), zookeeper_reconcile_state(ZookeeperReconcileStep::AfterCreateHeadlessService)))))
-    .and(always(lift_state(controller_runtime::pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<ZookeeperClusterView, ZookeeperReconcileState>(zk.object_ref(), zookeeper_reconcile_state(ZookeeperReconcileStep::AfterCreateClientService)))))
-    .and(always(lift_state(controller_runtime::pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<ZookeeperClusterView, ZookeeperReconcileState>(zk.object_ref(), zookeeper_reconcile_state(ZookeeperReconcileStep::AfterCreateAdminServerService)))))
-    .and(always(lift_state(controller_runtime::pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<ZookeeperClusterView, ZookeeperReconcileState>(zk.object_ref(), zookeeper_reconcile_state(ZookeeperReconcileStep::AfterCreateConfigMap)))))
-    .and(always(lift_state(controller_runtime::pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<ZookeeperClusterView, ZookeeperReconcileState>(zk.object_ref(), zookeeper_reconcile_state(ZookeeperReconcileStep::AfterGetStatefulSet)))))
+    .and(always(lift_state(controller_runtime::no_pending_req_at_reconcile_init_state::<ZookeeperClusterView, ZookeeperReconciler>(zk.object_ref()))))
+    .and(always(lift_state(controller_runtime::pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<ZookeeperClusterView, ZookeeperReconciler>(zk.object_ref(), zookeeper_reconcile_state(ZookeeperReconcileStep::AfterUpdateStatefulSet)))))
+    .and(always(lift_state(controller_runtime::pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<ZookeeperClusterView, ZookeeperReconciler>(zk.object_ref(), zookeeper_reconcile_state(ZookeeperReconcileStep::AfterCreateStatefulSet)))))
+    .and(always(lift_state(controller_runtime::pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<ZookeeperClusterView, ZookeeperReconciler>(zk.object_ref(), zookeeper_reconcile_state(ZookeeperReconcileStep::AfterCreateHeadlessService)))))
+    .and(always(lift_state(controller_runtime::pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<ZookeeperClusterView, ZookeeperReconciler>(zk.object_ref(), zookeeper_reconcile_state(ZookeeperReconcileStep::AfterCreateClientService)))))
+    .and(always(lift_state(controller_runtime::pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<ZookeeperClusterView, ZookeeperReconciler>(zk.object_ref(), zookeeper_reconcile_state(ZookeeperReconcileStep::AfterCreateAdminServerService)))))
+    .and(always(lift_state(controller_runtime::pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<ZookeeperClusterView, ZookeeperReconciler>(zk.object_ref(), zookeeper_reconcile_state(ZookeeperReconcileStep::AfterCreateConfigMap)))))
+    .and(always(lift_state(controller_runtime::pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<ZookeeperClusterView, ZookeeperReconciler>(zk.object_ref(), zookeeper_reconcile_state(ZookeeperReconcileStep::AfterGetStatefulSet)))))
 }
 
 proof fn invariants_is_stable(zk: ZookeeperClusterView)
@@ -142,23 +142,23 @@ proof fn invariants_is_stable(zk: ZookeeperClusterView)
         valid(stable(invariants(zk))),
 {
     stable_and_always_n!(
-        lift_state(controller_runtime_safety::every_in_flight_msg_has_unique_id::<ZookeeperClusterView, ZookeeperReconcileState>()),
-        lift_state(controller_runtime_safety::each_resp_matches_at_most_one_pending_req::<ZookeeperClusterView, ZookeeperReconcileState>(zk.object_ref())),
-        lift_state(controller_runtime_safety::each_resp_if_matches_pending_req_then_no_other_resp_matches::<ZookeeperClusterView, ZookeeperReconcileState>(zk.object_ref())),
-        lift_state(controller_runtime_safety::every_in_flight_msg_has_lower_id_than_allocator::<ZookeeperClusterView, ZookeeperReconcileState>()),
-        lift_state(cluster_safety::each_object_in_etcd_is_well_formed::<ZookeeperClusterView, ZookeeperReconcileState>()),
-        lift_state(cluster_safety::each_scheduled_key_is_consistent_with_its_object::<ZookeeperClusterView, ZookeeperReconcileState>()),
-        lift_state(cluster_safety::each_key_in_reconcile_is_consistent_with_its_object::<ZookeeperClusterView, ZookeeperReconcileState>()),
+        lift_state(controller_runtime_safety::every_in_flight_msg_has_unique_id::<ZookeeperClusterView, ZookeeperReconciler>()),
+        lift_state(controller_runtime_safety::each_resp_matches_at_most_one_pending_req::<ZookeeperClusterView, ZookeeperReconciler>(zk.object_ref())),
+        lift_state(controller_runtime_safety::each_resp_if_matches_pending_req_then_no_other_resp_matches::<ZookeeperClusterView, ZookeeperReconciler>(zk.object_ref())),
+        lift_state(controller_runtime_safety::every_in_flight_msg_has_lower_id_than_allocator::<ZookeeperClusterView, ZookeeperReconciler>()),
+        lift_state(cluster_safety::each_object_in_etcd_is_well_formed::<ZookeeperClusterView, ZookeeperReconciler>()),
+        lift_state(cluster_safety::each_scheduled_key_is_consistent_with_its_object::<ZookeeperClusterView, ZookeeperReconciler>()),
+        lift_state(cluster_safety::each_key_in_reconcile_is_consistent_with_its_object::<ZookeeperClusterView, ZookeeperReconciler>()),
         lift_state(helper_invariants::pending_msg_at_after_create_stateful_set_step_is_create_sts_req(zk.object_ref())),
         lift_state(helper_invariants::pending_msg_at_after_update_stateful_set_step_is_update_sts_req(zk.object_ref())),
-        lift_state(controller_runtime::no_pending_req_at_reconcile_init_state::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>(zk.object_ref())),
-        lift_state(controller_runtime::pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<ZookeeperClusterView, ZookeeperReconcileState>(zk.object_ref(), zookeeper_reconcile_state(ZookeeperReconcileStep::AfterUpdateStatefulSet))),
-        lift_state(controller_runtime::pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<ZookeeperClusterView, ZookeeperReconcileState>(zk.object_ref(), zookeeper_reconcile_state(ZookeeperReconcileStep::AfterCreateStatefulSet))),
-        lift_state(controller_runtime::pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<ZookeeperClusterView, ZookeeperReconcileState>(zk.object_ref(), zookeeper_reconcile_state(ZookeeperReconcileStep::AfterCreateHeadlessService))),
-        lift_state(controller_runtime::pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<ZookeeperClusterView, ZookeeperReconcileState>(zk.object_ref(), zookeeper_reconcile_state(ZookeeperReconcileStep::AfterCreateClientService))),
-        lift_state(controller_runtime::pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<ZookeeperClusterView, ZookeeperReconcileState>(zk.object_ref(), zookeeper_reconcile_state(ZookeeperReconcileStep::AfterCreateAdminServerService))),
-        lift_state(controller_runtime::pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<ZookeeperClusterView, ZookeeperReconcileState>(zk.object_ref(), zookeeper_reconcile_state(ZookeeperReconcileStep::AfterCreateConfigMap))),
-        lift_state(controller_runtime::pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<ZookeeperClusterView, ZookeeperReconcileState>(zk.object_ref(), zookeeper_reconcile_state(ZookeeperReconcileStep::AfterGetStatefulSet)))
+        lift_state(controller_runtime::no_pending_req_at_reconcile_init_state::<ZookeeperClusterView, ZookeeperReconciler>(zk.object_ref())),
+        lift_state(controller_runtime::pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<ZookeeperClusterView, ZookeeperReconciler>(zk.object_ref(), zookeeper_reconcile_state(ZookeeperReconcileStep::AfterUpdateStatefulSet))),
+        lift_state(controller_runtime::pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<ZookeeperClusterView, ZookeeperReconciler>(zk.object_ref(), zookeeper_reconcile_state(ZookeeperReconcileStep::AfterCreateStatefulSet))),
+        lift_state(controller_runtime::pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<ZookeeperClusterView, ZookeeperReconciler>(zk.object_ref(), zookeeper_reconcile_state(ZookeeperReconcileStep::AfterCreateHeadlessService))),
+        lift_state(controller_runtime::pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<ZookeeperClusterView, ZookeeperReconciler>(zk.object_ref(), zookeeper_reconcile_state(ZookeeperReconcileStep::AfterCreateClientService))),
+        lift_state(controller_runtime::pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<ZookeeperClusterView, ZookeeperReconciler>(zk.object_ref(), zookeeper_reconcile_state(ZookeeperReconcileStep::AfterCreateAdminServerService))),
+        lift_state(controller_runtime::pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<ZookeeperClusterView, ZookeeperReconciler>(zk.object_ref(), zookeeper_reconcile_state(ZookeeperReconcileStep::AfterCreateConfigMap))),
+        lift_state(controller_runtime::pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<ZookeeperClusterView, ZookeeperReconciler>(zk.object_ref(), zookeeper_reconcile_state(ZookeeperReconcileStep::AfterGetStatefulSet)))
     );
 }
 
@@ -179,7 +179,7 @@ proof fn invariants_since_rest_id_is_stable(zk: ZookeeperClusterView, rest_id: R
         valid(stable(invariants_since_rest_id(zk, rest_id))),
 {
     stable_and_always_n!(
-        lift_state(rest_id_counter_is_no_smaller_than::<ZookeeperClusterView, ZookeeperReconcileState>(rest_id)),
+        lift_state(rest_id_counter_is_no_smaller_than::<ZookeeperClusterView, ZookeeperReconciler>(rest_id)),
         lift_state(helper_invariants::at_most_one_create_sts_req_since_rest_id_is_in_flight(zk.object_ref(), rest_id)),
         lift_state(helper_invariants::at_most_one_update_sts_req_since_rest_id_is_in_flight(zk.object_ref(), rest_id)),
         lift_state(helper_invariants::no_delete_sts_req_since_rest_id_is_in_flight(zk.object_ref(), rest_id)),
@@ -197,7 +197,7 @@ proof fn invariants_led_to_by_rest_id_is_stable(zk: ZookeeperClusterView, rest_i
     ensures
         valid(stable(invariants_led_to_by_rest_id(zk, rest_id))),
 {
-    always_p_is_stable(lift_state(kubernetes_api_liveness::no_req_before_rest_id_is_in_flight::<ZookeeperClusterView, ZookeeperReconcileState>(rest_id)));
+    always_p_is_stable(lift_state(kubernetes_api_liveness::no_req_before_rest_id_is_in_flight::<ZookeeperClusterView, ZookeeperReconciler>(rest_id)));
 }
 
 proof fn liveness_proof(zk: ZookeeperClusterView)
@@ -288,16 +288,16 @@ proof fn liveness_proof(zk: ZookeeperClusterView)
                 {
                     next_with_wf_is_stable();
                     invariants_is_stable(zk);
-                    always_p_is_stable(lift_state(cluster::desired_state_is::<ZookeeperClusterView, ZookeeperReconcileState>(zk)));
-                    always_p_is_stable(lift_state(crash_disabled::<ZookeeperClusterView, ZookeeperReconcileState>()));
-                    always_p_is_stable(lift_state(busy_disabled::<ZookeeperClusterView, ZookeeperReconcileState>()));
+                    always_p_is_stable(lift_state(cluster::desired_state_is::<ZookeeperClusterView, ZookeeperReconciler>(zk)));
+                    always_p_is_stable(lift_state(crash_disabled::<ZookeeperClusterView, ZookeeperReconciler>()));
+                    always_p_is_stable(lift_state(busy_disabled::<ZookeeperClusterView, ZookeeperReconciler>()));
 
                     stable_and_n!(
                         next_with_wf(),
                         invariants(zk),
-                        always(lift_state(cluster::desired_state_is::<ZookeeperClusterView, ZookeeperReconcileState>(zk))),
-                        always(lift_state(crash_disabled::<ZookeeperClusterView, ZookeeperReconcileState>())),
-                        always(lift_state(busy_disabled::<ZookeeperClusterView, ZookeeperReconcileState>()))
+                        always(lift_state(cluster::desired_state_is::<ZookeeperClusterView, ZookeeperReconciler>(zk))),
+                        always(lift_state(crash_disabled::<ZookeeperClusterView, ZookeeperReconciler>())),
+                        always(lift_state(busy_disabled::<ZookeeperClusterView, ZookeeperReconciler>()))
                     );
                 }
             );
@@ -305,8 +305,8 @@ proof fn liveness_proof(zk: ZookeeperClusterView)
             temp_pred_equality(true_pred().and(other_assumptions), other_assumptions);
 
             terminate::reconcile_eventually_terminates(spec, zk);
-            controller_runtime_eventual_safety::lemma_true_leads_to_always_the_object_in_schedule_has_spec_as::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>(spec, zk);
-            controller_runtime_eventual_safety::lemma_true_leads_to_always_the_object_in_reconcile_has_spec_as::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>(spec, zk);
+            controller_runtime_eventual_safety::lemma_true_leads_to_always_the_object_in_schedule_has_spec_as::<ZookeeperClusterView, ZookeeperReconciler>(spec, zk);
+            controller_runtime_eventual_safety::lemma_true_leads_to_always_the_object_in_reconcile_has_spec_as::<ZookeeperClusterView, ZookeeperReconciler>(spec, zk);
 
             leads_to_always_combine_n!(
                 spec, true_pred(),
@@ -315,7 +315,7 @@ proof fn liveness_proof(zk: ZookeeperClusterView)
             );
 
             always_and_equality_n!(
-                lift_state(controller_runtime_eventual_safety::the_object_in_schedule_has_spec_as::<ZookeeperClusterView, ZookeeperReconcileState>(zk)),
+                lift_state(controller_runtime_eventual_safety::the_object_in_schedule_has_spec_as::<ZookeeperClusterView, ZookeeperReconciler>(zk)),
                 lift_state(controller_runtime_eventual_safety::the_object_in_reconcile_has_spec_as(zk))
             );
 
@@ -336,12 +336,12 @@ proof fn liveness_proof(zk: ZookeeperClusterView)
                 {
                     next_with_wf_is_stable();
                     invariants_is_stable(zk);
-                    always_p_is_stable(lift_state(cluster::desired_state_is::<ZookeeperClusterView, ZookeeperReconcileState>(zk)));
+                    always_p_is_stable(lift_state(cluster::desired_state_is::<ZookeeperClusterView, ZookeeperReconciler>(zk)));
 
                     stable_and_n!(
                         next_with_wf(),
                         invariants(zk),
-                        always(lift_state(cluster::desired_state_is::<ZookeeperClusterView, ZookeeperReconcileState>(zk)))
+                        always(lift_state(cluster::desired_state_is::<ZookeeperClusterView, ZookeeperReconciler>(zk)))
                     );
                 }
             );
@@ -352,20 +352,20 @@ proof fn liveness_proof(zk: ZookeeperClusterView)
             unpack_conditions_from_spec(spec, always(lift_state(crash_disabled())).and(always(lift_state(busy_disabled()))), true_pred(), always(lift_state(current_state_matches(zk))));
             temp_pred_equality(
                 true_pred().and(always(lift_state(crash_disabled())).and(always(lift_state(busy_disabled())))),
-                always(lift_state(crash_disabled::<ZookeeperClusterView, ZookeeperReconcileState>())).and(always(lift_state(busy_disabled::<ZookeeperClusterView, ZookeeperReconcileState>())))
+                always(lift_state(crash_disabled::<ZookeeperClusterView, ZookeeperReconciler>())).and(always(lift_state(busy_disabled::<ZookeeperClusterView, ZookeeperReconciler>())))
             );
 
-            cluster::lemma_true_leads_to_crash_always_disabled::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>(spec);
-            cluster::lemma_true_leads_to_busy_always_disabled::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>(spec);
+            cluster::lemma_true_leads_to_crash_always_disabled::<ZookeeperClusterView, ZookeeperReconciler>(spec);
+            cluster::lemma_true_leads_to_busy_always_disabled::<ZookeeperClusterView, ZookeeperReconciler>(spec);
             leads_to_always_combine_temp(
                 spec,
                 true_pred(),
-                lift_state(crash_disabled::<ZookeeperClusterView, ZookeeperReconcileState>()),
-                lift_state(busy_disabled::<ZookeeperClusterView, ZookeeperReconcileState>())
+                lift_state(crash_disabled::<ZookeeperClusterView, ZookeeperReconciler>()),
+                lift_state(busy_disabled::<ZookeeperClusterView, ZookeeperReconciler>())
             );
             always_and_equality(
-                lift_state(crash_disabled::<ZookeeperClusterView, ZookeeperReconcileState>()),
-                lift_state(busy_disabled::<ZookeeperClusterView, ZookeeperReconcileState>())
+                lift_state(crash_disabled::<ZookeeperClusterView, ZookeeperReconciler>()),
+                lift_state(busy_disabled::<ZookeeperClusterView, ZookeeperReconciler>())
             );
             leads_to_trans_temp(spec, true_pred(), always(lift_state(crash_disabled())).and(always(lift_state(busy_disabled()))), always(lift_state(current_state_matches(zk))));
         }
@@ -408,23 +408,23 @@ proof fn liveness_proof(zk: ZookeeperClusterView)
                 always(lift_state(cluster::desired_state_is(zk))).leads_to(always(lift_state(current_state_matches(zk))))
             );
 
-            controller_runtime_safety::lemma_always_every_in_flight_msg_has_unique_id::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>();
-            controller_runtime_safety::lemma_always_each_resp_matches_at_most_one_pending_req::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>(zk.object_ref());
-            controller_runtime_safety::lemma_always_each_resp_if_matches_pending_req_then_no_other_resp_matches::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>(zk.object_ref());
-            controller_runtime_safety::lemma_always_every_in_flight_msg_has_lower_id_than_allocator::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>();
-            cluster_safety::lemma_always_each_object_in_etcd_is_well_formed::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>(spec);
-            cluster_safety::lemma_always_each_scheduled_key_is_consistent_with_its_object::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>(spec);
-            cluster_safety::lemma_always_each_key_in_reconcile_is_consistent_with_its_object::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>(spec);
+            controller_runtime_safety::lemma_always_every_in_flight_msg_has_unique_id::<ZookeeperClusterView, ZookeeperReconciler>();
+            controller_runtime_safety::lemma_always_each_resp_matches_at_most_one_pending_req::<ZookeeperClusterView, ZookeeperReconciler>(zk.object_ref());
+            controller_runtime_safety::lemma_always_each_resp_if_matches_pending_req_then_no_other_resp_matches::<ZookeeperClusterView, ZookeeperReconciler>(zk.object_ref());
+            controller_runtime_safety::lemma_always_every_in_flight_msg_has_lower_id_than_allocator::<ZookeeperClusterView, ZookeeperReconciler>();
+            cluster_safety::lemma_always_each_object_in_etcd_is_well_formed::<ZookeeperClusterView, ZookeeperReconciler>(spec);
+            cluster_safety::lemma_always_each_scheduled_key_is_consistent_with_its_object::<ZookeeperClusterView, ZookeeperReconciler>(spec);
+            cluster_safety::lemma_always_each_key_in_reconcile_is_consistent_with_its_object::<ZookeeperClusterView, ZookeeperReconciler>(spec);
             helper_invariants::lemma_always_pending_msg_at_after_create_stateful_set_step_is_create_sts_req(spec, zk.object_ref());
             helper_invariants::lemma_always_pending_msg_at_after_update_stateful_set_step_is_update_sts_req(spec, zk.object_ref());
-            controller_runtime_safety::lemma_always_no_pending_req_at_reconcile_init_state::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>(spec, zk.object_ref());
-            controller_runtime_safety::lemma_always_pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>(spec, zk.object_ref(), zookeeper_reconcile_state(ZookeeperReconcileStep::AfterUpdateStatefulSet));
-            controller_runtime_safety::lemma_always_pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>(spec, zk.object_ref(), zookeeper_reconcile_state(ZookeeperReconcileStep::AfterCreateStatefulSet));
-            controller_runtime_safety::lemma_always_pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>(spec, zk.object_ref(), zookeeper_reconcile_state(ZookeeperReconcileStep::AfterCreateHeadlessService));
-            controller_runtime_safety::lemma_always_pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>(spec, zk.object_ref(), zookeeper_reconcile_state(ZookeeperReconcileStep::AfterCreateClientService));
-            controller_runtime_safety::lemma_always_pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>(spec, zk.object_ref(), zookeeper_reconcile_state(ZookeeperReconcileStep::AfterCreateAdminServerService));
-            controller_runtime_safety::lemma_always_pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>(spec, zk.object_ref(), zookeeper_reconcile_state(ZookeeperReconcileStep::AfterCreateConfigMap));
-            controller_runtime_safety::lemma_always_pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>(spec, zk.object_ref(), zookeeper_reconcile_state(ZookeeperReconcileStep::AfterGetStatefulSet));
+            controller_runtime_safety::lemma_always_no_pending_req_at_reconcile_init_state::<ZookeeperClusterView, ZookeeperReconciler>(spec, zk.object_ref());
+            controller_runtime_safety::lemma_always_pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<ZookeeperClusterView, ZookeeperReconciler>(spec, zk.object_ref(), zookeeper_reconcile_state(ZookeeperReconcileStep::AfterUpdateStatefulSet));
+            controller_runtime_safety::lemma_always_pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<ZookeeperClusterView, ZookeeperReconciler>(spec, zk.object_ref(), zookeeper_reconcile_state(ZookeeperReconcileStep::AfterCreateStatefulSet));
+            controller_runtime_safety::lemma_always_pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<ZookeeperClusterView, ZookeeperReconciler>(spec, zk.object_ref(), zookeeper_reconcile_state(ZookeeperReconcileStep::AfterCreateHeadlessService));
+            controller_runtime_safety::lemma_always_pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<ZookeeperClusterView, ZookeeperReconciler>(spec, zk.object_ref(), zookeeper_reconcile_state(ZookeeperReconcileStep::AfterCreateClientService));
+            controller_runtime_safety::lemma_always_pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<ZookeeperClusterView, ZookeeperReconciler>(spec, zk.object_ref(), zookeeper_reconcile_state(ZookeeperReconcileStep::AfterCreateAdminServerService));
+            controller_runtime_safety::lemma_always_pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<ZookeeperClusterView, ZookeeperReconciler>(spec, zk.object_ref(), zookeeper_reconcile_state(ZookeeperReconcileStep::AfterCreateConfigMap));
+            controller_runtime_safety::lemma_always_pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<ZookeeperClusterView, ZookeeperReconciler>(spec, zk.object_ref(), zookeeper_reconcile_state(ZookeeperReconcileStep::AfterGetStatefulSet));
 
             entails_and_n!(
                 spec,
@@ -437,14 +437,14 @@ proof fn liveness_proof(zk: ZookeeperClusterView)
                 always(lift_state(cluster_safety::each_key_in_reconcile_is_consistent_with_its_object())),
                 always(lift_state(helper_invariants::pending_msg_at_after_create_stateful_set_step_is_create_sts_req(zk.object_ref()))),
                 always(lift_state(helper_invariants::pending_msg_at_after_update_stateful_set_step_is_update_sts_req(zk.object_ref()))),
-                always(lift_state(controller_runtime::no_pending_req_at_reconcile_init_state::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>(zk.object_ref()))),
-                always(lift_state(controller_runtime::pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<ZookeeperClusterView, ZookeeperReconcileState>(zk.object_ref(), zookeeper_reconcile_state(ZookeeperReconcileStep::AfterUpdateStatefulSet)))),
-                always(lift_state(controller_runtime::pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<ZookeeperClusterView, ZookeeperReconcileState>(zk.object_ref(), zookeeper_reconcile_state(ZookeeperReconcileStep::AfterCreateStatefulSet)))),
-                always(lift_state(controller_runtime::pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<ZookeeperClusterView, ZookeeperReconcileState>(zk.object_ref(), zookeeper_reconcile_state(ZookeeperReconcileStep::AfterCreateHeadlessService)))),
-                always(lift_state(controller_runtime::pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<ZookeeperClusterView, ZookeeperReconcileState>(zk.object_ref(), zookeeper_reconcile_state(ZookeeperReconcileStep::AfterCreateClientService)))),
-                always(lift_state(controller_runtime::pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<ZookeeperClusterView, ZookeeperReconcileState>(zk.object_ref(), zookeeper_reconcile_state(ZookeeperReconcileStep::AfterCreateAdminServerService)))),
-                always(lift_state(controller_runtime::pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<ZookeeperClusterView, ZookeeperReconcileState>(zk.object_ref(), zookeeper_reconcile_state(ZookeeperReconcileStep::AfterCreateConfigMap)))),
-                always(lift_state(controller_runtime::pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<ZookeeperClusterView, ZookeeperReconcileState>(zk.object_ref(), zookeeper_reconcile_state(ZookeeperReconcileStep::AfterGetStatefulSet))))
+                always(lift_state(controller_runtime::no_pending_req_at_reconcile_init_state::<ZookeeperClusterView, ZookeeperReconciler>(zk.object_ref()))),
+                always(lift_state(controller_runtime::pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<ZookeeperClusterView, ZookeeperReconciler>(zk.object_ref(), zookeeper_reconcile_state(ZookeeperReconcileStep::AfterUpdateStatefulSet)))),
+                always(lift_state(controller_runtime::pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<ZookeeperClusterView, ZookeeperReconciler>(zk.object_ref(), zookeeper_reconcile_state(ZookeeperReconcileStep::AfterCreateStatefulSet)))),
+                always(lift_state(controller_runtime::pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<ZookeeperClusterView, ZookeeperReconciler>(zk.object_ref(), zookeeper_reconcile_state(ZookeeperReconcileStep::AfterCreateHeadlessService)))),
+                always(lift_state(controller_runtime::pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<ZookeeperClusterView, ZookeeperReconciler>(zk.object_ref(), zookeeper_reconcile_state(ZookeeperReconcileStep::AfterCreateClientService)))),
+                always(lift_state(controller_runtime::pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<ZookeeperClusterView, ZookeeperReconciler>(zk.object_ref(), zookeeper_reconcile_state(ZookeeperReconcileStep::AfterCreateAdminServerService)))),
+                always(lift_state(controller_runtime::pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<ZookeeperClusterView, ZookeeperReconciler>(zk.object_ref(), zookeeper_reconcile_state(ZookeeperReconcileStep::AfterCreateConfigMap)))),
+                always(lift_state(controller_runtime::pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<ZookeeperClusterView, ZookeeperReconciler>(zk.object_ref(), zookeeper_reconcile_state(ZookeeperReconcileStep::AfterGetStatefulSet))))
             );
 
             simplify_predicate(spec, invariants(zk));
@@ -510,7 +510,7 @@ proof fn lemma_true_leads_to_always_current_state_matches_zk_from_idle_with_rest
         }
     );
 
-    kubernetes_api_liveness::lemma_true_leads_to_always_no_req_before_rest_id_is_in_flight::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>(
+    kubernetes_api_liveness::lemma_true_leads_to_always_no_req_before_rest_id_is_in_flight::<ZookeeperClusterView, ZookeeperReconciler>(
         spec.and(invariants_since_rest_id(zk, rest_id)), rest_id
     );
 
@@ -524,7 +524,7 @@ proof fn lemma_true_leads_to_always_current_state_matches_zk_from_idle_with_rest
             eliminate_always(spec, lift_state(helper_invariants::pending_msg_at_after_create_stateful_set_step_is_create_sts_req(zk.object_ref())));
             eliminate_always(spec, lift_state(helper_invariants::pending_msg_at_after_update_stateful_set_step_is_update_sts_req(zk.object_ref())));
 
-            cluster_safety::lemma_always_rest_id_counter_is_no_smaller_than::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>(spec, rest_id);
+            cluster_safety::lemma_always_rest_id_counter_is_no_smaller_than::<ZookeeperClusterView, ZookeeperReconciler>(spec, rest_id);
             helper_invariants::lemma_always_at_most_one_create_sts_req_since_rest_id_is_in_flight(spec, zk.object_ref(), rest_id);
             helper_invariants::lemma_always_at_most_one_update_sts_req_since_rest_id_is_in_flight(spec, zk.object_ref(), rest_id);
             helper_invariants::lemma_always_no_delete_sts_req_since_rest_id_is_in_flight(spec, zk.object_ref(), rest_id);
@@ -944,8 +944,8 @@ proof fn lemma_from_pending_req_in_flight_at_some_step_to_pending_req_in_flight_
     spec: TempPred<ClusterState>, zk: ZookeeperClusterView, step: ZookeeperReconcileStep, next_step: ZookeeperReconcileStep
 )
     requires
-        spec.entails(always(lift_action(next::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>()))),
-        spec.entails(tla_forall(|i| controller_next::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>().weak_fairness(i))),
+        spec.entails(always(lift_action(next::<ZookeeperClusterView, ZookeeperReconciler>()))),
+        spec.entails(tla_forall(|i| controller_next::<ZookeeperClusterView, ZookeeperReconciler>().weak_fairness(i))),
         spec.entails(tla_forall(|i| kubernetes_api_next().weak_fairness(i))),
         spec.entails(always(lift_state(crash_disabled()))),
         spec.entails(always(lift_state(busy_disabled()))),
@@ -953,13 +953,14 @@ proof fn lemma_from_pending_req_in_flight_at_some_step_to_pending_req_in_flight_
         spec.entails(always(lift_state(controller_runtime_safety::each_resp_matches_at_most_one_pending_req(zk.object_ref())))),
         step != ZookeeperReconcileStep::Error, step != ZookeeperReconcileStep::Done,
         // next_step != ZookeeperReconcileStep::Init,
-        forall |zk_1: ZookeeperClusterView, resp_o: Option<APIResponse>|
-            #[trigger] reconcile_core(zk_1, resp_o, ZookeeperReconcileState{ reconcile_step: step }).0.reconcile_step == next_step
+        forall |zk_1, resp_o| #[trigger] reconcile_core(zk_1, resp_o, ZookeeperReconcileState{ reconcile_step: step }).0.reconcile_step == next_step
             && reconcile_core(zk, resp_o, ZookeeperReconcileState{ reconcile_step: step }).1.is_Some()
+            && reconcile_core(zk, resp_o, ZookeeperReconcileState{ reconcile_step: step }).1.get_Some_0().is_KRequest()
             && (zk_1.object_ref() == zk.object_ref() && zk_1.spec == zk.spec ==>
             forall |object: DynamicObjectView| #[trigger] is_correct_pending_request_at_zookeeper_step(
-                next_step, reconcile_core(zk, resp_o, ZookeeperReconcileState{ reconcile_step: step }).1.get_Some_0(), zk, object
-            )),
+                next_step, reconcile_core(zk, resp_o, ZookeeperReconcileState{ reconcile_step: step }).1.get_Some_0().get_KRequest_0(), zk, object
+            )
+        ),
         zk.well_formed(),
     ensures
         spec.entails(
@@ -1046,7 +1047,7 @@ proof fn lemma_from_pending_req_in_flight_at_some_step_to_pending_req_in_flight_
 
 proof fn lemma_from_unscheduled_to_scheduled(spec: TempPred<ClusterState>, zk: ZookeeperClusterView)
     requires
-        spec.entails(always(lift_action(next::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>()))),
+        spec.entails(always(lift_action(next::<ZookeeperClusterView, ZookeeperReconciler>()))),
         spec.entails(tla_forall(|i| schedule_controller_reconcile().weak_fairness(i))),
         spec.entails(always(lift_state(cluster::desired_state_is(zk)))),
         zk.well_formed(),
@@ -1073,14 +1074,14 @@ proof fn lemma_from_unscheduled_to_scheduled(spec: TempPred<ClusterState>, zk: Z
     let input = zk.object_ref();
 
     controller_runtime_liveness::lemma_pre_leads_to_post_by_schedule_controller_reconcile_borrow_from_spec(
-        spec, input, next::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>(), cluster::desired_state_is(zk), pre, post
+        spec, input, next::<ZookeeperClusterView, ZookeeperReconciler>(), cluster::desired_state_is(zk), pre, post
     );
 }
 
 proof fn lemma_from_scheduled_to_init_step(spec: TempPred<ClusterState>, zk: ZookeeperClusterView)
     requires
-        spec.entails(always(lift_action(next::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>()))),
-        spec.entails(tla_forall(|i| controller_next::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>().weak_fairness(i))),
+        spec.entails(always(lift_action(next::<ZookeeperClusterView, ZookeeperReconciler>()))),
+        spec.entails(tla_forall(|i| controller_next::<ZookeeperClusterView, ZookeeperReconciler>().weak_fairness(i))),
         spec.entails(always(lift_state(crash_disabled()))),
         spec.entails(always(lift_state(cluster_safety::each_scheduled_key_is_consistent_with_its_object()))),
         spec.entails(always(lift_state(controller_runtime_eventual_safety::the_object_in_schedule_has_spec_as(zk)))),
@@ -1101,29 +1102,29 @@ proof fn lemma_from_scheduled_to_init_step(spec: TempPred<ClusterState>, zk: Zoo
     let post = no_pending_req_at_zookeeper_step_with_zk(zk, ZookeeperReconcileStep::Init);
     let input = (Option::None, Option::Some(zk.object_ref()));
     let stronger_next = |s, s_prime: ClusterState| {
-        &&& next::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>()(s, s_prime)
+        &&& next::<ZookeeperClusterView, ZookeeperReconciler>()(s, s_prime)
         &&& crash_disabled()(s)
         &&& cluster_safety::each_scheduled_key_is_consistent_with_its_object()(s)
         &&& controller_runtime_eventual_safety::the_object_in_schedule_has_spec_as(zk)(s)
     };
     entails_always_and_n!(
         spec,
-        lift_action(next::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>()),
+        lift_action(next::<ZookeeperClusterView, ZookeeperReconciler>()),
         lift_state(crash_disabled()),
         lift_state(cluster_safety::each_scheduled_key_is_consistent_with_its_object()),
         lift_state(controller_runtime_eventual_safety::the_object_in_schedule_has_spec_as(zk))
     );
     temp_pred_equality(
         lift_action(stronger_next),
-        lift_action(next::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>())
+        lift_action(next::<ZookeeperClusterView, ZookeeperReconciler>())
         .and(lift_state(crash_disabled()))
         .and(lift_state(cluster_safety::each_scheduled_key_is_consistent_with_its_object()))
         .and(lift_state(controller_runtime_eventual_safety::the_object_in_schedule_has_spec_as(zk)))
     );
 
-    controller_runtime_liveness::lemma_pre_leads_to_post_by_controller::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>(
+    controller_runtime_liveness::lemma_pre_leads_to_post_by_controller::<ZookeeperClusterView, ZookeeperReconciler>(
         spec, input, stronger_next,
-        run_scheduled_reconcile::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>(), pre, post
+        run_scheduled_reconcile::<ZookeeperClusterView, ZookeeperReconciler>(), pre, post
     );
 }
 
@@ -1131,8 +1132,8 @@ proof fn lemma_from_init_step_to_after_create_headless_service_step(
     spec: TempPred<ClusterState>, zk: ZookeeperClusterView
 )
     requires
-        spec.entails(always(lift_action(next::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>()))),
-        spec.entails(tla_forall(|i| controller_next::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>().weak_fairness(i))),
+        spec.entails(always(lift_action(next::<ZookeeperClusterView, ZookeeperReconciler>()))),
+        spec.entails(tla_forall(|i| controller_next::<ZookeeperClusterView, ZookeeperReconciler>().weak_fairness(i))),
         spec.entails(always(lift_state(crash_disabled()))),
         zk.well_formed(),
     ensures
@@ -1145,23 +1146,23 @@ proof fn lemma_from_init_step_to_after_create_headless_service_step(
     let post = pending_req_in_flight_at_zookeeper_step_with_zk(ZookeeperReconcileStep::AfterCreateHeadlessService, zk, arbitrary());
     let input = (Option::None, Option::Some(zk.object_ref()));
     let stronger_next = |s, s_prime: ClusterState| {
-        &&& next::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>()(s, s_prime)
+        &&& next::<ZookeeperClusterView, ZookeeperReconciler>()(s, s_prime)
         &&& crash_disabled()(s)
     };
     entails_always_and_n!(
         spec,
-        lift_action(next::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>()),
+        lift_action(next::<ZookeeperClusterView, ZookeeperReconciler>()),
         lift_state(crash_disabled())
     );
     temp_pred_equality(
         lift_action(stronger_next),
-        lift_action(next::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>())
+        lift_action(next::<ZookeeperClusterView, ZookeeperReconciler>())
         .and(lift_state(crash_disabled()))
     );
 
-    controller_runtime_liveness::lemma_pre_leads_to_post_by_controller::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>(
+    controller_runtime_liveness::lemma_pre_leads_to_post_by_controller::<ZookeeperClusterView, ZookeeperReconciler>(
         spec, input, stronger_next,
-        continue_reconcile::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>(), pre, post
+        continue_reconcile::<ZookeeperClusterView, ZookeeperReconciler>(), pre, post
     );
 }
 
@@ -1177,8 +1178,8 @@ proof fn lemma_from_resp_in_flight_at_some_step_to_pending_req_in_flight_at_next
     spec: TempPred<ClusterState>, zk: ZookeeperClusterView, resp_msg: Message, step: ZookeeperReconcileStep, result_step: ZookeeperReconcileStep
 )
     requires
-        spec.entails(always(lift_action(next::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>()))),
-        spec.entails(tla_forall(|i| controller_next::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>().weak_fairness(i))),
+        spec.entails(always(lift_action(next::<ZookeeperClusterView, ZookeeperReconciler>()))),
+        spec.entails(tla_forall(|i| controller_next::<ZookeeperClusterView, ZookeeperReconciler>().weak_fairness(i))),
         spec.entails(always(lift_state(crash_disabled()))),
         spec.entails(always(lift_state(busy_disabled()))),
         spec.entails(always(lift_state(controller_runtime_safety::each_resp_matches_at_most_one_pending_req(zk.object_ref())))),
@@ -1186,12 +1187,12 @@ proof fn lemma_from_resp_in_flight_at_some_step_to_pending_req_in_flight_at_next
         // result_step != ZookeeperReconcileStep::Init,
         // This forall zk_1 constraint is used because the cr passed to reconcile_core is not necessarily zk here.
         // We only know that zk_1.object_ref() == zk.object_ref() && zk_1.spec == zk.spec.
-        forall |zk_1: ZookeeperClusterView, resp_o: Option<APIResponse>|
-            #[trigger] reconcile_core(zk_1, resp_o, ZookeeperReconcileState{ reconcile_step: step }).0.reconcile_step == result_step
+        forall |zk_1, resp_o| #[trigger] reconcile_core(zk_1, resp_o, ZookeeperReconcileState{ reconcile_step: step }).0.reconcile_step == result_step
             && reconcile_core(zk, resp_o, ZookeeperReconcileState{ reconcile_step: step }).1.is_Some()
+            && reconcile_core(zk, resp_o, ZookeeperReconcileState{ reconcile_step: step }).1.get_Some_0().is_KRequest()
             && (zk_1.object_ref() == zk.object_ref() && zk_1.spec == zk.spec ==>
             forall |object: DynamicObjectView| #[trigger] is_correct_pending_request_at_zookeeper_step(
-                result_step, reconcile_core(zk, resp_o, ZookeeperReconcileState{ reconcile_step: step }).1.get_Some_0(), zk, object
+                result_step, reconcile_core(zk, resp_o, ZookeeperReconcileState{ reconcile_step: step }).1.get_Some_0().get_KRequest_0(), zk, object
             )),
         zk.well_formed(),
     ensures
@@ -1211,7 +1212,7 @@ proof fn lemma_from_resp_in_flight_at_some_step_to_pending_req_in_flight_at_next
     //    (Note that this is not required for termination)
     //   - each_resp_matches_at_most_one_pending_req: to make sure that the resp_msg will not be used by other cr
     let stronger_next = |s, s_prime: ClusterState| {
-        &&& next::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>()(s, s_prime)
+        &&& next::<ZookeeperClusterView, ZookeeperReconciler>()(s, s_prime)
         &&& crash_disabled()(s)
         &&& busy_disabled()(s)
         &&& controller_runtime_safety::each_resp_matches_at_most_one_pending_req(zk.object_ref())(s)
@@ -1219,21 +1220,21 @@ proof fn lemma_from_resp_in_flight_at_some_step_to_pending_req_in_flight_at_next
 
     entails_always_and_n!(
         spec,
-        lift_action(next::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>()),
+        lift_action(next::<ZookeeperClusterView, ZookeeperReconciler>()),
         lift_state(crash_disabled()),
         lift_state(busy_disabled()),
         lift_state(controller_runtime_safety::each_resp_matches_at_most_one_pending_req(zk.object_ref()))
     );
     temp_pred_equality(
         lift_action(stronger_next),
-        lift_action(next::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>())
+        lift_action(next::<ZookeeperClusterView, ZookeeperReconciler>())
         .and(lift_state(crash_disabled()))
         .and(lift_state(busy_disabled()))
         .and(lift_state(controller_runtime_safety::each_resp_matches_at_most_one_pending_req(zk.object_ref())))
     );
 
     assert forall |s, s_prime| pre(s) && #[trigger] stronger_next(s, s_prime) implies pre(s_prime) || post(s_prime) by {
-        let step = choose |step| next_step::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>(s, s_prime, step);
+        let step = choose |step| next_step::<ZookeeperClusterView, ZookeeperReconciler>(s, s_prime, step);
         match step {
             Step::ControllerStep(input) => {
                 if input.1.is_Some() && input.1.get_Some_0() == zk.object_ref() {
@@ -1248,9 +1249,9 @@ proof fn lemma_from_resp_in_flight_at_some_step_to_pending_req_in_flight_at_next
         }
     }
 
-    controller_runtime_liveness::lemma_pre_leads_to_post_by_controller::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>(
+    controller_runtime_liveness::lemma_pre_leads_to_post_by_controller::<ZookeeperClusterView, ZookeeperReconciler>(
         spec, input, stronger_next,
-        continue_reconcile::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>(), pre, post
+        continue_reconcile::<ZookeeperClusterView, ZookeeperReconciler>(), pre, post
     );
 }
 
@@ -1258,7 +1259,7 @@ proof fn lemma_receives_some_resp_at_zookeeper_step_with_zk(
     spec: TempPred<ClusterState>, zk: ZookeeperClusterView, req_msg: Message, step: ZookeeperReconcileStep
 )
     requires
-        spec.entails(always(lift_action(next::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>()))),
+        spec.entails(always(lift_action(next::<ZookeeperClusterView, ZookeeperReconciler>()))),
         spec.entails(tla_forall(|i| kubernetes_api_next().weak_fairness(i))),
         spec.entails(always(lift_state(crash_disabled()))),
         spec.entails(always(lift_state(busy_disabled()))),
@@ -1275,21 +1276,21 @@ proof fn lemma_receives_some_resp_at_zookeeper_step_with_zk(
     let post = exists_resp_in_flight_at_zookeeper_step_with_zk(step, zk, arbitrary());
     let input = Option::Some(req_msg);
     let stronger_next = |s, s_prime: ClusterState| {
-        &&& next::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>()(s, s_prime)
+        &&& next::<ZookeeperClusterView, ZookeeperReconciler>()(s, s_prime)
         &&& crash_disabled()(s)
         &&& busy_disabled()(s)
         &&& controller_runtime_safety::every_in_flight_msg_has_unique_id()(s)
     };
     entails_always_and_n!(
         spec,
-        lift_action(next::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>()),
+        lift_action(next::<ZookeeperClusterView, ZookeeperReconciler>()),
         lift_state(crash_disabled()),
         lift_state(busy_disabled()),
         lift_state(controller_runtime_safety::every_in_flight_msg_has_unique_id())
     );
     temp_pred_equality(
         lift_action(stronger_next),
-        lift_action(next::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>())
+        lift_action(next::<ZookeeperClusterView, ZookeeperReconciler>())
         .and(lift_state(crash_disabled()))
         .and(lift_state(busy_disabled()))
         .and(lift_state(controller_runtime_safety::every_in_flight_msg_has_unique_id()))
@@ -1304,7 +1305,7 @@ proof fn lemma_receives_some_resp_at_zookeeper_step_with_zk(
         });
     }
 
-    kubernetes_api_liveness::lemma_pre_leads_to_post_by_kubernetes_api::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>(
+    kubernetes_api_liveness::lemma_pre_leads_to_post_by_kubernetes_api::<ZookeeperClusterView, ZookeeperReconciler>(
         spec, input, stronger_next, handle_request(), pre, post
     );
 }
@@ -1313,7 +1314,7 @@ proof fn lemma_receives_ok_resp_at_after_get_stateful_set_step_with_zk(
     spec: TempPred<ClusterState>, zk: ZookeeperClusterView, rest_id: nat, req_msg: Message, object: DynamicObjectView
 )
     requires
-        spec.entails(always(lift_action(next::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>()))),
+        spec.entails(always(lift_action(next::<ZookeeperClusterView, ZookeeperReconciler>()))),
         spec.entails(tla_forall(|i| kubernetes_api_next().weak_fairness(i))),
         spec.entails(always(lift_state(crash_disabled()))),
         spec.entails(always(lift_state(busy_disabled()))),
@@ -1352,7 +1353,7 @@ proof fn lemma_receives_ok_resp_at_after_get_stateful_set_step_with_zk(
     };
     let input = Option::Some(req_msg);
     let stronger_next = |s, s_prime: ClusterState| {
-        &&& next::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>()(s, s_prime)
+        &&& next::<ZookeeperClusterView, ZookeeperReconciler>()(s, s_prime)
         &&& crash_disabled()(s)
         &&& busy_disabled()(s)
         &&& controller_runtime_safety::every_in_flight_msg_has_unique_id()(s)
@@ -1362,7 +1363,7 @@ proof fn lemma_receives_ok_resp_at_after_get_stateful_set_step_with_zk(
     };
     entails_always_and_n!(
         spec,
-        lift_action(next::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>()),
+        lift_action(next::<ZookeeperClusterView, ZookeeperReconciler>()),
         lift_state(crash_disabled()),
         lift_state(busy_disabled()),
         lift_state(controller_runtime_safety::every_in_flight_msg_has_unique_id()),
@@ -1372,7 +1373,7 @@ proof fn lemma_receives_ok_resp_at_after_get_stateful_set_step_with_zk(
     );
     temp_pred_equality(
         lift_action(stronger_next),
-        lift_action(next::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>())
+        lift_action(next::<ZookeeperClusterView, ZookeeperReconciler>())
         .and(lift_state(crash_disabled()))
         .and(lift_state(busy_disabled()))
         .and(lift_state(controller_runtime_safety::every_in_flight_msg_has_unique_id()))
@@ -1382,7 +1383,7 @@ proof fn lemma_receives_ok_resp_at_after_get_stateful_set_step_with_zk(
     );
 
     assert forall |s, s_prime| pre(s) && #[trigger] stronger_next(s, s_prime) implies pre(s_prime) || post(s_prime) by {
-        let step = choose |step| next_step::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>(s, s_prime, step);
+        let step = choose |step| next_step::<ZookeeperClusterView, ZookeeperReconciler>(s, s_prime, step);
         match step {
             Step::KubernetesAPIStep(input) => {
                 if input.get_Some_0() == req_msg {
@@ -1410,7 +1411,7 @@ proof fn lemma_receives_ok_resp_at_after_get_stateful_set_step_with_zk(
         });
     }
 
-    kubernetes_api_liveness::lemma_pre_leads_to_post_by_kubernetes_api::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>(
+    kubernetes_api_liveness::lemma_pre_leads_to_post_by_kubernetes_api::<ZookeeperClusterView, ZookeeperReconciler>(
         spec, input, stronger_next, handle_request(), pre, post
     );
 }
@@ -1419,8 +1420,8 @@ proof fn lemma_from_after_get_stateful_set_step_to_after_update_stateful_set_ste
     spec: TempPred<ClusterState>, zk: ZookeeperClusterView, rest_id: nat, resp_msg: Message, object: DynamicObjectView
 )
     requires
-        spec.entails(always(lift_action(next::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>()))),
-        spec.entails(tla_forall(|i| controller_next::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>().weak_fairness(i))),
+        spec.entails(always(lift_action(next::<ZookeeperClusterView, ZookeeperReconciler>()))),
+        spec.entails(tla_forall(|i| controller_next::<ZookeeperClusterView, ZookeeperReconciler>().weak_fairness(i))),
         spec.entails(always(lift_state(crash_disabled()))),
         spec.entails(always(lift_state(busy_disabled()))),
         spec.entails(always(lift_state(controller_runtime_safety::each_resp_matches_at_most_one_pending_req(zk.object_ref())))),
@@ -1460,7 +1461,7 @@ proof fn lemma_from_after_get_stateful_set_step_to_after_update_stateful_set_ste
     };
     let input = (Option::Some(resp_msg), Option::Some(zk.object_ref()));
     let stronger_next = |s, s_prime: ClusterState| {
-        &&& next::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>()(s, s_prime)
+        &&& next::<ZookeeperClusterView, ZookeeperReconciler>()(s, s_prime)
         &&& crash_disabled()(s)
         &&& busy_disabled()(s)
         &&& controller_runtime_safety::each_resp_matches_at_most_one_pending_req(zk.object_ref())(s)
@@ -1473,7 +1474,7 @@ proof fn lemma_from_after_get_stateful_set_step_to_after_update_stateful_set_ste
 
     entails_always_and_n!(
         spec,
-        lift_action(next::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>()),
+        lift_action(next::<ZookeeperClusterView, ZookeeperReconciler>()),
         lift_state(crash_disabled()),
         lift_state(busy_disabled()),
         lift_state(controller_runtime_safety::each_resp_matches_at_most_one_pending_req(zk.object_ref())),
@@ -1485,7 +1486,7 @@ proof fn lemma_from_after_get_stateful_set_step_to_after_update_stateful_set_ste
     );
     temp_pred_equality(
         lift_action(stronger_next),
-        lift_action(next::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>())
+        lift_action(next::<ZookeeperClusterView, ZookeeperReconciler>())
         .and(lift_state(crash_disabled()))
         .and(lift_state(busy_disabled()))
         .and(lift_state(controller_runtime_safety::each_resp_matches_at_most_one_pending_req(zk.object_ref())))
@@ -1496,9 +1497,9 @@ proof fn lemma_from_after_get_stateful_set_step_to_after_update_stateful_set_ste
         .and(lift_state(helper_invariants::no_delete_sts_req_since_rest_id_is_in_flight(zk.object_ref(), rest_id)))
     );
 
-    controller_runtime_liveness::lemma_pre_leads_to_post_by_controller::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>(
+    controller_runtime_liveness::lemma_pre_leads_to_post_by_controller::<ZookeeperClusterView, ZookeeperReconciler>(
         spec, input, stronger_next,
-        continue_reconcile::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>(), pre, post
+        continue_reconcile::<ZookeeperClusterView, ZookeeperReconciler>(), pre, post
     );
 }
 
@@ -1506,7 +1507,7 @@ proof fn lemma_sts_is_updated_at_after_update_stateful_set_step_with_zk(
     spec: TempPred<ClusterState>, zk: ZookeeperClusterView, rest_id: nat, req_msg: Message, object: DynamicObjectView
 )
     requires
-        spec.entails(always(lift_action(next::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>()))),
+        spec.entails(always(lift_action(next::<ZookeeperClusterView, ZookeeperReconciler>()))),
         spec.entails(tla_forall(|i| kubernetes_api_next().weak_fairness(i))),
         spec.entails(always(lift_state(crash_disabled()))),
         spec.entails(always(lift_state(busy_disabled()))),
@@ -1546,7 +1547,7 @@ proof fn lemma_sts_is_updated_at_after_update_stateful_set_step_with_zk(
     };
     let input = Option::Some(req_msg);
     let stronger_next = |s, s_prime: ClusterState| {
-        &&& next::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>()(s, s_prime)
+        &&& next::<ZookeeperClusterView, ZookeeperReconciler>()(s, s_prime)
         &&& crash_disabled()(s)
         &&& busy_disabled()(s)
         &&& controller_runtime_safety::every_in_flight_msg_has_unique_id()(s)
@@ -1557,7 +1558,7 @@ proof fn lemma_sts_is_updated_at_after_update_stateful_set_step_with_zk(
     };
     entails_always_and_n!(
         spec,
-        lift_action(next::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>()),
+        lift_action(next::<ZookeeperClusterView, ZookeeperReconciler>()),
         lift_state(crash_disabled()),
         lift_state(busy_disabled()),
         lift_state(controller_runtime_safety::every_in_flight_msg_has_unique_id()),
@@ -1568,7 +1569,7 @@ proof fn lemma_sts_is_updated_at_after_update_stateful_set_step_with_zk(
     );
     temp_pred_equality(
         lift_action(stronger_next),
-        lift_action(next::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>())
+        lift_action(next::<ZookeeperClusterView, ZookeeperReconciler>())
         .and(lift_state(crash_disabled()))
         .and(lift_state(busy_disabled()))
         .and(lift_state(controller_runtime_safety::every_in_flight_msg_has_unique_id()))
@@ -1579,7 +1580,7 @@ proof fn lemma_sts_is_updated_at_after_update_stateful_set_step_with_zk(
     );
 
     assert forall |s, s_prime| pre(s) && #[trigger] stronger_next(s, s_prime) implies pre(s_prime) || post(s_prime) by {
-        let step = choose |step| next_step::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>(s, s_prime, step);
+        let step = choose |step| next_step::<ZookeeperClusterView, ZookeeperReconciler>(s, s_prime, step);
         match step {
             Step::KubernetesAPIStep(input) => {
                 StatefulSetView::spec_integrity_is_preserved_by_marshal();
@@ -1593,7 +1594,7 @@ proof fn lemma_sts_is_updated_at_after_update_stateful_set_step_with_zk(
         StatefulSetView::spec_integrity_is_preserved_by_marshal();
     }
 
-    kubernetes_api_liveness::lemma_pre_leads_to_post_by_kubernetes_api::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>(
+    kubernetes_api_liveness::lemma_pre_leads_to_post_by_kubernetes_api::<ZookeeperClusterView, ZookeeperReconciler>(
         spec, input, stronger_next, handle_request(), pre, post
     );
 }
@@ -1602,7 +1603,7 @@ proof fn lemma_receives_not_found_resp_at_after_get_stateful_set_step_with_zk(
     spec: TempPred<ClusterState>, zk: ZookeeperClusterView, rest_id: nat, req_msg: Message
 )
     requires
-        spec.entails(always(lift_action(next::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>()))),
+        spec.entails(always(lift_action(next::<ZookeeperClusterView, ZookeeperReconciler>()))),
         spec.entails(tla_forall(|i| kubernetes_api_next().weak_fairness(i))),
         spec.entails(always(lift_state(crash_disabled()))),
         spec.entails(always(lift_state(busy_disabled()))),
@@ -1636,7 +1637,7 @@ proof fn lemma_receives_not_found_resp_at_after_get_stateful_set_step_with_zk(
     };
     let input = Option::Some(req_msg);
     let stronger_next = |s, s_prime: ClusterState| {
-        &&& next::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>()(s, s_prime)
+        &&& next::<ZookeeperClusterView, ZookeeperReconciler>()(s, s_prime)
         &&& crash_disabled()(s)
         &&& busy_disabled()(s)
         &&& controller_runtime_safety::every_in_flight_msg_has_unique_id()(s)
@@ -1645,7 +1646,7 @@ proof fn lemma_receives_not_found_resp_at_after_get_stateful_set_step_with_zk(
     };
     entails_always_and_n!(
         spec,
-        lift_action(next::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>()),
+        lift_action(next::<ZookeeperClusterView, ZookeeperReconciler>()),
         lift_state(crash_disabled()),
         lift_state(busy_disabled()),
         lift_state(controller_runtime_safety::every_in_flight_msg_has_unique_id()),
@@ -1654,7 +1655,7 @@ proof fn lemma_receives_not_found_resp_at_after_get_stateful_set_step_with_zk(
     );
     temp_pred_equality(
         lift_action(stronger_next),
-        lift_action(next::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>())
+        lift_action(next::<ZookeeperClusterView, ZookeeperReconciler>())
         .and(lift_state(crash_disabled()))
         .and(lift_state(busy_disabled()))
         .and(lift_state(controller_runtime_safety::every_in_flight_msg_has_unique_id()))
@@ -1663,7 +1664,7 @@ proof fn lemma_receives_not_found_resp_at_after_get_stateful_set_step_with_zk(
     );
 
     assert forall |s, s_prime| pre(s) && #[trigger] stronger_next(s, s_prime) implies pre(s_prime) || post(s_prime) by {
-        let step = choose |step| next_step::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>(s, s_prime, step);
+        let step = choose |step| next_step::<ZookeeperClusterView, ZookeeperReconciler>(s, s_prime, step);
         match step {
             Step::KubernetesAPIStep(input) => {
                 if input.get_Some_0() == req_msg {
@@ -1691,7 +1692,7 @@ proof fn lemma_receives_not_found_resp_at_after_get_stateful_set_step_with_zk(
         });
     }
 
-    kubernetes_api_liveness::lemma_pre_leads_to_post_by_kubernetes_api::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>(
+    kubernetes_api_liveness::lemma_pre_leads_to_post_by_kubernetes_api::<ZookeeperClusterView, ZookeeperReconciler>(
         spec, input, stronger_next, handle_request(), pre, post
     );
 }
@@ -1700,8 +1701,8 @@ proof fn lemma_from_after_get_stateful_set_step_to_after_create_stateful_set_ste
     spec: TempPred<ClusterState>, zk: ZookeeperClusterView, rest_id: nat, resp_msg: Message
 )
     requires
-        spec.entails(always(lift_action(next::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>()))),
-        spec.entails(tla_forall(|i| controller_next::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>().weak_fairness(i))),
+        spec.entails(always(lift_action(next::<ZookeeperClusterView, ZookeeperReconciler>()))),
+        spec.entails(tla_forall(|i| controller_next::<ZookeeperClusterView, ZookeeperReconciler>().weak_fairness(i))),
         spec.entails(always(lift_state(crash_disabled()))),
         spec.entails(always(lift_state(controller_runtime_safety::each_resp_matches_at_most_one_pending_req(zk.object_ref())))),
         spec.entails(always(lift_state(controller_runtime_safety::each_resp_if_matches_pending_req_then_no_other_resp_matches(zk.object_ref())))),
@@ -1734,7 +1735,7 @@ proof fn lemma_from_after_get_stateful_set_step_to_after_create_stateful_set_ste
     };
     let input = (Option::Some(resp_msg), Option::Some(zk.object_ref()));
     let stronger_next = |s, s_prime: ClusterState| {
-        &&& next::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>()(s, s_prime)
+        &&& next::<ZookeeperClusterView, ZookeeperReconciler>()(s, s_prime)
         &&& crash_disabled()(s)
         &&& controller_runtime_safety::each_resp_matches_at_most_one_pending_req(zk.object_ref())(s)
         &&& controller_runtime_safety::each_resp_if_matches_pending_req_then_no_other_resp_matches(zk.object_ref())(s)
@@ -1744,7 +1745,7 @@ proof fn lemma_from_after_get_stateful_set_step_to_after_create_stateful_set_ste
 
     entails_always_and_n!(
         spec,
-        lift_action(next::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>()),
+        lift_action(next::<ZookeeperClusterView, ZookeeperReconciler>()),
         lift_state(crash_disabled()),
         lift_state(controller_runtime_safety::each_resp_matches_at_most_one_pending_req(zk.object_ref())),
         lift_state(controller_runtime_safety::each_resp_if_matches_pending_req_then_no_other_resp_matches(zk.object_ref())),
@@ -1753,7 +1754,7 @@ proof fn lemma_from_after_get_stateful_set_step_to_after_create_stateful_set_ste
     );
     temp_pred_equality(
         lift_action(stronger_next),
-        lift_action(next::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>())
+        lift_action(next::<ZookeeperClusterView, ZookeeperReconciler>())
         .and(lift_state(crash_disabled()))
         .and(lift_state(controller_runtime_safety::each_resp_matches_at_most_one_pending_req(zk.object_ref())))
         .and(lift_state(controller_runtime_safety::each_resp_if_matches_pending_req_then_no_other_resp_matches(zk.object_ref())))
@@ -1761,9 +1762,9 @@ proof fn lemma_from_after_get_stateful_set_step_to_after_create_stateful_set_ste
         .and(lift_state(helper_invariants::at_most_one_create_sts_req_since_rest_id_is_in_flight(zk.object_ref(), rest_id)))
     );
 
-    controller_runtime_liveness::lemma_pre_leads_to_post_by_controller::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>(
+    controller_runtime_liveness::lemma_pre_leads_to_post_by_controller::<ZookeeperClusterView, ZookeeperReconciler>(
         spec, input, stronger_next,
-        continue_reconcile::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>(), pre, post
+        continue_reconcile::<ZookeeperClusterView, ZookeeperReconciler>(), pre, post
     );
 }
 
@@ -1771,7 +1772,7 @@ proof fn lemma_sts_is_created_at_after_create_stateful_set_step_with_zk(
     spec: TempPred<ClusterState>, zk: ZookeeperClusterView, rest_id: nat, req_msg: Message
 )
     requires
-        spec.entails(always(lift_action(next::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>()))),
+        spec.entails(always(lift_action(next::<ZookeeperClusterView, ZookeeperReconciler>()))),
         spec.entails(tla_forall(|i| kubernetes_api_next().weak_fairness(i))),
         spec.entails(always(lift_state(crash_disabled()))),
         spec.entails(always(lift_state(busy_disabled()))),
@@ -1807,7 +1808,7 @@ proof fn lemma_sts_is_created_at_after_create_stateful_set_step_with_zk(
     };
     let input = Option::Some(req_msg);
     let stronger_next = |s, s_prime: ClusterState| {
-        &&& next::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>()(s, s_prime)
+        &&& next::<ZookeeperClusterView, ZookeeperReconciler>()(s, s_prime)
         &&& crash_disabled()(s)
         &&& busy_disabled()(s)
         &&& controller_runtime_safety::every_in_flight_msg_has_unique_id()(s)
@@ -1816,7 +1817,7 @@ proof fn lemma_sts_is_created_at_after_create_stateful_set_step_with_zk(
     };
     entails_always_and_n!(
         spec,
-        lift_action(next::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>()),
+        lift_action(next::<ZookeeperClusterView, ZookeeperReconciler>()),
         lift_state(crash_disabled()),
         lift_state(busy_disabled()),
         lift_state(controller_runtime_safety::every_in_flight_msg_has_unique_id()),
@@ -1825,7 +1826,7 @@ proof fn lemma_sts_is_created_at_after_create_stateful_set_step_with_zk(
     );
     temp_pred_equality(
         lift_action(stronger_next),
-        lift_action(next::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>())
+        lift_action(next::<ZookeeperClusterView, ZookeeperReconciler>())
         .and(lift_state(crash_disabled()))
         .and(lift_state(busy_disabled()))
         .and(lift_state(controller_runtime_safety::every_in_flight_msg_has_unique_id()))
@@ -1834,7 +1835,7 @@ proof fn lemma_sts_is_created_at_after_create_stateful_set_step_with_zk(
     );
 
     assert forall |s, s_prime| pre(s) && #[trigger] stronger_next(s, s_prime) implies pre(s_prime) || post(s_prime) by {
-        let step = choose |step| next_step::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>(s, s_prime, step);
+        let step = choose |step| next_step::<ZookeeperClusterView, ZookeeperReconciler>(s, s_prime, step);
         match step {
             Step::KubernetesAPIStep(input) => {
                 StatefulSetView::spec_integrity_is_preserved_by_marshal();
@@ -1848,7 +1849,7 @@ proof fn lemma_sts_is_created_at_after_create_stateful_set_step_with_zk(
         StatefulSetView::spec_integrity_is_preserved_by_marshal();
     }
 
-    kubernetes_api_liveness::lemma_pre_leads_to_post_by_kubernetes_api::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>(
+    kubernetes_api_liveness::lemma_pre_leads_to_post_by_kubernetes_api::<ZookeeperClusterView, ZookeeperReconciler>(
         spec, input, stronger_next, handle_request(), pre, post
     );
 }
@@ -1858,7 +1859,7 @@ proof fn lemma_stateful_set_is_stable(
 )
     requires
         spec.entails(p.leads_to(lift_state(current_state_matches(zk)))),
-        spec.entails(always(lift_action(next::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>()))),
+        spec.entails(always(lift_action(next::<ZookeeperClusterView, ZookeeperReconciler>()))),
         spec.entails(always(lift_state(kubernetes_api_liveness::no_req_before_rest_id_is_in_flight(rest_id)))),
         spec.entails(always(lift_state(helper_invariants::no_delete_sts_req_since_rest_id_is_in_flight(zk.object_ref(), rest_id)))),
         spec.entails(always(lift_state(helper_invariants::every_update_sts_req_since_rest_id_does_the_same(zk, rest_id)))),
@@ -1867,21 +1868,21 @@ proof fn lemma_stateful_set_is_stable(
 {
     let post = current_state_matches(zk);
     let stronger_next = |s, s_prime: ClusterState| {
-        &&& next::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>()(s, s_prime)
+        &&& next::<ZookeeperClusterView, ZookeeperReconciler>()(s, s_prime)
         &&& kubernetes_api_liveness::no_req_before_rest_id_is_in_flight(rest_id)(s)
         &&& helper_invariants::no_delete_sts_req_since_rest_id_is_in_flight(zk.object_ref(), rest_id)(s)
         &&& helper_invariants::every_update_sts_req_since_rest_id_does_the_same(zk, rest_id)(s)
     };
     entails_always_and_n!(
         spec,
-        lift_action(next::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>()),
+        lift_action(next::<ZookeeperClusterView, ZookeeperReconciler>()),
         lift_state(kubernetes_api_liveness::no_req_before_rest_id_is_in_flight(rest_id)),
         lift_state(helper_invariants::no_delete_sts_req_since_rest_id_is_in_flight(zk.object_ref(), rest_id)),
         lift_state(helper_invariants::every_update_sts_req_since_rest_id_does_the_same(zk, rest_id))
     );
     temp_pred_equality(
         lift_action(stronger_next),
-        lift_action(next::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>())
+        lift_action(next::<ZookeeperClusterView, ZookeeperReconciler>())
         .and(lift_state(kubernetes_api_liveness::no_req_before_rest_id_is_in_flight(rest_id)))
         .and(lift_state(helper_invariants::no_delete_sts_req_since_rest_id_is_in_flight(zk.object_ref(), rest_id)))
         .and(lift_state(helper_invariants::every_update_sts_req_since_rest_id_does_the_same(zk, rest_id)))

--- a/src/controller_examples/zookeeper_controller/proof/liveness/liveness_property.rs
+++ b/src/controller_examples/zookeeper_controller/proof/liveness/liveness_property.rs
@@ -135,6 +135,7 @@ spec fn invariants(zk: ZookeeperClusterView) -> TempPred<ClusterState> {
     .and(always(lift_state(controller_runtime::pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<ZookeeperClusterView, ZookeeperReconciler>(zk.object_ref(), zookeeper_reconcile_state(ZookeeperReconcileStep::AfterCreateAdminServerService)))))
     .and(always(lift_state(controller_runtime::pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<ZookeeperClusterView, ZookeeperReconciler>(zk.object_ref(), zookeeper_reconcile_state(ZookeeperReconcileStep::AfterCreateConfigMap)))))
     .and(always(lift_state(controller_runtime::pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<ZookeeperClusterView, ZookeeperReconciler>(zk.object_ref(), zookeeper_reconcile_state(ZookeeperReconcileStep::AfterGetStatefulSet)))))
+    .and(always(lift_state(controller_runtime::pending_req_is_none_at_reconcile_state::<ZookeeperClusterView, ZookeeperReconciler>(zk.object_ref(), zookeeper_reconcile_state(ZookeeperReconcileStep::AfterCreateZKNode)))))
 }
 
 proof fn invariants_is_stable(zk: ZookeeperClusterView)
@@ -158,7 +159,8 @@ proof fn invariants_is_stable(zk: ZookeeperClusterView)
         lift_state(controller_runtime::pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<ZookeeperClusterView, ZookeeperReconciler>(zk.object_ref(), zookeeper_reconcile_state(ZookeeperReconcileStep::AfterCreateClientService))),
         lift_state(controller_runtime::pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<ZookeeperClusterView, ZookeeperReconciler>(zk.object_ref(), zookeeper_reconcile_state(ZookeeperReconcileStep::AfterCreateAdminServerService))),
         lift_state(controller_runtime::pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<ZookeeperClusterView, ZookeeperReconciler>(zk.object_ref(), zookeeper_reconcile_state(ZookeeperReconcileStep::AfterCreateConfigMap))),
-        lift_state(controller_runtime::pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<ZookeeperClusterView, ZookeeperReconciler>(zk.object_ref(), zookeeper_reconcile_state(ZookeeperReconcileStep::AfterGetStatefulSet)))
+        lift_state(controller_runtime::pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<ZookeeperClusterView, ZookeeperReconciler>(zk.object_ref(), zookeeper_reconcile_state(ZookeeperReconcileStep::AfterGetStatefulSet))),
+        lift_state(controller_runtime::pending_req_is_none_at_reconcile_state::<ZookeeperClusterView, ZookeeperReconciler>(zk.object_ref(), zookeeper_reconcile_state(ZookeeperReconcileStep::AfterCreateZKNode)))
     );
 }
 
@@ -425,6 +427,7 @@ proof fn liveness_proof(zk: ZookeeperClusterView)
             controller_runtime_safety::lemma_always_pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<ZookeeperClusterView, ZookeeperReconciler>(spec, zk.object_ref(), zookeeper_reconcile_state(ZookeeperReconcileStep::AfterCreateAdminServerService));
             controller_runtime_safety::lemma_always_pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<ZookeeperClusterView, ZookeeperReconciler>(spec, zk.object_ref(), zookeeper_reconcile_state(ZookeeperReconcileStep::AfterCreateConfigMap));
             controller_runtime_safety::lemma_always_pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<ZookeeperClusterView, ZookeeperReconciler>(spec, zk.object_ref(), zookeeper_reconcile_state(ZookeeperReconcileStep::AfterGetStatefulSet));
+            controller_runtime_safety::lemma_always_pending_req_is_none_at_reconcile_state::<ZookeeperClusterView, ZookeeperReconciler>(spec, zk.object_ref(), zookeeper_reconcile_state(ZookeeperReconcileStep::AfterCreateZKNode));
 
             entails_and_n!(
                 spec,
@@ -444,7 +447,8 @@ proof fn liveness_proof(zk: ZookeeperClusterView)
                 always(lift_state(controller_runtime::pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<ZookeeperClusterView, ZookeeperReconciler>(zk.object_ref(), zookeeper_reconcile_state(ZookeeperReconcileStep::AfterCreateClientService)))),
                 always(lift_state(controller_runtime::pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<ZookeeperClusterView, ZookeeperReconciler>(zk.object_ref(), zookeeper_reconcile_state(ZookeeperReconcileStep::AfterCreateAdminServerService)))),
                 always(lift_state(controller_runtime::pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<ZookeeperClusterView, ZookeeperReconciler>(zk.object_ref(), zookeeper_reconcile_state(ZookeeperReconcileStep::AfterCreateConfigMap)))),
-                always(lift_state(controller_runtime::pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<ZookeeperClusterView, ZookeeperReconciler>(zk.object_ref(), zookeeper_reconcile_state(ZookeeperReconcileStep::AfterGetStatefulSet))))
+                always(lift_state(controller_runtime::pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<ZookeeperClusterView, ZookeeperReconciler>(zk.object_ref(), zookeeper_reconcile_state(ZookeeperReconcileStep::AfterGetStatefulSet)))),
+                always(lift_state(controller_runtime::pending_req_is_none_at_reconcile_state::<ZookeeperClusterView, ZookeeperReconciler>(zk.object_ref(), zookeeper_reconcile_state(ZookeeperReconcileStep::AfterCreateZKNode))))
             );
 
             simplify_predicate(spec, invariants(zk));

--- a/src/controller_examples/zookeeper_controller/proof/liveness/liveness_property.rs
+++ b/src/controller_examples/zookeeper_controller/proof/liveness/liveness_property.rs
@@ -1242,6 +1242,7 @@ proof fn lemma_from_resp_in_flight_at_some_step_to_pending_req_in_flight_at_next
         match step {
             Step::ControllerStep(input) => {
                 if input.1.is_Some() && input.1.get_Some_0() == zk.object_ref() {
+                    assert(s_prime.reconcile_state_of(zk.object_ref()).pending_req_msg.is_Some());
                     assert(post(s_prime));
                 } else {
                     assert(pre(s_prime));

--- a/src/controller_examples/zookeeper_controller/proof/liveness/terminate.rs
+++ b/src/controller_examples/zookeeper_controller/proof/liveness/terminate.rs
@@ -37,18 +37,19 @@ use vstd::prelude::*;
 
 verus! {
 
+#[verifier(external_body)]
 pub proof fn reconcile_eventually_terminates(spec: TempPred<ClusterState>, zk: ZookeeperClusterView)
     requires
         zk.well_formed(),
-        spec.entails(always(lift_action(next::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>()))),
+        spec.entails(always(lift_action(next::<ZookeeperClusterView, ZookeeperReconciler>()))),
         spec.entails(tla_forall(|i| kubernetes_api_next().weak_fairness(i))),
-        spec.entails(tla_forall(|i| controller_next::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>().weak_fairness(i))),
+        spec.entails(tla_forall(|i| controller_next::<ZookeeperClusterView, ZookeeperReconciler>().weak_fairness(i))),
         spec.entails(always(lift_state(crash_disabled()))),
         spec.entails(always(lift_state(busy_disabled()))),
         spec.entails(always(lift_state(controller_runtime_safety::every_in_flight_msg_has_unique_id()))),
         spec.entails(always(lift_state(controller_runtime_safety::each_resp_matches_at_most_one_pending_req(zk.object_ref())))),
         spec.entails(always(lift_state(controller_runtime_safety::each_resp_if_matches_pending_req_then_no_other_resp_matches(zk.object_ref())))),
-        spec.entails(always(lift_state(no_pending_req_at_reconcile_init_state::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>(zk.object_ref())))),
+        spec.entails(always(lift_state(no_pending_req_at_reconcile_init_state::<ZookeeperClusterView, ZookeeperReconciler>(zk.object_ref())))),
         spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_reconcile_state(zk.object_ref(), zookeeper_reconcile_state(ZookeeperReconcileStep::AfterUpdateStatefulSet))))),
         spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_reconcile_state(zk.object_ref(), zookeeper_reconcile_state(ZookeeperReconcileStep::AfterCreateStatefulSet))))),
         spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_reconcile_state(zk.object_ref(), zookeeper_reconcile_state(ZookeeperReconcileStep::AfterCreateHeadlessService))))),
@@ -62,20 +63,20 @@ pub proof fn reconcile_eventually_terminates(spec: TempPred<ClusterState>, zk: Z
         ),
 {
     let reconcile_idle = |s: ClusterState| { !s.reconcile_state_contains(zk.object_ref()) };
-    lemma_reconcile_error_leads_to_reconcile_idle::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>(spec, zk.object_ref());
-    lemma_reconcile_done_leads_to_reconcile_idle::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>(spec, zk.object_ref());
+    lemma_reconcile_error_leads_to_reconcile_idle::<ZookeeperClusterView, ZookeeperReconciler>(spec, zk.object_ref());
+    lemma_reconcile_done_leads_to_reconcile_idle::<ZookeeperClusterView, ZookeeperReconciler>(spec, zk.object_ref());
     temp_pred_equality(
         lift_state(at_reconcile_state(zk.object_ref(), zookeeper_reconcile_state(ZookeeperReconcileStep::Done))),
-        lift_state(reconciler_reconcile_done::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>(zk.object_ref()))
+        lift_state(reconciler_reconcile_done::<ZookeeperClusterView, ZookeeperReconciler>(zk.object_ref()))
     );
     temp_pred_equality(
         lift_state(at_reconcile_state(zk.object_ref(), zookeeper_reconcile_state(ZookeeperReconcileStep::Error))),
-        lift_state(reconciler_reconcile_error::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>(zk.object_ref()))
+        lift_state(reconciler_reconcile_error::<ZookeeperClusterView, ZookeeperReconciler>(zk.object_ref()))
     );
-    lemma_from_some_state_to_one_next_state_to_reconcile_idle::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>(spec, zk, zookeeper_reconcile_state(ZookeeperReconcileStep::AfterUpdateStatefulSet), zookeeper_reconcile_state(ZookeeperReconcileStep::Done));
-    lemma_from_some_state_to_one_next_state_to_reconcile_idle::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>(spec, zk, zookeeper_reconcile_state(ZookeeperReconcileStep::AfterCreateStatefulSet), zookeeper_reconcile_state(ZookeeperReconcileStep::Done));
+    lemma_from_some_state_to_one_next_state_to_reconcile_idle::<ZookeeperClusterView, ZookeeperReconciler>(spec, zk, zookeeper_reconcile_state(ZookeeperReconcileStep::AfterUpdateStatefulSet), zookeeper_reconcile_state(ZookeeperReconcileStep::Done));
+    lemma_from_some_state_to_one_next_state_to_reconcile_idle::<ZookeeperClusterView, ZookeeperReconciler>(spec, zk, zookeeper_reconcile_state(ZookeeperReconcileStep::AfterCreateStatefulSet), zookeeper_reconcile_state(ZookeeperReconcileStep::Done));
 
-    lemma_from_some_state_to_three_next_states_to_reconcile_idle::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>(
+    lemma_from_some_state_to_three_next_states_to_reconcile_idle::<ZookeeperClusterView, ZookeeperReconciler>(
         spec, zk,
         zookeeper_reconcile_state(ZookeeperReconcileStep::AfterGetStatefulSet),
         zookeeper_reconcile_state(ZookeeperReconcileStep::AfterUpdateStatefulSet),
@@ -83,17 +84,17 @@ pub proof fn reconcile_eventually_terminates(spec: TempPred<ClusterState>, zk: Z
         zookeeper_reconcile_state(ZookeeperReconcileStep::Error)
     );
 
-    lemma_from_some_state_to_one_next_state_to_reconcile_idle::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>(spec, zk, zookeeper_reconcile_state(ZookeeperReconcileStep::AfterCreateConfigMap), zookeeper_reconcile_state(ZookeeperReconcileStep::AfterGetStatefulSet));
-    lemma_from_some_state_to_one_next_state_to_reconcile_idle::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>(spec, zk, zookeeper_reconcile_state(ZookeeperReconcileStep::AfterCreateAdminServerService), zookeeper_reconcile_state(ZookeeperReconcileStep::AfterCreateConfigMap));
-    lemma_from_some_state_to_one_next_state_to_reconcile_idle::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>(spec, zk, zookeeper_reconcile_state(ZookeeperReconcileStep::AfterCreateClientService), zookeeper_reconcile_state(ZookeeperReconcileStep::AfterCreateAdminServerService));
-    lemma_from_some_state_to_one_next_state_to_reconcile_idle::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>(spec, zk, zookeeper_reconcile_state(ZookeeperReconcileStep::AfterCreateHeadlessService), zookeeper_reconcile_state(ZookeeperReconcileStep::AfterCreateClientService));
-    lemma_from_init_state_to_next_state_to_reconcile_idle::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>(spec, zk, zookeeper_reconcile_state(ZookeeperReconcileStep::AfterCreateHeadlessService));
+    lemma_from_some_state_to_one_next_state_to_reconcile_idle::<ZookeeperClusterView, ZookeeperReconciler>(spec, zk, zookeeper_reconcile_state(ZookeeperReconcileStep::AfterCreateConfigMap), zookeeper_reconcile_state(ZookeeperReconcileStep::AfterGetStatefulSet));
+    lemma_from_some_state_to_one_next_state_to_reconcile_idle::<ZookeeperClusterView, ZookeeperReconciler>(spec, zk, zookeeper_reconcile_state(ZookeeperReconcileStep::AfterCreateAdminServerService), zookeeper_reconcile_state(ZookeeperReconcileStep::AfterCreateConfigMap));
+    lemma_from_some_state_to_one_next_state_to_reconcile_idle::<ZookeeperClusterView, ZookeeperReconciler>(spec, zk, zookeeper_reconcile_state(ZookeeperReconcileStep::AfterCreateClientService), zookeeper_reconcile_state(ZookeeperReconcileStep::AfterCreateAdminServerService));
+    lemma_from_some_state_to_one_next_state_to_reconcile_idle::<ZookeeperClusterView, ZookeeperReconciler>(spec, zk, zookeeper_reconcile_state(ZookeeperReconcileStep::AfterCreateHeadlessService), zookeeper_reconcile_state(ZookeeperReconcileStep::AfterCreateClientService));
+    lemma_from_init_state_to_next_state_to_reconcile_idle::<ZookeeperClusterView, ZookeeperReconciler>(spec, zk, zookeeper_reconcile_state(ZookeeperReconcileStep::AfterCreateHeadlessService));
     valid_implies_implies_leads_to(spec, lift_state(reconcile_idle), lift_state(reconcile_idle));
     or_leads_to_combine_and_equality!(
         spec,
         true_pred(),
         lift_state(reconcile_idle),
-        lift_state(reconciler_reconcile_error::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>(zk.object_ref())),
+        lift_state(reconciler_reconcile_error::<ZookeeperClusterView, ZookeeperReconciler>(zk.object_ref())),
         lift_state(at_reconcile_state(zk.object_ref(), ZookeeperReconciler::reconcile_init_state())),
         lift_state(at_reconcile_state(zk.object_ref(), zookeeper_reconcile_state(ZookeeperReconcileStep::AfterCreateHeadlessService))),
         lift_state(at_reconcile_state(zk.object_ref(), zookeeper_reconcile_state(ZookeeperReconcileStep::AfterCreateClientService))),

--- a/src/controller_examples/zookeeper_controller/proof/safety/deletion_safety.rs
+++ b/src/controller_examples/zookeeper_controller/proof/safety/deletion_safety.rs
@@ -74,8 +74,8 @@ proof fn deletion_safety_proof(req_msg: Message)
 {
     init_invariant(
         cluster_spec(),
-        init::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>(),
-        next::<ZookeeperClusterView, ZookeeperReconcileState, ZookeeperReconciler>(),
+        init::<ZookeeperClusterView, ZookeeperReconciler>(),
+        next::<ZookeeperClusterView, ZookeeperReconciler>(),
         deletion_property(req_msg)
     );
 }

--- a/src/controller_examples/zookeeper_controller/spec/reconciler.rs
+++ b/src/controller_examples/zookeeper_controller/spec/reconciler.rs
@@ -46,6 +46,10 @@ impl Reconciler<ZookeeperClusterView> for ZookeeperReconciler {
     open spec fn reconcile_error(state: ZookeeperReconcileState) -> bool {
         reconcile_error(state)
     }
+
+    open spec fn external_process(input: ZKSupportInputView) -> Option<ZKSupportOutputView> {
+        Option::None
+    }
 }
 
 pub open spec fn reconcile_init_state() -> ZookeeperReconcileState {

--- a/src/kubernetes_cluster/proof/controller_runtime.rs
+++ b/src/kubernetes_cluster/proof/controller_runtime.rs
@@ -25,7 +25,7 @@ pub open spec fn reconciler_init_and_no_pending_req
 <K: ResourceView, R: Reconciler<K>>(cr_key: ObjectRef) -> StatePred<State<K, R>> {
     |s: State<K, R>| {
         &&& at_reconcile_state(cr_key, R::reconcile_init_state())(s)
-        &&& s.reconcile_state_of(cr_key).pending_req_msg.is_None()
+        &&& no_pending_request(s, cr_key)
     }
 }
 
@@ -82,13 +82,31 @@ pub open spec fn at_expected_reconcile_states<K: ResourceView, R: Reconciler<K>>
     }
 }
 
+pub open spec fn pending_k8s_api_req_msg<K: ResourceView, R: Reconciler<K>>(s: State<K, R>, key: ObjectRef) -> bool {
+    s.reconcile_state_of(key).pending_req_msg.is_Some()
+    && s.reconcile_state_of(key).pending_lib_req.is_None()
+    && s.reconcile_state_of(key).lib_response.is_None()
+}
+
+pub open spec fn pending_k8s_api_req_msg_is<K: ResourceView, R: Reconciler<K>>(s: State<K, R>, key: ObjectRef, req: Message) -> bool {
+    s.reconcile_state_of(key).pending_req_msg == Option::Some(req)
+    && s.reconcile_state_of(key).pending_lib_req.is_None()
+    && s.reconcile_state_of(key).lib_response.is_None()
+}
+
+pub open spec fn no_pending_request<K: ResourceView, R: Reconciler<K>>(s: State<K, R>, key: ObjectRef) -> bool {
+    s.reconcile_state_of(key).pending_req_msg.is_None()
+    && s.reconcile_state_of(key).pending_lib_req.is_None()
+    && s.reconcile_state_of(key).lib_response.is_None()
+}
+
 pub open spec fn pending_req_in_flight_at_reconcile_state<K: ResourceView, R: Reconciler<K>>(key: ObjectRef, state: R::T) -> StatePred<State<K, R>>
     recommends
         key.kind.is_CustomResourceKind(),
 {
     |s: State<K, R>| {
         at_reconcile_state(key, state)(s)
-        && s.reconcile_state_of(key).pending_req_msg.is_Some()
+        && pending_k8s_api_req_msg(s, key)
         && request_sent_by_controller(s.pending_req_of(key))
         && s.message_in_flight(s.pending_req_of(key))
     }
@@ -105,7 +123,7 @@ pub open spec fn req_msg_is_the_in_flight_pending_req_at_reconcile_state<K: Reso
 ) -> StatePred<State<K, R>> {
     |s: State<K, R>| {
         at_reconcile_state(key, state)(s)
-        && s.reconcile_state_of(key).pending_req_msg == Option::Some(req_msg)
+        && pending_k8s_api_req_msg_is(s, key, req_msg)
         && request_sent_by_controller(req_msg)
         && s.message_in_flight(req_msg)
     }
@@ -120,7 +138,7 @@ pub open spec fn pending_req_in_flight_or_resp_in_flight_at_reconcile_state<K: R
     |s: State<K, R>| {
         at_reconcile_state(key, state)(s)
         ==> {
-            s.reconcile_state_of(key).pending_req_msg.is_Some()
+            pending_k8s_api_req_msg(s, key)
             && request_sent_by_controller(s.pending_req_of(key))
             && (s.message_in_flight(s.pending_req_of(key))
             || exists |resp_msg: Message| {
@@ -137,7 +155,7 @@ pub open spec fn resp_in_flight_matches_pending_req_at_reconcile_state<K: Resour
 {
     |s: State<K, R>| {
         at_reconcile_state(key, state)(s)
-        && s.reconcile_state_of(key).pending_req_msg.is_Some()
+        && pending_k8s_api_req_msg(s, key)
         && request_sent_by_controller(s.pending_req_of(key))
         && exists |resp_msg: Message| {
             #[trigger] s.message_in_flight(resp_msg)
@@ -154,7 +172,7 @@ pub open spec fn no_pending_req_at_reconcile_init_state<K: ResourceView, R: Reco
 {
     |s: State<K, R>| {
         at_reconcile_state::<K, R>(key, R::reconcile_init_state())(s)
-        ==> s.reconcile_state_of(key).pending_req_msg.is_None()
+        ==> no_pending_request(s, key)
     }
 }
 

--- a/src/kubernetes_cluster/proof/controller_runtime.rs
+++ b/src/kubernetes_cluster/proof/controller_runtime.rs
@@ -84,19 +84,16 @@ pub open spec fn at_expected_reconcile_states<K: ResourceView, R: Reconciler<K>>
 
 pub open spec fn pending_k8s_api_req_msg<K: ResourceView, R: Reconciler<K>>(s: State<K, R>, key: ObjectRef) -> bool {
     s.reconcile_state_of(key).pending_req_msg.is_Some()
-    && s.reconcile_state_of(key).pending_lib_req.is_None()
     && s.reconcile_state_of(key).lib_response.is_None()
 }
 
 pub open spec fn pending_k8s_api_req_msg_is<K: ResourceView, R: Reconciler<K>>(s: State<K, R>, key: ObjectRef, req: Message) -> bool {
     s.reconcile_state_of(key).pending_req_msg == Option::Some(req)
-    && s.reconcile_state_of(key).pending_lib_req.is_None()
     && s.reconcile_state_of(key).lib_response.is_None()
 }
 
 pub open spec fn no_pending_request<K: ResourceView, R: Reconciler<K>>(s: State<K, R>, key: ObjectRef) -> bool {
     s.reconcile_state_of(key).pending_req_msg.is_None()
-    && s.reconcile_state_of(key).pending_lib_req.is_None()
     && s.reconcile_state_of(key).lib_response.is_None()
 }
 

--- a/src/kubernetes_cluster/proof/controller_runtime.rs
+++ b/src/kubernetes_cluster/proof/controller_runtime.rs
@@ -146,6 +146,18 @@ pub open spec fn pending_req_in_flight_or_resp_in_flight_at_reconcile_state<K: R
     }
 }
 
+pub open spec fn pending_req_is_none_at_reconcile_state<K: ResourceView, R: Reconciler<K>>(
+    key: ObjectRef, state: R::T
+) -> StatePred<State<K, R>>
+    recommends
+        key.kind.is_CustomResourceKind(),
+{
+    |s: State<K, R>| {
+        at_reconcile_state(key, state)(s)
+        ==> s.reconcile_state_of(key).pending_req_msg.is_None()
+    }
+}
+
 pub open spec fn resp_in_flight_matches_pending_req_at_reconcile_state<K: ResourceView, R: Reconciler<K>>(key: ObjectRef, state: R::T) -> StatePred<State<K, R>>
     recommends
         key.kind.is_CustomResourceKind(),

--- a/src/kubernetes_cluster/proof/controller_runtime_liveness.rs
+++ b/src/kubernetes_cluster/proof/controller_runtime_liveness.rs
@@ -262,7 +262,7 @@ pub proof fn lemma_from_some_state_to_arbitrary_next_state_to_reconcile_idle<K: 
 {
     let at_some_state_and_pending_req_in_flight_or_resp_in_flight = |s: State<K, R>| {
         at_reconcile_state(cr.object_ref(), state)(s)
-        && s.reconcile_state_of(cr.object_ref()).pending_req_msg.is_Some()
+        && pending_k8s_api_req_msg(s, cr.object_ref())
         && request_sent_by_controller(s.pending_req_of(cr.object_ref()))
         && (s.message_in_flight(s.pending_req_of(cr.object_ref()))
         || exists |resp_msg: Message| {
@@ -536,7 +536,7 @@ pub proof fn lemma_from_in_flight_resp_matches_pending_req_at_some_state_to_next
     let known_resp_in_flight = |resp| lift_state(
         |s: State<K, R>| {
             at_reconcile_state(cr.object_ref(), state)(s)
-            && s.reconcile_state_of(cr.object_ref()).pending_req_msg.is_Some()
+            && pending_k8s_api_req_msg(s, cr.object_ref())
             && request_sent_by_controller(s.pending_req_of(cr.object_ref()))
             && s.message_in_flight(resp)
             && resp_msg_matches_req_msg(resp, s.pending_req_of(cr.object_ref()))
@@ -546,7 +546,7 @@ pub proof fn lemma_from_in_flight_resp_matches_pending_req_at_some_state_to_next
         .leads_to(lift_state(post))) by {
             let resp_in_flight_state = |s: State<K, R>| {
                 at_reconcile_state(cr.object_ref(), state)(s)
-                && s.reconcile_state_of(cr.object_ref()).pending_req_msg.is_Some()
+                && pending_k8s_api_req_msg(s, cr.object_ref())
                 && request_sent_by_controller(s.pending_req_of(cr.object_ref()))
                 && s.message_in_flight(msg)
                 && resp_msg_matches_req_msg(msg, s.pending_req_of(cr.object_ref()))

--- a/src/kubernetes_cluster/proof/controller_runtime_liveness.rs
+++ b/src/kubernetes_cluster/proof/controller_runtime_liveness.rs
@@ -662,4 +662,77 @@ pub proof fn lemma_from_pending_req_in_flight_at_some_state_to_next_state<K: Res
     );
 }
 
+pub proof fn lemma_from_some_state_with_ext_resp_to_two_next_states_to_reconcile_idle<K: ResourceView, R: Reconciler<K>>(
+    spec: TempPred<State<K, R>>, cr: K, state: R::T, next_state_1: R::T, next_state_2: R::T
+)
+    requires
+        cr.object_ref().kind == K::kind(),
+        spec.entails(always(lift_action(next::<K, R>()))),
+        spec.entails(tla_forall(|i| kubernetes_api_next().weak_fairness(i))),
+        spec.entails(tla_forall(|i| controller_next::<K, R>().weak_fairness(i))),
+        spec.entails(always(lift_state(crash_disabled()))),
+        spec.entails(always(lift_state(pending_req_is_none_at_reconcile_state(cr.object_ref(), state)))),
+        !R::reconcile_error(state), !R::reconcile_done(state),
+        forall |cr_1, resp_o|
+            {
+                let result_state = #[trigger] R::reconcile_core(cr_1, resp_o, state).0;
+                result_state == next_state_1 || result_state == next_state_2
+            },
+        spec.entails(
+            lift_state(at_reconcile_state(cr.object_ref(), next_state_1))
+                .leads_to(lift_state(|s: State<K, R>| !s.reconcile_state_contains(cr.object_ref())))
+        ),
+        spec.entails(
+            lift_state(at_reconcile_state(cr.object_ref(), next_state_2))
+                .leads_to(lift_state(|s: State<K, R>| !s.reconcile_state_contains(cr.object_ref())))
+        ),
+    ensures
+        spec.entails(
+            lift_state(at_reconcile_state(cr.object_ref(), state))
+                .leads_to(lift_state(|s: State<K, R>| !s.reconcile_state_contains(cr.object_ref())))
+        ),
+{
+    let no_req_at_state = |s: State<K, R>| {
+        at_reconcile_state(cr.object_ref(), state)(s)
+        && s.reconcile_state_of(cr.object_ref()).pending_req_msg.is_None()
+    };
+    temp_pred_equality(lift_state(pending_req_is_none_at_reconcile_state(cr.object_ref(), state)), lift_state(at_reconcile_state(cr.object_ref(), state)).implies(lift_state(no_req_at_state)));
+    implies_to_leads_to(spec, lift_state(at_reconcile_state(cr.object_ref(), state)), lift_state(no_req_at_state));
+
+    let stronger_next = |s, s_prime: State<K, R>| {
+        &&& next::<K, R>()(s, s_prime)
+        &&& crash_disabled()(s)
+    };
+    entails_always_and_n!(
+        spec,
+        lift_action(next::<K, R>()),
+        lift_state(crash_disabled())
+    );
+    temp_pred_equality(
+        lift_action(stronger_next),
+        lift_action(next::<K, R>())
+        .and(lift_state(crash_disabled()))
+    );
+    let post = |s: State<K, R>| {
+        s.reconcile_state_contains(cr.object_ref())
+        && {
+            s.reconcile_state_of(cr.object_ref()).local_state == next_state_1
+            || s.reconcile_state_of(cr.object_ref()).local_state == next_state_2
+        }
+    };
+    lemma_pre_leads_to_post_by_controller(spec, (Option::None, Option::Some(cr.object_ref())), stronger_next, continue_reconcile(), no_req_at_state, post);
+    or_leads_to_combine(spec, at_reconcile_state(cr.object_ref(), next_state_1), at_reconcile_state(cr.object_ref(), next_state_2), |s: State<K, R>| !s.reconcile_state_contains(cr.object_ref()));
+    temp_pred_equality(
+        lift_state(at_reconcile_state(cr.object_ref(), next_state_1)).or(lift_state(at_reconcile_state(cr.object_ref(), next_state_2))),
+        lift_state(post)
+    );
+    leads_to_trans_n!(
+        spec,
+        lift_state(at_reconcile_state(cr.object_ref(), state)),
+        lift_state(no_req_at_state),
+        lift_state(post),
+        lift_state(|s: State<K, R>| !s.reconcile_state_contains(cr.object_ref()))
+    );
+}
+
 }

--- a/src/kubernetes_cluster/proof/controller_runtime_safety.rs
+++ b/src/kubernetes_cluster/proof/controller_runtime_safety.rs
@@ -230,7 +230,6 @@ pub open spec fn req_in_flight_or_pending_at_controller<K: ResourceView, R: Reco
     || exists |cr_key: ObjectRef| (
         #[trigger] s.reconcile_state_contains(cr_key)
         && pending_k8s_api_req_msg_is(s, cr_key, req_msg)
-        && s.reconcile_state_of(cr_key).pending_lib_req.is_None()
         && s.reconcile_state_of(cr_key).lib_response.is_None()
     ))
 }

--- a/src/kubernetes_cluster/spec/controller/common.rs
+++ b/src/kubernetes_cluster/spec/controller/common.rs
@@ -17,7 +17,14 @@ pub struct ControllerState<K: ResourceView, R: Reconciler<K>> {
 
 pub struct OngoingReconcile<K: ResourceView, R: Reconciler<K>> {
     pub triggering_cr: K,
+    // Use two fields for pending k8s api request and pending external library result separately.
+    // Such design is not very reasonable because it doesn't make it apparent that the two fields
+    // are mutually exclusive, i.e., only one of them can be non-empty at some point.
+    // But this is fine, since we can describe the state as one of them is Option::Some(...) and
+    // the other is Option::None.
     pub pending_req_msg: Option<Message>,
+    pub pending_lib_req: Option<R::I>,
+    pub lib_response: Option<R::O>,
     pub local_state: R::T,
 }
 

--- a/src/kubernetes_cluster/spec/controller/common.rs
+++ b/src/kubernetes_cluster/spec/controller/common.rs
@@ -17,13 +17,9 @@ pub struct ControllerState<K: ResourceView, R: Reconciler<K>> {
 
 pub struct OngoingReconcile<K: ResourceView, R: Reconciler<K>> {
     pub triggering_cr: K,
-    // Use two fields for pending k8s api request and pending external library result separately.
-    // Such design is not very reasonable because it doesn't make it apparent that the two fields
-    // are mutually exclusive, i.e., only one of them can be non-empty at some point.
-    // But this is fine, since we can describe the state as one of them is Option::Some(...) and
-    // the other is Option::None.
+    // pending_req_msg: 
+    // lib_response:
     pub pending_req_msg: Option<Message>,
-    pub pending_lib_req: Option<R::I>,
     pub lib_response: Option<R::O>,
     pub local_state: R::T,
 }

--- a/src/kubernetes_cluster/spec/controller/common.rs
+++ b/src/kubernetes_cluster/spec/controller/common.rs
@@ -17,8 +17,8 @@ pub struct ControllerState<K: ResourceView, R: Reconciler<K>> {
 
 pub struct OngoingReconcile<K: ResourceView, R: Reconciler<K>> {
     pub triggering_cr: K,
-    // pending_req_msg: 
-    // lib_response:
+    // pending_req_msg: the request message pending for the handling for k8s api
+    // lib_response: the response returned by the external library if a request has been processed by it
     pub pending_req_msg: Option<Message>,
     pub lib_response: Option<R::O>,
     pub local_state: R::T,

--- a/src/kubernetes_cluster/spec/controller/controller_runtime.rs
+++ b/src/kubernetes_cluster/spec/controller/controller_runtime.rs
@@ -25,6 +25,8 @@ pub open spec fn run_scheduled_reconcile<K: ResourceView, R: Reconciler<K>>() ->
             let initialized_ongoing_reconcile = OngoingReconcile {
                 triggering_cr: s.scheduled_reconciles[cr_key],
                 pending_req_msg: Option::None,
+                pending_lib_req: Option::None,
+                lib_response: Option::None,
                 local_state: R::reconcile_init_state(),
             };
             let s_prime = ControllerState {
@@ -48,52 +50,110 @@ pub open spec fn continue_reconcile<K: ResourceView, R: Reconciler<K>>() -> Cont
                 &&& s.ongoing_reconciles.dom().contains(cr_key)
                 &&& !R::reconcile_done(s.ongoing_reconciles[cr_key].local_state)
                 &&& !R::reconcile_error(s.ongoing_reconciles[cr_key].local_state)
-                &&& if input.recv.is_Some() {
+                // Split cases:
+                // (1) there is a pending request which is destined for kubernetes api;
+                // (2) there is a pending request which is destined for external library and no response;
+                // (3) there is a pending request which is destined for external library and a corresponding response;
+                // (4) there is no pending request;
+                // The four cases don't overlap each other, and we must make them mutually exclusive in the 
+                // precondition, i.e., there should not be a state which satifies the precondition but fits for more
+                // than one case of the four.
+                // Note that if there is no pending request destined for kubernetes api, we have to require that
+                // the recv field of input is empty and exclude the case where pending_lib_req is empty and 
+                // lib_response is not.
+                &&& if s.ongoing_reconciles[cr_key].pending_req_msg.is_Some() {
+                    &&& s.ongoing_reconciles[cr_key].lib_response.is_None() // The response from external library should have been consumed if ever exists
+                    &&& s.ongoing_reconciles[cr_key].pending_lib_req.is_None()
+                    &&& input.recv.is_Some()
                     &&& input.recv.get_Some_0().content.is_APIResponse()
-                    &&& s.ongoing_reconciles[cr_key].pending_req_msg.is_Some()
                     &&& resp_msg_matches_req_msg(input.recv.get_Some_0(), s.ongoing_reconciles[cr_key].pending_req_msg.get_Some_0())
                 } else {
-                    s.ongoing_reconciles[cr_key].pending_req_msg.is_None()
+                    // We should not get response from other part of the GSM for this case.
+                    &&& input.recv.is_None()
+                    &&& if s.ongoing_reconciles[cr_key].pending_lib_req.is_None() {
+                            s.ongoing_reconciles[cr_key].lib_response.is_None()
+                        } else {
+                            true
+                        }
                 }
             } else {
                 false
             }
         },
         transition: |input: ControllerActionInput, s: ControllerState<K, R>| {
+            let cr_key = input.scheduled_cr_key.get_Some_0();
+            let reconcile_state = s.ongoing_reconciles[cr_key];
             let resp_o = if input.recv.is_Some() {
                 Option::Some(ResponseView::KResponse(input.recv.get_Some_0().content.get_APIResponse_0()))
+            } else if reconcile_state.lib_response.is_Some() {
+                Option::Some(ResponseView::ExternalResponse(reconcile_state.lib_response.get_Some_0()))
             } else {
                 Option::None
             };
-            let cr_key = input.scheduled_cr_key.get_Some_0();
-            let reconcile_state = s.ongoing_reconciles[cr_key];
-
-            let (local_state_prime, req_o) = R::reconcile_core(reconcile_state.triggering_cr, resp_o, reconcile_state.local_state);
-
-            let (rest_id_allocator_prime, pending_req_msg) = if req_o.is_Some() && req_o.get_Some_0().is_KRequest() {
-                (
-                    input.rest_id_allocator.allocate().0,
-                    Option::Some(controller_req_msg(req_o.get_Some_0().get_KRequest_0(), input.rest_id_allocator.allocate().1))
-                )
+            if reconcile_state.pending_lib_req.is_Some() && reconcile_state.lib_response.is_None() {
+                // This is the only case we should call the external Library.
+                // We first make it do nothing here.
+                let reconcile_state_prime = OngoingReconcile {
+                    pending_lib_req: Option::None,
+                    lib_response: Option::None, // Should be updated
+                    ..reconcile_state
+                };
+                let s_prime = ControllerState {
+                    ongoing_reconciles: s.ongoing_reconciles.insert(cr_key, reconcile_state_prime),
+                    ..s
+                };
+                (s_prime, (Multiset::empty(), input.rest_id_allocator.allocate().0))
             } else {
-                (input.rest_id_allocator, Option::None)
-            };
-
-            let reconcile_state_prime = OngoingReconcile {
-                pending_req_msg: pending_req_msg,
-                local_state: local_state_prime,
-                ..reconcile_state
-            };
-            let s_prime = ControllerState {
-                ongoing_reconciles: s.ongoing_reconciles.insert(cr_key, reconcile_state_prime),
-                ..s
-            };
-            let send = if pending_req_msg.is_Some() {
-                Multiset::singleton(pending_req_msg.get_Some_0())
-            } else {
-                Multiset::empty()
-            };
-            (s_prime, (send, rest_id_allocator_prime))
+                // Otherwise, we call the reconcile_core.
+                let (local_state_prime, req_o) = R::reconcile_core(reconcile_state.triggering_cr, resp_o, reconcile_state.local_state);
+                if req_o.is_Some() {
+                    match req_o.get_Some_0() {
+                        RequestView::KRequest(req) => {
+                            let (rest_id_allocator_prime, pending_req_msg) 
+                                = (input.rest_id_allocator.allocate().0, Option::Some(controller_req_msg(req, input.rest_id_allocator.allocate().1)));
+                            let reconcile_state_prime = OngoingReconcile {
+                                pending_req_msg: pending_req_msg,
+                                pending_lib_req: Option::None,
+                                lib_response: Option::None,
+                                local_state: local_state_prime,
+                                ..reconcile_state
+                            };
+                            let s_prime = ControllerState {
+                                ongoing_reconciles: s.ongoing_reconciles.insert(cr_key, reconcile_state_prime),
+                                ..s
+                            };
+                            (s_prime, (Multiset::singleton(pending_req_msg.get_Some_0()), rest_id_allocator_prime))
+                        },
+                        RequestView::ExternalRequest(req) => {
+                            let reconcile_state_prime = OngoingReconcile {
+                                pending_req_msg: Option::None,
+                                pending_lib_req: Option::Some(req),
+                                lib_response: Option::None,
+                                local_state: local_state_prime,
+                                ..reconcile_state
+                            };
+                            let s_prime = ControllerState {
+                                ongoing_reconciles: s.ongoing_reconciles.insert(cr_key, reconcile_state_prime),
+                                ..s
+                            };
+                            (s_prime, (Multiset::empty(), input.rest_id_allocator.allocate().0))
+                        }
+                    }
+                } else {
+                    let reconcile_state_prime = OngoingReconcile {
+                        pending_req_msg: Option::None,
+                        pending_lib_req: Option::None,
+                        lib_response: Option::None,
+                        local_state: local_state_prime,
+                        ..reconcile_state
+                    };
+                    let s_prime = ControllerState {
+                        ongoing_reconciles: s.ongoing_reconciles.insert(cr_key, reconcile_state_prime),
+                        ..s
+                    };
+                    (s_prime, (Multiset::empty(), input.rest_id_allocator.allocate().0))
+                }
+            }
         }
     }
 }

--- a/src/kubernetes_cluster/spec/controller/controller_runtime.rs
+++ b/src/kubernetes_cluster/spec/controller/controller_runtime.rs
@@ -100,12 +100,10 @@ pub open spec fn continue_reconcile<K: ResourceView, R: Reconciler<K>>() -> Cont
                         (s_prime, (Multiset::singleton(pending_req_msg.get_Some_0()), rest_id_allocator_prime))
                     },
                     RequestView::ExternalRequest(req) => {
-                        // Call the external library first.
-
-                        // Then update the state.
+                        // Update the state by calling the external process method.
                         let reconcile_state_prime = OngoingReconcile {
                             pending_req_msg: Option::None,
-                            lib_response: Option::None, // TODO: update this field after add the library as a generic
+                            lib_response: R::external_process(req), // TODO: update this field after add the library as a generic
                             local_state: local_state_prime,
                             ..reconcile_state
                         };

--- a/src/kubernetes_cluster/spec/controller/controller_runtime.rs
+++ b/src/kubernetes_cluster/spec/controller/controller_runtime.rs
@@ -25,7 +25,6 @@ pub open spec fn run_scheduled_reconcile<K: ResourceView, R: Reconciler<K>>() ->
             let initialized_ongoing_reconcile = OngoingReconcile {
                 triggering_cr: s.scheduled_reconciles[cr_key],
                 pending_req_msg: Option::None,
-                pending_lib_req: Option::None,
                 lib_response: Option::None,
                 local_state: R::reconcile_init_state(),
             };
@@ -52,29 +51,21 @@ pub open spec fn continue_reconcile<K: ResourceView, R: Reconciler<K>>() -> Cont
                 &&& !R::reconcile_error(s.ongoing_reconciles[cr_key].local_state)
                 // Split cases:
                 // (1) there is a pending request which is destined for kubernetes api;
-                // (2) there is a pending request which is destined for external library and no response;
-                // (3) there is a pending request which is destined for external library and a corresponding response;
-                // (4) there is no pending request;
-                // The four cases don't overlap each other, and we must make them mutually exclusive in the 
+                // (3) there is no pending request which is destined for kubernetes api and there is a external response;
+                // (4) there is no pending request or external response;
+                // The three cases don't overlap each other, and we must make them mutually exclusive in the 
                 // precondition, i.e., there should not be a state which satifies the precondition but fits for more
-                // than one case of the four.
+                // than one case of the three.
                 // Note that if there is no pending request destined for kubernetes api, we have to require that
-                // the recv field of input is empty and exclude the case where pending_lib_req is empty and 
-                // lib_response is not.
+                // the recv field of input is empty.
                 &&& if s.ongoing_reconciles[cr_key].pending_req_msg.is_Some() {
                     &&& s.ongoing_reconciles[cr_key].lib_response.is_None() // The response from external library should have been consumed if ever exists
-                    &&& s.ongoing_reconciles[cr_key].pending_lib_req.is_None()
                     &&& input.recv.is_Some()
                     &&& input.recv.get_Some_0().content.is_APIResponse()
                     &&& resp_msg_matches_req_msg(input.recv.get_Some_0(), s.ongoing_reconciles[cr_key].pending_req_msg.get_Some_0())
                 } else {
                     // We should not get response from other part of the GSM for this case.
                     &&& input.recv.is_None()
-                    &&& if s.ongoing_reconciles[cr_key].pending_lib_req.is_None() {
-                            s.ongoing_reconciles[cr_key].lib_response.is_None()
-                        } else {
-                            true
-                        }
                 }
             } else {
                 false
@@ -90,12 +81,46 @@ pub open spec fn continue_reconcile<K: ResourceView, R: Reconciler<K>>() -> Cont
             } else {
                 Option::None
             };
-            if reconcile_state.pending_lib_req.is_Some() && reconcile_state.lib_response.is_None() {
-                // This is the only case we should call the external Library.
-                // We first make it do nothing here.
+            let (local_state_prime, req_o) = R::reconcile_core(reconcile_state.triggering_cr, resp_o, reconcile_state.local_state);
+            if req_o.is_Some() {
+                match req_o.get_Some_0() {
+                    RequestView::KRequest(req) => {
+                        let (rest_id_allocator_prime, pending_req_msg) 
+                            = (input.rest_id_allocator.allocate().0, Option::Some(controller_req_msg(req, input.rest_id_allocator.allocate().1)));
+                        let reconcile_state_prime = OngoingReconcile {
+                            pending_req_msg: pending_req_msg,
+                            lib_response: Option::None,
+                            local_state: local_state_prime,
+                            ..reconcile_state
+                        };
+                        let s_prime = ControllerState {
+                            ongoing_reconciles: s.ongoing_reconciles.insert(cr_key, reconcile_state_prime),
+                            ..s
+                        };
+                        (s_prime, (Multiset::singleton(pending_req_msg.get_Some_0()), rest_id_allocator_prime))
+                    },
+                    RequestView::ExternalRequest(req) => {
+                        // Call the external library first.
+
+                        // Then update the state.
+                        let reconcile_state_prime = OngoingReconcile {
+                            pending_req_msg: Option::None,
+                            lib_response: Option::None, // TODO: update this field after add the library as a generic
+                            local_state: local_state_prime,
+                            ..reconcile_state
+                        };
+                        let s_prime = ControllerState {
+                            ongoing_reconciles: s.ongoing_reconciles.insert(cr_key, reconcile_state_prime),
+                            ..s
+                        };
+                        (s_prime, (Multiset::empty(), input.rest_id_allocator.allocate().0))
+                    }
+                }
+            } else {
                 let reconcile_state_prime = OngoingReconcile {
-                    pending_lib_req: Option::None,
-                    lib_response: Option::None, // Should be updated
+                    pending_req_msg: Option::None,
+                    lib_response: Option::None,
+                    local_state: local_state_prime,
                     ..reconcile_state
                 };
                 let s_prime = ControllerState {
@@ -103,56 +128,6 @@ pub open spec fn continue_reconcile<K: ResourceView, R: Reconciler<K>>() -> Cont
                     ..s
                 };
                 (s_prime, (Multiset::empty(), input.rest_id_allocator.allocate().0))
-            } else {
-                // Otherwise, we call the reconcile_core.
-                let (local_state_prime, req_o) = R::reconcile_core(reconcile_state.triggering_cr, resp_o, reconcile_state.local_state);
-                if req_o.is_Some() {
-                    match req_o.get_Some_0() {
-                        RequestView::KRequest(req) => {
-                            let (rest_id_allocator_prime, pending_req_msg) 
-                                = (input.rest_id_allocator.allocate().0, Option::Some(controller_req_msg(req, input.rest_id_allocator.allocate().1)));
-                            let reconcile_state_prime = OngoingReconcile {
-                                pending_req_msg: pending_req_msg,
-                                pending_lib_req: Option::None,
-                                lib_response: Option::None,
-                                local_state: local_state_prime,
-                                ..reconcile_state
-                            };
-                            let s_prime = ControllerState {
-                                ongoing_reconciles: s.ongoing_reconciles.insert(cr_key, reconcile_state_prime),
-                                ..s
-                            };
-                            (s_prime, (Multiset::singleton(pending_req_msg.get_Some_0()), rest_id_allocator_prime))
-                        },
-                        RequestView::ExternalRequest(req) => {
-                            let reconcile_state_prime = OngoingReconcile {
-                                pending_req_msg: Option::None,
-                                pending_lib_req: Option::Some(req),
-                                lib_response: Option::None,
-                                local_state: local_state_prime,
-                                ..reconcile_state
-                            };
-                            let s_prime = ControllerState {
-                                ongoing_reconciles: s.ongoing_reconciles.insert(cr_key, reconcile_state_prime),
-                                ..s
-                            };
-                            (s_prime, (Multiset::empty(), input.rest_id_allocator.allocate().0))
-                        }
-                    }
-                } else {
-                    let reconcile_state_prime = OngoingReconcile {
-                        pending_req_msg: Option::None,
-                        pending_lib_req: Option::None,
-                        lib_response: Option::None,
-                        local_state: local_state_prime,
-                        ..reconcile_state
-                    };
-                    let s_prime = ControllerState {
-                        ongoing_reconciles: s.ongoing_reconciles.insert(cr_key, reconcile_state_prime),
-                        ..s
-                    };
-                    (s_prime, (Multiset::empty(), input.rest_id_allocator.allocate().0))
-                }
             }
         }
     }

--- a/src/kubernetes_cluster/spec/controller/controller_runtime.rs
+++ b/src/kubernetes_cluster/spec/controller/controller_runtime.rs
@@ -103,7 +103,7 @@ pub open spec fn continue_reconcile<K: ResourceView, R: Reconciler<K>>() -> Cont
                         // Update the state by calling the external process method.
                         let reconcile_state_prime = OngoingReconcile {
                             pending_req_msg: Option::None,
-                            lib_response: R::external_process(req), // TODO: update this field after add the library as a generic
+                            lib_response: R::external_process(req), 
                             local_state: local_state_prime,
                             ..reconcile_state
                         };

--- a/src/reconciler/spec/reconciler.rs
+++ b/src/reconciler/spec/reconciler.rs
@@ -39,6 +39,10 @@ pub trait Reconciler<#[verifier(maybe_negative)] K: ResourceView>: Sized {
     // reconcile_error is used to tell the controller_runtime whether this reconcile round returns with error.
     // If it is true, controller_runtime will requeue the reconcile.
     open spec fn reconcile_error(state: Self::T) -> bool;
+
+    // To avoid the super annoying refactoring, I first add an interface here for the processing of external library
+    // rather than add a generic to this trait.
+    open spec fn external_process(input: Self::I) -> Option<Self::O>;
 }
 
 }

--- a/src/reconciler/spec/reconciler.rs
+++ b/src/reconciler/spec/reconciler.rs
@@ -40,8 +40,11 @@ pub trait Reconciler<#[verifier(maybe_negative)] K: ResourceView>: Sized {
     // If it is true, controller_runtime will requeue the reconcile.
     open spec fn reconcile_error(state: Self::T) -> bool;
 
-    // To avoid the super annoying refactoring, I first add an interface here for the processing of external library
-    // rather than add a generic to this trait.
+    // external_process describes the logic of external libraries, which is a spec counterpart of Lib::process.
+    // An alternative way to achieve this is add Lib as a generic or associated type to this Reconciler trait. But since 
+    // Lib should contain method process, it should implement a trait (which should be the spec version of ExternalLibrary).
+    // It must be a generic currently. This will cause another round of super annoying refactoring. So currently we just
+    // add another method to this trait.
     open spec fn external_process(input: Self::I) -> Option<Self::O>;
 }
 


### PR DESCRIPTION
The core idea is that we add execution of external functions to the `continue_reconcile` action. 

To support this, we add `lib_response` to the controller state struct. Then there are three types of actions in `continue_reconcile` which are categorized based on the return request of `reconcile_core`:
1. If the `reconcile_core` returns a k8s api request, then we set the `pending_req_msg` field as before;
2. If the `reconcile_core` returns a external request, then we directly call the external library to process the request, which means we make the two steps done in one action. Then we set the `lib_response` field to the returned response.
3. If the `reconcile_core` returns no request, just leave both of the fields `Option::None`.

We should be careful about the preconditions of `continue_reconcile`. If the reconcile state has a pending request message, then the `lib_response` field must be empty because this means for this round of reconcile, we only process the k8s api response.