### PR TITLE
Use closure to describe reconcile states in controller runtime proof

### DIFF
--- a/src/controller_examples/rabbitmq_controller/proof/common.rs
+++ b/src/controller_examples/rabbitmq_controller/proof/common.rs
@@ -30,6 +30,14 @@ pub open spec fn rabbitmq_reconcile_state(step: RabbitmqReconcileStep) -> Rabbit
     }
 }
 
+pub open spec fn get_reconcile_state(rabbitmq: RabbitmqClusterView, step: RabbitmqReconcileStep) -> StatePred<ClusterState> {
+    at_expected_reconcile_states(rabbitmq.object_ref(), |s: RabbitmqReconcileState| s.reconcile_step == step)
+}
+
+pub open spec fn get_closure(step: RabbitmqReconcileStep) -> FnSpec(RabbitmqReconcileState) -> bool {
+    |s: RabbitmqReconcileState| s.reconcile_step == step
+}
+
 pub open spec fn at_rabbitmq_step(key: ObjectRef, step: RabbitmqReconcileStep) -> StatePred<ClusterState>
     recommends
         key.kind.is_CustomResourceKind()

--- a/src/controller_examples/rabbitmq_controller/proof/common.rs
+++ b/src/controller_examples/rabbitmq_controller/proof/common.rs
@@ -30,14 +30,6 @@ pub open spec fn rabbitmq_reconcile_state(step: RabbitmqReconcileStep) -> Rabbit
     }
 }
 
-pub open spec fn get_reconcile_state(rabbitmq: RabbitmqClusterView, step: RabbitmqReconcileStep) -> StatePred<ClusterState> {
-    at_expected_reconcile_states(rabbitmq.object_ref(), |s: RabbitmqReconcileState| s.reconcile_step == step)
-}
-
-pub open spec fn get_closure(step: RabbitmqReconcileStep) -> FnSpec(RabbitmqReconcileState) -> bool {
-    |s: RabbitmqReconcileState| s.reconcile_step == step
-}
-
 pub open spec fn at_rabbitmq_step(key: ObjectRef, step: RabbitmqReconcileStep) -> StatePred<ClusterState>
     recommends
         key.kind.is_CustomResourceKind()

--- a/src/controller_examples/rabbitmq_controller/proof/common.rs
+++ b/src/controller_examples/rabbitmq_controller/proof/common.rs
@@ -24,12 +24,6 @@ pub open spec fn cluster_spec() -> TempPred<ClusterState> {
     sm_spec::<RabbitmqClusterView, RabbitmqReconciler>()
 }
 
-pub open spec fn rabbitmq_reconcile_state(step: RabbitmqReconcileStep) -> RabbitmqReconcileState {
-    RabbitmqReconcileState {
-        reconcile_step: step
-    }
-}
-
 pub open spec fn at_rabbitmq_step(key: ObjectRef, step: RabbitmqReconcileStep) -> StatePred<ClusterState>
     recommends
         key.kind.is_CustomResourceKind()
@@ -38,6 +32,10 @@ pub open spec fn at_rabbitmq_step(key: ObjectRef, step: RabbitmqReconcileStep) -
         &&& s.reconcile_state_contains(key)
         &&& s.reconcile_state_of(key).local_state.reconcile_step == step
     }
+}
+
+pub open spec fn at_step_closure(step: RabbitmqReconcileStep) -> FnSpec(RabbitmqReconcileState) -> bool {
+    |s: RabbitmqReconcileState| s.reconcile_step == step
 }
 
 pub open spec fn at_rabbitmq_step_with_rabbitmq(rabbitmq: RabbitmqClusterView, step: RabbitmqReconcileStep) -> StatePred<ClusterState> {

--- a/src/controller_examples/rabbitmq_controller/proof/liveness.rs
+++ b/src/controller_examples/rabbitmq_controller/proof/liveness.rs
@@ -127,21 +127,21 @@ spec fn invariants(rabbitmq: RabbitmqClusterView) -> TempPred<ClusterState> {
     .and(always(lift_state(cluster_safety::each_key_in_reconcile_is_consistent_with_its_object())))
     .and(always(lift_state(safety::pending_msg_at_after_create_server_config_map_step_is_create_cm_req(rabbitmq.object_ref()))))
     .and(always(lift_state(safety::pending_msg_at_after_update_server_config_map_step_is_update_cm_req(rabbitmq.object_ref()))))
-    .and(always(lift_state(controller_runtime::pending_req_is_none_at_reconcile_state::<RabbitmqClusterView, RabbitmqReconciler>(rabbitmq.object_ref(), get_closure(RabbitmqReconcileStep::Init)))))
-    .and(always(lift_state(controller_runtime::pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<RabbitmqClusterView, RabbitmqReconciler>(rabbitmq.object_ref(), get_closure(RabbitmqReconcileStep::AfterCreateHeadlessService)))))
-    .and(always(lift_state(controller_runtime::pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<RabbitmqClusterView, RabbitmqReconciler>(rabbitmq.object_ref(), get_closure(RabbitmqReconcileStep::AfterCreateService)))))
-    .and(always(lift_state(controller_runtime::pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<RabbitmqClusterView, RabbitmqReconciler>(rabbitmq.object_ref(), get_closure(RabbitmqReconcileStep::AfterCreateErlangCookieSecret)))))
-    .and(always(lift_state(controller_runtime::pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<RabbitmqClusterView, RabbitmqReconciler>(rabbitmq.object_ref(), get_closure(RabbitmqReconcileStep::AfterCreateDefaultUserSecret)))))
-    .and(always(lift_state(controller_runtime::pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<RabbitmqClusterView, RabbitmqReconciler>(rabbitmq.object_ref(), get_closure(RabbitmqReconcileStep::AfterCreatePluginsConfigMap)))))
-    .and(always(lift_state(controller_runtime::pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<RabbitmqClusterView, RabbitmqReconciler>(rabbitmq.object_ref(), get_closure(RabbitmqReconcileStep::AfterGetServerConfigMap)))))
-    .and(always(lift_state(controller_runtime::pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<RabbitmqClusterView, RabbitmqReconciler>(rabbitmq.object_ref(), get_closure(RabbitmqReconcileStep::AfterCreateServerConfigMap)))))
-    .and(always(lift_state(controller_runtime::pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<RabbitmqClusterView, RabbitmqReconciler>(rabbitmq.object_ref(), get_closure(RabbitmqReconcileStep::AfterUpdateServerConfigMap)))))
-    .and(always(lift_state(controller_runtime::pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<RabbitmqClusterView, RabbitmqReconciler>(rabbitmq.object_ref(), get_closure(RabbitmqReconcileStep::AfterCreateServiceAccount)))))
-    .and(always(lift_state(controller_runtime::pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<RabbitmqClusterView, RabbitmqReconciler>(rabbitmq.object_ref(), get_closure(RabbitmqReconcileStep::AfterCreateRole)))))
-    .and(always(lift_state(controller_runtime::pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<RabbitmqClusterView, RabbitmqReconciler>(rabbitmq.object_ref(), get_closure(RabbitmqReconcileStep::AfterCreateRoleBinding)))))
-    .and(always(lift_state(controller_runtime::pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<RabbitmqClusterView, RabbitmqReconciler>(rabbitmq.object_ref(), get_closure(RabbitmqReconcileStep::AfterGetStatefulSet)))))
-    .and(always(lift_state(controller_runtime::pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<RabbitmqClusterView, RabbitmqReconciler>(rabbitmq.object_ref(), get_closure(RabbitmqReconcileStep::AfterCreateStatefulSet)))))
-    .and(always(lift_state(controller_runtime::pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<RabbitmqClusterView, RabbitmqReconciler>(rabbitmq.object_ref(), get_closure(RabbitmqReconcileStep::AfterUpdateStatefulSet)))))
+    .and(always(lift_state(controller_runtime::pending_req_is_none_at_reconcile_state::<RabbitmqClusterView, RabbitmqReconciler>(rabbitmq.object_ref(), at_step_closure(RabbitmqReconcileStep::Init)))))
+    .and(always(lift_state(controller_runtime::pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<RabbitmqClusterView, RabbitmqReconciler>(rabbitmq.object_ref(), at_step_closure(RabbitmqReconcileStep::AfterCreateHeadlessService)))))
+    .and(always(lift_state(controller_runtime::pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<RabbitmqClusterView, RabbitmqReconciler>(rabbitmq.object_ref(), at_step_closure(RabbitmqReconcileStep::AfterCreateService)))))
+    .and(always(lift_state(controller_runtime::pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<RabbitmqClusterView, RabbitmqReconciler>(rabbitmq.object_ref(), at_step_closure(RabbitmqReconcileStep::AfterCreateErlangCookieSecret)))))
+    .and(always(lift_state(controller_runtime::pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<RabbitmqClusterView, RabbitmqReconciler>(rabbitmq.object_ref(), at_step_closure(RabbitmqReconcileStep::AfterCreateDefaultUserSecret)))))
+    .and(always(lift_state(controller_runtime::pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<RabbitmqClusterView, RabbitmqReconciler>(rabbitmq.object_ref(), at_step_closure(RabbitmqReconcileStep::AfterCreatePluginsConfigMap)))))
+    .and(always(lift_state(controller_runtime::pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<RabbitmqClusterView, RabbitmqReconciler>(rabbitmq.object_ref(), at_step_closure(RabbitmqReconcileStep::AfterGetServerConfigMap)))))
+    .and(always(lift_state(controller_runtime::pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<RabbitmqClusterView, RabbitmqReconciler>(rabbitmq.object_ref(), at_step_closure(RabbitmqReconcileStep::AfterCreateServerConfigMap)))))
+    .and(always(lift_state(controller_runtime::pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<RabbitmqClusterView, RabbitmqReconciler>(rabbitmq.object_ref(), at_step_closure(RabbitmqReconcileStep::AfterUpdateServerConfigMap)))))
+    .and(always(lift_state(controller_runtime::pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<RabbitmqClusterView, RabbitmqReconciler>(rabbitmq.object_ref(), at_step_closure(RabbitmqReconcileStep::AfterCreateServiceAccount)))))
+    .and(always(lift_state(controller_runtime::pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<RabbitmqClusterView, RabbitmqReconciler>(rabbitmq.object_ref(), at_step_closure(RabbitmqReconcileStep::AfterCreateRole)))))
+    .and(always(lift_state(controller_runtime::pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<RabbitmqClusterView, RabbitmqReconciler>(rabbitmq.object_ref(), at_step_closure(RabbitmqReconcileStep::AfterCreateRoleBinding)))))
+    .and(always(lift_state(controller_runtime::pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<RabbitmqClusterView, RabbitmqReconciler>(rabbitmq.object_ref(), at_step_closure(RabbitmqReconcileStep::AfterGetStatefulSet)))))
+    .and(always(lift_state(controller_runtime::pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<RabbitmqClusterView, RabbitmqReconciler>(rabbitmq.object_ref(), at_step_closure(RabbitmqReconcileStep::AfterCreateStatefulSet)))))
+    .and(always(lift_state(controller_runtime::pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<RabbitmqClusterView, RabbitmqReconciler>(rabbitmq.object_ref(), at_step_closure(RabbitmqReconcileStep::AfterUpdateStatefulSet)))))
 }
 
 proof fn invariants_is_stable(rabbitmq: RabbitmqClusterView)
@@ -158,21 +158,21 @@ proof fn invariants_is_stable(rabbitmq: RabbitmqClusterView)
         lift_state(cluster_safety::each_key_in_reconcile_is_consistent_with_its_object::<RabbitmqClusterView, RabbitmqReconciler>()),
         lift_state(safety::pending_msg_at_after_create_server_config_map_step_is_create_cm_req(rabbitmq.object_ref())),
         lift_state(safety::pending_msg_at_after_update_server_config_map_step_is_update_cm_req(rabbitmq.object_ref())),
-        lift_state(controller_runtime::pending_req_is_none_at_reconcile_state::<RabbitmqClusterView, RabbitmqReconciler>(rabbitmq.object_ref(), get_closure(RabbitmqReconcileStep::Init))),
-        lift_state(controller_runtime::pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<RabbitmqClusterView, RabbitmqReconciler>(rabbitmq.object_ref(), get_closure(RabbitmqReconcileStep::AfterCreateHeadlessService))),
-        lift_state(controller_runtime::pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<RabbitmqClusterView, RabbitmqReconciler>(rabbitmq.object_ref(), get_closure(RabbitmqReconcileStep::AfterCreateService))),
-        lift_state(controller_runtime::pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<RabbitmqClusterView, RabbitmqReconciler>(rabbitmq.object_ref(), get_closure(RabbitmqReconcileStep::AfterCreateErlangCookieSecret))),
-        lift_state(controller_runtime::pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<RabbitmqClusterView, RabbitmqReconciler>(rabbitmq.object_ref(), get_closure(RabbitmqReconcileStep::AfterCreateDefaultUserSecret))),
-        lift_state(controller_runtime::pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<RabbitmqClusterView, RabbitmqReconciler>(rabbitmq.object_ref(), get_closure(RabbitmqReconcileStep::AfterCreatePluginsConfigMap))),
-        lift_state(controller_runtime::pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<RabbitmqClusterView, RabbitmqReconciler>(rabbitmq.object_ref(), get_closure(RabbitmqReconcileStep::AfterGetServerConfigMap))),
-        lift_state(controller_runtime::pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<RabbitmqClusterView, RabbitmqReconciler>(rabbitmq.object_ref(), get_closure(RabbitmqReconcileStep::AfterCreateServerConfigMap))),
-        lift_state(controller_runtime::pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<RabbitmqClusterView, RabbitmqReconciler>(rabbitmq.object_ref(), get_closure(RabbitmqReconcileStep::AfterUpdateServerConfigMap))),
-        lift_state(controller_runtime::pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<RabbitmqClusterView, RabbitmqReconciler>(rabbitmq.object_ref(), get_closure(RabbitmqReconcileStep::AfterCreateServiceAccount))),
-        lift_state(controller_runtime::pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<RabbitmqClusterView, RabbitmqReconciler>(rabbitmq.object_ref(), get_closure(RabbitmqReconcileStep::AfterCreateRole))),
-        lift_state(controller_runtime::pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<RabbitmqClusterView, RabbitmqReconciler>(rabbitmq.object_ref(), get_closure(RabbitmqReconcileStep::AfterCreateRoleBinding))),
-        lift_state(controller_runtime::pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<RabbitmqClusterView, RabbitmqReconciler>(rabbitmq.object_ref(), get_closure(RabbitmqReconcileStep::AfterGetStatefulSet))),
-        lift_state(controller_runtime::pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<RabbitmqClusterView, RabbitmqReconciler>(rabbitmq.object_ref(), get_closure(RabbitmqReconcileStep::AfterCreateStatefulSet))),
-        lift_state(controller_runtime::pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<RabbitmqClusterView, RabbitmqReconciler>(rabbitmq.object_ref(), get_closure(RabbitmqReconcileStep::AfterUpdateStatefulSet)))
+        lift_state(controller_runtime::pending_req_is_none_at_reconcile_state::<RabbitmqClusterView, RabbitmqReconciler>(rabbitmq.object_ref(), at_step_closure(RabbitmqReconcileStep::Init))),
+        lift_state(controller_runtime::pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<RabbitmqClusterView, RabbitmqReconciler>(rabbitmq.object_ref(), at_step_closure(RabbitmqReconcileStep::AfterCreateHeadlessService))),
+        lift_state(controller_runtime::pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<RabbitmqClusterView, RabbitmqReconciler>(rabbitmq.object_ref(), at_step_closure(RabbitmqReconcileStep::AfterCreateService))),
+        lift_state(controller_runtime::pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<RabbitmqClusterView, RabbitmqReconciler>(rabbitmq.object_ref(), at_step_closure(RabbitmqReconcileStep::AfterCreateErlangCookieSecret))),
+        lift_state(controller_runtime::pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<RabbitmqClusterView, RabbitmqReconciler>(rabbitmq.object_ref(), at_step_closure(RabbitmqReconcileStep::AfterCreateDefaultUserSecret))),
+        lift_state(controller_runtime::pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<RabbitmqClusterView, RabbitmqReconciler>(rabbitmq.object_ref(), at_step_closure(RabbitmqReconcileStep::AfterCreatePluginsConfigMap))),
+        lift_state(controller_runtime::pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<RabbitmqClusterView, RabbitmqReconciler>(rabbitmq.object_ref(), at_step_closure(RabbitmqReconcileStep::AfterGetServerConfigMap))),
+        lift_state(controller_runtime::pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<RabbitmqClusterView, RabbitmqReconciler>(rabbitmq.object_ref(), at_step_closure(RabbitmqReconcileStep::AfterCreateServerConfigMap))),
+        lift_state(controller_runtime::pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<RabbitmqClusterView, RabbitmqReconciler>(rabbitmq.object_ref(), at_step_closure(RabbitmqReconcileStep::AfterUpdateServerConfigMap))),
+        lift_state(controller_runtime::pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<RabbitmqClusterView, RabbitmqReconciler>(rabbitmq.object_ref(), at_step_closure(RabbitmqReconcileStep::AfterCreateServiceAccount))),
+        lift_state(controller_runtime::pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<RabbitmqClusterView, RabbitmqReconciler>(rabbitmq.object_ref(), at_step_closure(RabbitmqReconcileStep::AfterCreateRole))),
+        lift_state(controller_runtime::pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<RabbitmqClusterView, RabbitmqReconciler>(rabbitmq.object_ref(), at_step_closure(RabbitmqReconcileStep::AfterCreateRoleBinding))),
+        lift_state(controller_runtime::pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<RabbitmqClusterView, RabbitmqReconciler>(rabbitmq.object_ref(), at_step_closure(RabbitmqReconcileStep::AfterGetStatefulSet))),
+        lift_state(controller_runtime::pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<RabbitmqClusterView, RabbitmqReconciler>(rabbitmq.object_ref(), at_step_closure(RabbitmqReconcileStep::AfterCreateStatefulSet))),
+        lift_state(controller_runtime::pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<RabbitmqClusterView, RabbitmqReconciler>(rabbitmq.object_ref(), at_step_closure(RabbitmqReconcileStep::AfterUpdateStatefulSet)))
     );
 }
 
@@ -365,48 +365,48 @@ proof fn sm_spec_entails_all_invariants(rabbitmq: RabbitmqClusterView)
     cluster_safety::lemma_always_each_key_in_reconcile_is_consistent_with_its_object::<RabbitmqClusterView, RabbitmqReconciler>(spec);
     safety::lemma_always_pending_msg_at_after_create_server_config_map_step_is_create_cm_req(spec, rabbitmq.object_ref());
     safety::lemma_always_pending_msg_at_after_update_server_config_map_step_is_update_cm_req(spec, rabbitmq.object_ref());
-    controller_runtime_safety::lemma_always_pending_req_is_none_at_reconcile_state::<RabbitmqClusterView, RabbitmqReconciler>(spec, rabbitmq.object_ref(), get_closure(RabbitmqReconcileStep::Init));
+    controller_runtime_safety::lemma_always_pending_req_is_none_at_reconcile_state::<RabbitmqClusterView, RabbitmqReconciler>(spec, rabbitmq.object_ref(), at_step_closure(RabbitmqReconcileStep::Init));
     controller_runtime_safety::lemma_always_pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<RabbitmqClusterView, RabbitmqReconciler>(
-        spec, rabbitmq.object_ref(), get_closure(RabbitmqReconcileStep::AfterCreateHeadlessService)
+        spec, rabbitmq.object_ref(), at_step_closure(RabbitmqReconcileStep::AfterCreateHeadlessService)
     );
     controller_runtime_safety::lemma_always_pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<RabbitmqClusterView, RabbitmqReconciler>(
-        spec, rabbitmq.object_ref(), get_closure(RabbitmqReconcileStep::AfterCreateService)
+        spec, rabbitmq.object_ref(), at_step_closure(RabbitmqReconcileStep::AfterCreateService)
     );
     controller_runtime_safety::lemma_always_pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<RabbitmqClusterView, RabbitmqReconciler>(
-        spec, rabbitmq.object_ref(), get_closure(RabbitmqReconcileStep::AfterCreateErlangCookieSecret)
+        spec, rabbitmq.object_ref(), at_step_closure(RabbitmqReconcileStep::AfterCreateErlangCookieSecret)
     );
     controller_runtime_safety::lemma_always_pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<RabbitmqClusterView, RabbitmqReconciler>(
-        spec, rabbitmq.object_ref(), get_closure(RabbitmqReconcileStep::AfterCreateDefaultUserSecret)
+        spec, rabbitmq.object_ref(), at_step_closure(RabbitmqReconcileStep::AfterCreateDefaultUserSecret)
     );
     controller_runtime_safety::lemma_always_pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<RabbitmqClusterView, RabbitmqReconciler>(
-        spec, rabbitmq.object_ref(), get_closure(RabbitmqReconcileStep::AfterCreatePluginsConfigMap)
+        spec, rabbitmq.object_ref(), at_step_closure(RabbitmqReconcileStep::AfterCreatePluginsConfigMap)
     );
     controller_runtime_safety::lemma_always_pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<RabbitmqClusterView, RabbitmqReconciler>(
-        spec, rabbitmq.object_ref(), get_closure(RabbitmqReconcileStep::AfterGetServerConfigMap)
+        spec, rabbitmq.object_ref(), at_step_closure(RabbitmqReconcileStep::AfterGetServerConfigMap)
     );
     controller_runtime_safety::lemma_always_pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<RabbitmqClusterView, RabbitmqReconciler>(
-        spec, rabbitmq.object_ref(), get_closure(RabbitmqReconcileStep::AfterCreateServerConfigMap)
+        spec, rabbitmq.object_ref(), at_step_closure(RabbitmqReconcileStep::AfterCreateServerConfigMap)
     );
     controller_runtime_safety::lemma_always_pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<RabbitmqClusterView, RabbitmqReconciler>(
-        spec, rabbitmq.object_ref(), get_closure(RabbitmqReconcileStep::AfterUpdateServerConfigMap)
+        spec, rabbitmq.object_ref(), at_step_closure(RabbitmqReconcileStep::AfterUpdateServerConfigMap)
     );
     controller_runtime_safety::lemma_always_pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<RabbitmqClusterView, RabbitmqReconciler>(
-        spec, rabbitmq.object_ref(), get_closure(RabbitmqReconcileStep::AfterCreateServiceAccount)
+        spec, rabbitmq.object_ref(), at_step_closure(RabbitmqReconcileStep::AfterCreateServiceAccount)
     );
     controller_runtime_safety::lemma_always_pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<RabbitmqClusterView, RabbitmqReconciler>(
-        spec, rabbitmq.object_ref(), get_closure(RabbitmqReconcileStep::AfterCreateRole)
+        spec, rabbitmq.object_ref(), at_step_closure(RabbitmqReconcileStep::AfterCreateRole)
     );
     controller_runtime_safety::lemma_always_pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<RabbitmqClusterView, RabbitmqReconciler>(
-        spec, rabbitmq.object_ref(), get_closure(RabbitmqReconcileStep::AfterCreateRoleBinding)
+        spec, rabbitmq.object_ref(), at_step_closure(RabbitmqReconcileStep::AfterCreateRoleBinding)
     );
     controller_runtime_safety::lemma_always_pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<RabbitmqClusterView, RabbitmqReconciler>(
-        spec, rabbitmq.object_ref(), get_closure(RabbitmqReconcileStep::AfterGetStatefulSet)
+        spec, rabbitmq.object_ref(), at_step_closure(RabbitmqReconcileStep::AfterGetStatefulSet)
     );
     controller_runtime_safety::lemma_always_pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<RabbitmqClusterView, RabbitmqReconciler>(
-        spec, rabbitmq.object_ref(), get_closure(RabbitmqReconcileStep::AfterCreateStatefulSet)
+        spec, rabbitmq.object_ref(), at_step_closure(RabbitmqReconcileStep::AfterCreateStatefulSet)
     );
     controller_runtime_safety::lemma_always_pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<RabbitmqClusterView, RabbitmqReconciler>(
-        spec, rabbitmq.object_ref(), get_closure(RabbitmqReconcileStep::AfterUpdateStatefulSet)
+        spec, rabbitmq.object_ref(), at_step_closure(RabbitmqReconcileStep::AfterUpdateStatefulSet)
     );
     entails_always_and_n!(
         spec,
@@ -419,21 +419,21 @@ proof fn sm_spec_entails_all_invariants(rabbitmq: RabbitmqClusterView)
         lift_state(cluster_safety::each_key_in_reconcile_is_consistent_with_its_object::<RabbitmqClusterView, RabbitmqReconciler>()),
         lift_state(safety::pending_msg_at_after_create_server_config_map_step_is_create_cm_req(rabbitmq.object_ref())),
         lift_state(safety::pending_msg_at_after_update_server_config_map_step_is_update_cm_req(rabbitmq.object_ref())),
-        lift_state(controller_runtime::pending_req_is_none_at_reconcile_state::<RabbitmqClusterView, RabbitmqReconciler>(rabbitmq.object_ref(), get_closure(RabbitmqReconcileStep::Init))),
-        lift_state(controller_runtime::pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<RabbitmqClusterView, RabbitmqReconciler>(rabbitmq.object_ref(), get_closure(RabbitmqReconcileStep::AfterCreateHeadlessService))),
-        lift_state(controller_runtime::pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<RabbitmqClusterView, RabbitmqReconciler>(rabbitmq.object_ref(), get_closure(RabbitmqReconcileStep::AfterCreateService))),
-        lift_state(controller_runtime::pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<RabbitmqClusterView, RabbitmqReconciler>(rabbitmq.object_ref(), get_closure(RabbitmqReconcileStep::AfterCreateErlangCookieSecret))),
-        lift_state(controller_runtime::pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<RabbitmqClusterView, RabbitmqReconciler>(rabbitmq.object_ref(), get_closure(RabbitmqReconcileStep::AfterCreateDefaultUserSecret))),
-        lift_state(controller_runtime::pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<RabbitmqClusterView, RabbitmqReconciler>(rabbitmq.object_ref(), get_closure(RabbitmqReconcileStep::AfterCreatePluginsConfigMap))),
-        lift_state(controller_runtime::pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<RabbitmqClusterView, RabbitmqReconciler>(rabbitmq.object_ref(), get_closure(RabbitmqReconcileStep::AfterGetServerConfigMap))),
-        lift_state(controller_runtime::pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<RabbitmqClusterView, RabbitmqReconciler>(rabbitmq.object_ref(), get_closure(RabbitmqReconcileStep::AfterCreateServerConfigMap))),
-        lift_state(controller_runtime::pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<RabbitmqClusterView, RabbitmqReconciler>(rabbitmq.object_ref(), get_closure(RabbitmqReconcileStep::AfterUpdateServerConfigMap))),
-        lift_state(controller_runtime::pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<RabbitmqClusterView, RabbitmqReconciler>(rabbitmq.object_ref(), get_closure(RabbitmqReconcileStep::AfterCreateServiceAccount))),
-        lift_state(controller_runtime::pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<RabbitmqClusterView, RabbitmqReconciler>(rabbitmq.object_ref(), get_closure(RabbitmqReconcileStep::AfterCreateRole))),
-        lift_state(controller_runtime::pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<RabbitmqClusterView, RabbitmqReconciler>(rabbitmq.object_ref(), get_closure(RabbitmqReconcileStep::AfterCreateRoleBinding))),
-        lift_state(controller_runtime::pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<RabbitmqClusterView, RabbitmqReconciler>(rabbitmq.object_ref(), get_closure(RabbitmqReconcileStep::AfterGetStatefulSet))),
-        lift_state(controller_runtime::pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<RabbitmqClusterView, RabbitmqReconciler>(rabbitmq.object_ref(), get_closure(RabbitmqReconcileStep::AfterCreateStatefulSet))),
-        lift_state(controller_runtime::pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<RabbitmqClusterView, RabbitmqReconciler>(rabbitmq.object_ref(), get_closure(RabbitmqReconcileStep::AfterUpdateStatefulSet)))
+        lift_state(controller_runtime::pending_req_is_none_at_reconcile_state::<RabbitmqClusterView, RabbitmqReconciler>(rabbitmq.object_ref(), at_step_closure(RabbitmqReconcileStep::Init))),
+        lift_state(controller_runtime::pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<RabbitmqClusterView, RabbitmqReconciler>(rabbitmq.object_ref(), at_step_closure(RabbitmqReconcileStep::AfterCreateHeadlessService))),
+        lift_state(controller_runtime::pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<RabbitmqClusterView, RabbitmqReconciler>(rabbitmq.object_ref(), at_step_closure(RabbitmqReconcileStep::AfterCreateService))),
+        lift_state(controller_runtime::pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<RabbitmqClusterView, RabbitmqReconciler>(rabbitmq.object_ref(), at_step_closure(RabbitmqReconcileStep::AfterCreateErlangCookieSecret))),
+        lift_state(controller_runtime::pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<RabbitmqClusterView, RabbitmqReconciler>(rabbitmq.object_ref(), at_step_closure(RabbitmqReconcileStep::AfterCreateDefaultUserSecret))),
+        lift_state(controller_runtime::pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<RabbitmqClusterView, RabbitmqReconciler>(rabbitmq.object_ref(), at_step_closure(RabbitmqReconcileStep::AfterCreatePluginsConfigMap))),
+        lift_state(controller_runtime::pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<RabbitmqClusterView, RabbitmqReconciler>(rabbitmq.object_ref(), at_step_closure(RabbitmqReconcileStep::AfterGetServerConfigMap))),
+        lift_state(controller_runtime::pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<RabbitmqClusterView, RabbitmqReconciler>(rabbitmq.object_ref(), at_step_closure(RabbitmqReconcileStep::AfterCreateServerConfigMap))),
+        lift_state(controller_runtime::pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<RabbitmqClusterView, RabbitmqReconciler>(rabbitmq.object_ref(), at_step_closure(RabbitmqReconcileStep::AfterUpdateServerConfigMap))),
+        lift_state(controller_runtime::pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<RabbitmqClusterView, RabbitmqReconciler>(rabbitmq.object_ref(), at_step_closure(RabbitmqReconcileStep::AfterCreateServiceAccount))),
+        lift_state(controller_runtime::pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<RabbitmqClusterView, RabbitmqReconciler>(rabbitmq.object_ref(), at_step_closure(RabbitmqReconcileStep::AfterCreateRole))),
+        lift_state(controller_runtime::pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<RabbitmqClusterView, RabbitmqReconciler>(rabbitmq.object_ref(), at_step_closure(RabbitmqReconcileStep::AfterCreateRoleBinding))),
+        lift_state(controller_runtime::pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<RabbitmqClusterView, RabbitmqReconciler>(rabbitmq.object_ref(), at_step_closure(RabbitmqReconcileStep::AfterGetStatefulSet))),
+        lift_state(controller_runtime::pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<RabbitmqClusterView, RabbitmqReconciler>(rabbitmq.object_ref(), at_step_closure(RabbitmqReconcileStep::AfterCreateStatefulSet))),
+        lift_state(controller_runtime::pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<RabbitmqClusterView, RabbitmqReconciler>(rabbitmq.object_ref(), at_step_closure(RabbitmqReconcileStep::AfterUpdateStatefulSet)))
     );
 }
 

--- a/src/controller_examples/rabbitmq_controller/proof/liveness.rs
+++ b/src/controller_examples/rabbitmq_controller/proof/liveness.rs
@@ -127,21 +127,21 @@ spec fn invariants(rabbitmq: RabbitmqClusterView) -> TempPred<ClusterState> {
     .and(always(lift_state(cluster_safety::each_key_in_reconcile_is_consistent_with_its_object())))
     .and(always(lift_state(safety::pending_msg_at_after_create_server_config_map_step_is_create_cm_req(rabbitmq.object_ref()))))
     .and(always(lift_state(safety::pending_msg_at_after_update_server_config_map_step_is_update_cm_req(rabbitmq.object_ref()))))
-    .and(always(lift_state(controller_runtime::no_pending_req_at_reconcile_init_state::<RabbitmqClusterView, RabbitmqReconciler>(rabbitmq.object_ref()))))
-    .and(always(lift_state(controller_runtime::pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<RabbitmqClusterView, RabbitmqReconciler>(rabbitmq.object_ref(), rabbitmq_reconcile_state(RabbitmqReconcileStep::AfterCreateHeadlessService)))))
-    .and(always(lift_state(controller_runtime::pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<RabbitmqClusterView, RabbitmqReconciler>(rabbitmq.object_ref(), rabbitmq_reconcile_state(RabbitmqReconcileStep::AfterCreateService)))))
-    .and(always(lift_state(controller_runtime::pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<RabbitmqClusterView, RabbitmqReconciler>(rabbitmq.object_ref(), rabbitmq_reconcile_state(RabbitmqReconcileStep::AfterCreateErlangCookieSecret)))))
-    .and(always(lift_state(controller_runtime::pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<RabbitmqClusterView, RabbitmqReconciler>(rabbitmq.object_ref(), rabbitmq_reconcile_state(RabbitmqReconcileStep::AfterCreateDefaultUserSecret)))))
-    .and(always(lift_state(controller_runtime::pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<RabbitmqClusterView, RabbitmqReconciler>(rabbitmq.object_ref(), rabbitmq_reconcile_state(RabbitmqReconcileStep::AfterCreatePluginsConfigMap)))))
-    .and(always(lift_state(controller_runtime::pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<RabbitmqClusterView, RabbitmqReconciler>(rabbitmq.object_ref(), rabbitmq_reconcile_state(RabbitmqReconcileStep::AfterGetServerConfigMap)))))
-    .and(always(lift_state(controller_runtime::pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<RabbitmqClusterView, RabbitmqReconciler>(rabbitmq.object_ref(), rabbitmq_reconcile_state(RabbitmqReconcileStep::AfterCreateServerConfigMap)))))
-    .and(always(lift_state(controller_runtime::pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<RabbitmqClusterView, RabbitmqReconciler>(rabbitmq.object_ref(), rabbitmq_reconcile_state(RabbitmqReconcileStep::AfterUpdateServerConfigMap)))))
-    .and(always(lift_state(controller_runtime::pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<RabbitmqClusterView, RabbitmqReconciler>(rabbitmq.object_ref(), rabbitmq_reconcile_state(RabbitmqReconcileStep::AfterCreateServiceAccount)))))
-    .and(always(lift_state(controller_runtime::pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<RabbitmqClusterView, RabbitmqReconciler>(rabbitmq.object_ref(), rabbitmq_reconcile_state(RabbitmqReconcileStep::AfterCreateRole)))))
-    .and(always(lift_state(controller_runtime::pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<RabbitmqClusterView, RabbitmqReconciler>(rabbitmq.object_ref(), rabbitmq_reconcile_state(RabbitmqReconcileStep::AfterCreateRoleBinding)))))
-    .and(always(lift_state(controller_runtime::pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<RabbitmqClusterView, RabbitmqReconciler>(rabbitmq.object_ref(), rabbitmq_reconcile_state(RabbitmqReconcileStep::AfterGetStatefulSet)))))
-    .and(always(lift_state(controller_runtime::pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<RabbitmqClusterView, RabbitmqReconciler>(rabbitmq.object_ref(), rabbitmq_reconcile_state(RabbitmqReconcileStep::AfterCreateStatefulSet)))))
-    .and(always(lift_state(controller_runtime::pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<RabbitmqClusterView, RabbitmqReconciler>(rabbitmq.object_ref(), rabbitmq_reconcile_state(RabbitmqReconcileStep::AfterUpdateStatefulSet)))))
+    .and(always(lift_state(controller_runtime::pending_req_is_none_at_reconcile_state::<RabbitmqClusterView, RabbitmqReconciler>(rabbitmq.object_ref(), get_closure(RabbitmqReconcileStep::Init)))))
+    .and(always(lift_state(controller_runtime::pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<RabbitmqClusterView, RabbitmqReconciler>(rabbitmq.object_ref(), get_closure(RabbitmqReconcileStep::AfterCreateHeadlessService)))))
+    .and(always(lift_state(controller_runtime::pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<RabbitmqClusterView, RabbitmqReconciler>(rabbitmq.object_ref(), get_closure(RabbitmqReconcileStep::AfterCreateService)))))
+    .and(always(lift_state(controller_runtime::pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<RabbitmqClusterView, RabbitmqReconciler>(rabbitmq.object_ref(), get_closure(RabbitmqReconcileStep::AfterCreateErlangCookieSecret)))))
+    .and(always(lift_state(controller_runtime::pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<RabbitmqClusterView, RabbitmqReconciler>(rabbitmq.object_ref(), get_closure(RabbitmqReconcileStep::AfterCreateDefaultUserSecret)))))
+    .and(always(lift_state(controller_runtime::pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<RabbitmqClusterView, RabbitmqReconciler>(rabbitmq.object_ref(), get_closure(RabbitmqReconcileStep::AfterCreatePluginsConfigMap)))))
+    .and(always(lift_state(controller_runtime::pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<RabbitmqClusterView, RabbitmqReconciler>(rabbitmq.object_ref(), get_closure(RabbitmqReconcileStep::AfterGetServerConfigMap)))))
+    .and(always(lift_state(controller_runtime::pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<RabbitmqClusterView, RabbitmqReconciler>(rabbitmq.object_ref(), get_closure(RabbitmqReconcileStep::AfterCreateServerConfigMap)))))
+    .and(always(lift_state(controller_runtime::pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<RabbitmqClusterView, RabbitmqReconciler>(rabbitmq.object_ref(), get_closure(RabbitmqReconcileStep::AfterUpdateServerConfigMap)))))
+    .and(always(lift_state(controller_runtime::pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<RabbitmqClusterView, RabbitmqReconciler>(rabbitmq.object_ref(), get_closure(RabbitmqReconcileStep::AfterCreateServiceAccount)))))
+    .and(always(lift_state(controller_runtime::pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<RabbitmqClusterView, RabbitmqReconciler>(rabbitmq.object_ref(), get_closure(RabbitmqReconcileStep::AfterCreateRole)))))
+    .and(always(lift_state(controller_runtime::pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<RabbitmqClusterView, RabbitmqReconciler>(rabbitmq.object_ref(), get_closure(RabbitmqReconcileStep::AfterCreateRoleBinding)))))
+    .and(always(lift_state(controller_runtime::pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<RabbitmqClusterView, RabbitmqReconciler>(rabbitmq.object_ref(), get_closure(RabbitmqReconcileStep::AfterGetStatefulSet)))))
+    .and(always(lift_state(controller_runtime::pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<RabbitmqClusterView, RabbitmqReconciler>(rabbitmq.object_ref(), get_closure(RabbitmqReconcileStep::AfterCreateStatefulSet)))))
+    .and(always(lift_state(controller_runtime::pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<RabbitmqClusterView, RabbitmqReconciler>(rabbitmq.object_ref(), get_closure(RabbitmqReconcileStep::AfterUpdateStatefulSet)))))
 }
 
 proof fn invariants_is_stable(rabbitmq: RabbitmqClusterView)
@@ -158,21 +158,21 @@ proof fn invariants_is_stable(rabbitmq: RabbitmqClusterView)
         lift_state(cluster_safety::each_key_in_reconcile_is_consistent_with_its_object::<RabbitmqClusterView, RabbitmqReconciler>()),
         lift_state(safety::pending_msg_at_after_create_server_config_map_step_is_create_cm_req(rabbitmq.object_ref())),
         lift_state(safety::pending_msg_at_after_update_server_config_map_step_is_update_cm_req(rabbitmq.object_ref())),
-        lift_state(controller_runtime::no_pending_req_at_reconcile_init_state::<RabbitmqClusterView, RabbitmqReconciler>(rabbitmq.object_ref())),
-        lift_state(controller_runtime::pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<RabbitmqClusterView, RabbitmqReconciler>(rabbitmq.object_ref(), rabbitmq_reconcile_state(RabbitmqReconcileStep::AfterCreateHeadlessService))),
-        lift_state(controller_runtime::pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<RabbitmqClusterView, RabbitmqReconciler>(rabbitmq.object_ref(), rabbitmq_reconcile_state(RabbitmqReconcileStep::AfterCreateService))),
-        lift_state(controller_runtime::pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<RabbitmqClusterView, RabbitmqReconciler>(rabbitmq.object_ref(), rabbitmq_reconcile_state(RabbitmqReconcileStep::AfterCreateErlangCookieSecret))),
-        lift_state(controller_runtime::pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<RabbitmqClusterView, RabbitmqReconciler>(rabbitmq.object_ref(), rabbitmq_reconcile_state(RabbitmqReconcileStep::AfterCreateDefaultUserSecret))),
-        lift_state(controller_runtime::pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<RabbitmqClusterView, RabbitmqReconciler>(rabbitmq.object_ref(), rabbitmq_reconcile_state(RabbitmqReconcileStep::AfterCreatePluginsConfigMap))),
-        lift_state(controller_runtime::pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<RabbitmqClusterView, RabbitmqReconciler>(rabbitmq.object_ref(), rabbitmq_reconcile_state(RabbitmqReconcileStep::AfterGetServerConfigMap))),
-        lift_state(controller_runtime::pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<RabbitmqClusterView, RabbitmqReconciler>(rabbitmq.object_ref(), rabbitmq_reconcile_state(RabbitmqReconcileStep::AfterCreateServerConfigMap))),
-        lift_state(controller_runtime::pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<RabbitmqClusterView, RabbitmqReconciler>(rabbitmq.object_ref(), rabbitmq_reconcile_state(RabbitmqReconcileStep::AfterUpdateServerConfigMap))),
-        lift_state(controller_runtime::pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<RabbitmqClusterView, RabbitmqReconciler>(rabbitmq.object_ref(), rabbitmq_reconcile_state(RabbitmqReconcileStep::AfterCreateServiceAccount))),
-        lift_state(controller_runtime::pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<RabbitmqClusterView, RabbitmqReconciler>(rabbitmq.object_ref(), rabbitmq_reconcile_state(RabbitmqReconcileStep::AfterCreateRole))),
-        lift_state(controller_runtime::pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<RabbitmqClusterView, RabbitmqReconciler>(rabbitmq.object_ref(), rabbitmq_reconcile_state(RabbitmqReconcileStep::AfterCreateRoleBinding))),
-        lift_state(controller_runtime::pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<RabbitmqClusterView, RabbitmqReconciler>(rabbitmq.object_ref(), rabbitmq_reconcile_state(RabbitmqReconcileStep::AfterGetStatefulSet))),
-        lift_state(controller_runtime::pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<RabbitmqClusterView, RabbitmqReconciler>(rabbitmq.object_ref(), rabbitmq_reconcile_state(RabbitmqReconcileStep::AfterCreateStatefulSet))),
-        lift_state(controller_runtime::pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<RabbitmqClusterView, RabbitmqReconciler>(rabbitmq.object_ref(), rabbitmq_reconcile_state(RabbitmqReconcileStep::AfterUpdateStatefulSet)))
+        lift_state(controller_runtime::pending_req_is_none_at_reconcile_state::<RabbitmqClusterView, RabbitmqReconciler>(rabbitmq.object_ref(), get_closure(RabbitmqReconcileStep::Init))),
+        lift_state(controller_runtime::pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<RabbitmqClusterView, RabbitmqReconciler>(rabbitmq.object_ref(), get_closure(RabbitmqReconcileStep::AfterCreateHeadlessService))),
+        lift_state(controller_runtime::pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<RabbitmqClusterView, RabbitmqReconciler>(rabbitmq.object_ref(), get_closure(RabbitmqReconcileStep::AfterCreateService))),
+        lift_state(controller_runtime::pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<RabbitmqClusterView, RabbitmqReconciler>(rabbitmq.object_ref(), get_closure(RabbitmqReconcileStep::AfterCreateErlangCookieSecret))),
+        lift_state(controller_runtime::pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<RabbitmqClusterView, RabbitmqReconciler>(rabbitmq.object_ref(), get_closure(RabbitmqReconcileStep::AfterCreateDefaultUserSecret))),
+        lift_state(controller_runtime::pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<RabbitmqClusterView, RabbitmqReconciler>(rabbitmq.object_ref(), get_closure(RabbitmqReconcileStep::AfterCreatePluginsConfigMap))),
+        lift_state(controller_runtime::pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<RabbitmqClusterView, RabbitmqReconciler>(rabbitmq.object_ref(), get_closure(RabbitmqReconcileStep::AfterGetServerConfigMap))),
+        lift_state(controller_runtime::pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<RabbitmqClusterView, RabbitmqReconciler>(rabbitmq.object_ref(), get_closure(RabbitmqReconcileStep::AfterCreateServerConfigMap))),
+        lift_state(controller_runtime::pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<RabbitmqClusterView, RabbitmqReconciler>(rabbitmq.object_ref(), get_closure(RabbitmqReconcileStep::AfterUpdateServerConfigMap))),
+        lift_state(controller_runtime::pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<RabbitmqClusterView, RabbitmqReconciler>(rabbitmq.object_ref(), get_closure(RabbitmqReconcileStep::AfterCreateServiceAccount))),
+        lift_state(controller_runtime::pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<RabbitmqClusterView, RabbitmqReconciler>(rabbitmq.object_ref(), get_closure(RabbitmqReconcileStep::AfterCreateRole))),
+        lift_state(controller_runtime::pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<RabbitmqClusterView, RabbitmqReconciler>(rabbitmq.object_ref(), get_closure(RabbitmqReconcileStep::AfterCreateRoleBinding))),
+        lift_state(controller_runtime::pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<RabbitmqClusterView, RabbitmqReconciler>(rabbitmq.object_ref(), get_closure(RabbitmqReconcileStep::AfterGetStatefulSet))),
+        lift_state(controller_runtime::pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<RabbitmqClusterView, RabbitmqReconciler>(rabbitmq.object_ref(), get_closure(RabbitmqReconcileStep::AfterCreateStatefulSet))),
+        lift_state(controller_runtime::pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<RabbitmqClusterView, RabbitmqReconciler>(rabbitmq.object_ref(), get_closure(RabbitmqReconcileStep::AfterUpdateStatefulSet)))
     );
 }
 
@@ -365,48 +365,48 @@ proof fn sm_spec_entails_all_invariants(rabbitmq: RabbitmqClusterView)
     cluster_safety::lemma_always_each_key_in_reconcile_is_consistent_with_its_object::<RabbitmqClusterView, RabbitmqReconciler>(spec);
     safety::lemma_always_pending_msg_at_after_create_server_config_map_step_is_create_cm_req(spec, rabbitmq.object_ref());
     safety::lemma_always_pending_msg_at_after_update_server_config_map_step_is_update_cm_req(spec, rabbitmq.object_ref());
-    controller_runtime_safety::lemma_always_no_pending_req_at_reconcile_init_state::<RabbitmqClusterView, RabbitmqReconciler>(spec, rabbitmq.object_ref());
+    controller_runtime_safety::lemma_always_pending_req_is_none_at_reconcile_state::<RabbitmqClusterView, RabbitmqReconciler>(spec, rabbitmq.object_ref(), get_closure(RabbitmqReconcileStep::Init));
     controller_runtime_safety::lemma_always_pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<RabbitmqClusterView, RabbitmqReconciler>(
-        spec, rabbitmq.object_ref(), rabbitmq_reconcile_state(RabbitmqReconcileStep::AfterCreateHeadlessService)
+        spec, rabbitmq.object_ref(), get_closure(RabbitmqReconcileStep::AfterCreateHeadlessService)
     );
     controller_runtime_safety::lemma_always_pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<RabbitmqClusterView, RabbitmqReconciler>(
-        spec, rabbitmq.object_ref(), rabbitmq_reconcile_state(RabbitmqReconcileStep::AfterCreateService)
+        spec, rabbitmq.object_ref(), get_closure(RabbitmqReconcileStep::AfterCreateService)
     );
     controller_runtime_safety::lemma_always_pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<RabbitmqClusterView, RabbitmqReconciler>(
-        spec, rabbitmq.object_ref(), rabbitmq_reconcile_state(RabbitmqReconcileStep::AfterCreateErlangCookieSecret)
+        spec, rabbitmq.object_ref(), get_closure(RabbitmqReconcileStep::AfterCreateErlangCookieSecret)
     );
     controller_runtime_safety::lemma_always_pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<RabbitmqClusterView, RabbitmqReconciler>(
-        spec, rabbitmq.object_ref(), rabbitmq_reconcile_state(RabbitmqReconcileStep::AfterCreateDefaultUserSecret)
+        spec, rabbitmq.object_ref(), get_closure(RabbitmqReconcileStep::AfterCreateDefaultUserSecret)
     );
     controller_runtime_safety::lemma_always_pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<RabbitmqClusterView, RabbitmqReconciler>(
-        spec, rabbitmq.object_ref(), rabbitmq_reconcile_state(RabbitmqReconcileStep::AfterCreatePluginsConfigMap)
+        spec, rabbitmq.object_ref(), get_closure(RabbitmqReconcileStep::AfterCreatePluginsConfigMap)
     );
     controller_runtime_safety::lemma_always_pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<RabbitmqClusterView, RabbitmqReconciler>(
-        spec, rabbitmq.object_ref(), rabbitmq_reconcile_state(RabbitmqReconcileStep::AfterGetServerConfigMap)
+        spec, rabbitmq.object_ref(), get_closure(RabbitmqReconcileStep::AfterGetServerConfigMap)
     );
     controller_runtime_safety::lemma_always_pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<RabbitmqClusterView, RabbitmqReconciler>(
-        spec, rabbitmq.object_ref(), rabbitmq_reconcile_state(RabbitmqReconcileStep::AfterCreateServerConfigMap)
+        spec, rabbitmq.object_ref(), get_closure(RabbitmqReconcileStep::AfterCreateServerConfigMap)
     );
     controller_runtime_safety::lemma_always_pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<RabbitmqClusterView, RabbitmqReconciler>(
-        spec, rabbitmq.object_ref(), rabbitmq_reconcile_state(RabbitmqReconcileStep::AfterUpdateServerConfigMap)
+        spec, rabbitmq.object_ref(), get_closure(RabbitmqReconcileStep::AfterUpdateServerConfigMap)
     );
     controller_runtime_safety::lemma_always_pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<RabbitmqClusterView, RabbitmqReconciler>(
-        spec, rabbitmq.object_ref(), rabbitmq_reconcile_state(RabbitmqReconcileStep::AfterCreateServiceAccount)
+        spec, rabbitmq.object_ref(), get_closure(RabbitmqReconcileStep::AfterCreateServiceAccount)
     );
     controller_runtime_safety::lemma_always_pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<RabbitmqClusterView, RabbitmqReconciler>(
-        spec, rabbitmq.object_ref(), rabbitmq_reconcile_state(RabbitmqReconcileStep::AfterCreateRole)
+        spec, rabbitmq.object_ref(), get_closure(RabbitmqReconcileStep::AfterCreateRole)
     );
     controller_runtime_safety::lemma_always_pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<RabbitmqClusterView, RabbitmqReconciler>(
-        spec, rabbitmq.object_ref(), rabbitmq_reconcile_state(RabbitmqReconcileStep::AfterCreateRoleBinding)
+        spec, rabbitmq.object_ref(), get_closure(RabbitmqReconcileStep::AfterCreateRoleBinding)
     );
     controller_runtime_safety::lemma_always_pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<RabbitmqClusterView, RabbitmqReconciler>(
-        spec, rabbitmq.object_ref(), rabbitmq_reconcile_state(RabbitmqReconcileStep::AfterGetStatefulSet)
+        spec, rabbitmq.object_ref(), get_closure(RabbitmqReconcileStep::AfterGetStatefulSet)
     );
     controller_runtime_safety::lemma_always_pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<RabbitmqClusterView, RabbitmqReconciler>(
-        spec, rabbitmq.object_ref(), rabbitmq_reconcile_state(RabbitmqReconcileStep::AfterCreateStatefulSet)
+        spec, rabbitmq.object_ref(), get_closure(RabbitmqReconcileStep::AfterCreateStatefulSet)
     );
     controller_runtime_safety::lemma_always_pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<RabbitmqClusterView, RabbitmqReconciler>(
-        spec, rabbitmq.object_ref(), rabbitmq_reconcile_state(RabbitmqReconcileStep::AfterUpdateStatefulSet)
+        spec, rabbitmq.object_ref(), get_closure(RabbitmqReconcileStep::AfterUpdateStatefulSet)
     );
     entails_always_and_n!(
         spec,
@@ -419,21 +419,21 @@ proof fn sm_spec_entails_all_invariants(rabbitmq: RabbitmqClusterView)
         lift_state(cluster_safety::each_key_in_reconcile_is_consistent_with_its_object::<RabbitmqClusterView, RabbitmqReconciler>()),
         lift_state(safety::pending_msg_at_after_create_server_config_map_step_is_create_cm_req(rabbitmq.object_ref())),
         lift_state(safety::pending_msg_at_after_update_server_config_map_step_is_update_cm_req(rabbitmq.object_ref())),
-        lift_state(controller_runtime::no_pending_req_at_reconcile_init_state::<RabbitmqClusterView, RabbitmqReconciler>(rabbitmq.object_ref())),
-        lift_state(controller_runtime::pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<RabbitmqClusterView, RabbitmqReconciler>(rabbitmq.object_ref(), rabbitmq_reconcile_state(RabbitmqReconcileStep::AfterCreateHeadlessService))),
-        lift_state(controller_runtime::pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<RabbitmqClusterView, RabbitmqReconciler>(rabbitmq.object_ref(), rabbitmq_reconcile_state(RabbitmqReconcileStep::AfterCreateService))),
-        lift_state(controller_runtime::pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<RabbitmqClusterView, RabbitmqReconciler>(rabbitmq.object_ref(), rabbitmq_reconcile_state(RabbitmqReconcileStep::AfterCreateErlangCookieSecret))),
-        lift_state(controller_runtime::pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<RabbitmqClusterView, RabbitmqReconciler>(rabbitmq.object_ref(), rabbitmq_reconcile_state(RabbitmqReconcileStep::AfterCreateDefaultUserSecret))),
-        lift_state(controller_runtime::pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<RabbitmqClusterView, RabbitmqReconciler>(rabbitmq.object_ref(), rabbitmq_reconcile_state(RabbitmqReconcileStep::AfterCreatePluginsConfigMap))),
-        lift_state(controller_runtime::pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<RabbitmqClusterView, RabbitmqReconciler>(rabbitmq.object_ref(), rabbitmq_reconcile_state(RabbitmqReconcileStep::AfterGetServerConfigMap))),
-        lift_state(controller_runtime::pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<RabbitmqClusterView, RabbitmqReconciler>(rabbitmq.object_ref(), rabbitmq_reconcile_state(RabbitmqReconcileStep::AfterCreateServerConfigMap))),
-        lift_state(controller_runtime::pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<RabbitmqClusterView, RabbitmqReconciler>(rabbitmq.object_ref(), rabbitmq_reconcile_state(RabbitmqReconcileStep::AfterUpdateServerConfigMap))),
-        lift_state(controller_runtime::pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<RabbitmqClusterView, RabbitmqReconciler>(rabbitmq.object_ref(), rabbitmq_reconcile_state(RabbitmqReconcileStep::AfterCreateServiceAccount))),
-        lift_state(controller_runtime::pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<RabbitmqClusterView, RabbitmqReconciler>(rabbitmq.object_ref(), rabbitmq_reconcile_state(RabbitmqReconcileStep::AfterCreateRole))),
-        lift_state(controller_runtime::pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<RabbitmqClusterView, RabbitmqReconciler>(rabbitmq.object_ref(), rabbitmq_reconcile_state(RabbitmqReconcileStep::AfterCreateRoleBinding))),
-        lift_state(controller_runtime::pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<RabbitmqClusterView, RabbitmqReconciler>(rabbitmq.object_ref(), rabbitmq_reconcile_state(RabbitmqReconcileStep::AfterGetStatefulSet))),
-        lift_state(controller_runtime::pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<RabbitmqClusterView, RabbitmqReconciler>(rabbitmq.object_ref(), rabbitmq_reconcile_state(RabbitmqReconcileStep::AfterCreateStatefulSet))),
-        lift_state(controller_runtime::pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<RabbitmqClusterView, RabbitmqReconciler>(rabbitmq.object_ref(), rabbitmq_reconcile_state(RabbitmqReconcileStep::AfterUpdateStatefulSet)))
+        lift_state(controller_runtime::pending_req_is_none_at_reconcile_state::<RabbitmqClusterView, RabbitmqReconciler>(rabbitmq.object_ref(), get_closure(RabbitmqReconcileStep::Init))),
+        lift_state(controller_runtime::pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<RabbitmqClusterView, RabbitmqReconciler>(rabbitmq.object_ref(), get_closure(RabbitmqReconcileStep::AfterCreateHeadlessService))),
+        lift_state(controller_runtime::pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<RabbitmqClusterView, RabbitmqReconciler>(rabbitmq.object_ref(), get_closure(RabbitmqReconcileStep::AfterCreateService))),
+        lift_state(controller_runtime::pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<RabbitmqClusterView, RabbitmqReconciler>(rabbitmq.object_ref(), get_closure(RabbitmqReconcileStep::AfterCreateErlangCookieSecret))),
+        lift_state(controller_runtime::pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<RabbitmqClusterView, RabbitmqReconciler>(rabbitmq.object_ref(), get_closure(RabbitmqReconcileStep::AfterCreateDefaultUserSecret))),
+        lift_state(controller_runtime::pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<RabbitmqClusterView, RabbitmqReconciler>(rabbitmq.object_ref(), get_closure(RabbitmqReconcileStep::AfterCreatePluginsConfigMap))),
+        lift_state(controller_runtime::pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<RabbitmqClusterView, RabbitmqReconciler>(rabbitmq.object_ref(), get_closure(RabbitmqReconcileStep::AfterGetServerConfigMap))),
+        lift_state(controller_runtime::pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<RabbitmqClusterView, RabbitmqReconciler>(rabbitmq.object_ref(), get_closure(RabbitmqReconcileStep::AfterCreateServerConfigMap))),
+        lift_state(controller_runtime::pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<RabbitmqClusterView, RabbitmqReconciler>(rabbitmq.object_ref(), get_closure(RabbitmqReconcileStep::AfterUpdateServerConfigMap))),
+        lift_state(controller_runtime::pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<RabbitmqClusterView, RabbitmqReconciler>(rabbitmq.object_ref(), get_closure(RabbitmqReconcileStep::AfterCreateServiceAccount))),
+        lift_state(controller_runtime::pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<RabbitmqClusterView, RabbitmqReconciler>(rabbitmq.object_ref(), get_closure(RabbitmqReconcileStep::AfterCreateRole))),
+        lift_state(controller_runtime::pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<RabbitmqClusterView, RabbitmqReconciler>(rabbitmq.object_ref(), get_closure(RabbitmqReconcileStep::AfterCreateRoleBinding))),
+        lift_state(controller_runtime::pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<RabbitmqClusterView, RabbitmqReconciler>(rabbitmq.object_ref(), get_closure(RabbitmqReconcileStep::AfterGetStatefulSet))),
+        lift_state(controller_runtime::pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<RabbitmqClusterView, RabbitmqReconciler>(rabbitmq.object_ref(), get_closure(RabbitmqReconcileStep::AfterCreateStatefulSet))),
+        lift_state(controller_runtime::pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<RabbitmqClusterView, RabbitmqReconciler>(rabbitmq.object_ref(), get_closure(RabbitmqReconcileStep::AfterUpdateStatefulSet)))
     );
 }
 

--- a/src/controller_examples/rabbitmq_controller/proof/terminate.rs
+++ b/src/controller_examples/rabbitmq_controller/proof/terminate.rs
@@ -156,8 +156,4 @@ pub open spec fn at_step_state_pred(rabbitmq: RabbitmqClusterView, step: Rabbitm
     at_expected_reconcile_states(rabbitmq.object_ref(), |s: RabbitmqReconcileState| s.reconcile_step == step)
 }
 
-pub open spec fn at_step_closure(step: RabbitmqReconcileStep) -> FnSpec(RabbitmqReconcileState) -> bool {
-    |s: RabbitmqReconcileState| s.reconcile_step == step
-}
-
 }

--- a/src/controller_examples/rabbitmq_controller/proof/terminate.rs
+++ b/src/controller_examples/rabbitmq_controller/proof/terminate.rs
@@ -52,7 +52,7 @@ pub proof fn reconcile_eventually_terminates(spec: TempPred<ClusterState>, rabbi
         forall |step: RabbitmqReconcileStep|
         step != RabbitmqReconcileStep::Init && step != RabbitmqReconcileStep::Error && step != RabbitmqReconcileStep::Done
         ==> spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<RabbitmqClusterView, RabbitmqReconciler>(
-            rabbitmq.object_ref(), (#[trigger] get_closure(step))
+            rabbitmq.object_ref(), (#[trigger] at_step_closure(step))
         )))),
     ensures
         spec.entails(
@@ -63,20 +63,20 @@ pub proof fn reconcile_eventually_terminates(spec: TempPred<ClusterState>, rabbi
     lemma_reconcile_error_leads_to_reconcile_idle::<RabbitmqClusterView, RabbitmqReconciler>(spec, rabbitmq.object_ref());
     lemma_reconcile_done_leads_to_reconcile_idle::<RabbitmqClusterView, RabbitmqReconciler>(spec, rabbitmq.object_ref());
     temp_pred_equality(
-        lift_state(get_reconcile_state(rabbitmq, RabbitmqReconcileStep::Done)),
+        lift_state(at_step_state_pred(rabbitmq, RabbitmqReconcileStep::Done)),
         lift_state(reconciler_reconcile_done::<RabbitmqClusterView, RabbitmqReconciler>(rabbitmq.object_ref()))
     );
     temp_pred_equality(
-        lift_state(get_reconcile_state(rabbitmq, RabbitmqReconcileStep::Error)),
+        lift_state(at_step_state_pred(rabbitmq, RabbitmqReconcileStep::Error)),
         lift_state(reconciler_reconcile_error::<RabbitmqClusterView, RabbitmqReconciler>(rabbitmq.object_ref()))
     );
-    lemma_from_some_state_to_arbitrary_next_state_to_reconcile_idle::<RabbitmqClusterView, RabbitmqReconciler>(spec, rabbitmq, get_closure(RabbitmqReconcileStep::AfterUpdateStatefulSet), get_closure(RabbitmqReconcileStep::Done));
-    lemma_from_some_state_to_arbitrary_next_state_to_reconcile_idle::<RabbitmqClusterView, RabbitmqReconciler>(spec, rabbitmq, get_closure(RabbitmqReconcileStep::AfterCreateStatefulSet), get_closure(RabbitmqReconcileStep::Done));
+    lemma_from_some_state_to_arbitrary_next_state_to_reconcile_idle::<RabbitmqClusterView, RabbitmqReconciler>(spec, rabbitmq, at_step_closure(RabbitmqReconcileStep::AfterUpdateStatefulSet), at_step_closure(RabbitmqReconcileStep::Done));
+    lemma_from_some_state_to_arbitrary_next_state_to_reconcile_idle::<RabbitmqClusterView, RabbitmqReconciler>(spec, rabbitmq, at_step_closure(RabbitmqReconcileStep::AfterCreateStatefulSet), at_step_closure(RabbitmqReconcileStep::Done));
     or_leads_to_combine_n!(
         spec,
-        lift_state(get_reconcile_state(rabbitmq, RabbitmqReconcileStep::AfterUpdateStatefulSet)),
-        lift_state(get_reconcile_state(rabbitmq, RabbitmqReconcileStep::AfterCreateStatefulSet)),
-        lift_state(get_reconcile_state(rabbitmq, RabbitmqReconcileStep::Error));
+        lift_state(at_step_state_pred(rabbitmq, RabbitmqReconcileStep::AfterUpdateStatefulSet)),
+        lift_state(at_step_state_pred(rabbitmq, RabbitmqReconcileStep::AfterCreateStatefulSet)),
+        lift_state(at_step_state_pred(rabbitmq, RabbitmqReconcileStep::Error));
         lift_state(|s: ClusterState| { !s.reconcile_state_contains(rabbitmq.object_ref()) })
     );
     let next_state = |s: RabbitmqReconcileState| {
@@ -85,25 +85,25 @@ pub proof fn reconcile_eventually_terminates(spec: TempPred<ClusterState>, rabbi
         || s.reconcile_step == RabbitmqReconcileStep::Error
     };
     temp_pred_equality(
-        lift_state(get_reconcile_state(rabbitmq, RabbitmqReconcileStep::AfterUpdateStatefulSet))
-        .or(lift_state(get_reconcile_state(rabbitmq, RabbitmqReconcileStep::AfterCreateStatefulSet)))
-        .or(lift_state(get_reconcile_state(rabbitmq, RabbitmqReconcileStep::Error))),
+        lift_state(at_step_state_pred(rabbitmq, RabbitmqReconcileStep::AfterUpdateStatefulSet))
+        .or(lift_state(at_step_state_pred(rabbitmq, RabbitmqReconcileStep::AfterCreateStatefulSet)))
+        .or(lift_state(at_step_state_pred(rabbitmq, RabbitmqReconcileStep::Error))),
         lift_state(at_expected_reconcile_states(rabbitmq.object_ref(), next_state))
     );
     lemma_from_some_state_to_arbitrary_next_state_to_reconcile_idle::<RabbitmqClusterView, RabbitmqReconciler>(
-        spec, rabbitmq, get_closure(RabbitmqReconcileStep::AfterGetStatefulSet), next_state
+        spec, rabbitmq, at_step_closure(RabbitmqReconcileStep::AfterGetStatefulSet), next_state
     );
-    lemma_from_some_state_to_arbitrary_next_state_to_reconcile_idle::<RabbitmqClusterView, RabbitmqReconciler>(spec, rabbitmq, get_closure(RabbitmqReconcileStep::AfterCreateRoleBinding), get_closure(RabbitmqReconcileStep::AfterGetStatefulSet));
-    lemma_from_some_state_to_arbitrary_next_state_to_reconcile_idle::<RabbitmqClusterView, RabbitmqReconciler>(spec, rabbitmq, get_closure(RabbitmqReconcileStep::AfterCreateRole), get_closure(RabbitmqReconcileStep::AfterCreateRoleBinding));
-    lemma_from_some_state_to_arbitrary_next_state_to_reconcile_idle::<RabbitmqClusterView, RabbitmqReconciler>(spec, rabbitmq, get_closure(RabbitmqReconcileStep::AfterCreateServiceAccount), get_closure(RabbitmqReconcileStep::AfterCreateRole));
-    lemma_from_some_state_to_arbitrary_next_state_to_reconcile_idle::<RabbitmqClusterView, RabbitmqReconciler>(spec, rabbitmq, get_closure(RabbitmqReconcileStep::AfterCreateServerConfigMap), get_closure(RabbitmqReconcileStep::AfterCreateServiceAccount));
-    lemma_from_some_state_to_arbitrary_next_state_to_reconcile_idle::<RabbitmqClusterView, RabbitmqReconciler>(spec, rabbitmq, get_closure(RabbitmqReconcileStep::AfterUpdateServerConfigMap), get_closure(RabbitmqReconcileStep::AfterCreateServiceAccount));
+    lemma_from_some_state_to_arbitrary_next_state_to_reconcile_idle::<RabbitmqClusterView, RabbitmqReconciler>(spec, rabbitmq, at_step_closure(RabbitmqReconcileStep::AfterCreateRoleBinding), at_step_closure(RabbitmqReconcileStep::AfterGetStatefulSet));
+    lemma_from_some_state_to_arbitrary_next_state_to_reconcile_idle::<RabbitmqClusterView, RabbitmqReconciler>(spec, rabbitmq, at_step_closure(RabbitmqReconcileStep::AfterCreateRole), at_step_closure(RabbitmqReconcileStep::AfterCreateRoleBinding));
+    lemma_from_some_state_to_arbitrary_next_state_to_reconcile_idle::<RabbitmqClusterView, RabbitmqReconciler>(spec, rabbitmq, at_step_closure(RabbitmqReconcileStep::AfterCreateServiceAccount), at_step_closure(RabbitmqReconcileStep::AfterCreateRole));
+    lemma_from_some_state_to_arbitrary_next_state_to_reconcile_idle::<RabbitmqClusterView, RabbitmqReconciler>(spec, rabbitmq, at_step_closure(RabbitmqReconcileStep::AfterCreateServerConfigMap), at_step_closure(RabbitmqReconcileStep::AfterCreateServiceAccount));
+    lemma_from_some_state_to_arbitrary_next_state_to_reconcile_idle::<RabbitmqClusterView, RabbitmqReconciler>(spec, rabbitmq, at_step_closure(RabbitmqReconcileStep::AfterUpdateServerConfigMap), at_step_closure(RabbitmqReconcileStep::AfterCreateServiceAccount));
 
     or_leads_to_combine_n!(
         spec,
-        lift_state(get_reconcile_state(rabbitmq, RabbitmqReconcileStep::AfterUpdateServerConfigMap)),
-        lift_state(get_reconcile_state(rabbitmq, RabbitmqReconcileStep::AfterCreateServerConfigMap)),
-        lift_state(get_reconcile_state(rabbitmq, RabbitmqReconcileStep::Error));
+        lift_state(at_step_state_pred(rabbitmq, RabbitmqReconcileStep::AfterUpdateServerConfigMap)),
+        lift_state(at_step_state_pred(rabbitmq, RabbitmqReconcileStep::AfterCreateServerConfigMap)),
+        lift_state(at_step_state_pred(rabbitmq, RabbitmqReconcileStep::Error));
         lift_state(|s: ClusterState| { !s.reconcile_state_contains(rabbitmq.object_ref()) })
     );
     let next_state_1 = |s: RabbitmqReconcileState| {
@@ -112,44 +112,52 @@ pub proof fn reconcile_eventually_terminates(spec: TempPred<ClusterState>, rabbi
         || s.reconcile_step == RabbitmqReconcileStep::Error
     };
     temp_pred_equality(
-        lift_state(get_reconcile_state(rabbitmq, RabbitmqReconcileStep::AfterUpdateServerConfigMap))
-        .or(lift_state(get_reconcile_state(rabbitmq, RabbitmqReconcileStep::AfterCreateServerConfigMap)))
-        .or(lift_state(get_reconcile_state(rabbitmq, RabbitmqReconcileStep::Error))),
+        lift_state(at_step_state_pred(rabbitmq, RabbitmqReconcileStep::AfterUpdateServerConfigMap))
+        .or(lift_state(at_step_state_pred(rabbitmq, RabbitmqReconcileStep::AfterCreateServerConfigMap)))
+        .or(lift_state(at_step_state_pred(rabbitmq, RabbitmqReconcileStep::Error))),
         lift_state(at_expected_reconcile_states(rabbitmq.object_ref(), next_state_1))
     );
     lemma_from_some_state_to_arbitrary_next_state_to_reconcile_idle::<RabbitmqClusterView, RabbitmqReconciler>(
-        spec, rabbitmq, get_closure(RabbitmqReconcileStep::AfterGetServerConfigMap), next_state_1
+        spec, rabbitmq, at_step_closure(RabbitmqReconcileStep::AfterGetServerConfigMap), next_state_1
     );
-    lemma_from_some_state_to_arbitrary_next_state_to_reconcile_idle::<RabbitmqClusterView, RabbitmqReconciler>(spec, rabbitmq, get_closure(RabbitmqReconcileStep::AfterCreatePluginsConfigMap), get_closure(RabbitmqReconcileStep::AfterGetServerConfigMap));
-    lemma_from_some_state_to_arbitrary_next_state_to_reconcile_idle::<RabbitmqClusterView, RabbitmqReconciler>(spec, rabbitmq, get_closure(RabbitmqReconcileStep::AfterCreateDefaultUserSecret), get_closure(RabbitmqReconcileStep::AfterCreatePluginsConfigMap));
-    lemma_from_some_state_to_arbitrary_next_state_to_reconcile_idle::<RabbitmqClusterView, RabbitmqReconciler>(spec, rabbitmq, get_closure(RabbitmqReconcileStep::AfterCreateErlangCookieSecret), get_closure(RabbitmqReconcileStep::AfterCreateDefaultUserSecret));
-    lemma_from_some_state_to_arbitrary_next_state_to_reconcile_idle::<RabbitmqClusterView, RabbitmqReconciler>(spec, rabbitmq, get_closure(RabbitmqReconcileStep::AfterCreateService), get_closure(RabbitmqReconcileStep::AfterCreateErlangCookieSecret));
-    lemma_from_some_state_to_arbitrary_next_state_to_reconcile_idle::<RabbitmqClusterView, RabbitmqReconciler>(spec, rabbitmq, get_closure(RabbitmqReconcileStep::AfterCreateHeadlessService), get_closure(RabbitmqReconcileStep::AfterCreateService));
-    lemma_from_init_state_to_next_state_to_reconcile_idle::<RabbitmqClusterView, RabbitmqReconciler>(spec, rabbitmq, get_closure(RabbitmqReconcileStep::Init), get_closure(RabbitmqReconcileStep::AfterCreateHeadlessService));
+    lemma_from_some_state_to_arbitrary_next_state_to_reconcile_idle::<RabbitmqClusterView, RabbitmqReconciler>(spec, rabbitmq, at_step_closure(RabbitmqReconcileStep::AfterCreatePluginsConfigMap), at_step_closure(RabbitmqReconcileStep::AfterGetServerConfigMap));
+    lemma_from_some_state_to_arbitrary_next_state_to_reconcile_idle::<RabbitmqClusterView, RabbitmqReconciler>(spec, rabbitmq, at_step_closure(RabbitmqReconcileStep::AfterCreateDefaultUserSecret), at_step_closure(RabbitmqReconcileStep::AfterCreatePluginsConfigMap));
+    lemma_from_some_state_to_arbitrary_next_state_to_reconcile_idle::<RabbitmqClusterView, RabbitmqReconciler>(spec, rabbitmq, at_step_closure(RabbitmqReconcileStep::AfterCreateErlangCookieSecret), at_step_closure(RabbitmqReconcileStep::AfterCreateDefaultUserSecret));
+    lemma_from_some_state_to_arbitrary_next_state_to_reconcile_idle::<RabbitmqClusterView, RabbitmqReconciler>(spec, rabbitmq, at_step_closure(RabbitmqReconcileStep::AfterCreateService), at_step_closure(RabbitmqReconcileStep::AfterCreateErlangCookieSecret));
+    lemma_from_some_state_to_arbitrary_next_state_to_reconcile_idle::<RabbitmqClusterView, RabbitmqReconciler>(spec, rabbitmq, at_step_closure(RabbitmqReconcileStep::AfterCreateHeadlessService), at_step_closure(RabbitmqReconcileStep::AfterCreateService));
+    lemma_from_init_state_to_next_state_to_reconcile_idle::<RabbitmqClusterView, RabbitmqReconciler>(spec, rabbitmq, at_step_closure(RabbitmqReconcileStep::Init), at_step_closure(RabbitmqReconcileStep::AfterCreateHeadlessService));
     valid_implies_implies_leads_to(spec, lift_state(reconcile_idle), lift_state(reconcile_idle));
     or_leads_to_combine_and_equality!(
         spec,
         true_pred(),
         lift_state(reconcile_idle),
-        lift_state(get_reconcile_state(rabbitmq, RabbitmqReconcileStep::Init)),
-        lift_state(get_reconcile_state(rabbitmq, RabbitmqReconcileStep::AfterCreateHeadlessService)),
-        lift_state(get_reconcile_state(rabbitmq, RabbitmqReconcileStep::AfterCreateService)),
-        lift_state(get_reconcile_state(rabbitmq, RabbitmqReconcileStep::AfterCreateErlangCookieSecret)),
-        lift_state(get_reconcile_state(rabbitmq, RabbitmqReconcileStep::AfterCreateDefaultUserSecret)),
-        lift_state(get_reconcile_state(rabbitmq, RabbitmqReconcileStep::AfterCreatePluginsConfigMap)),
-        lift_state(get_reconcile_state(rabbitmq, RabbitmqReconcileStep::AfterGetServerConfigMap)),
-        lift_state(get_reconcile_state(rabbitmq, RabbitmqReconcileStep::AfterCreateServerConfigMap)),
-        lift_state(get_reconcile_state(rabbitmq, RabbitmqReconcileStep::AfterUpdateServerConfigMap)),
-        lift_state(get_reconcile_state(rabbitmq, RabbitmqReconcileStep::AfterCreateServiceAccount)),
-        lift_state(get_reconcile_state(rabbitmq, RabbitmqReconcileStep::AfterCreateRole)),
-        lift_state(get_reconcile_state(rabbitmq, RabbitmqReconcileStep::AfterCreateRoleBinding)),
-        lift_state(get_reconcile_state(rabbitmq, RabbitmqReconcileStep::AfterGetStatefulSet)),
-        lift_state(get_reconcile_state(rabbitmq, RabbitmqReconcileStep::AfterCreateStatefulSet)),
-        lift_state(get_reconcile_state(rabbitmq, RabbitmqReconcileStep::AfterUpdateStatefulSet)),
-        lift_state(get_reconcile_state(rabbitmq, RabbitmqReconcileStep::Done)),
-        lift_state(get_reconcile_state(rabbitmq, RabbitmqReconcileStep::Error));
+        lift_state(at_step_state_pred(rabbitmq, RabbitmqReconcileStep::Init)),
+        lift_state(at_step_state_pred(rabbitmq, RabbitmqReconcileStep::AfterCreateHeadlessService)),
+        lift_state(at_step_state_pred(rabbitmq, RabbitmqReconcileStep::AfterCreateService)),
+        lift_state(at_step_state_pred(rabbitmq, RabbitmqReconcileStep::AfterCreateErlangCookieSecret)),
+        lift_state(at_step_state_pred(rabbitmq, RabbitmqReconcileStep::AfterCreateDefaultUserSecret)),
+        lift_state(at_step_state_pred(rabbitmq, RabbitmqReconcileStep::AfterCreatePluginsConfigMap)),
+        lift_state(at_step_state_pred(rabbitmq, RabbitmqReconcileStep::AfterGetServerConfigMap)),
+        lift_state(at_step_state_pred(rabbitmq, RabbitmqReconcileStep::AfterCreateServerConfigMap)),
+        lift_state(at_step_state_pred(rabbitmq, RabbitmqReconcileStep::AfterUpdateServerConfigMap)),
+        lift_state(at_step_state_pred(rabbitmq, RabbitmqReconcileStep::AfterCreateServiceAccount)),
+        lift_state(at_step_state_pred(rabbitmq, RabbitmqReconcileStep::AfterCreateRole)),
+        lift_state(at_step_state_pred(rabbitmq, RabbitmqReconcileStep::AfterCreateRoleBinding)),
+        lift_state(at_step_state_pred(rabbitmq, RabbitmqReconcileStep::AfterGetStatefulSet)),
+        lift_state(at_step_state_pred(rabbitmq, RabbitmqReconcileStep::AfterCreateStatefulSet)),
+        lift_state(at_step_state_pred(rabbitmq, RabbitmqReconcileStep::AfterUpdateStatefulSet)),
+        lift_state(at_step_state_pred(rabbitmq, RabbitmqReconcileStep::Done)),
+        lift_state(at_step_state_pred(rabbitmq, RabbitmqReconcileStep::Error));
         lift_state(reconcile_idle)
     );
+}
+
+pub open spec fn at_step_state_pred(rabbitmq: RabbitmqClusterView, step: RabbitmqReconcileStep) -> StatePred<ClusterState> {
+    at_expected_reconcile_states(rabbitmq.object_ref(), |s: RabbitmqReconcileState| s.reconcile_step == step)
+}
+
+pub open spec fn at_step_closure(step: RabbitmqReconcileStep) -> FnSpec(RabbitmqReconcileState) -> bool {
+    |s: RabbitmqReconcileState| s.reconcile_step == step
 }
 
 }

--- a/src/controller_examples/rabbitmq_controller/proof/terminate.rs
+++ b/src/controller_examples/rabbitmq_controller/proof/terminate.rs
@@ -28,7 +28,7 @@ use crate::kubernetes_cluster::{
 };
 use crate::rabbitmq_controller::{
     common::RabbitmqReconcileStep,
-    proof::{common::*, safety::*},
+    proof::common::*,
     spec::{rabbitmqcluster::*, reconciler::*},
 };
 use crate::reconciler::spec::reconciler::*;
@@ -47,10 +47,13 @@ pub proof fn reconcile_eventually_terminates(spec: TempPred<ClusterState>, rabbi
         spec.entails(always(lift_state(controller_runtime_safety::every_in_flight_msg_has_unique_id()))),
         spec.entails(always(lift_state(controller_runtime_safety::each_resp_matches_at_most_one_pending_req(rabbitmq.object_ref())))),
         spec.entails(always(lift_state(controller_runtime_safety::each_resp_if_matches_pending_req_then_no_other_resp_matches(rabbitmq.object_ref())))),
-        spec.entails(always(lift_state(no_pending_req_at_reconcile_init_state::<RabbitmqClusterView, RabbitmqReconciler>(rabbitmq.object_ref())))),
+        spec.entails(always(lift_state(pending_req_is_none_at_reconcile_state::<RabbitmqClusterView, RabbitmqReconciler>(
+            rabbitmq.object_ref(), |s: RabbitmqReconcileState| s.reconcile_step == RabbitmqReconcileStep::Init)))),
         forall |step: RabbitmqReconcileStep|
         step != RabbitmqReconcileStep::Init && step != RabbitmqReconcileStep::Error && step != RabbitmqReconcileStep::Done
-        ==> spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_reconcile_state(rabbitmq.object_ref(), #[trigger] rabbitmq_reconcile_state(step))))),
+        ==> spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<RabbitmqClusterView, RabbitmqReconciler>(
+            rabbitmq.object_ref(), (#[trigger] get_closure(step))
+        )))),
     ensures
         spec.entails(
             true_pred().leads_to(lift_state(|s: ClusterState| !s.reconcile_state_contains(rabbitmq.object_ref())))
@@ -67,33 +70,62 @@ pub proof fn reconcile_eventually_terminates(spec: TempPred<ClusterState>, rabbi
         lift_state(get_reconcile_state(rabbitmq, RabbitmqReconcileStep::Error)),
         lift_state(reconciler_reconcile_error::<RabbitmqClusterView, RabbitmqReconciler>(rabbitmq.object_ref()))
     );
-    lemma_from_some_state_to_one_next_state_to_reconcile_idle::<RabbitmqClusterView, RabbitmqReconciler>(spec, rabbitmq, rabbitmq_reconcile_state(RabbitmqReconcileStep::AfterUpdateStatefulSet), rabbitmq_reconcile_state(RabbitmqReconcileStep::Done));
-    lemma_from_some_state_to_one_next_state_to_reconcile_idle::<RabbitmqClusterView, RabbitmqReconciler>(spec, rabbitmq, rabbitmq_reconcile_state(RabbitmqReconcileStep::AfterCreateStatefulSet), rabbitmq_reconcile_state(RabbitmqReconcileStep::Done));
-    lemma_from_some_state_to_three_next_states_to_reconcile_idle::<RabbitmqClusterView, RabbitmqReconciler>(
-        spec, rabbitmq,
-        rabbitmq_reconcile_state(RabbitmqReconcileStep::AfterGetStatefulSet),
-        rabbitmq_reconcile_state(RabbitmqReconcileStep::AfterUpdateStatefulSet),
-        rabbitmq_reconcile_state(RabbitmqReconcileStep::AfterCreateStatefulSet),
-        rabbitmq_reconcile_state(RabbitmqReconcileStep::Error)
+    lemma_from_some_state_to_arbitrary_next_state_to_reconcile_idle::<RabbitmqClusterView, RabbitmqReconciler>(spec, rabbitmq, get_closure(RabbitmqReconcileStep::AfterUpdateStatefulSet), get_closure(RabbitmqReconcileStep::Done));
+    lemma_from_some_state_to_arbitrary_next_state_to_reconcile_idle::<RabbitmqClusterView, RabbitmqReconciler>(spec, rabbitmq, get_closure(RabbitmqReconcileStep::AfterCreateStatefulSet), get_closure(RabbitmqReconcileStep::Done));
+    or_leads_to_combine_n!(
+        spec,
+        lift_state(get_reconcile_state(rabbitmq, RabbitmqReconcileStep::AfterUpdateStatefulSet)),
+        lift_state(get_reconcile_state(rabbitmq, RabbitmqReconcileStep::AfterCreateStatefulSet)),
+        lift_state(get_reconcile_state(rabbitmq, RabbitmqReconcileStep::Error));
+        lift_state(|s: ClusterState| { !s.reconcile_state_contains(rabbitmq.object_ref()) })
     );
-    lemma_from_some_state_to_one_next_state_to_reconcile_idle::<RabbitmqClusterView, RabbitmqReconciler>(spec, rabbitmq, rabbitmq_reconcile_state(RabbitmqReconcileStep::AfterCreateRoleBinding), rabbitmq_reconcile_state(RabbitmqReconcileStep::AfterGetStatefulSet));
-    lemma_from_some_state_to_one_next_state_to_reconcile_idle::<RabbitmqClusterView, RabbitmqReconciler>(spec, rabbitmq, rabbitmq_reconcile_state(RabbitmqReconcileStep::AfterCreateRole), rabbitmq_reconcile_state(RabbitmqReconcileStep::AfterCreateRoleBinding));
-    lemma_from_some_state_to_one_next_state_to_reconcile_idle::<RabbitmqClusterView, RabbitmqReconciler>(spec, rabbitmq, rabbitmq_reconcile_state(RabbitmqReconcileStep::AfterCreateServiceAccount), rabbitmq_reconcile_state(RabbitmqReconcileStep::AfterCreateRole));
-    lemma_from_some_state_to_one_next_state_to_reconcile_idle::<RabbitmqClusterView, RabbitmqReconciler>(spec, rabbitmq, rabbitmq_reconcile_state(RabbitmqReconcileStep::AfterCreateServerConfigMap), rabbitmq_reconcile_state(RabbitmqReconcileStep::AfterCreateServiceAccount));
-    lemma_from_some_state_to_one_next_state_to_reconcile_idle::<RabbitmqClusterView, RabbitmqReconciler>(spec, rabbitmq, rabbitmq_reconcile_state(RabbitmqReconcileStep::AfterUpdateServerConfigMap), rabbitmq_reconcile_state(RabbitmqReconcileStep::AfterCreateServiceAccount));
-    lemma_from_some_state_to_three_next_states_to_reconcile_idle::<RabbitmqClusterView, RabbitmqReconciler>(
-        spec, rabbitmq,
-        rabbitmq_reconcile_state(RabbitmqReconcileStep::AfterGetServerConfigMap),
-        rabbitmq_reconcile_state(RabbitmqReconcileStep::AfterUpdateServerConfigMap),
-        rabbitmq_reconcile_state(RabbitmqReconcileStep::AfterCreateServerConfigMap),
-        rabbitmq_reconcile_state(RabbitmqReconcileStep::Error)
+    let next_state = |s: RabbitmqReconcileState| {
+        s.reconcile_step == RabbitmqReconcileStep::AfterUpdateStatefulSet
+        || s.reconcile_step == RabbitmqReconcileStep::AfterCreateStatefulSet 
+        || s.reconcile_step == RabbitmqReconcileStep::Error
+    };
+    temp_pred_equality(
+        lift_state(get_reconcile_state(rabbitmq, RabbitmqReconcileStep::AfterUpdateStatefulSet))
+        .or(lift_state(get_reconcile_state(rabbitmq, RabbitmqReconcileStep::AfterCreateStatefulSet)))
+        .or(lift_state(get_reconcile_state(rabbitmq, RabbitmqReconcileStep::Error))),
+        lift_state(at_expected_reconcile_states(rabbitmq.object_ref(), next_state))
     );
-    lemma_from_some_state_to_one_next_state_to_reconcile_idle::<RabbitmqClusterView, RabbitmqReconciler>(spec, rabbitmq, rabbitmq_reconcile_state(RabbitmqReconcileStep::AfterCreatePluginsConfigMap), rabbitmq_reconcile_state(RabbitmqReconcileStep::AfterGetServerConfigMap));
-    lemma_from_some_state_to_one_next_state_to_reconcile_idle::<RabbitmqClusterView, RabbitmqReconciler>(spec, rabbitmq, rabbitmq_reconcile_state(RabbitmqReconcileStep::AfterCreateDefaultUserSecret), rabbitmq_reconcile_state(RabbitmqReconcileStep::AfterCreatePluginsConfigMap));
-    lemma_from_some_state_to_one_next_state_to_reconcile_idle::<RabbitmqClusterView, RabbitmqReconciler>(spec, rabbitmq, rabbitmq_reconcile_state(RabbitmqReconcileStep::AfterCreateErlangCookieSecret), rabbitmq_reconcile_state(RabbitmqReconcileStep::AfterCreateDefaultUserSecret));
-    lemma_from_some_state_to_one_next_state_to_reconcile_idle::<RabbitmqClusterView, RabbitmqReconciler>(spec, rabbitmq, rabbitmq_reconcile_state(RabbitmqReconcileStep::AfterCreateService), rabbitmq_reconcile_state(RabbitmqReconcileStep::AfterCreateErlangCookieSecret));
-    lemma_from_some_state_to_one_next_state_to_reconcile_idle::<RabbitmqClusterView, RabbitmqReconciler>(spec, rabbitmq, rabbitmq_reconcile_state(RabbitmqReconcileStep::AfterCreateHeadlessService), rabbitmq_reconcile_state(RabbitmqReconcileStep::AfterCreateService));
-    lemma_from_init_state_to_next_state_to_reconcile_idle::<RabbitmqClusterView, RabbitmqReconciler>(spec, rabbitmq, rabbitmq_reconcile_state(RabbitmqReconcileStep::AfterCreateHeadlessService));
+    lemma_from_some_state_to_arbitrary_next_state_to_reconcile_idle::<RabbitmqClusterView, RabbitmqReconciler>(
+        spec, rabbitmq, get_closure(RabbitmqReconcileStep::AfterGetStatefulSet), next_state
+    );
+    lemma_from_some_state_to_arbitrary_next_state_to_reconcile_idle::<RabbitmqClusterView, RabbitmqReconciler>(spec, rabbitmq, get_closure(RabbitmqReconcileStep::AfterCreateRoleBinding), get_closure(RabbitmqReconcileStep::AfterGetStatefulSet));
+    lemma_from_some_state_to_arbitrary_next_state_to_reconcile_idle::<RabbitmqClusterView, RabbitmqReconciler>(spec, rabbitmq, get_closure(RabbitmqReconcileStep::AfterCreateRole), get_closure(RabbitmqReconcileStep::AfterCreateRoleBinding));
+    lemma_from_some_state_to_arbitrary_next_state_to_reconcile_idle::<RabbitmqClusterView, RabbitmqReconciler>(spec, rabbitmq, get_closure(RabbitmqReconcileStep::AfterCreateServiceAccount), get_closure(RabbitmqReconcileStep::AfterCreateRole));
+    lemma_from_some_state_to_arbitrary_next_state_to_reconcile_idle::<RabbitmqClusterView, RabbitmqReconciler>(spec, rabbitmq, get_closure(RabbitmqReconcileStep::AfterCreateServerConfigMap), get_closure(RabbitmqReconcileStep::AfterCreateServiceAccount));
+    lemma_from_some_state_to_arbitrary_next_state_to_reconcile_idle::<RabbitmqClusterView, RabbitmqReconciler>(spec, rabbitmq, get_closure(RabbitmqReconcileStep::AfterUpdateServerConfigMap), get_closure(RabbitmqReconcileStep::AfterCreateServiceAccount));
+
+    or_leads_to_combine_n!(
+        spec,
+        lift_state(get_reconcile_state(rabbitmq, RabbitmqReconcileStep::AfterUpdateServerConfigMap)),
+        lift_state(get_reconcile_state(rabbitmq, RabbitmqReconcileStep::AfterCreateServerConfigMap)),
+        lift_state(get_reconcile_state(rabbitmq, RabbitmqReconcileStep::Error));
+        lift_state(|s: ClusterState| { !s.reconcile_state_contains(rabbitmq.object_ref()) })
+    );
+    let next_state_1 = |s: RabbitmqReconcileState| {
+        s.reconcile_step == RabbitmqReconcileStep::AfterUpdateServerConfigMap
+        || s.reconcile_step == RabbitmqReconcileStep::AfterCreateServerConfigMap 
+        || s.reconcile_step == RabbitmqReconcileStep::Error
+    };
+    temp_pred_equality(
+        lift_state(get_reconcile_state(rabbitmq, RabbitmqReconcileStep::AfterUpdateServerConfigMap))
+        .or(lift_state(get_reconcile_state(rabbitmq, RabbitmqReconcileStep::AfterCreateServerConfigMap)))
+        .or(lift_state(get_reconcile_state(rabbitmq, RabbitmqReconcileStep::Error))),
+        lift_state(at_expected_reconcile_states(rabbitmq.object_ref(), next_state_1))
+    );
+    lemma_from_some_state_to_arbitrary_next_state_to_reconcile_idle::<RabbitmqClusterView, RabbitmqReconciler>(
+        spec, rabbitmq, get_closure(RabbitmqReconcileStep::AfterGetServerConfigMap), next_state_1
+    );
+    lemma_from_some_state_to_arbitrary_next_state_to_reconcile_idle::<RabbitmqClusterView, RabbitmqReconciler>(spec, rabbitmq, get_closure(RabbitmqReconcileStep::AfterCreatePluginsConfigMap), get_closure(RabbitmqReconcileStep::AfterGetServerConfigMap));
+    lemma_from_some_state_to_arbitrary_next_state_to_reconcile_idle::<RabbitmqClusterView, RabbitmqReconciler>(spec, rabbitmq, get_closure(RabbitmqReconcileStep::AfterCreateDefaultUserSecret), get_closure(RabbitmqReconcileStep::AfterCreatePluginsConfigMap));
+    lemma_from_some_state_to_arbitrary_next_state_to_reconcile_idle::<RabbitmqClusterView, RabbitmqReconciler>(spec, rabbitmq, get_closure(RabbitmqReconcileStep::AfterCreateErlangCookieSecret), get_closure(RabbitmqReconcileStep::AfterCreateDefaultUserSecret));
+    lemma_from_some_state_to_arbitrary_next_state_to_reconcile_idle::<RabbitmqClusterView, RabbitmqReconciler>(spec, rabbitmq, get_closure(RabbitmqReconcileStep::AfterCreateService), get_closure(RabbitmqReconcileStep::AfterCreateErlangCookieSecret));
+    lemma_from_some_state_to_arbitrary_next_state_to_reconcile_idle::<RabbitmqClusterView, RabbitmqReconciler>(spec, rabbitmq, get_closure(RabbitmqReconcileStep::AfterCreateHeadlessService), get_closure(RabbitmqReconcileStep::AfterCreateService));
+    lemma_from_init_state_to_next_state_to_reconcile_idle::<RabbitmqClusterView, RabbitmqReconciler>(spec, rabbitmq, get_closure(RabbitmqReconcileStep::Init), get_closure(RabbitmqReconcileStep::AfterCreateHeadlessService));
     valid_implies_implies_leads_to(spec, lift_state(reconcile_idle), lift_state(reconcile_idle));
     or_leads_to_combine_and_equality!(
         spec,
@@ -118,10 +150,6 @@ pub proof fn reconcile_eventually_terminates(spec: TempPred<ClusterState>, rabbi
         lift_state(get_reconcile_state(rabbitmq, RabbitmqReconcileStep::Error));
         lift_state(reconcile_idle)
     );
-}
-
-pub open spec fn get_reconcile_state(rabbitmq: RabbitmqClusterView, step: RabbitmqReconcileStep) -> StatePred<ClusterState> {
-    at_reconcile_state(rabbitmq.object_ref(), rabbitmq_reconcile_state(step))
 }
 
 }

--- a/src/controller_examples/zookeeper_controller/mod.rs
+++ b/src/controller_examples/zookeeper_controller/mod.rs
@@ -2,5 +2,5 @@
 // SPDX-License-Identifier: MIT
 pub mod common;
 pub mod exec;
-// pub mod proof;
+pub mod proof;
 pub mod spec;

--- a/src/controller_examples/zookeeper_controller/proof/common.rs
+++ b/src/controller_examples/zookeeper_controller/proof/common.rs
@@ -24,9 +24,10 @@ pub open spec fn cluster_spec() -> TempPred<ClusterState> {
     sm_spec::<ZookeeperClusterView,ZookeeperReconciler>()
 }
 
-pub open spec fn zookeeper_reconcile_state(step: ZookeeperReconcileStep) -> ZookeeperReconcileState {
+pub open spec fn zookeeper_reconcile_state(step: ZookeeperReconcileStep, sts: Option<StatefulSetView>) -> ZookeeperReconcileState {
     ZookeeperReconcileState {
-        reconcile_step: step
+        reconcile_step: step,
+        sts_from_get: sts,
     }
 }
 

--- a/src/controller_examples/zookeeper_controller/proof/common.rs
+++ b/src/controller_examples/zookeeper_controller/proof/common.rs
@@ -24,11 +24,15 @@ pub open spec fn cluster_spec() -> TempPred<ClusterState> {
     sm_spec::<ZookeeperClusterView,ZookeeperReconciler>()
 }
 
-pub open spec fn zookeeper_reconcile_state(step: ZookeeperReconcileStep, sts: Option<StatefulSetView>) -> ZookeeperReconcileState {
+pub open spec fn zookeeper_reconcile_state_with_sts(step: ZookeeperReconcileStep, sts: Option<StatefulSetView>) -> ZookeeperReconcileState {
     ZookeeperReconcileState {
         reconcile_step: step,
         sts_from_get: sts,
     }
+}
+
+pub open spec fn zookeeper_reconcile_state(step: ZookeeperReconcileStep) -> FnSpec(ZookeeperReconcileState) -> bool {
+    |s: ZookeeperReconcileState| s.reconcile_step == step
 }
 
 pub open spec fn at_zookeeper_step(key: ObjectRef, step: ZookeeperReconcileStep) -> StatePred<ClusterState>

--- a/src/controller_examples/zookeeper_controller/proof/liveness/liveness_property.rs
+++ b/src/controller_examples/zookeeper_controller/proof/liveness/liveness_property.rs
@@ -127,13 +127,14 @@ spec fn invariants(zk: ZookeeperClusterView) -> TempPred<ClusterState> {
     .and(always(lift_state(cluster_safety::each_key_in_reconcile_is_consistent_with_its_object())))
     .and(always(lift_state(helper_invariants::pending_msg_at_after_create_stateful_set_step_is_create_sts_req(zk.object_ref()))))
     .and(always(lift_state(helper_invariants::pending_msg_at_after_update_stateful_set_step_is_update_sts_req(zk.object_ref()))))
-    .and(always(lift_state(controller_runtime::no_pending_req_at_reconcile_init_state::<ZookeeperClusterView, ZookeeperReconciler>(zk.object_ref()))))
+    .and(always(lift_state(controller_runtime::pending_req_is_none_at_reconcile_state::<ZookeeperClusterView, ZookeeperReconciler>(zk.object_ref(), zookeeper_reconcile_state(ZookeeperReconcileStep::Init)))))
     .and(always(lift_state(controller_runtime::pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<ZookeeperClusterView, ZookeeperReconciler>(zk.object_ref(), zookeeper_reconcile_state(ZookeeperReconcileStep::AfterUpdateStatefulSet)))))
     .and(always(lift_state(controller_runtime::pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<ZookeeperClusterView, ZookeeperReconciler>(zk.object_ref(), zookeeper_reconcile_state(ZookeeperReconcileStep::AfterCreateStatefulSet)))))
     .and(always(lift_state(controller_runtime::pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<ZookeeperClusterView, ZookeeperReconciler>(zk.object_ref(), zookeeper_reconcile_state(ZookeeperReconcileStep::AfterCreateHeadlessService)))))
     .and(always(lift_state(controller_runtime::pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<ZookeeperClusterView, ZookeeperReconciler>(zk.object_ref(), zookeeper_reconcile_state(ZookeeperReconcileStep::AfterCreateClientService)))))
     .and(always(lift_state(controller_runtime::pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<ZookeeperClusterView, ZookeeperReconciler>(zk.object_ref(), zookeeper_reconcile_state(ZookeeperReconcileStep::AfterCreateAdminServerService)))))
     .and(always(lift_state(controller_runtime::pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<ZookeeperClusterView, ZookeeperReconciler>(zk.object_ref(), zookeeper_reconcile_state(ZookeeperReconcileStep::AfterCreateConfigMap)))))
+    .and(always(lift_state(controller_runtime::pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<ZookeeperClusterView, ZookeeperReconciler>(zk.object_ref(), zookeeper_reconcile_state(ZookeeperReconcileStep::AfterGetStatefulSet)))))
     .and(always(lift_state(controller_runtime::pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<ZookeeperClusterView, ZookeeperReconciler>(zk.object_ref(), zookeeper_reconcile_state(ZookeeperReconcileStep::AfterGetStatefulSet)))))
     .and(always(lift_state(controller_runtime::pending_req_is_none_at_reconcile_state::<ZookeeperClusterView, ZookeeperReconciler>(zk.object_ref(), zookeeper_reconcile_state(ZookeeperReconcileStep::AfterCreateZKNode)))))
 }
@@ -420,13 +421,13 @@ proof fn liveness_proof(zk: ZookeeperClusterView)
             helper_invariants::lemma_always_pending_msg_at_after_create_stateful_set_step_is_create_sts_req(spec, zk.object_ref());
             helper_invariants::lemma_always_pending_msg_at_after_update_stateful_set_step_is_update_sts_req(spec, zk.object_ref());
             controller_runtime_safety::lemma_always_no_pending_req_at_reconcile_init_state::<ZookeeperClusterView, ZookeeperReconciler>(spec, zk.object_ref());
-            controller_runtime_safety::lemma_always_pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<ZookeeperClusterView, ZookeeperReconciler>(spec, zk.object_ref(), zookeeper_reconcile_state(ZookeeperReconcileStep::AfterUpdateStatefulSet));
-            controller_runtime_safety::lemma_always_pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<ZookeeperClusterView, ZookeeperReconciler>(spec, zk.object_ref(), zookeeper_reconcile_state(ZookeeperReconcileStep::AfterCreateStatefulSet));
-            controller_runtime_safety::lemma_always_pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<ZookeeperClusterView, ZookeeperReconciler>(spec, zk.object_ref(), zookeeper_reconcile_state(ZookeeperReconcileStep::AfterCreateHeadlessService));
-            controller_runtime_safety::lemma_always_pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<ZookeeperClusterView, ZookeeperReconciler>(spec, zk.object_ref(), zookeeper_reconcile_state(ZookeeperReconcileStep::AfterCreateClientService));
-            controller_runtime_safety::lemma_always_pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<ZookeeperClusterView, ZookeeperReconciler>(spec, zk.object_ref(), zookeeper_reconcile_state(ZookeeperReconcileStep::AfterCreateAdminServerService));
-            controller_runtime_safety::lemma_always_pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<ZookeeperClusterView, ZookeeperReconciler>(spec, zk.object_ref(), zookeeper_reconcile_state(ZookeeperReconcileStep::AfterCreateConfigMap));
-            controller_runtime_safety::lemma_always_pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<ZookeeperClusterView, ZookeeperReconciler>(spec, zk.object_ref(), zookeeper_reconcile_state(ZookeeperReconcileStep::AfterGetStatefulSet));
+            controller_runtime_safety::lemma_always_pending_req_in_flight_or_resp_in_flight_at_reconcile_state_1::<ZookeeperClusterView, ZookeeperReconciler>(spec, zk.object_ref(), zookeeper_reconcile_state(ZookeeperReconcileStep::AfterUpdateStatefulSet));
+            controller_runtime_safety::lemma_always_pending_req_in_flight_or_resp_in_flight_at_reconcile_state_1::<ZookeeperClusterView, ZookeeperReconciler>(spec, zk.object_ref(), zookeeper_reconcile_state(ZookeeperReconcileStep::AfterCreateStatefulSet));
+            controller_runtime_safety::lemma_always_pending_req_in_flight_or_resp_in_flight_at_reconcile_state_1::<ZookeeperClusterView, ZookeeperReconciler>(spec, zk.object_ref(), zookeeper_reconcile_state(ZookeeperReconcileStep::AfterCreateHeadlessService));
+            controller_runtime_safety::lemma_always_pending_req_in_flight_or_resp_in_flight_at_reconcile_state_1::<ZookeeperClusterView, ZookeeperReconciler>(spec, zk.object_ref(), zookeeper_reconcile_state(ZookeeperReconcileStep::AfterCreateClientService));
+            controller_runtime_safety::lemma_always_pending_req_in_flight_or_resp_in_flight_at_reconcile_state_1::<ZookeeperClusterView, ZookeeperReconciler>(spec, zk.object_ref(), zookeeper_reconcile_state(ZookeeperReconcileStep::AfterCreateAdminServerService));
+            controller_runtime_safety::lemma_always_pending_req_in_flight_or_resp_in_flight_at_reconcile_state_1::<ZookeeperClusterView, ZookeeperReconciler>(spec, zk.object_ref(), zookeeper_reconcile_state(ZookeeperReconcileStep::AfterCreateConfigMap));
+            controller_runtime_safety::lemma_always_pending_req_in_flight_or_resp_in_flight_at_reconcile_state_1::<ZookeeperClusterView, ZookeeperReconciler>(spec, zk.object_ref(), zookeeper_reconcile_state(ZookeeperReconcileStep::AfterGetStatefulSet));
             controller_runtime_safety::lemma_always_pending_req_is_none_at_reconcile_state::<ZookeeperClusterView, ZookeeperReconciler>(spec, zk.object_ref(), zookeeper_reconcile_state(ZookeeperReconcileStep::AfterCreateZKNode));
 
             entails_and_n!(

--- a/src/controller_examples/zookeeper_controller/proof/liveness/mod.rs
+++ b/src/controller_examples/zookeeper_controller/proof/liveness/mod.rs
@@ -1,5 +1,5 @@
 // Copyright 2022 VMware, Inc.
 // SPDX-License-Identifier: MIT
-pub mod helper_invariants;
-pub mod liveness_property;
+// pub mod helper_invariants;
+// pub mod liveness_property;
 pub mod terminate;

--- a/src/controller_examples/zookeeper_controller/proof/liveness/terminate.rs
+++ b/src/controller_examples/zookeeper_controller/proof/liveness/terminate.rs
@@ -48,16 +48,16 @@ pub proof fn reconcile_eventually_terminates(spec: TempPred<ClusterState>, zk: Z
         spec.entails(always(lift_state(controller_runtime_safety::every_in_flight_msg_has_unique_id()))),
         spec.entails(always(lift_state(controller_runtime_safety::each_resp_matches_at_most_one_pending_req(zk.object_ref())))),
         spec.entails(always(lift_state(controller_runtime_safety::each_resp_if_matches_pending_req_then_no_other_resp_matches(zk.object_ref())))),
-        spec.entails(always(pending_req_xxx(zk.object_ref(), ZookeeperReconcileStep::AfterUpdateStatefulSet))),
-        spec.entails(always(pending_req_xxx(zk.object_ref(), ZookeeperReconcileStep::AfterCreateStatefulSet))),
-        spec.entails(always(pending_req_xxx(zk.object_ref(), ZookeeperReconcileStep::AfterCreateHeadlessService))),
-        spec.entails(always(pending_req_xxx(zk.object_ref(), ZookeeperReconcileStep::AfterCreateClientService))),
-        spec.entails(always(pending_req_xxx(zk.object_ref(), ZookeeperReconcileStep::AfterCreateAdminServerService))),
-        spec.entails(always(pending_req_xxx(zk.object_ref(), ZookeeperReconcileStep::AfterCreateConfigMap))),
-        spec.entails(always(pending_req_xxx(zk.object_ref(), ZookeeperReconcileStep::AfterGetStatefulSet))),
-        spec.entails(always(pending_req_xxx(zk.object_ref(), ZookeeperReconcileStep::AfterUpdateZKNode))),
-        spec.entails(always(pending_req_none(zk.object_ref(), ZookeeperReconcileStep::AfterCreateZKNode))),
-        spec.entails(always(pending_req_none(zk.object_ref(), ZookeeperReconcileStep::Init))),
+        spec.entails(always(pending_req_or_resp_at(zk.object_ref(), ZookeeperReconcileStep::AfterUpdateStatefulSet))),
+        spec.entails(always(pending_req_or_resp_at(zk.object_ref(), ZookeeperReconcileStep::AfterCreateStatefulSet))),
+        spec.entails(always(pending_req_or_resp_at(zk.object_ref(), ZookeeperReconcileStep::AfterCreateHeadlessService))),
+        spec.entails(always(pending_req_or_resp_at(zk.object_ref(), ZookeeperReconcileStep::AfterCreateClientService))),
+        spec.entails(always(pending_req_or_resp_at(zk.object_ref(), ZookeeperReconcileStep::AfterCreateAdminServerService))),
+        spec.entails(always(pending_req_or_resp_at(zk.object_ref(), ZookeeperReconcileStep::AfterCreateConfigMap))),
+        spec.entails(always(pending_req_or_resp_at(zk.object_ref(), ZookeeperReconcileStep::AfterGetStatefulSet))),
+        spec.entails(always(pending_req_or_resp_at(zk.object_ref(), ZookeeperReconcileStep::AfterUpdateZKNode))),
+        spec.entails(always(pending_req_is_none(zk.object_ref(), ZookeeperReconcileStep::AfterCreateZKNode))),
+        spec.entails(always(pending_req_is_none(zk.object_ref(), ZookeeperReconcileStep::Init))),
     ensures
         spec.entails(
             true_pred().leads_to(lift_state(|s: ClusterState| !s.reconcile_state_contains(zk.object_ref())))
@@ -191,13 +191,13 @@ pub open spec fn get_reconcile_state(zk: ZookeeperClusterView, step: ZookeeperRe
     )
 }
 
-pub open spec fn pending_req_xxx(key: ObjectRef, step: ZookeeperReconcileStep) -> TempPred<ClusterState> {
+pub open spec fn pending_req_or_resp_at(key: ObjectRef, step: ZookeeperReconcileStep) -> TempPred<ClusterState> {
     lift_state(pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<ZookeeperClusterView, ZookeeperReconciler>(
         key, |s: ZookeeperReconcileState| s.reconcile_step == step
     ))
 }
 
-pub open spec fn pending_req_none(key: ObjectRef, step: ZookeeperReconcileStep) -> TempPred<ClusterState> {
+pub open spec fn pending_req_is_none(key: ObjectRef, step: ZookeeperReconcileStep) -> TempPred<ClusterState> {
     lift_state(pending_req_is_none_at_reconcile_state::<ZookeeperClusterView, ZookeeperReconciler>(
         key, |s: ZookeeperReconcileState| s.reconcile_step == step
     ))

--- a/src/controller_examples/zookeeper_controller/proof/liveness/terminate.rs
+++ b/src/controller_examples/zookeeper_controller/proof/liveness/terminate.rs
@@ -67,19 +67,19 @@ pub proof fn reconcile_eventually_terminates(spec: TempPred<ClusterState>, zk: Z
     lemma_reconcile_error_leads_to_reconcile_idle::<ZookeeperClusterView, ZookeeperReconciler>(spec, zk.object_ref());
     lemma_reconcile_done_leads_to_reconcile_idle::<ZookeeperClusterView, ZookeeperReconciler>(spec, zk.object_ref());
     temp_pred_equality(
-        lift_state(get_reconcile_state(zk, ZookeeperReconcileStep::Done)),
+        lift_state(at_step(zk, ZookeeperReconcileStep::Done)),
         lift_state(reconciler_reconcile_done::<ZookeeperClusterView, ZookeeperReconciler>(zk.object_ref()))
     );
     temp_pred_equality(
-        lift_state(get_reconcile_state(zk, ZookeeperReconcileStep::Error)),
+        lift_state(at_step(zk, ZookeeperReconcileStep::Error)),
         lift_state(reconciler_reconcile_error::<ZookeeperClusterView, ZookeeperReconciler>(zk.object_ref()))
     );
     or_leads_to_combine(
-        spec, get_reconcile_state(zk, ZookeeperReconcileStep::Done), get_reconcile_state(zk, ZookeeperReconcileStep::Error),
+        spec, at_step(zk, ZookeeperReconcileStep::Done), at_step(zk, ZookeeperReconcileStep::Error),
         reconcile_idle
     );
     temp_pred_equality(
-        lift_state(get_reconcile_state(zk, ZookeeperReconcileStep::Done)).or(lift_state(get_reconcile_state(zk, ZookeeperReconcileStep::Error))),
+        lift_state(at_step(zk, ZookeeperReconcileStep::Done)).or(lift_state(at_step(zk, ZookeeperReconcileStep::Error))),
         lift_state(at_expected_reconcile_states(
             zk.object_ref(),
             |s: ZookeeperReconcileState| {s.reconcile_step == ZookeeperReconcileStep::Error || s.reconcile_step == ZookeeperReconcileStep::Done}
@@ -99,11 +99,11 @@ pub proof fn reconcile_eventually_terminates(spec: TempPred<ClusterState>, zk: Z
     );
 
     or_leads_to_combine(
-        spec, get_reconcile_state(zk, ZookeeperReconcileStep::AfterUpdateStatefulSet), get_reconcile_state(zk, ZookeeperReconcileStep::Error),
+        spec, at_step(zk, ZookeeperReconcileStep::AfterUpdateStatefulSet), at_step(zk, ZookeeperReconcileStep::Error),
         reconcile_idle
     );
     temp_pred_equality(
-        lift_state(get_reconcile_state(zk, ZookeeperReconcileStep::AfterUpdateStatefulSet)).or(lift_state(get_reconcile_state(zk, ZookeeperReconcileStep::Error))),
+        lift_state(at_step(zk, ZookeeperReconcileStep::AfterUpdateStatefulSet)).or(lift_state(at_step(zk, ZookeeperReconcileStep::Error))),
         lift_state(at_expected_reconcile_states(
             zk.object_ref(),
             |s: ZookeeperReconcileState| {s.reconcile_step == ZookeeperReconcileStep::AfterUpdateStatefulSet || s.reconcile_step == ZookeeperReconcileStep::Error}
@@ -115,15 +115,15 @@ pub proof fn reconcile_eventually_terminates(spec: TempPred<ClusterState>, zk: Z
     );
     or_leads_to_combine_n!(
         spec,
-        lift_state(get_reconcile_state(zk, ZookeeperReconcileStep::AfterCreateStatefulSet)),
-        lift_state(get_reconcile_state(zk, ZookeeperReconcileStep::AfterUpdateZKNode)),
-        lift_state(get_reconcile_state(zk, ZookeeperReconcileStep::Error));
+        lift_state(at_step(zk, ZookeeperReconcileStep::AfterCreateStatefulSet)),
+        lift_state(at_step(zk, ZookeeperReconcileStep::AfterUpdateZKNode)),
+        lift_state(at_step(zk, ZookeeperReconcileStep::Error));
         lift_state(reconcile_idle)
     );
     temp_pred_equality(
-        lift_state(get_reconcile_state(zk, ZookeeperReconcileStep::AfterCreateStatefulSet))
-        .or(lift_state(get_reconcile_state(zk, ZookeeperReconcileStep::AfterUpdateZKNode)))
-        .or(lift_state(get_reconcile_state(zk, ZookeeperReconcileStep::Error))),
+        lift_state(at_step(zk, ZookeeperReconcileStep::AfterCreateStatefulSet))
+        .or(lift_state(at_step(zk, ZookeeperReconcileStep::AfterUpdateZKNode)))
+        .or(lift_state(at_step(zk, ZookeeperReconcileStep::Error))),
         lift_state(at_expected_reconcile_states(
             zk.object_ref(),
             |s: ZookeeperReconcileState| {
@@ -170,22 +170,22 @@ pub proof fn reconcile_eventually_terminates(spec: TempPred<ClusterState>, zk: Z
         true_pred(),
         lift_state(reconcile_idle),
         lift_state(reconciler_reconcile_error::<ZookeeperClusterView, ZookeeperReconciler>(zk.object_ref())),
-        lift_state(get_reconcile_state(zk, ZookeeperReconcileStep::Init)),
-        lift_state(get_reconcile_state(zk, ZookeeperReconcileStep::AfterCreateHeadlessService)),
-        lift_state(get_reconcile_state(zk, ZookeeperReconcileStep::AfterCreateClientService)),
-        lift_state(get_reconcile_state(zk, ZookeeperReconcileStep::AfterCreateAdminServerService)),
-        lift_state(get_reconcile_state(zk, ZookeeperReconcileStep::AfterCreateConfigMap)),
-        lift_state(get_reconcile_state(zk, ZookeeperReconcileStep::AfterGetStatefulSet)),
-        lift_state(get_reconcile_state(zk, ZookeeperReconcileStep::AfterCreateStatefulSet)),
-        lift_state(get_reconcile_state(zk, ZookeeperReconcileStep::AfterUpdateStatefulSet)),
-        lift_state(get_reconcile_state(zk, ZookeeperReconcileStep::AfterCreateZKNode)),
-        lift_state(get_reconcile_state(zk, ZookeeperReconcileStep::AfterUpdateZKNode)),
-        lift_state(get_reconcile_state(zk, ZookeeperReconcileStep::Done));
+        lift_state(at_step(zk, ZookeeperReconcileStep::Init)),
+        lift_state(at_step(zk, ZookeeperReconcileStep::AfterCreateHeadlessService)),
+        lift_state(at_step(zk, ZookeeperReconcileStep::AfterCreateClientService)),
+        lift_state(at_step(zk, ZookeeperReconcileStep::AfterCreateAdminServerService)),
+        lift_state(at_step(zk, ZookeeperReconcileStep::AfterCreateConfigMap)),
+        lift_state(at_step(zk, ZookeeperReconcileStep::AfterGetStatefulSet)),
+        lift_state(at_step(zk, ZookeeperReconcileStep::AfterCreateStatefulSet)),
+        lift_state(at_step(zk, ZookeeperReconcileStep::AfterUpdateStatefulSet)),
+        lift_state(at_step(zk, ZookeeperReconcileStep::AfterCreateZKNode)),
+        lift_state(at_step(zk, ZookeeperReconcileStep::AfterUpdateZKNode)),
+        lift_state(at_step(zk, ZookeeperReconcileStep::Done));
         lift_state(reconcile_idle)
     );
 }
 
-pub open spec fn get_reconcile_state(zk: ZookeeperClusterView, step: ZookeeperReconcileStep) -> StatePred<ClusterState> {
+pub open spec fn at_step(zk: ZookeeperClusterView, step: ZookeeperReconcileStep) -> StatePred<ClusterState> {
     at_expected_reconcile_states::<ZookeeperClusterView, ZookeeperReconciler>(
         zk.object_ref(), |s: ZookeeperReconcileState| s.reconcile_step == step
     )

--- a/src/controller_examples/zookeeper_controller/proof/liveness/terminate.rs
+++ b/src/controller_examples/zookeeper_controller/proof/liveness/terminate.rs
@@ -48,15 +48,16 @@ pub proof fn reconcile_eventually_terminates(spec: TempPred<ClusterState>, zk: Z
         spec.entails(always(lift_state(controller_runtime_safety::every_in_flight_msg_has_unique_id()))),
         spec.entails(always(lift_state(controller_runtime_safety::each_resp_matches_at_most_one_pending_req(zk.object_ref())))),
         spec.entails(always(lift_state(controller_runtime_safety::each_resp_if_matches_pending_req_then_no_other_resp_matches(zk.object_ref())))),
-        spec.entails(always(lift_state(no_pending_req_at_reconcile_init_state::<ZookeeperClusterView, ZookeeperReconciler>(zk.object_ref())))),
-        spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_reconcile_state(zk.object_ref(), zookeeper_reconcile_state(ZookeeperReconcileStep::AfterUpdateStatefulSet))))),
-        spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_reconcile_state(zk.object_ref(), zookeeper_reconcile_state(ZookeeperReconcileStep::AfterCreateStatefulSet))))),
-        spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_reconcile_state(zk.object_ref(), zookeeper_reconcile_state(ZookeeperReconcileStep::AfterCreateHeadlessService))))),
-        spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_reconcile_state(zk.object_ref(), zookeeper_reconcile_state(ZookeeperReconcileStep::AfterCreateClientService))))),
-        spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_reconcile_state(zk.object_ref(), zookeeper_reconcile_state(ZookeeperReconcileStep::AfterCreateAdminServerService))))),
-        spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_reconcile_state(zk.object_ref(), zookeeper_reconcile_state(ZookeeperReconcileStep::AfterCreateConfigMap))))),
-        spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_reconcile_state(zk.object_ref(), zookeeper_reconcile_state(ZookeeperReconcileStep::AfterGetStatefulSet))))),
-        spec.entails(always(lift_state(pending_req_is_none_at_reconcile_state(zk.object_ref(), zookeeper_reconcile_state(ZookeeperReconcileStep::AfterCreateZKNode))))),
+        spec.entails(always(pending_req_xxx(zk.object_ref(), ZookeeperReconcileStep::AfterUpdateStatefulSet))),
+        spec.entails(always(pending_req_xxx(zk.object_ref(), ZookeeperReconcileStep::AfterCreateStatefulSet))),
+        spec.entails(always(pending_req_xxx(zk.object_ref(), ZookeeperReconcileStep::AfterCreateHeadlessService))),
+        spec.entails(always(pending_req_xxx(zk.object_ref(), ZookeeperReconcileStep::AfterCreateClientService))),
+        spec.entails(always(pending_req_xxx(zk.object_ref(), ZookeeperReconcileStep::AfterCreateAdminServerService))),
+        spec.entails(always(pending_req_xxx(zk.object_ref(), ZookeeperReconcileStep::AfterCreateConfigMap))),
+        spec.entails(always(pending_req_xxx(zk.object_ref(), ZookeeperReconcileStep::AfterGetStatefulSet))),
+        spec.entails(always(pending_req_xxx(zk.object_ref(), ZookeeperReconcileStep::AfterUpdateZKNode))),
+        spec.entails(always(pending_req_none(zk.object_ref(), ZookeeperReconcileStep::AfterCreateZKNode))),
+        spec.entails(always(pending_req_none(zk.object_ref(), ZookeeperReconcileStep::Init))),
     ensures
         spec.entails(
             true_pred().leads_to(lift_state(|s: ClusterState| !s.reconcile_state_contains(zk.object_ref())))
@@ -66,51 +67,140 @@ pub proof fn reconcile_eventually_terminates(spec: TempPred<ClusterState>, zk: Z
     lemma_reconcile_error_leads_to_reconcile_idle::<ZookeeperClusterView, ZookeeperReconciler>(spec, zk.object_ref());
     lemma_reconcile_done_leads_to_reconcile_idle::<ZookeeperClusterView, ZookeeperReconciler>(spec, zk.object_ref());
     temp_pred_equality(
-        lift_state(at_reconcile_state(zk.object_ref(), zookeeper_reconcile_state(ZookeeperReconcileStep::Done))),
+        lift_state(get_reconcile_state(zk, ZookeeperReconcileStep::Done)),
         lift_state(reconciler_reconcile_done::<ZookeeperClusterView, ZookeeperReconciler>(zk.object_ref()))
     );
     temp_pred_equality(
-        lift_state(at_reconcile_state(zk.object_ref(), zookeeper_reconcile_state(ZookeeperReconcileStep::Error))),
+        lift_state(get_reconcile_state(zk, ZookeeperReconcileStep::Error)),
         lift_state(reconciler_reconcile_error::<ZookeeperClusterView, ZookeeperReconciler>(zk.object_ref()))
     );
+    or_leads_to_combine(
+        spec, get_reconcile_state(zk, ZookeeperReconcileStep::Done), get_reconcile_state(zk, ZookeeperReconcileStep::Error),
+        reconcile_idle
+    );
+    temp_pred_equality(
+        lift_state(get_reconcile_state(zk, ZookeeperReconcileStep::Done)).or(lift_state(get_reconcile_state(zk, ZookeeperReconcileStep::Error))),
+        lift_state(at_expected_reconcile_states(
+            zk.object_ref(),
+            |s: ZookeeperReconcileState| {s.reconcile_step == ZookeeperReconcileStep::Error || s.reconcile_step == ZookeeperReconcileStep::Done}
+        ))
+    );
     lemma_from_some_state_with_ext_resp_to_two_next_states_to_reconcile_idle::<ZookeeperClusterView, ZookeeperReconciler>(
-        spec, zk, zookeeper_reconcile_state(ZookeeperReconcileStep::AfterCreateZKNode),
-        zookeeper_reconcile_state(ZookeeperReconcileStep::Error), zookeeper_reconcile_state(ZookeeperReconcileStep::Done)
+        spec, zk, |s: ZookeeperReconcileState| s.reconcile_step == ZookeeperReconcileStep::AfterCreateZKNode,
+        |s: ZookeeperReconcileState| {s.reconcile_step == ZookeeperReconcileStep::Error || s.reconcile_step == ZookeeperReconcileStep::Done}
     );
-    lemma_from_some_state_to_one_next_state_to_reconcile_idle::<ZookeeperClusterView, ZookeeperReconciler>(spec, zk, zookeeper_reconcile_state(ZookeeperReconcileStep::AfterUpdateStatefulSet), zookeeper_reconcile_state(ZookeeperReconcileStep::AfterCreateZKNode));
-    lemma_from_some_state_to_one_next_state_to_reconcile_idle::<ZookeeperClusterView, ZookeeperReconciler>(spec, zk, zookeeper_reconcile_state(ZookeeperReconcileStep::AfterCreateStatefulSet), zookeeper_reconcile_state(ZookeeperReconcileStep::AfterCreateZKNode));
-
-    lemma_from_some_state_to_three_next_states_to_reconcile_idle::<ZookeeperClusterView, ZookeeperReconciler>(
-        spec, zk,
-        zookeeper_reconcile_state(ZookeeperReconcileStep::AfterGetStatefulSet),
-        zookeeper_reconcile_state(ZookeeperReconcileStep::AfterUpdateStatefulSet),
-        zookeeper_reconcile_state(ZookeeperReconcileStep::AfterCreateStatefulSet),
-        zookeeper_reconcile_state(ZookeeperReconcileStep::Error)
+    lemma_from_some_state_to_arbitrary_next_state_to_reconcile_idle::<ZookeeperClusterView, ZookeeperReconciler>(
+        spec, zk, |s: ZookeeperReconcileState| s.reconcile_step == ZookeeperReconcileStep::AfterUpdateStatefulSet, 
+        |s: ZookeeperReconcileState| s.reconcile_step == ZookeeperReconcileStep::AfterCreateZKNode
+    );
+    lemma_from_some_state_to_arbitrary_next_state_to_reconcile_idle::<ZookeeperClusterView, ZookeeperReconciler>(
+        spec, zk, |s: ZookeeperReconcileState| s.reconcile_step == ZookeeperReconcileStep::AfterCreateStatefulSet, 
+        |s: ZookeeperReconcileState| s.reconcile_step == ZookeeperReconcileStep::AfterCreateZKNode
     );
 
-    lemma_from_some_state_to_one_next_state_to_reconcile_idle::<ZookeeperClusterView, ZookeeperReconciler>(spec, zk, zookeeper_reconcile_state(ZookeeperReconcileStep::AfterCreateConfigMap), zookeeper_reconcile_state(ZookeeperReconcileStep::AfterGetStatefulSet));
-    lemma_from_some_state_to_one_next_state_to_reconcile_idle::<ZookeeperClusterView, ZookeeperReconciler>(spec, zk, zookeeper_reconcile_state(ZookeeperReconcileStep::AfterCreateAdminServerService), zookeeper_reconcile_state(ZookeeperReconcileStep::AfterCreateConfigMap));
-    lemma_from_some_state_to_one_next_state_to_reconcile_idle::<ZookeeperClusterView, ZookeeperReconciler>(spec, zk, zookeeper_reconcile_state(ZookeeperReconcileStep::AfterCreateClientService), zookeeper_reconcile_state(ZookeeperReconcileStep::AfterCreateAdminServerService));
-    lemma_from_some_state_to_one_next_state_to_reconcile_idle::<ZookeeperClusterView, ZookeeperReconciler>(spec, zk, zookeeper_reconcile_state(ZookeeperReconcileStep::AfterCreateHeadlessService), zookeeper_reconcile_state(ZookeeperReconcileStep::AfterCreateClientService));
-    lemma_from_init_state_to_next_state_to_reconcile_idle::<ZookeeperClusterView, ZookeeperReconciler>(spec, zk, zookeeper_reconcile_state(ZookeeperReconcileStep::AfterCreateHeadlessService));
+    or_leads_to_combine(
+        spec, get_reconcile_state(zk, ZookeeperReconcileStep::AfterUpdateStatefulSet), get_reconcile_state(zk, ZookeeperReconcileStep::Error),
+        reconcile_idle
+    );
+    temp_pred_equality(
+        lift_state(get_reconcile_state(zk, ZookeeperReconcileStep::AfterUpdateStatefulSet)).or(lift_state(get_reconcile_state(zk, ZookeeperReconcileStep::Error))),
+        lift_state(at_expected_reconcile_states(
+            zk.object_ref(),
+            |s: ZookeeperReconcileState| {s.reconcile_step == ZookeeperReconcileStep::AfterUpdateStatefulSet || s.reconcile_step == ZookeeperReconcileStep::Error}
+        ))
+    );
+    lemma_from_some_state_to_arbitrary_next_state_to_reconcile_idle::<ZookeeperClusterView, ZookeeperReconciler>(
+        spec, zk, |s: ZookeeperReconcileState| s.reconcile_step == ZookeeperReconcileStep::AfterUpdateZKNode,
+        |s: ZookeeperReconcileState| {s.reconcile_step == ZookeeperReconcileStep::AfterUpdateStatefulSet || s.reconcile_step == ZookeeperReconcileStep::Error}
+    );
+    or_leads_to_combine_n!(
+        spec, 
+        lift_state(get_reconcile_state(zk, ZookeeperReconcileStep::AfterCreateStatefulSet)), 
+        lift_state(get_reconcile_state(zk, ZookeeperReconcileStep::AfterUpdateZKNode)),
+        lift_state(get_reconcile_state(zk, ZookeeperReconcileStep::Error));
+        lift_state(reconcile_idle)
+    );
+    temp_pred_equality(
+        lift_state(get_reconcile_state(zk, ZookeeperReconcileStep::AfterCreateStatefulSet))
+        .or(lift_state(get_reconcile_state(zk, ZookeeperReconcileStep::AfterUpdateZKNode)))
+        .or(lift_state(get_reconcile_state(zk, ZookeeperReconcileStep::Error))),
+        lift_state(at_expected_reconcile_states(
+            zk.object_ref(),
+            |s: ZookeeperReconcileState| {
+                s.reconcile_step == ZookeeperReconcileStep::AfterCreateStatefulSet 
+                || s.reconcile_step == ZookeeperReconcileStep::AfterUpdateZKNode
+                || s.reconcile_step == ZookeeperReconcileStep::Error
+            }
+        ))
+    );
+    lemma_from_some_state_to_arbitrary_next_state_to_reconcile_idle::<ZookeeperClusterView, ZookeeperReconciler>(
+        spec, zk, |s: ZookeeperReconcileState| s.reconcile_step == ZookeeperReconcileStep::AfterGetStatefulSet,
+        |s: ZookeeperReconcileState| {
+            s.reconcile_step == ZookeeperReconcileStep::AfterCreateStatefulSet 
+            || s.reconcile_step == ZookeeperReconcileStep::AfterUpdateZKNode
+            || s.reconcile_step == ZookeeperReconcileStep::Error
+        }
+    );
+    lemma_from_some_state_to_arbitrary_next_state_to_reconcile_idle::<ZookeeperClusterView, ZookeeperReconciler>(
+        spec, zk, |s: ZookeeperReconcileState| s.reconcile_step == ZookeeperReconcileStep::AfterCreateConfigMap, 
+        |s: ZookeeperReconcileState| s.reconcile_step == ZookeeperReconcileStep::AfterGetStatefulSet
+    );
+    lemma_from_some_state_to_arbitrary_next_state_to_reconcile_idle::<ZookeeperClusterView, ZookeeperReconciler>(
+        spec, zk, |s: ZookeeperReconcileState| s.reconcile_step == ZookeeperReconcileStep::AfterCreateAdminServerService, 
+        |s: ZookeeperReconcileState| s.reconcile_step == ZookeeperReconcileStep::AfterCreateConfigMap
+    );
+    lemma_from_some_state_to_arbitrary_next_state_to_reconcile_idle::<ZookeeperClusterView, ZookeeperReconciler>(
+        spec, zk, |s: ZookeeperReconcileState| s.reconcile_step == ZookeeperReconcileStep::AfterCreateClientService, 
+        |s: ZookeeperReconcileState| s.reconcile_step == ZookeeperReconcileStep::AfterCreateAdminServerService
+    );
+    lemma_from_some_state_to_arbitrary_next_state_to_reconcile_idle::<ZookeeperClusterView, ZookeeperReconciler>(
+        spec, zk, |s: ZookeeperReconcileState| s.reconcile_step == ZookeeperReconcileStep::AfterCreateHeadlessService, 
+        |s: ZookeeperReconcileState| s.reconcile_step == ZookeeperReconcileStep::AfterCreateClientService
+    );
+    lemma_from_some_state_to_arbitrary_next_state_to_reconcile_idle::<ZookeeperClusterView, ZookeeperReconciler>(
+        spec, zk, |s: ZookeeperReconcileState| s.reconcile_step == ZookeeperReconcileStep::AfterCreateStatefulSet, 
+        |s: ZookeeperReconcileState| s.reconcile_step == ZookeeperReconcileStep::AfterCreateZKNode
+    );
+    lemma_from_init_state_to_next_state_to_reconcile_idle::<ZookeeperClusterView, ZookeeperReconciler>(
+        spec, zk, |s: ZookeeperReconcileState| s.reconcile_step == ZookeeperReconcileStep::Init,
+        |s: ZookeeperReconcileState| s.reconcile_step == ZookeeperReconcileStep::AfterCreateHeadlessService);
     valid_implies_implies_leads_to(spec, lift_state(reconcile_idle), lift_state(reconcile_idle));
     or_leads_to_combine_and_equality!(
         spec,
         true_pred(),
         lift_state(reconcile_idle),
         lift_state(reconciler_reconcile_error::<ZookeeperClusterView, ZookeeperReconciler>(zk.object_ref())),
-        lift_state(at_reconcile_state(zk.object_ref(), ZookeeperReconciler::reconcile_init_state())),
-        lift_state(at_reconcile_state(zk.object_ref(), zookeeper_reconcile_state(ZookeeperReconcileStep::AfterCreateHeadlessService))),
-        lift_state(at_reconcile_state(zk.object_ref(), zookeeper_reconcile_state(ZookeeperReconcileStep::AfterCreateClientService))),
-        lift_state(at_reconcile_state(zk.object_ref(), zookeeper_reconcile_state(ZookeeperReconcileStep::AfterCreateAdminServerService))),
-        lift_state(at_reconcile_state(zk.object_ref(), zookeeper_reconcile_state(ZookeeperReconcileStep::AfterCreateConfigMap))),
-        lift_state(at_reconcile_state(zk.object_ref(), zookeeper_reconcile_state(ZookeeperReconcileStep::AfterGetStatefulSet))),
-        lift_state(at_reconcile_state(zk.object_ref(), zookeeper_reconcile_state(ZookeeperReconcileStep::AfterCreateStatefulSet))),
-        lift_state(at_reconcile_state(zk.object_ref(), zookeeper_reconcile_state(ZookeeperReconcileStep::AfterUpdateStatefulSet))),
-        lift_state(at_reconcile_state(zk.object_ref(), zookeeper_reconcile_state(ZookeeperReconcileStep::AfterCreateZKNode))),
-        lift_state(at_reconcile_state(zk.object_ref(), zookeeper_reconcile_state(ZookeeperReconcileStep::Done)));
+        lift_state(get_reconcile_state(zk, ZookeeperReconcileStep::Init)),
+        lift_state(get_reconcile_state(zk, ZookeeperReconcileStep::AfterCreateHeadlessService)),
+        lift_state(get_reconcile_state(zk, ZookeeperReconcileStep::AfterCreateClientService)),
+        lift_state(get_reconcile_state(zk, ZookeeperReconcileStep::AfterCreateAdminServerService)),
+        lift_state(get_reconcile_state(zk, ZookeeperReconcileStep::AfterCreateConfigMap)),
+        lift_state(get_reconcile_state(zk, ZookeeperReconcileStep::AfterGetStatefulSet)),
+        lift_state(get_reconcile_state(zk, ZookeeperReconcileStep::AfterCreateStatefulSet)),
+        lift_state(get_reconcile_state(zk, ZookeeperReconcileStep::AfterUpdateStatefulSet)),
+        lift_state(get_reconcile_state(zk, ZookeeperReconcileStep::AfterCreateZKNode)),
+        lift_state(get_reconcile_state(zk, ZookeeperReconcileStep::AfterUpdateZKNode)),
+        lift_state(get_reconcile_state(zk, ZookeeperReconcileStep::Done));
         lift_state(reconcile_idle)
     );
+}
+
+pub open spec fn get_reconcile_state(zk: ZookeeperClusterView, step: ZookeeperReconcileStep) -> StatePred<ClusterState> {
+    at_expected_reconcile_states::<ZookeeperClusterView, ZookeeperReconciler>(
+        zk.object_ref(), |s: ZookeeperReconcileState| s.reconcile_step == step
+    )
+}
+
+pub open spec fn pending_req_xxx(key: ObjectRef, step: ZookeeperReconcileStep) -> TempPred<ClusterState> {
+    lift_state(pending_req_in_flight_or_resp_in_flight_at_reconcile_state_1::<ZookeeperClusterView, ZookeeperReconciler>(
+        key, |s: ZookeeperReconcileState| s.reconcile_step == step
+    ))
+}
+
+pub open spec fn pending_req_none(key: ObjectRef, step: ZookeeperReconcileStep) -> TempPred<ClusterState> {
+    lift_state(pending_req_is_none_at_reconcile_state::<ZookeeperClusterView, ZookeeperReconciler>(
+        key, |s: ZookeeperReconcileState| s.reconcile_step == step
+    ))
 }
 
 }

--- a/src/controller_examples/zookeeper_controller/proof/liveness/terminate.rs
+++ b/src/controller_examples/zookeeper_controller/proof/liveness/terminate.rs
@@ -90,11 +90,11 @@ pub proof fn reconcile_eventually_terminates(spec: TempPred<ClusterState>, zk: Z
         |s: ZookeeperReconcileState| {s.reconcile_step == ZookeeperReconcileStep::Error || s.reconcile_step == ZookeeperReconcileStep::Done}
     );
     lemma_from_some_state_to_arbitrary_next_state_to_reconcile_idle::<ZookeeperClusterView, ZookeeperReconciler>(
-        spec, zk, |s: ZookeeperReconcileState| s.reconcile_step == ZookeeperReconcileStep::AfterUpdateStatefulSet, 
+        spec, zk, |s: ZookeeperReconcileState| s.reconcile_step == ZookeeperReconcileStep::AfterUpdateStatefulSet,
         |s: ZookeeperReconcileState| s.reconcile_step == ZookeeperReconcileStep::AfterCreateZKNode
     );
     lemma_from_some_state_to_arbitrary_next_state_to_reconcile_idle::<ZookeeperClusterView, ZookeeperReconciler>(
-        spec, zk, |s: ZookeeperReconcileState| s.reconcile_step == ZookeeperReconcileStep::AfterCreateStatefulSet, 
+        spec, zk, |s: ZookeeperReconcileState| s.reconcile_step == ZookeeperReconcileStep::AfterCreateStatefulSet,
         |s: ZookeeperReconcileState| s.reconcile_step == ZookeeperReconcileStep::AfterCreateZKNode
     );
 
@@ -114,8 +114,8 @@ pub proof fn reconcile_eventually_terminates(spec: TempPred<ClusterState>, zk: Z
         |s: ZookeeperReconcileState| {s.reconcile_step == ZookeeperReconcileStep::AfterUpdateStatefulSet || s.reconcile_step == ZookeeperReconcileStep::Error}
     );
     or_leads_to_combine_n!(
-        spec, 
-        lift_state(get_reconcile_state(zk, ZookeeperReconcileStep::AfterCreateStatefulSet)), 
+        spec,
+        lift_state(get_reconcile_state(zk, ZookeeperReconcileStep::AfterCreateStatefulSet)),
         lift_state(get_reconcile_state(zk, ZookeeperReconcileStep::AfterUpdateZKNode)),
         lift_state(get_reconcile_state(zk, ZookeeperReconcileStep::Error));
         lift_state(reconcile_idle)
@@ -127,7 +127,7 @@ pub proof fn reconcile_eventually_terminates(spec: TempPred<ClusterState>, zk: Z
         lift_state(at_expected_reconcile_states(
             zk.object_ref(),
             |s: ZookeeperReconcileState| {
-                s.reconcile_step == ZookeeperReconcileStep::AfterCreateStatefulSet 
+                s.reconcile_step == ZookeeperReconcileStep::AfterCreateStatefulSet
                 || s.reconcile_step == ZookeeperReconcileStep::AfterUpdateZKNode
                 || s.reconcile_step == ZookeeperReconcileStep::Error
             }
@@ -136,29 +136,29 @@ pub proof fn reconcile_eventually_terminates(spec: TempPred<ClusterState>, zk: Z
     lemma_from_some_state_to_arbitrary_next_state_to_reconcile_idle::<ZookeeperClusterView, ZookeeperReconciler>(
         spec, zk, |s: ZookeeperReconcileState| s.reconcile_step == ZookeeperReconcileStep::AfterGetStatefulSet,
         |s: ZookeeperReconcileState| {
-            s.reconcile_step == ZookeeperReconcileStep::AfterCreateStatefulSet 
+            s.reconcile_step == ZookeeperReconcileStep::AfterCreateStatefulSet
             || s.reconcile_step == ZookeeperReconcileStep::AfterUpdateZKNode
             || s.reconcile_step == ZookeeperReconcileStep::Error
         }
     );
     lemma_from_some_state_to_arbitrary_next_state_to_reconcile_idle::<ZookeeperClusterView, ZookeeperReconciler>(
-        spec, zk, |s: ZookeeperReconcileState| s.reconcile_step == ZookeeperReconcileStep::AfterCreateConfigMap, 
+        spec, zk, |s: ZookeeperReconcileState| s.reconcile_step == ZookeeperReconcileStep::AfterCreateConfigMap,
         |s: ZookeeperReconcileState| s.reconcile_step == ZookeeperReconcileStep::AfterGetStatefulSet
     );
     lemma_from_some_state_to_arbitrary_next_state_to_reconcile_idle::<ZookeeperClusterView, ZookeeperReconciler>(
-        spec, zk, |s: ZookeeperReconcileState| s.reconcile_step == ZookeeperReconcileStep::AfterCreateAdminServerService, 
+        spec, zk, |s: ZookeeperReconcileState| s.reconcile_step == ZookeeperReconcileStep::AfterCreateAdminServerService,
         |s: ZookeeperReconcileState| s.reconcile_step == ZookeeperReconcileStep::AfterCreateConfigMap
     );
     lemma_from_some_state_to_arbitrary_next_state_to_reconcile_idle::<ZookeeperClusterView, ZookeeperReconciler>(
-        spec, zk, |s: ZookeeperReconcileState| s.reconcile_step == ZookeeperReconcileStep::AfterCreateClientService, 
+        spec, zk, |s: ZookeeperReconcileState| s.reconcile_step == ZookeeperReconcileStep::AfterCreateClientService,
         |s: ZookeeperReconcileState| s.reconcile_step == ZookeeperReconcileStep::AfterCreateAdminServerService
     );
     lemma_from_some_state_to_arbitrary_next_state_to_reconcile_idle::<ZookeeperClusterView, ZookeeperReconciler>(
-        spec, zk, |s: ZookeeperReconcileState| s.reconcile_step == ZookeeperReconcileStep::AfterCreateHeadlessService, 
+        spec, zk, |s: ZookeeperReconcileState| s.reconcile_step == ZookeeperReconcileStep::AfterCreateHeadlessService,
         |s: ZookeeperReconcileState| s.reconcile_step == ZookeeperReconcileStep::AfterCreateClientService
     );
     lemma_from_some_state_to_arbitrary_next_state_to_reconcile_idle::<ZookeeperClusterView, ZookeeperReconciler>(
-        spec, zk, |s: ZookeeperReconcileState| s.reconcile_step == ZookeeperReconcileStep::AfterCreateStatefulSet, 
+        spec, zk, |s: ZookeeperReconcileState| s.reconcile_step == ZookeeperReconcileStep::AfterCreateStatefulSet,
         |s: ZookeeperReconcileState| s.reconcile_step == ZookeeperReconcileStep::AfterCreateZKNode
     );
     lemma_from_init_state_to_next_state_to_reconcile_idle::<ZookeeperClusterView, ZookeeperReconciler>(
@@ -192,7 +192,7 @@ pub open spec fn get_reconcile_state(zk: ZookeeperClusterView, step: ZookeeperRe
 }
 
 pub open spec fn pending_req_xxx(key: ObjectRef, step: ZookeeperReconcileStep) -> TempPred<ClusterState> {
-    lift_state(pending_req_in_flight_or_resp_in_flight_at_reconcile_state_1::<ZookeeperClusterView, ZookeeperReconciler>(
+    lift_state(pending_req_in_flight_or_resp_in_flight_at_reconcile_state::<ZookeeperClusterView, ZookeeperReconciler>(
         key, |s: ZookeeperReconcileState| s.reconcile_step == step
     ))
 }

--- a/src/controller_examples/zookeeper_controller/proof/mod.rs
+++ b/src/controller_examples/zookeeper_controller/proof/mod.rs
@@ -2,4 +2,4 @@
 // SPDX-License-Identifier: MIT
 pub mod common;
 pub mod liveness;
-pub mod safety;
+// pub mod safety;

--- a/src/kubernetes_cluster/proof/controller_runtime.rs
+++ b/src/kubernetes_cluster/proof/controller_runtime.rs
@@ -127,26 +127,6 @@ pub open spec fn req_msg_is_the_in_flight_pending_req_at_reconcile_state<K: Reso
 }
 
 pub open spec fn pending_req_in_flight_or_resp_in_flight_at_reconcile_state<K: ResourceView, R: Reconciler<K>>(
-    key: ObjectRef, state: R::T
-) -> StatePred<State<K, R>>
-    recommends
-        key.kind.is_CustomResourceKind(),
-{
-    |s: State<K, R>| {
-        at_reconcile_state(key, state)(s)
-        ==> {
-            pending_k8s_api_req_msg(s, key)
-            && request_sent_by_controller(s.pending_req_of(key))
-            && (s.message_in_flight(s.pending_req_of(key))
-            || exists |resp_msg: Message| {
-                #[trigger] s.message_in_flight(resp_msg)
-                && resp_msg_matches_req_msg(resp_msg, s.pending_req_of(key))
-            })
-        }
-    }
-}
-
-pub open spec fn pending_req_in_flight_or_resp_in_flight_at_reconcile_state_1<K: ResourceView, R: Reconciler<K>>(
     key: ObjectRef, state: FnSpec(R::T) -> bool
 ) -> StatePred<State<K, R>>
     recommends

--- a/src/kubernetes_cluster/proof/controller_runtime_liveness.rs
+++ b/src/kubernetes_cluster/proof/controller_runtime_liveness.rs
@@ -246,7 +246,7 @@ pub proof fn lemma_from_some_state_to_arbitrary_next_state_to_reconcile_idle<K: 
         spec.entails(always(lift_state(controller_runtime_safety::every_in_flight_msg_has_unique_id()))),
         spec.entails(always(lift_state(controller_runtime_safety::each_resp_matches_at_most_one_pending_req(cr.object_ref())))),
         spec.entails(always(lift_state(controller_runtime_safety::each_resp_if_matches_pending_req_then_no_other_resp_matches(cr.object_ref())))),
-        spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_reconcile_state_1(cr.object_ref(), state)))),
+        spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_reconcile_state(cr.object_ref(), state)))),
         forall |s| (#[trigger] state(s)) ==> !R::reconcile_error(s) && !R::reconcile_done(s),
         forall |cr_1, resp_o, s|
             state(s) ==>
@@ -271,7 +271,7 @@ pub proof fn lemma_from_some_state_to_arbitrary_next_state_to_reconcile_idle<K: 
             && resp_msg_matches_req_msg(resp_msg, s.pending_req_of(cr.object_ref()))
         })
     };
-    temp_pred_equality::<State<K, R>>(lift_state(pending_req_in_flight_or_resp_in_flight_at_reconcile_state_1(cr.object_ref(), state)), lift_state(at_expected_reconcile_states(cr.object_ref(), state)).implies(lift_state(at_some_state_and_pending_req_in_flight_or_resp_in_flight)));
+    temp_pred_equality::<State<K, R>>(lift_state(pending_req_in_flight_or_resp_in_flight_at_reconcile_state(cr.object_ref(), state)), lift_state(at_expected_reconcile_states(cr.object_ref(), state)).implies(lift_state(at_some_state_and_pending_req_in_flight_or_resp_in_flight)));
     implies_to_leads_to::<State<K, R>>(spec, lift_state(at_expected_reconcile_states(cr.object_ref(), state)), lift_state(at_some_state_and_pending_req_in_flight_or_resp_in_flight));
 
     let req_in_flight = pending_req_in_flight_at_reconcile_state(cr.object_ref(), state);
@@ -292,148 +292,6 @@ pub proof fn lemma_from_some_state_to_arbitrary_next_state_to_reconcile_idle<K: 
         lift_state(at_expected_reconcile_states(cr.object_ref(), next_state)),
         lift_state(|s: State<K, R>| !s.reconcile_state_contains(cr.object_ref()))
     );
-}
-
-#[verifier(external_body)]
-pub proof fn lemma_from_some_state_to_one_next_state_to_reconcile_idle<K: ResourceView, R: Reconciler<K>>(
-    spec: TempPred<State<K, R>>, cr: K, state: R::T, next_state: R::T
-)
-    requires
-        cr.object_ref().kind == K::kind(),
-        spec.entails(always(lift_action(next::<K, R>()))),
-        spec.entails(tla_forall(|i| kubernetes_api_next().weak_fairness(i))),
-        spec.entails(tla_forall(|i| controller_next::<K, R>().weak_fairness(i))),
-        spec.entails(always(lift_state(crash_disabled()))),
-        spec.entails(always(lift_state(busy_disabled()))),
-        spec.entails(always(lift_state(controller_runtime_safety::every_in_flight_msg_has_unique_id()))),
-        spec.entails(always(lift_state(controller_runtime_safety::each_resp_matches_at_most_one_pending_req(cr.object_ref())))),
-        spec.entails(always(lift_state(controller_runtime_safety::each_resp_if_matches_pending_req_then_no_other_resp_matches(cr.object_ref())))),
-        spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_reconcile_state(cr.object_ref(), state)))),
-        !R::reconcile_error(state), !R::reconcile_done(state),
-        forall |cr_1, resp_o|
-            #[trigger] R::reconcile_core(cr_1, resp_o, state).0 == next_state,
-        spec.entails(
-            lift_state(at_reconcile_state(cr.object_ref(), next_state))
-                .leads_to(lift_state(|s: State<K, R>| !s.reconcile_state_contains(cr.object_ref())))
-        ),
-    ensures
-        spec.entails(
-            lift_state(at_reconcile_state(cr.object_ref(), state))
-                .leads_to(lift_state(|s: State<K, R>| !s.reconcile_state_contains(cr.object_ref())))
-        ),
-{
-    let filter = |s: R::T| { s == next_state };
-    temp_pred_equality(
-        lift_state(at_reconcile_state::<K, R>(cr.object_ref(), next_state)),
-        lift_state(at_expected_reconcile_states::<K, R>(cr.object_ref(), filter))
-    );
-    // lemma_from_some_state_to_arbitrary_next_state_to_reconcile_idle::<K, R>(spec, cr, state, filter);
-}
-
-#[verifier(external_body)]
-pub proof fn lemma_from_some_state_to_two_next_states_to_reconcile_idle<K: ResourceView, R: Reconciler<K>>(
-    spec: TempPred<State<K, R>>, cr: K, state: R::T, next_state_1: R::T, next_state_2: R::T
-)
-    requires
-        cr.object_ref().kind == K::kind(),
-        spec.entails(always(lift_action(next::<K, R>()))),
-        spec.entails(tla_forall(|i| kubernetes_api_next().weak_fairness(i))),
-        spec.entails(tla_forall(|i| controller_next::<K, R>().weak_fairness(i))),
-        spec.entails(always(lift_state(crash_disabled()))),
-        spec.entails(always(lift_state(busy_disabled()))),
-        spec.entails(always(lift_state(controller_runtime_safety::every_in_flight_msg_has_unique_id()))),
-        spec.entails(always(lift_state(controller_runtime_safety::each_resp_matches_at_most_one_pending_req(cr.object_ref())))),
-        spec.entails(always(lift_state(controller_runtime_safety::each_resp_if_matches_pending_req_then_no_other_resp_matches(cr.object_ref())))),
-        spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_reconcile_state(cr.object_ref(), state)))),
-        !R::reconcile_error(state), !R::reconcile_done(state),
-        forall |cr_1, resp_o|
-            {
-                let result_state = #[trigger] R::reconcile_core(cr_1, resp_o, state).0;
-                result_state == next_state_1 || result_state == next_state_2
-            },
-        spec.entails(
-            lift_state(at_reconcile_state(cr.object_ref(), next_state_1))
-                .leads_to(lift_state(|s: State<K, R>| !s.reconcile_state_contains(cr.object_ref())))
-        ),
-        spec.entails(
-            lift_state(at_reconcile_state(cr.object_ref(), next_state_2))
-                .leads_to(lift_state(|s: State<K, R>| !s.reconcile_state_contains(cr.object_ref())))
-        ),
-    ensures
-        spec.entails(
-            lift_state(at_reconcile_state(cr.object_ref(), state))
-                .leads_to(lift_state(|s: State<K, R>| !s.reconcile_state_contains(cr.object_ref())))
-        ),
-{
-    temp_pred_equality(
-        lift_state(at_reconcile_state::<K, R>(cr.object_ref(), next_state_1))
-        .or(lift_state(at_reconcile_state::<K, R>(cr.object_ref(), next_state_2))),
-        lift_state(at_expected_reconcile_states::<K, R>(cr.object_ref(), |s: R::T| s == next_state_1 || s == next_state_2))
-    );
-    or_leads_to_combine(
-        spec,
-        at_reconcile_state(cr.object_ref(), next_state_1),
-        at_reconcile_state(cr.object_ref(), next_state_2),
-        |s: State<K, R>| !s.reconcile_state_contains(cr.object_ref())
-    );
-    // lemma_from_some_state_to_arbitrary_next_state_to_reconcile_idle::<K, R>(spec, cr, state, |s: R::T| s == next_state_1 || s == next_state_2);
-}
-
-#[verifier(external_body)]
-pub proof fn lemma_from_some_state_to_three_next_states_to_reconcile_idle<K: ResourceView, R: Reconciler<K>>(
-    spec: TempPred<State<K, R>>, cr: K, state: R::T, next_state_1: R::T, next_state_2: R::T, next_state_3: R::T
-)
-    requires
-        cr.object_ref().kind == K::kind(),
-        spec.entails(always(lift_action(next::<K, R>()))),
-        spec.entails(tla_forall(|i| kubernetes_api_next().weak_fairness(i))),
-        spec.entails(tla_forall(|i| controller_next::<K, R>().weak_fairness(i))),
-        spec.entails(always(lift_state(crash_disabled()))),
-        spec.entails(always(lift_state(busy_disabled()))),
-        spec.entails(always(lift_state(controller_runtime_safety::every_in_flight_msg_has_unique_id()))),
-        spec.entails(always(lift_state(controller_runtime_safety::each_resp_matches_at_most_one_pending_req(cr.object_ref())))),
-        spec.entails(always(lift_state(controller_runtime_safety::each_resp_if_matches_pending_req_then_no_other_resp_matches(cr.object_ref())))),
-        spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_reconcile_state(cr.object_ref(), state)))),
-        !R::reconcile_error(state), !R::reconcile_done(state),
-        forall |cr_1, resp_o|
-            {
-                let result_state = #[trigger] R::reconcile_core(cr_1, resp_o, state).0;
-                result_state == next_state_1 || result_state == next_state_2 || result_state == next_state_3
-            },
-        spec.entails(
-            lift_state(at_reconcile_state(cr.object_ref(), next_state_1))
-                .leads_to(lift_state(|s: State<K, R>| !s.reconcile_state_contains(cr.object_ref())))
-        ),
-        spec.entails(
-            lift_state(at_reconcile_state(cr.object_ref(), next_state_2))
-                .leads_to(lift_state(|s: State<K, R>| !s.reconcile_state_contains(cr.object_ref())))
-        ),
-        spec.entails(
-            lift_state(at_reconcile_state(cr.object_ref(), next_state_3))
-                .leads_to(lift_state(|s: State<K, R>| !s.reconcile_state_contains(cr.object_ref())))
-        ),
-    ensures
-        spec.entails(
-            lift_state(at_reconcile_state(cr.object_ref(), state))
-                .leads_to(lift_state(|s: State<K, R>| !s.reconcile_state_contains(cr.object_ref())))
-        ),
-{
-    temp_pred_equality(
-        lift_state(at_reconcile_state::<K, R>(cr.object_ref(), next_state_1))
-        .or(lift_state(at_reconcile_state::<K, R>(cr.object_ref(), next_state_2)))
-        .or(lift_state(at_reconcile_state::<K, R>(cr.object_ref(), next_state_3))),
-        lift_state(at_expected_reconcile_states::<K, R>(cr.object_ref(), |s: R::T| s == next_state_1 || s == next_state_2 || s == next_state_3))
-    );
-    or_leads_to_combine_n!(
-        spec,
-        lift_state(at_reconcile_state(cr.object_ref(), next_state_1)),
-        lift_state(at_reconcile_state(cr.object_ref(), next_state_2)),
-        lift_state(at_reconcile_state(cr.object_ref(), next_state_3));
-        lift_state(|s: State<K, R>| !s.reconcile_state_contains(cr.object_ref()))
-    );
-    // lemma_from_some_state_to_arbitrary_next_state_to_reconcile_idle::<K, R>(
-    //     spec, cr, state, |s: R::T| s == next_state_1 || s == next_state_2 || s == next_state_3
-    // );
 }
 
 pub proof fn lemma_from_init_state_to_next_state_to_reconcile_idle<K: ResourceView, R: Reconciler<K>>(

--- a/src/kubernetes_cluster/proof/controller_runtime_liveness.rs
+++ b/src/kubernetes_cluster/proof/controller_runtime_liveness.rs
@@ -234,7 +234,7 @@ pub proof fn lemma_true_leads_to_reconcile_scheduled_by_assumption<K: ResourceVi
 }
 
 pub proof fn lemma_from_some_state_to_arbitrary_next_state_to_reconcile_idle<K: ResourceView, R: Reconciler<K>>(
-    spec: TempPred<State<K, R>>, cr: K, state: R::T, next_state: FnSpec(R::T) -> bool
+    spec: TempPred<State<K, R>>, cr: K, state: FnSpec(R::T) -> bool, next_state: FnSpec(R::T) -> bool
 )
     requires
         cr.object_ref().kind == K::kind(),
@@ -246,22 +246,23 @@ pub proof fn lemma_from_some_state_to_arbitrary_next_state_to_reconcile_idle<K: 
         spec.entails(always(lift_state(controller_runtime_safety::every_in_flight_msg_has_unique_id()))),
         spec.entails(always(lift_state(controller_runtime_safety::each_resp_matches_at_most_one_pending_req(cr.object_ref())))),
         spec.entails(always(lift_state(controller_runtime_safety::each_resp_if_matches_pending_req_then_no_other_resp_matches(cr.object_ref())))),
-        spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_reconcile_state(cr.object_ref(), state)))),
-        !R::reconcile_error(state), !R::reconcile_done(state),
-        forall |cr_1, resp_o|
-            #[trigger] next_state(R::reconcile_core(cr_1, resp_o, state).0),
+        spec.entails(always(lift_state(pending_req_in_flight_or_resp_in_flight_at_reconcile_state_1(cr.object_ref(), state)))),
+        forall |s| (#[trigger] state(s)) ==> !R::reconcile_error(s) && !R::reconcile_done(s),
+        forall |cr_1, resp_o, s|
+            state(s) ==>
+            #[trigger] next_state(R::reconcile_core(cr_1, resp_o, s).0),
         spec.entails(
             lift_state(at_expected_reconcile_states(cr.object_ref(), next_state))
                 .leads_to(lift_state(|s: State<K, R>| !s.reconcile_state_contains(cr.object_ref())))
         ),
     ensures
         spec.entails(
-            lift_state(at_reconcile_state(cr.object_ref(), state))
+            lift_state(at_expected_reconcile_states(cr.object_ref(), state))
                 .leads_to(lift_state(|s: State<K, R>| !s.reconcile_state_contains(cr.object_ref())))
         ),
 {
     let at_some_state_and_pending_req_in_flight_or_resp_in_flight = |s: State<K, R>| {
-        at_reconcile_state(cr.object_ref(), state)(s)
+        at_expected_reconcile_states(cr.object_ref(), state)(s)
         && pending_k8s_api_req_msg(s, cr.object_ref())
         && request_sent_by_controller(s.pending_req_of(cr.object_ref()))
         && (s.message_in_flight(s.pending_req_of(cr.object_ref()))
@@ -270,8 +271,8 @@ pub proof fn lemma_from_some_state_to_arbitrary_next_state_to_reconcile_idle<K: 
             && resp_msg_matches_req_msg(resp_msg, s.pending_req_of(cr.object_ref()))
         })
     };
-    temp_pred_equality::<State<K, R>>(lift_state(pending_req_in_flight_or_resp_in_flight_at_reconcile_state(cr.object_ref(), state)), lift_state(at_reconcile_state(cr.object_ref(), state)).implies(lift_state(at_some_state_and_pending_req_in_flight_or_resp_in_flight)));
-    implies_to_leads_to::<State<K, R>>(spec, lift_state(at_reconcile_state(cr.object_ref(), state)), lift_state(at_some_state_and_pending_req_in_flight_or_resp_in_flight));
+    temp_pred_equality::<State<K, R>>(lift_state(pending_req_in_flight_or_resp_in_flight_at_reconcile_state_1(cr.object_ref(), state)), lift_state(at_expected_reconcile_states(cr.object_ref(), state)).implies(lift_state(at_some_state_and_pending_req_in_flight_or_resp_in_flight)));
+    implies_to_leads_to::<State<K, R>>(spec, lift_state(at_expected_reconcile_states(cr.object_ref(), state)), lift_state(at_some_state_and_pending_req_in_flight_or_resp_in_flight));
 
     let req_in_flight = pending_req_in_flight_at_reconcile_state(cr.object_ref(), state);
     let resp_in_flight = resp_in_flight_matches_pending_req_at_reconcile_state(cr.object_ref(), state);
@@ -286,7 +287,7 @@ pub proof fn lemma_from_some_state_to_arbitrary_next_state_to_reconcile_idle<K: 
     );
     leads_to_trans_n!(
         spec,
-        lift_state(at_reconcile_state(cr.object_ref(), state)),
+        lift_state(at_expected_reconcile_states(cr.object_ref(), state)),
         lift_state(at_some_state_and_pending_req_in_flight_or_resp_in_flight),
         lift_state(at_expected_reconcile_states(cr.object_ref(), next_state)),
         lift_state(|s: State<K, R>| !s.reconcile_state_contains(cr.object_ref()))
@@ -326,7 +327,7 @@ pub proof fn lemma_from_some_state_to_one_next_state_to_reconcile_idle<K: Resour
         lift_state(at_reconcile_state::<K, R>(cr.object_ref(), next_state)),
         lift_state(at_expected_reconcile_states::<K, R>(cr.object_ref(), filter))
     );
-    lemma_from_some_state_to_arbitrary_next_state_to_reconcile_idle::<K, R>(spec, cr, state, filter);
+    // lemma_from_some_state_to_arbitrary_next_state_to_reconcile_idle::<K, R>(spec, cr, state, filter);
 }
 
 #[verifier(external_body)]
@@ -375,7 +376,7 @@ pub proof fn lemma_from_some_state_to_two_next_states_to_reconcile_idle<K: Resou
         at_reconcile_state(cr.object_ref(), next_state_2),
         |s: State<K, R>| !s.reconcile_state_contains(cr.object_ref())
     );
-    lemma_from_some_state_to_arbitrary_next_state_to_reconcile_idle::<K, R>(spec, cr, state, |s: R::T| s == next_state_1 || s == next_state_2);
+    // lemma_from_some_state_to_arbitrary_next_state_to_reconcile_idle::<K, R>(spec, cr, state, |s: R::T| s == next_state_1 || s == next_state_2);
 }
 
 #[verifier(external_body)]
@@ -430,13 +431,13 @@ pub proof fn lemma_from_some_state_to_three_next_states_to_reconcile_idle<K: Res
         lift_state(at_reconcile_state(cr.object_ref(), next_state_3));
         lift_state(|s: State<K, R>| !s.reconcile_state_contains(cr.object_ref()))
     );
-    lemma_from_some_state_to_arbitrary_next_state_to_reconcile_idle::<K, R>(
-        spec, cr, state, |s: R::T| s == next_state_1 || s == next_state_2 || s == next_state_3
-    );
+    // lemma_from_some_state_to_arbitrary_next_state_to_reconcile_idle::<K, R>(
+    //     spec, cr, state, |s: R::T| s == next_state_1 || s == next_state_2 || s == next_state_3
+    // );
 }
 
 pub proof fn lemma_from_init_state_to_next_state_to_reconcile_idle<K: ResourceView, R: Reconciler<K>>(
-    spec: TempPred<State<K, R>>, cr: K, next_state: R::T
+    spec: TempPred<State<K, R>>, cr: K, init_state: FnSpec(R::T) -> bool, next_state: FnSpec(R::T) -> bool
 )
     requires
         cr.object_ref().kind == K::kind(),
@@ -444,30 +445,33 @@ pub proof fn lemma_from_init_state_to_next_state_to_reconcile_idle<K: ResourceVi
         spec.entails(tla_forall(|i| controller_next::<K, R>().weak_fairness(i))),
         spec.entails(always(lift_state(crash_disabled()))),
         spec.entails(always(lift_state(controller_runtime_safety::every_in_flight_msg_has_unique_id()))),
-        spec.entails(always(lift_state(no_pending_req_at_reconcile_init_state::<K, R>(cr.object_ref())))),
-        !R::reconcile_error(R::reconcile_init_state()),
-        !R::reconcile_done(R::reconcile_init_state()),
-        forall |cr_1, resp_o|
-            #[trigger] R::reconcile_core(cr_1, resp_o, R::reconcile_init_state()).0 == next_state,
+        spec.entails(always(lift_state(pending_req_is_none_at_reconcile_state::<K, R>(cr.object_ref(), init_state)))),
+        forall |s| (#[trigger] init_state(s)) ==> !R::reconcile_error(s) && !R::reconcile_done(s),
+        forall |cr_1, resp_o, s|
+            init_state(s) ==>
+            next_state(#[trigger] R::reconcile_core(cr_1, resp_o, s).0),
         spec.entails(
-            lift_state(at_reconcile_state(cr.object_ref(), next_state))
+            lift_state(at_expected_reconcile_states(cr.object_ref(), next_state))
                 .leads_to(lift_state(|s: State<K, R>| !s.reconcile_state_contains(cr.object_ref())))
         ),
     ensures
         spec.entails(
-            lift_state(at_reconcile_state(cr.object_ref(), R::reconcile_init_state()))
+            lift_state(at_expected_reconcile_states(cr.object_ref(), init_state))
                 .leads_to(lift_state(|s: State<K, R>| !s.reconcile_state_contains(cr.object_ref())))
         ),
 {
+    let no_pending_req = |s: State<K, R>| {
+        at_expected_reconcile_states(cr.object_ref(), init_state)(s)
+        && s.reconcile_state_of(cr.object_ref()).pending_req_msg.is_None()
+    };
     temp_pred_equality::<State<K, R>>(
-        lift_state(no_pending_req_at_reconcile_init_state::<K, R>(cr.object_ref())),
-        lift_state(at_reconcile_state(cr.object_ref(), R::reconcile_init_state()))
-        .implies(lift_state(reconciler_init_and_no_pending_req::<K, R>(cr.object_ref())))
+        lift_state(pending_req_is_none_at_reconcile_state::<K, R>(cr.object_ref(), init_state)),
+        lift_state(at_expected_reconcile_states(cr.object_ref(), init_state)).implies(lift_state(no_pending_req))
     );
     implies_to_leads_to(
         spec,
-        lift_state(at_reconcile_state(cr.object_ref(), R::reconcile_init_state())),
-        lift_state(reconciler_init_and_no_pending_req::<K, R>(cr.object_ref()))
+        lift_state(at_expected_reconcile_states(cr.object_ref(), init_state)),
+        lift_state(no_pending_req)
     );
     let stronger_next = |s, s_prime: State<K, R>| {
         next::<K, R>()(s, s_prime)
@@ -478,20 +482,20 @@ pub proof fn lemma_from_init_state_to_next_state_to_reconcile_idle<K: ResourceVi
         spec, (Option::None, Option::Some(cr.object_ref())),
         stronger_next,
         continue_reconcile::<K, R>(),
-        reconciler_init_and_no_pending_req::<K, R>(cr.object_ref()),
-        at_reconcile_state(cr.object_ref(), next_state)
+        no_pending_req,
+        at_expected_reconcile_states(cr.object_ref(), next_state)
     );
     leads_to_trans_n!(
         spec,
-        lift_state(at_reconcile_state(cr.object_ref(), R::reconcile_init_state())),
-        lift_state(reconciler_init_and_no_pending_req::<K, R>(cr.object_ref())),
-        lift_state(at_reconcile_state(cr.object_ref(), next_state)),
+        lift_state(at_expected_reconcile_states(cr.object_ref(), init_state)),
+        lift_state(no_pending_req),
+        lift_state(at_expected_reconcile_states(cr.object_ref(), next_state)),
         lift_state(|s: State<K, R>| !s.reconcile_state_contains(cr.object_ref()))
     );
 }
 
 pub proof fn lemma_from_in_flight_resp_matches_pending_req_at_some_state_to_next_state<K: ResourceView, R: Reconciler<K>>(
-    spec: TempPred<State<K, R>>, cr: K, state: R::T, next_state: FnSpec(R::T) -> bool
+    spec: TempPred<State<K, R>>, cr: K, state: FnSpec(R::T) -> bool, next_state: FnSpec(R::T) -> bool
 )
     requires
         cr.object_ref().kind == K::kind(),
@@ -502,9 +506,10 @@ pub proof fn lemma_from_in_flight_resp_matches_pending_req_at_some_state_to_next
         spec.entails(always(lift_state(controller_runtime_safety::every_in_flight_msg_has_unique_id()))),
         spec.entails(always(lift_state(controller_runtime_safety::each_resp_matches_at_most_one_pending_req(cr.object_ref())))),
         spec.entails(always(lift_state(controller_runtime_safety::each_resp_if_matches_pending_req_then_no_other_resp_matches(cr.object_ref())))),
-        !R::reconcile_error(state), !R::reconcile_done(state),
-        forall |cr_1, resp_o|
-            #[trigger] next_state(R::reconcile_core(cr_1, resp_o, state).0),
+        forall |s| (#[trigger] state(s)) ==> !R::reconcile_error(s) && !R::reconcile_done(s),
+        forall |cr_1, resp_o, s|
+            state(s) ==>
+            #[trigger] next_state(R::reconcile_core(cr_1, resp_o, s).0),
     ensures
         spec.entails(
             lift_state(resp_in_flight_matches_pending_req_at_reconcile_state::<K, R>(cr.object_ref(), state))
@@ -535,7 +540,7 @@ pub proof fn lemma_from_in_flight_resp_matches_pending_req_at_some_state_to_next
     );
     let known_resp_in_flight = |resp| lift_state(
         |s: State<K, R>| {
-            at_reconcile_state(cr.object_ref(), state)(s)
+            at_expected_reconcile_states(cr.object_ref(), state)(s)
             && pending_k8s_api_req_msg(s, cr.object_ref())
             && request_sent_by_controller(s.pending_req_of(cr.object_ref()))
             && s.message_in_flight(resp)
@@ -545,7 +550,7 @@ pub proof fn lemma_from_in_flight_resp_matches_pending_req_at_some_state_to_next
     assert forall |msg: Message| spec.entails(#[trigger] known_resp_in_flight(msg)
         .leads_to(lift_state(post))) by {
             let resp_in_flight_state = |s: State<K, R>| {
-                at_reconcile_state(cr.object_ref(), state)(s)
+                at_expected_reconcile_states(cr.object_ref(), state)(s)
                 && pending_k8s_api_req_msg(s, cr.object_ref())
                 && request_sent_by_controller(s.pending_req_of(cr.object_ref()))
                 && s.message_in_flight(msg)
@@ -575,7 +580,7 @@ pub proof fn lemma_from_in_flight_resp_matches_pending_req_at_some_state_to_next
 }
 
 pub proof fn lemma_from_pending_req_in_flight_at_some_state_to_next_state<K: ResourceView, R: Reconciler<K>>(
-    spec: TempPred<State<K, R>>, cr: K, state: R::T, next_state: FnSpec(R::T) -> bool
+    spec: TempPred<State<K, R>>, cr: K, state: FnSpec(R::T) -> bool, next_state: FnSpec(R::T) -> bool
 )
     requires
         cr.object_ref().kind == K::kind(),
@@ -587,9 +592,10 @@ pub proof fn lemma_from_pending_req_in_flight_at_some_state_to_next_state<K: Res
         spec.entails(always(lift_state(controller_runtime_safety::every_in_flight_msg_has_unique_id()))),
         spec.entails(always(lift_state(controller_runtime_safety::each_resp_matches_at_most_one_pending_req(cr.object_ref())))),
         spec.entails(always(lift_state(controller_runtime_safety::each_resp_if_matches_pending_req_then_no_other_resp_matches(cr.object_ref())))),
-        !R::reconcile_error(state), !R::reconcile_done(state),
-        forall |cr_1, resp_o|
-            #[trigger] next_state(R::reconcile_core(cr_1, resp_o, state).0),
+        forall |s| (#[trigger] state(s)) ==> !R::reconcile_error(s) && !R::reconcile_done(s),
+        forall |cr_1, resp_o, s|
+            state(s) ==>
+            #[trigger] next_state(R::reconcile_core(cr_1, resp_o, s).0),
     ensures
         spec.entails(
             lift_state(pending_req_in_flight_at_reconcile_state(cr.object_ref(), state))
@@ -663,7 +669,7 @@ pub proof fn lemma_from_pending_req_in_flight_at_some_state_to_next_state<K: Res
 }
 
 pub proof fn lemma_from_some_state_with_ext_resp_to_two_next_states_to_reconcile_idle<K: ResourceView, R: Reconciler<K>>(
-    spec: TempPred<State<K, R>>, cr: K, state: R::T, next_state_1: R::T, next_state_2: R::T
+    spec: TempPred<State<K, R>>, cr: K, state: FnSpec(R::T) -> bool, next_state: FnSpec(R::T) -> bool
 )
     requires
         cr.object_ref().kind == K::kind(),
@@ -672,32 +678,25 @@ pub proof fn lemma_from_some_state_with_ext_resp_to_two_next_states_to_reconcile
         spec.entails(tla_forall(|i| controller_next::<K, R>().weak_fairness(i))),
         spec.entails(always(lift_state(crash_disabled()))),
         spec.entails(always(lift_state(pending_req_is_none_at_reconcile_state(cr.object_ref(), state)))),
-        !R::reconcile_error(state), !R::reconcile_done(state),
-        forall |cr_1, resp_o|
-            {
-                let result_state = #[trigger] R::reconcile_core(cr_1, resp_o, state).0;
-                result_state == next_state_1 || result_state == next_state_2
-            },
+        forall |s| (#[trigger] state(s)) ==> !R::reconcile_error(s) && !R::reconcile_done(s),
+        forall |cr_1, resp_o, s|
+            state(s) ==> next_state(#[trigger] R::reconcile_core(cr_1, resp_o, s).0),
         spec.entails(
-            lift_state(at_reconcile_state(cr.object_ref(), next_state_1))
-                .leads_to(lift_state(|s: State<K, R>| !s.reconcile_state_contains(cr.object_ref())))
-        ),
-        spec.entails(
-            lift_state(at_reconcile_state(cr.object_ref(), next_state_2))
+            lift_state(at_expected_reconcile_states(cr.object_ref(), next_state))
                 .leads_to(lift_state(|s: State<K, R>| !s.reconcile_state_contains(cr.object_ref())))
         ),
     ensures
         spec.entails(
-            lift_state(at_reconcile_state(cr.object_ref(), state))
+            lift_state(at_expected_reconcile_states(cr.object_ref(), state))
                 .leads_to(lift_state(|s: State<K, R>| !s.reconcile_state_contains(cr.object_ref())))
         ),
 {
     let no_req_at_state = |s: State<K, R>| {
-        at_reconcile_state(cr.object_ref(), state)(s)
+        at_expected_reconcile_states(cr.object_ref(), state)(s)
         && s.reconcile_state_of(cr.object_ref()).pending_req_msg.is_None()
     };
-    temp_pred_equality(lift_state(pending_req_is_none_at_reconcile_state(cr.object_ref(), state)), lift_state(at_reconcile_state(cr.object_ref(), state)).implies(lift_state(no_req_at_state)));
-    implies_to_leads_to(spec, lift_state(at_reconcile_state(cr.object_ref(), state)), lift_state(no_req_at_state));
+    temp_pred_equality(lift_state(pending_req_is_none_at_reconcile_state(cr.object_ref(), state)), lift_state(at_expected_reconcile_states(cr.object_ref(), state)).implies(lift_state(no_req_at_state)));
+    implies_to_leads_to(spec, lift_state(at_expected_reconcile_states(cr.object_ref(), state)), lift_state(no_req_at_state));
 
     let stronger_next = |s, s_prime: State<K, R>| {
         &&& next::<K, R>()(s, s_prime)
@@ -713,24 +712,12 @@ pub proof fn lemma_from_some_state_with_ext_resp_to_two_next_states_to_reconcile
         lift_action(next::<K, R>())
         .and(lift_state(crash_disabled()))
     );
-    let post = |s: State<K, R>| {
-        s.reconcile_state_contains(cr.object_ref())
-        && {
-            s.reconcile_state_of(cr.object_ref()).local_state == next_state_1
-            || s.reconcile_state_of(cr.object_ref()).local_state == next_state_2
-        }
-    };
-    lemma_pre_leads_to_post_by_controller(spec, (Option::None, Option::Some(cr.object_ref())), stronger_next, continue_reconcile(), no_req_at_state, post);
-    or_leads_to_combine(spec, at_reconcile_state(cr.object_ref(), next_state_1), at_reconcile_state(cr.object_ref(), next_state_2), |s: State<K, R>| !s.reconcile_state_contains(cr.object_ref()));
-    temp_pred_equality(
-        lift_state(at_reconcile_state(cr.object_ref(), next_state_1)).or(lift_state(at_reconcile_state(cr.object_ref(), next_state_2))),
-        lift_state(post)
-    );
+    lemma_pre_leads_to_post_by_controller(spec, (Option::None, Option::Some(cr.object_ref())), stronger_next, continue_reconcile(), no_req_at_state, at_expected_reconcile_states(cr.object_ref(), next_state));
     leads_to_trans_n!(
         spec,
-        lift_state(at_reconcile_state(cr.object_ref(), state)),
+        lift_state(at_expected_reconcile_states(cr.object_ref(), state)),
         lift_state(no_req_at_state),
-        lift_state(post),
+        lift_state(at_expected_reconcile_states(cr.object_ref(), next_state)),
         lift_state(|s: State<K, R>| !s.reconcile_state_contains(cr.object_ref()))
     );
 }

--- a/src/kubernetes_cluster/proof/controller_runtime_safety.rs
+++ b/src/kubernetes_cluster/proof/controller_runtime_safety.rs
@@ -552,6 +552,88 @@ pub proof fn lemma_always_pending_req_in_flight_or_resp_in_flight_at_reconcile_s
     init_invariant::<State<K, R>>(spec, init::<K, R>(), stronger_next, invariant);
 }
 
+pub proof fn lemma_always_pending_req_in_flight_or_resp_in_flight_at_reconcile_state_1<K: ResourceView, R: Reconciler<K>>(
+    spec: TempPred<State<K, R>>, key: ObjectRef, state: FnSpec(R::T) -> bool
+)
+    requires
+        forall |s| (#[trigger] state(s)) ==> s != R::reconcile_init_state(),
+        forall |cr, resp_o, pre_state| #[trigger] state(R::reconcile_core(cr, resp_o, pre_state).0)
+            ==> {
+                let req = R::reconcile_core(cr, resp_o, pre_state).1;
+                &&& req.is_Some()
+                &&& req.get_Some_0().is_KRequest()
+            },
+        spec.entails(lift_state(init::<K, R>())),
+        spec.entails(always(lift_action(next::<K, R>()))),
+        spec.entails(always(lift_state(each_resp_matches_at_most_one_pending_req::<K, R>(key)))),
+    ensures
+        spec.entails(
+            always(lift_state(pending_req_in_flight_or_resp_in_flight_at_reconcile_state_1(key, state)))
+        ),
+{
+    let invariant = pending_req_in_flight_or_resp_in_flight_at_reconcile_state_1(key, state);
+    let stronger_next = |s, s_prime: State<K, R>| {
+        &&& next::<K, R>()(s, s_prime)
+        &&& each_resp_matches_at_most_one_pending_req::<K, R>(key)(s)
+    };
+    assert forall |s, s_prime: State<K, R>| invariant(s) && #[trigger] stronger_next(s, s_prime) implies invariant(s_prime) by {
+        if at_expected_reconcile_states(key, state)(s_prime) {
+            let next_step = choose |step| next_step::<K, R>(s, s_prime, step);
+            assert(!next_step.is_RestartController());
+            let resp = choose |msg| {
+                #[trigger] s.message_in_flight(msg)
+                && resp_msg_matches_req_msg(msg, s.pending_req_of(key))
+            };
+            match next_step {
+                Step::KubernetesAPIStep(input) => {
+                    if input == Option::Some(s.pending_req_of(key)) {
+                        let resp_msg = transition_by_etcd(s.pending_req_of(key), s.kubernetes_api_state).1;
+                        assert(s_prime.message_in_flight(resp_msg));
+                    } else {
+                        if !s.message_in_flight(s.pending_req_of(key)) {
+                            assert(s_prime.message_in_flight(resp));
+                        }
+                    }
+                }
+                Step::KubernetesBusy(input) => {
+                    if input == Option::Some(s.pending_req_of(key)) {
+                        let resp_msg = form_matched_resp_msg(s.pending_req_of(key), Result::Err(APIError::ServerTimeout));
+                        assert(s_prime.message_in_flight(resp_msg));
+                    } else {
+                        if !s.message_in_flight(s.pending_req_of(key)) {
+                            assert(s_prime.message_in_flight(resp));
+                        }
+                    }
+                }
+                Step::ControllerStep(input) => {
+                    let cr_key = input.1.get_Some_0();
+                    if cr_key != key {
+                        if s.message_in_flight(s.pending_req_of(key)) {
+                            assert(s_prime.message_in_flight(s_prime.pending_req_of(key)));
+                        } else {
+                            assert(s_prime.message_in_flight(resp));
+                        }
+                    } else {
+                        assert(s_prime.message_in_flight(s_prime.pending_req_of(key)));
+                    }
+                }
+                Step::ClientStep(input) => {
+                    if s.message_in_flight(s.pending_req_of(key)) {
+                        assert(s_prime.message_in_flight(s_prime.pending_req_of(key)));
+                    } else {
+                        assert(s_prime.message_in_flight(resp));
+                    }
+                }
+                _ => {
+                    assert(invariant(s_prime));
+                }
+            }
+        }
+    }
+    strengthen_next::<State<K, R>>(spec, next::<K, R>(), each_resp_matches_at_most_one_pending_req::<K, R>(key), stronger_next);
+    init_invariant::<State<K, R>>(spec, init::<K, R>(), stronger_next, invariant);
+}
+
 pub proof fn lemma_always_no_pending_req_at_reconcile_init_state<K: ResourceView, R: Reconciler<K>>(
     spec: TempPred<State<K, R>>, key: ObjectRef
 )
@@ -580,11 +662,11 @@ pub proof fn lemma_always_no_pending_req_at_reconcile_init_state<K: ResourceView
 }
 
 pub proof fn lemma_always_pending_req_is_none_at_reconcile_state<K: ResourceView, R: Reconciler<K>>(
-    spec: TempPred<State<K, R>>, key: ObjectRef, state: R::T
+    spec: TempPred<State<K, R>>, key: ObjectRef, state: FnSpec(R::T) -> bool
 )
     requires
-        state != R::reconcile_init_state(),
-        forall |cr, resp_o, pre_state| #[trigger] R::reconcile_core(cr, resp_o, pre_state).0 == state
+        forall |s| (#[trigger] state(s)) ==> s != R::reconcile_init_state(),
+        forall |cr, resp_o, pre_state| #[trigger] state(R::reconcile_core(cr, resp_o, pre_state).0)
             ==> {
                 let req = R::reconcile_core(cr, resp_o, pre_state).1;
                 req.is_None()

--- a/src/kubernetes_cluster/proof/controller_runtime_safety.rs
+++ b/src/kubernetes_cluster/proof/controller_runtime_safety.rs
@@ -583,7 +583,6 @@ pub proof fn lemma_always_pending_req_is_none_at_reconcile_state<K: ResourceView
     spec: TempPred<State<K, R>>, key: ObjectRef, state: FnSpec(R::T) -> bool
 )
     requires
-        forall |s| (#[trigger] state(s)) ==> s != R::reconcile_init_state(),
         forall |cr, resp_o, pre_state| #[trigger] state(R::reconcile_core(cr, resp_o, pre_state).0)
             ==> {
                 let req = R::reconcile_core(cr, resp_o, pre_state).1;


### PR DESCRIPTION
After adding a new field to `ZookeeperReconcileState`, describing a specific reconcile state becomes more troublesome. However, sometimes we only care about part of the reconcile state, and that is enough for proving certain properties. Thus, we introduce closure to replace a concrete reconcile state in those controller runtime lemmas.