### PR TITLE
Add simplified specs to the zookeeper external library

### DIFF
--- a/src/controller_examples/rabbitmq_controller/spec/reconciler.rs
+++ b/src/controller_examples/rabbitmq_controller/spec/reconciler.rs
@@ -24,11 +24,13 @@ pub struct RabbitmqReconcileState {
 
 pub struct RabbitmqReconciler {}
 
+pub struct EmptyState {}
+
 impl Reconciler<RabbitmqClusterView> for RabbitmqReconciler {
     type T = RabbitmqReconcileState;
-    type I = ();
-    type O = ();
-    type S = ();
+    type LibRequest = ();
+    type LibResponse = ();
+    type LibState = EmptyState;
 
     open spec fn reconcile_init_state() -> RabbitmqReconcileState {
         reconcile_init_state()
@@ -48,8 +50,12 @@ impl Reconciler<RabbitmqClusterView> for RabbitmqReconciler {
         reconcile_error(state)
     }
 
-    open spec fn external_process(input: (), state: Option<()>) -> (Option<()>, Option<()>) {
-        (Option::None, Option::None)
+    open spec fn external_process(input: (), state: EmptyState) -> (Option<()>, EmptyState) {
+        (Option::None, EmptyState{})
+    }
+
+    open spec fn library_init_state() -> EmptyState {
+        EmptyState{}
     }
 }
 

--- a/src/controller_examples/rabbitmq_controller/spec/reconciler.rs
+++ b/src/controller_examples/rabbitmq_controller/spec/reconciler.rs
@@ -28,6 +28,8 @@ impl Reconciler<RabbitmqClusterView> for RabbitmqReconciler {
     type T = RabbitmqReconcileState;
     type I = ();
     type O = ();
+    type S = ();
+
     open spec fn reconcile_init_state() -> RabbitmqReconcileState {
         reconcile_init_state()
     }
@@ -46,8 +48,8 @@ impl Reconciler<RabbitmqClusterView> for RabbitmqReconciler {
         reconcile_error(state)
     }
 
-    open spec fn external_process(input: ()) -> Option<()> {
-        Option::None
+    open spec fn external_process(input: (), state: Option<()>) -> (Option<()>, Option<()>) {
+        (Option::None, Option::None)
     }
 }
 

--- a/src/controller_examples/rabbitmq_controller/spec/reconciler.rs
+++ b/src/controller_examples/rabbitmq_controller/spec/reconciler.rs
@@ -28,9 +28,9 @@ pub struct EmptyState {}
 
 impl Reconciler<RabbitmqClusterView> for RabbitmqReconciler {
     type T = RabbitmqReconcileState;
-    type LibRequest = ();
-    type LibResponse = ();
-    type LibState = EmptyState;
+    type ExternalAPIInput = ();
+    type ExternalAPIOutput = ();
+    type ExternalState = EmptyState;
 
     open spec fn reconcile_init_state() -> RabbitmqReconcileState {
         reconcile_init_state()
@@ -50,11 +50,11 @@ impl Reconciler<RabbitmqClusterView> for RabbitmqReconciler {
         reconcile_error(state)
     }
 
-    open spec fn external_process(input: (), state: EmptyState) -> (Option<()>, EmptyState) {
+    open spec fn external_transition(input: (), state: EmptyState) -> (Option<()>, EmptyState) {
         (Option::None, EmptyState{})
     }
 
-    open spec fn library_init_state() -> EmptyState {
+    open spec fn init_external_state() -> EmptyState {
         EmptyState{}
     }
 }

--- a/src/controller_examples/simple_controller/spec/reconciler.rs
+++ b/src/controller_examples/simple_controller/spec/reconciler.rs
@@ -31,9 +31,9 @@ pub struct EmptyState {}
 
 impl Reconciler<CustomResourceView> for SimpleReconciler {
     type T = SimpleReconcileState;
-    type LibRequest = ();
-    type LibResponse = ();
-    type LibState = EmptyState;
+    type ExternalAPIInput = ();
+    type ExternalAPIOutput = ();
+    type ExternalState = EmptyState;
 
     open spec fn reconcile_init_state() -> SimpleReconcileState {
         reconcile_init_state()
@@ -53,11 +53,11 @@ impl Reconciler<CustomResourceView> for SimpleReconciler {
         reconcile_error(state)
     }
 
-    open spec fn external_process(input: (), state: EmptyState) -> (Option<()>, EmptyState) {
+    open spec fn external_transition(input: (), state: EmptyState) -> (Option<()>, EmptyState) {
         (Option::None, EmptyState{})
     }
 
-    open spec fn library_init_state() -> EmptyState {
+    open spec fn init_external_state() -> EmptyState {
         EmptyState{}
     }
 }

--- a/src/controller_examples/simple_controller/spec/reconciler.rs
+++ b/src/controller_examples/simple_controller/spec/reconciler.rs
@@ -27,11 +27,13 @@ pub struct SimpleReconcileState {
 /// including reconcile function (reconcile_core) and triggering conditions (reconcile_trigger)
 pub struct SimpleReconciler {}
 
+pub struct EmptyState {}
+
 impl Reconciler<CustomResourceView> for SimpleReconciler {
     type T = SimpleReconcileState;
-    type I = ();
-    type O = ();
-    type S = ();
+    type LibRequest = ();
+    type LibResponse = ();
+    type LibState = EmptyState;
 
     open spec fn reconcile_init_state() -> SimpleReconcileState {
         reconcile_init_state()
@@ -51,8 +53,12 @@ impl Reconciler<CustomResourceView> for SimpleReconciler {
         reconcile_error(state)
     }
 
-    open spec fn external_process(input: (), state: Option<()>) -> (Option<()>, Option<()>) {
-        (Option::None, Option::None)
+    open spec fn external_process(input: (), state: EmptyState) -> (Option<()>, EmptyState) {
+        (Option::None, EmptyState{})
+    }
+
+    open spec fn library_init_state() -> EmptyState {
+        EmptyState{}
     }
 }
 

--- a/src/controller_examples/simple_controller/spec/reconciler.rs
+++ b/src/controller_examples/simple_controller/spec/reconciler.rs
@@ -31,6 +31,8 @@ impl Reconciler<CustomResourceView> for SimpleReconciler {
     type T = SimpleReconcileState;
     type I = ();
     type O = ();
+    type S = ();
+
     open spec fn reconcile_init_state() -> SimpleReconcileState {
         reconcile_init_state()
     }
@@ -49,8 +51,8 @@ impl Reconciler<CustomResourceView> for SimpleReconciler {
         reconcile_error(state)
     }
 
-    open spec fn external_process(input: ()) -> Option<()> {
-        Option::None
+    open spec fn external_process(input: (), state: Option<()>) -> (Option<()>, Option<()>) {
+        (Option::None, Option::None)
     }
 }
 

--- a/src/controller_examples/zookeeper_controller/exec/reconciler.rs
+++ b/src/controller_examples/zookeeper_controller/exec/reconciler.rs
@@ -43,14 +43,14 @@ pub struct ZookeeperReconciler {}
 
 
 #[verifier(external)]
-impl Reconciler<ZookeeperCluster, ZookeeperReconcileState, ZKSupportInput, ZKSupportOutput, ZKSupport> for ZookeeperReconciler {
+impl Reconciler<ZookeeperCluster, ZookeeperReconcileState, ZKAPIInput, ZKAPIOutput, ZKAPI> for ZookeeperReconciler {
     fn reconcile_init_state(&self) -> ZookeeperReconcileState {
         reconcile_init_state()
     }
 
     fn reconcile_core(
-        &self, zk: &ZookeeperCluster, resp_o: Option<Response<ZKSupportOutput>>, state: ZookeeperReconcileState
-    ) -> (ZookeeperReconcileState, Option<Request<ZKSupportInput>>) {
+        &self, zk: &ZookeeperCluster, resp_o: Option<Response<ZKAPIOutput>>, state: ZookeeperReconcileState
+    ) -> (ZookeeperReconcileState, Option<Request<ZKAPIInput>>) {
         reconcile_core(zk, resp_o, state)
     }
 
@@ -100,8 +100,8 @@ pub fn reconcile_error(state: &ZookeeperReconcileState) -> (res: bool)
 // TODO: make the shim layer pass zk, instead of zk_ref, to reconcile_core
 
 pub fn reconcile_core(
-    zk: &ZookeeperCluster, resp_o: Option<Response<ZKSupportOutput>>, state: ZookeeperReconcileState
-) -> (res: (ZookeeperReconcileState, Option<Request<ZKSupportInput>>))
+    zk: &ZookeeperCluster, resp_o: Option<Response<ZKAPIOutput>>, state: ZookeeperReconcileState
+) -> (res: (ZookeeperReconcileState, Option<Request<ZKAPIInput>>))
     requires
         zk@.metadata.name.is_Some(),
         zk@.metadata.namespace.is_Some(),
@@ -197,7 +197,7 @@ pub fn reconcile_core(
                         let path = cluster_size_zk_node_path(zk);
                         let uri = zk_service_uri(zk);
                         let replicas = i32_to_string(zk.spec().replicas());
-                        let ext_req = ZKSupportInput::ReconcileZKNode(path, uri, replicas);
+                        let ext_req = ZKAPIInput::ReconcileZKNode(path, uri, replicas);
                         proof {
                             zk_support_input_to_view_match(path, uri, replicas);
                         }
@@ -234,7 +234,7 @@ pub fn reconcile_core(
             let path = cluster_size_zk_node_path(zk);
             let uri = zk_service_uri(zk);
             let replicas = i32_to_string(zk.spec().replicas());
-            let ext_req = ZKSupportInput::ReconcileZKNode(path, uri, replicas);
+            let ext_req = ZKAPIInput::ReconcileZKNode(path, uri, replicas);
             proof {
                 zk_support_input_to_view_match(path, uri, replicas);
             }
@@ -248,7 +248,7 @@ pub fn reconcile_core(
             let path = cluster_size_zk_node_path(zk);
             let uri = zk_service_uri(zk);
             let replicas = i32_to_string(zk.spec().replicas());
-            let ext_req = ZKSupportInput::ReconcileZKNode(path, uri, replicas);
+            let ext_req = ZKAPIInput::ReconcileZKNode(path, uri, replicas);
             proof {
                 zk_support_input_to_view_match(path, uri, replicas);
             }

--- a/src/controller_examples/zookeeper_controller/exec/zookeeper_lib/lib.rs
+++ b/src/controller_examples/zookeeper_controller/exec/zookeeper_lib/lib.rs
@@ -5,56 +5,58 @@ use crate::reconciler::exec::external::*;
 use crate::zookeeper_controller::common::*;
 use crate::zookeeper_controller::exec::zookeeper_lib::helper_funcs::*;
 use crate::zookeeper_controller::exec::zookeepercluster::*;
-use crate::zookeeper_controller::spec::zookeeper_lib::{ZKSupportInputView, ZKSupportOutputView, ZKNodeResultView};
+use crate::zookeeper_controller::spec::zookeeper_lib::{
+    ZKAPIInputView, ZKAPIOutputView, ZKNodeResultView,
+};
 use vstd::{prelude::*, string::*};
 
 verus! {
 
 #[is_variant]
-pub enum ZKSupportInput {
+pub enum ZKAPIInput {
     ReconcileZKNode(String,String,String),
 }
 
 #[is_variant]
-pub enum ZKSupportOutput {
+pub enum ZKAPIOutput {
     ReconcileZKNode(ZKNodeResult),
 }
 
-impl ToView for ZKSupportInput {
-    type V = ZKSupportInputView;
-    spec fn to_view(&self) -> ZKSupportInputView {
+impl ToView for ZKAPIInput {
+    type V = ZKAPIInputView;
+    spec fn to_view(&self) -> ZKAPIInputView {
         match self {
-            ZKSupportInput::ReconcileZKNode(path, uri, replicas)
-                => ZKSupportInputView::ReconcileZKNode(path@, uri@, replicas@),
+            ZKAPIInput::ReconcileZKNode(path, uri, replicas)
+                => ZKAPIInputView::ReconcileZKNode(path@, uri@, replicas@),
         }
     }
 }
 
 pub proof fn zk_support_input_to_view_match(path: String, uri: String, replicas: String)
     ensures
-        ZKSupportInput::ReconcileZKNode(path, uri, replicas).to_view()
-            == ZKSupportInputView::ReconcileZKNode(path@, uri@, replicas@) {}
+        ZKAPIInput::ReconcileZKNode(path, uri, replicas).to_view()
+            == ZKAPIInputView::ReconcileZKNode(path@, uri@, replicas@) {}
 
 
-impl ToView for ZKSupportOutput {
-    type V = ZKSupportOutputView;
-    spec fn to_view(&self) -> ZKSupportOutputView {
+impl ToView for ZKAPIOutput {
+    type V = ZKAPIOutputView;
+    spec fn to_view(&self) -> ZKAPIOutputView {
         match self {
-            ZKSupportOutput::ReconcileZKNode(result) => ZKSupportOutputView::ReconcileZKNode(ZKNodeResultView{res: result.res}),
+            ZKAPIOutput::ReconcileZKNode(result) => ZKAPIOutputView::ReconcileZKNode(ZKNodeResultView{res: result.res}),
         }
     }
 }
 
 pub proof fn zk_support_output_to_view_match(result: ZKNodeResult)
     ensures
-        ZKSupportOutput::ReconcileZKNode(result).to_view() == ZKSupportOutputView::ReconcileZKNode(ZKNodeResultView{res: result.res}) {}
+        ZKAPIOutput::ReconcileZKNode(result).to_view() == ZKAPIOutputView::ReconcileZKNode(ZKNodeResultView{res: result.res}) {}
 
-impl ZKSupportOutput {
+impl ZKAPIOutput {
     pub fn is_reconcile_zk_node(&self) -> (res: bool)
         ensures res <==> self.is_ReconcileZKNode(),
     {
         match self {
-            ZKSupportOutput::ReconcileZKNode(_) => true,
+            ZKAPIOutput::ReconcileZKNode(_) => true,
         }
     }
 
@@ -66,19 +68,19 @@ impl ZKSupportOutput {
             result.res.is_Ok() <==> self.get_ReconcileZKNode_0().res.is_Ok(),
     {
         match self {
-            ZKSupportOutput::ReconcileZKNode(result) => result,
+            ZKAPIOutput::ReconcileZKNode(result) => result,
         }
     }
 }
 
-pub struct ZKSupport {}
+pub struct ZKAPI {}
 
-impl ExternalLibrary<ZKSupportInput, ZKSupportOutput> for ZKSupport {
+impl ExternalLibrary<ZKAPIInput, ZKAPIOutput> for ZKAPI {
     #[verifier(external)]
-    fn process(input: ZKSupportInput) -> Option<ZKSupportOutput> {
+    fn process(input: ZKAPIInput) -> Option<ZKAPIOutput> {
         match input {
-            ZKSupportInput::ReconcileZKNode(path, uri, replicas)
-                => Option::Some(ZKSupportOutput::ReconcileZKNode(reconcile_zk_node(path, uri, replicas))),
+            ZKAPIInput::ReconcileZKNode(path, uri, replicas)
+                => Option::Some(ZKAPIOutput::ReconcileZKNode(reconcile_zk_node(path, uri, replicas))),
         }
     }
 }

--- a/src/controller_examples/zookeeper_controller/exec/zookeeper_lib/lib.rs
+++ b/src/controller_examples/zookeeper_controller/exec/zookeeper_lib/lib.rs
@@ -75,7 +75,7 @@ impl ZKAPIOutput {
 
 pub struct ZKAPI {}
 
-impl ExternalLibrary<ZKAPIInput, ZKAPIOutput> for ZKAPI {
+impl ExternalAPI<ZKAPIInput, ZKAPIOutput> for ZKAPI {
     #[verifier(external)]
     fn process(input: ZKAPIInput) -> Option<ZKAPIOutput> {
         match input {

--- a/src/controller_examples/zookeeper_controller/exec/zookeeper_lib/lib.rs
+++ b/src/controller_examples/zookeeper_controller/exec/zookeeper_lib/lib.rs
@@ -5,7 +5,7 @@ use crate::reconciler::exec::external::*;
 use crate::zookeeper_controller::common::*;
 use crate::zookeeper_controller::exec::zookeeper_lib::helper_funcs::*;
 use crate::zookeeper_controller::exec::zookeepercluster::*;
-use crate::zookeeper_controller::spec::zookeeper_lib::*;
+use crate::zookeeper_controller::spec::zookeeper_lib::{ZKSupportInputView, ZKSupportOutputView, ZKNodeResultView};
 use vstd::{prelude::*, string::*};
 
 verus! {

--- a/src/controller_examples/zookeeper_controller/exec/zookeeper_lib/lib.rs
+++ b/src/controller_examples/zookeeper_controller/exec/zookeeper_lib/lib.rs
@@ -77,7 +77,7 @@ pub struct ZKAPI {}
 
 impl ExternalAPI<ZKAPIInput, ZKAPIOutput> for ZKAPI {
     #[verifier(external)]
-    fn process(input: ZKAPIInput) -> Option<ZKAPIOutput> {
+    fn transition(input: ZKAPIInput) -> Option<ZKAPIOutput> {
         match input {
             ZKAPIInput::ReconcileZKNode(path, uri, replicas)
                 => Option::Some(ZKAPIOutput::ReconcileZKNode(reconcile_zk_node(path, uri, replicas))),

--- a/src/controller_examples/zookeeper_controller/spec/reconciler.rs
+++ b/src/controller_examples/zookeeper_controller/spec/reconciler.rs
@@ -27,8 +27,8 @@ pub struct ZookeeperReconciler {}
 
 impl Reconciler<ZookeeperClusterView> for ZookeeperReconciler {
     type T = ZookeeperReconcileState;
-    type I = ZKSupportInputView;
-    type O = ZKSupportOutputView;
+    type I = ZKAPIInputView;
+    type O = ZKAPIOutputView;
     type S = ZooKeeperState;
 
     open spec fn reconcile_init_state() -> ZookeeperReconcileState {
@@ -36,8 +36,8 @@ impl Reconciler<ZookeeperClusterView> for ZookeeperReconciler {
     }
 
     open spec fn reconcile_core(
-        zk: ZookeeperClusterView, resp_o: Option<ResponseView<ZKSupportOutputView>>, state: ZookeeperReconcileState
-    ) -> (ZookeeperReconcileState, Option<RequestView<ZKSupportInputView>>) {
+        zk: ZookeeperClusterView, resp_o: Option<ResponseView<ZKAPIOutputView>>, state: ZookeeperReconcileState
+    ) -> (ZookeeperReconcileState, Option<RequestView<ZKAPIInputView>>) {
         reconcile_core(zk, resp_o, state)
     }
 
@@ -49,7 +49,7 @@ impl Reconciler<ZookeeperClusterView> for ZookeeperReconciler {
         reconcile_error(state)
     }
 
-    open spec fn external_process(input: ZKSupportInputView, state: Option<ZooKeeperState>) -> (Option<ZKSupportOutputView>, Option<ZooKeeperState>) {
+    open spec fn external_process(input: ZKAPIInputView, state: Option<ZooKeeperState>) -> (Option<ZKAPIOutputView>, Option<ZooKeeperState>) {
         external_process(input, state)
     }
 }
@@ -76,8 +76,8 @@ pub open spec fn reconcile_error(state: ZookeeperReconcileState) -> bool {
 }
 
 pub open spec fn reconcile_core(
-    zk: ZookeeperClusterView, resp_o: Option<ResponseView<ZKSupportOutputView>>, state: ZookeeperReconcileState
-) -> (ZookeeperReconcileState, Option<RequestView<ZKSupportInputView>>)
+    zk: ZookeeperClusterView, resp_o: Option<ResponseView<ZKAPIOutputView>>, state: ZookeeperReconcileState
+) -> (ZookeeperReconcileState, Option<RequestView<ZKAPIInputView>>)
     recommends
         zk.metadata.name.is_Some(),
         zk.metadata.namespace.is_Some(),
@@ -159,7 +159,7 @@ pub open spec fn reconcile_core(
                             sts_from_get: Option::Some(found_stateful_set),
                             ..state
                         };
-                        let ext_req = ZKSupportInputView::ReconcileZKNode(
+                        let ext_req = ZKAPIInputView::ReconcileZKNode(
                             cluster_size_zk_node_path(zk), zk_service_uri(zk), int_to_string_view(zk.spec.replicas)
                         );
                         (state_prime, Option::Some(RequestView::ExternalRequest(ext_req)))
@@ -201,7 +201,7 @@ pub open spec fn reconcile_core(
                 reconcile_step: ZookeeperReconcileStep::AfterCreateZKNode,
                 ..state
             };
-            let ext_req = ZKSupportInputView::ReconcileZKNode(
+            let ext_req = ZKAPIInputView::ReconcileZKNode(
                 cluster_size_zk_node_path(zk), zk_service_uri(zk), int_to_string_view(zk.spec.replicas)
             );
             (state_prime, Option::Some(RequestView::ExternalRequest(ext_req)))
@@ -211,7 +211,7 @@ pub open spec fn reconcile_core(
                 reconcile_step: ZookeeperReconcileStep::AfterCreateZKNode,
                 ..state
             };
-            let ext_req = ZKSupportInputView::ReconcileZKNode(
+            let ext_req = ZKAPIInputView::ReconcileZKNode(
                 cluster_size_zk_node_path(zk), zk_service_uri(zk), int_to_string_view(zk.spec.replicas)
             );
             (state_prime, Option::Some(RequestView::ExternalRequest(ext_req)))

--- a/src/controller_examples/zookeeper_controller/spec/reconciler.rs
+++ b/src/controller_examples/zookeeper_controller/spec/reconciler.rs
@@ -29,7 +29,7 @@ impl Reconciler<ZookeeperClusterView> for ZookeeperReconciler {
     type T = ZookeeperReconcileState;
     type I = ZKSupportInputView;
     type O = ZKSupportOutputView;
-    type S = ();
+    type S = ZooKeeperState;
 
     open spec fn reconcile_init_state() -> ZookeeperReconcileState {
         reconcile_init_state()
@@ -49,8 +49,8 @@ impl Reconciler<ZookeeperClusterView> for ZookeeperReconciler {
         reconcile_error(state)
     }
 
-    open spec fn external_process(input: ZKSupportInputView, state: Option<()>) -> (Option<ZKSupportOutputView>, Option<()>) {
-        (Option::None, Option::None)
+    open spec fn external_process(input: ZKSupportInputView, state: Option<ZooKeeperState>) -> (Option<ZKSupportOutputView>, Option<ZooKeeperState>) {
+        external_process(input, state)
     }
 }
 

--- a/src/controller_examples/zookeeper_controller/spec/reconciler.rs
+++ b/src/controller_examples/zookeeper_controller/spec/reconciler.rs
@@ -27,9 +27,9 @@ pub struct ZookeeperReconciler {}
 
 impl Reconciler<ZookeeperClusterView> for ZookeeperReconciler {
     type T = ZookeeperReconcileState;
-    type I = ZKAPIInputView;
-    type O = ZKAPIOutputView;
-    type S = ZooKeeperState;
+    type LibRequest = ZKAPIInputView;
+    type LibResponse = ZKAPIOutputView;
+    type LibState = ZooKeeperState;
 
     open spec fn reconcile_init_state() -> ZookeeperReconcileState {
         reconcile_init_state()
@@ -49,8 +49,12 @@ impl Reconciler<ZookeeperClusterView> for ZookeeperReconciler {
         reconcile_error(state)
     }
 
-    open spec fn external_process(input: ZKAPIInputView, state: Option<ZooKeeperState>) -> (Option<ZKAPIOutputView>, Option<ZooKeeperState>) {
+    open spec fn external_process(input: ZKAPIInputView, state: ZooKeeperState) -> (Option<ZKAPIOutputView>, ZooKeeperState) {
         external_process(input, state)
+    }
+
+    open spec fn library_init_state() -> ZooKeeperState {
+        ZooKeeperState::default()
     }
 }
 

--- a/src/controller_examples/zookeeper_controller/spec/reconciler.rs
+++ b/src/controller_examples/zookeeper_controller/spec/reconciler.rs
@@ -27,9 +27,9 @@ pub struct ZookeeperReconciler {}
 
 impl Reconciler<ZookeeperClusterView> for ZookeeperReconciler {
     type T = ZookeeperReconcileState;
-    type LibRequest = ZKAPIInputView;
-    type LibResponse = ZKAPIOutputView;
-    type LibState = ZooKeeperState;
+    type ExternalAPIInput = ZKAPIInputView;
+    type ExternalAPIOutput = ZKAPIOutputView;
+    type ExternalState = ZooKeeperState;
 
     open spec fn reconcile_init_state() -> ZookeeperReconcileState {
         reconcile_init_state()
@@ -49,11 +49,11 @@ impl Reconciler<ZookeeperClusterView> for ZookeeperReconciler {
         reconcile_error(state)
     }
 
-    open spec fn external_process(input: ZKAPIInputView, state: ZooKeeperState) -> (Option<ZKAPIOutputView>, ZooKeeperState) {
-        external_process(input, state)
+    open spec fn external_transition(input: ZKAPIInputView, state: ZooKeeperState) -> (Option<ZKAPIOutputView>, ZooKeeperState) {
+        external_transition(input, state)
     }
 
-    open spec fn library_init_state() -> ZooKeeperState {
+    open spec fn init_external_state() -> ZooKeeperState {
         ZooKeeperState::default()
     }
 }

--- a/src/controller_examples/zookeeper_controller/spec/reconciler.rs
+++ b/src/controller_examples/zookeeper_controller/spec/reconciler.rs
@@ -29,6 +29,7 @@ impl Reconciler<ZookeeperClusterView> for ZookeeperReconciler {
     type T = ZookeeperReconcileState;
     type I = ZKSupportInputView;
     type O = ZKSupportOutputView;
+    type S = ();
 
     open spec fn reconcile_init_state() -> ZookeeperReconcileState {
         reconcile_init_state()
@@ -48,8 +49,8 @@ impl Reconciler<ZookeeperClusterView> for ZookeeperReconciler {
         reconcile_error(state)
     }
 
-    open spec fn external_process(input: ZKSupportInputView) -> Option<ZKSupportOutputView> {
-        Option::None
+    open spec fn external_process(input: ZKSupportInputView, state: Option<()>) -> (Option<ZKSupportOutputView>, Option<()>) {
+        (Option::None, Option::None)
     }
 }
 

--- a/src/controller_examples/zookeeper_controller/spec/zookeeper_lib.rs
+++ b/src/controller_examples/zookeeper_controller/spec/zookeeper_lib.rs
@@ -32,7 +32,7 @@ impl ZooKeeperState {
     }
 }
 
-pub open spec fn external_process(input: ZKAPIInputView, state: ZooKeeperState) -> (Option<ZKAPIOutputView>, ZooKeeperState) {
+pub open spec fn external_transition(input: ZKAPIInputView, state: ZooKeeperState) -> (Option<ZKAPIOutputView>, ZooKeeperState) {
     match input {
         ZKAPIInputView::ReconcileZKNode(path,uri,replicas) => reconcile_zk_node(path, uri, replicas, state),
     }

--- a/src/controller_examples/zookeeper_controller/spec/zookeeper_lib.rs
+++ b/src/controller_examples/zookeeper_controller/spec/zookeeper_lib.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MIT
 use crate::pervasive_ext::string_view::*;
 use crate::zookeeper_controller::{common::*, spec::zookeepercluster::*};
-use vstd::prelude::*;
+use vstd::{prelude::*, string::*};
 
 verus! {
 
@@ -20,10 +20,36 @@ pub struct ZKNodeResultView {
     pub res: Result<(), Error>,
 }
 
-pub struct ZooKeeperState {}
+pub struct ZooKeeperState {
+    pub data: Map<StringView, StringView>,
+}
 
-// pub open spec external_process(input: ZKSupportInputView, state: ZooKeeperState) -> (Option<ZKSupportOutputView>, ZooKeeperState> {
+pub open spec fn external_process(input: ZKSupportInputView, state: Option<ZooKeeperState>) -> (Option<ZKSupportOutputView>, Option<ZooKeeperState>) {
+    match input {
+        ZKSupportInputView::ReconcileZKNode(path,uri,replicas) => reconcile_zk_node(path, uri, replicas, state),
+    }
+}
 
-// }
+pub open spec fn reconcile_zk_node(
+    path: StringView, uri: StringView, replicas: StringView, state: Option<ZooKeeperState>
+) -> (Option<ZKSupportOutputView>, Option<ZooKeeperState>) {
+    let old_state = if state.is_None() { ZooKeeperState{ data: Map::empty() } } else { state.get_Some_0() };
+    if old_state.data.contains_key(uri + path) {
+        let state_prime = ZooKeeperState {
+            data: old_state.data.insert(uri + path, new_strlit("CLUSTER_SIZE=")@ + replicas),
+            ..old_state
+        };
+        (Option::Some(ZKSupportOutputView::ReconcileZKNode(ZKNodeResultView{ res: Ok(()) })), Option::Some(state_prime))
+    } else {
+        let new_data = old_state.data
+                    .insert(uri + new_strlit("/zookeeper-operator")@, new_strlit("")@)
+                    .insert(uri + path, new_strlit("CLUSTER_SIZE=")@ + replicas);
+        let state_prime = ZooKeeperState {
+            data: new_data,
+            ..old_state
+        };
+        (Option::Some(ZKSupportOutputView::ReconcileZKNode(ZKNodeResultView{ res: Ok(()) })), Option::Some(state_prime))
+    }
+}
 
 }

--- a/src/controller_examples/zookeeper_controller/spec/zookeeper_lib.rs
+++ b/src/controller_examples/zookeeper_controller/spec/zookeeper_lib.rs
@@ -20,4 +20,10 @@ pub struct ZKNodeResultView {
     pub res: Result<(), Error>,
 }
 
+pub struct ZooKeeperState {}
+
+// pub open spec external_process(input: ZKSupportInputView, state: ZooKeeperState) -> (Option<ZKSupportOutputView>, ZooKeeperState> {
+
+// }
+
 }

--- a/src/controller_examples/zookeeper_controller/spec/zookeeper_lib.rs
+++ b/src/controller_examples/zookeeper_controller/spec/zookeeper_lib.rs
@@ -7,12 +7,12 @@ use vstd::{prelude::*, string::*};
 verus! {
 
 #[is_variant]
-pub enum ZKSupportInputView {
+pub enum ZKAPIInputView {
     ReconcileZKNode(StringView,StringView,StringView),
 }
 
 #[is_variant]
-pub enum ZKSupportOutputView {
+pub enum ZKAPIOutputView {
     ReconcileZKNode(ZKNodeResultView),
 }
 
@@ -24,22 +24,22 @@ pub struct ZooKeeperState {
     pub data: Map<StringView, StringView>,
 }
 
-pub open spec fn external_process(input: ZKSupportInputView, state: Option<ZooKeeperState>) -> (Option<ZKSupportOutputView>, Option<ZooKeeperState>) {
+pub open spec fn external_process(input: ZKAPIInputView, state: Option<ZooKeeperState>) -> (Option<ZKAPIOutputView>, Option<ZooKeeperState>) {
     match input {
-        ZKSupportInputView::ReconcileZKNode(path,uri,replicas) => reconcile_zk_node(path, uri, replicas, state),
+        ZKAPIInputView::ReconcileZKNode(path,uri,replicas) => reconcile_zk_node(path, uri, replicas, state),
     }
 }
 
 pub open spec fn reconcile_zk_node(
     path: StringView, uri: StringView, replicas: StringView, state: Option<ZooKeeperState>
-) -> (Option<ZKSupportOutputView>, Option<ZooKeeperState>) {
+) -> (Option<ZKAPIOutputView>, Option<ZooKeeperState>) {
     let old_state = if state.is_None() { ZooKeeperState{ data: Map::empty() } } else { state.get_Some_0() };
     if old_state.data.contains_key(uri + path) {
         let state_prime = ZooKeeperState {
             data: old_state.data.insert(uri + path, new_strlit("CLUSTER_SIZE=")@ + replicas),
             ..old_state
         };
-        (Option::Some(ZKSupportOutputView::ReconcileZKNode(ZKNodeResultView{ res: Ok(()) })), Option::Some(state_prime))
+        (Option::Some(ZKAPIOutputView::ReconcileZKNode(ZKNodeResultView{ res: Ok(()) })), Option::Some(state_prime))
     } else {
         let new_data = old_state.data
                     .insert(uri + new_strlit("/zookeeper-operator")@, new_strlit("")@)
@@ -48,7 +48,7 @@ pub open spec fn reconcile_zk_node(
             data: new_data,
             ..old_state
         };
-        (Option::Some(ZKSupportOutputView::ReconcileZKNode(ZKNodeResultView{ res: Ok(()) })), Option::Some(state_prime))
+        (Option::Some(ZKAPIOutputView::ReconcileZKNode(ZKNodeResultView{ res: Ok(()) })), Option::Some(state_prime))
     }
 }
 

--- a/src/kubernetes_cluster/proof/controller_runtime.rs
+++ b/src/kubernetes_cluster/proof/controller_runtime.rs
@@ -84,17 +84,17 @@ pub open spec fn at_expected_reconcile_states<K: ResourceView, R: Reconciler<K>>
 
 pub open spec fn pending_k8s_api_req_msg<K: ResourceView, R: Reconciler<K>>(s: State<K, R>, key: ObjectRef) -> bool {
     s.reconcile_state_of(key).pending_req_msg.is_Some()
-    && s.reconcile_state_of(key).lib_response.is_None()
+    && s.reconcile_state_of(key).pending_external_api_output.is_None()
 }
 
 pub open spec fn pending_k8s_api_req_msg_is<K: ResourceView, R: Reconciler<K>>(s: State<K, R>, key: ObjectRef, req: Message) -> bool {
     s.reconcile_state_of(key).pending_req_msg == Option::Some(req)
-    && s.reconcile_state_of(key).lib_response.is_None()
+    && s.reconcile_state_of(key).pending_external_api_output.is_None()
 }
 
 pub open spec fn no_pending_request<K: ResourceView, R: Reconciler<K>>(s: State<K, R>, key: ObjectRef) -> bool {
     s.reconcile_state_of(key).pending_req_msg.is_None()
-    && s.reconcile_state_of(key).lib_response.is_None()
+    && s.reconcile_state_of(key).pending_external_api_output.is_None()
 }
 
 pub open spec fn pending_req_in_flight_at_reconcile_state<K: ResourceView, R: Reconciler<K>>(key: ObjectRef, state: FnSpec(R::T) -> bool) -> StatePred<State<K, R>>

--- a/src/kubernetes_cluster/proof/controller_runtime_safety.rs
+++ b/src/kubernetes_cluster/proof/controller_runtime_safety.rs
@@ -230,7 +230,7 @@ pub open spec fn req_in_flight_or_pending_at_controller<K: ResourceView, R: Reco
     || exists |cr_key: ObjectRef| (
         #[trigger] s.reconcile_state_contains(cr_key)
         && pending_k8s_api_req_msg_is(s, cr_key, req_msg)
-        && s.reconcile_state_of(cr_key).lib_response.is_None()
+        && s.reconcile_state_of(cr_key).pending_external_api_output.is_None()
     ))
 }
 

--- a/src/kubernetes_cluster/spec/controller/common.rs
+++ b/src/kubernetes_cluster/spec/controller/common.rs
@@ -13,7 +13,7 @@ verus! {
 pub struct ControllerState<K: ResourceView, R: Reconciler<K>> {
     pub ongoing_reconciles: Map<ObjectRef, OngoingReconcile<K, R>>,
     pub scheduled_reconciles: Map<ObjectRef, K>,
-    pub external_lib_state: Option<R::S>,
+    pub external_lib_state: R::LibState,
 }
 
 pub struct OngoingReconcile<K: ResourceView, R: Reconciler<K>> {
@@ -21,7 +21,7 @@ pub struct OngoingReconcile<K: ResourceView, R: Reconciler<K>> {
     // pending_req_msg: the request message pending for the handling for k8s api
     // lib_response: the response returned by the external library if a request has been processed by it
     pub pending_req_msg: Option<Message>,
-    pub lib_response: Option<R::O>,
+    pub lib_response: Option<R::LibResponse>,
     pub local_state: R::T,
 }
 
@@ -52,7 +52,7 @@ pub open spec fn init_controller_state<K: ResourceView, R: Reconciler<K>>() -> C
     ControllerState {
         ongoing_reconciles: Map::empty(),
         scheduled_reconciles: Map::empty(),
-        external_lib_state: Option::None,
+        external_lib_state: R::library_init_state(),
     }
 }
 

--- a/src/kubernetes_cluster/spec/controller/common.rs
+++ b/src/kubernetes_cluster/spec/controller/common.rs
@@ -13,6 +13,7 @@ verus! {
 pub struct ControllerState<K: ResourceView, R: Reconciler<K>> {
     pub ongoing_reconciles: Map<ObjectRef, OngoingReconcile<K, R>>,
     pub scheduled_reconciles: Map<ObjectRef, K>,
+    pub external_lib_state: Option<R::S>,
 }
 
 pub struct OngoingReconcile<K: ResourceView, R: Reconciler<K>> {
@@ -51,6 +52,7 @@ pub open spec fn init_controller_state<K: ResourceView, R: Reconciler<K>>() -> C
     ControllerState {
         ongoing_reconciles: Map::empty(),
         scheduled_reconciles: Map::empty(),
+        external_lib_state: Option::None,
     }
 }
 

--- a/src/kubernetes_cluster/spec/controller/common.rs
+++ b/src/kubernetes_cluster/spec/controller/common.rs
@@ -13,15 +13,15 @@ verus! {
 pub struct ControllerState<K: ResourceView, R: Reconciler<K>> {
     pub ongoing_reconciles: Map<ObjectRef, OngoingReconcile<K, R>>,
     pub scheduled_reconciles: Map<ObjectRef, K>,
-    pub external_lib_state: R::LibState,
+    pub external_state: R::ExternalState,
 }
 
 pub struct OngoingReconcile<K: ResourceView, R: Reconciler<K>> {
     pub triggering_cr: K,
     // pending_req_msg: the request message pending for the handling for k8s api
-    // lib_response: the response returned by the external library if a request has been processed by it
+    // pending_external_api_output: the response returned by the external library if a request has been processed by it
     pub pending_req_msg: Option<Message>,
-    pub lib_response: Option<R::LibResponse>,
+    pub pending_external_api_output: Option<R::ExternalAPIOutput>,
     pub local_state: R::T,
 }
 
@@ -52,7 +52,7 @@ pub open spec fn init_controller_state<K: ResourceView, R: Reconciler<K>>() -> C
     ControllerState {
         ongoing_reconciles: Map::empty(),
         scheduled_reconciles: Map::empty(),
-        external_lib_state: R::library_init_state(),
+        external_state: R::init_external_state(),
     }
 }
 

--- a/src/kubernetes_cluster/spec/controller/controller_runtime.rs
+++ b/src/kubernetes_cluster/spec/controller/controller_runtime.rs
@@ -101,16 +101,16 @@ pub open spec fn continue_reconcile<K: ResourceView, R: Reconciler<K>>() -> Cont
                     },
                     RequestView::ExternalRequest(req) => {
                         // Update the state by calling the external process method.
-                        let (lib_resp_opt, next_lib_state) = R::external_transition(req, s.external_state);
+                        let (external_api_output_opt, external_state_prime) = R::external_transition(req, s.external_state);
                         let reconcile_state_prime = OngoingReconcile {
                             pending_req_msg: Option::None,
-                            pending_external_api_output: lib_resp_opt,
+                            pending_external_api_output: external_api_output_opt,
                             local_state: local_state_prime,
                             ..reconcile_state
                         };
                         let s_prime = ControllerState {
                             ongoing_reconciles: s.ongoing_reconciles.insert(cr_key, reconcile_state_prime),
-                            external_state: next_lib_state,
+                            external_state: external_state_prime,
                             ..s
                         };
                         (s_prime, (Multiset::empty(), input.rest_id_allocator.allocate().0))

--- a/src/kubernetes_cluster/spec/controller/controller_runtime.rs
+++ b/src/kubernetes_cluster/spec/controller/controller_runtime.rs
@@ -53,7 +53,7 @@ pub open spec fn continue_reconcile<K: ResourceView, R: Reconciler<K>>() -> Cont
                 // (1) there is a pending request which is destined for kubernetes api;
                 // (3) there is no pending request which is destined for kubernetes api and there is a external response;
                 // (4) there is no pending request or external response;
-                // The three cases don't overlap each other, and we must make them mutually exclusive in the 
+                // The three cases don't overlap each other, and we must make them mutually exclusive in the
                 // precondition, i.e., there should not be a state which satifies the precondition but fits for more
                 // than one case of the three.
                 // Note that if there is no pending request destined for kubernetes api, we have to require that
@@ -85,7 +85,7 @@ pub open spec fn continue_reconcile<K: ResourceView, R: Reconciler<K>>() -> Cont
             if req_o.is_Some() {
                 match req_o.get_Some_0() {
                     RequestView::KRequest(req) => {
-                        let (rest_id_allocator_prime, pending_req_msg) 
+                        let (rest_id_allocator_prime, pending_req_msg)
                             = (input.rest_id_allocator.allocate().0, Option::Some(controller_req_msg(req, input.rest_id_allocator.allocate().1)));
                         let reconcile_state_prime = OngoingReconcile {
                             pending_req_msg: pending_req_msg,
@@ -101,14 +101,16 @@ pub open spec fn continue_reconcile<K: ResourceView, R: Reconciler<K>>() -> Cont
                     },
                     RequestView::ExternalRequest(req) => {
                         // Update the state by calling the external process method.
+                        let (lib_resp_opt, next_lib_state) = R::external_process(req, s.external_lib_state);
                         let reconcile_state_prime = OngoingReconcile {
                             pending_req_msg: Option::None,
-                            lib_response: R::external_process(req), 
+                            lib_response: lib_resp_opt,
                             local_state: local_state_prime,
                             ..reconcile_state
                         };
                         let s_prime = ControllerState {
                             ongoing_reconciles: s.ongoing_reconciles.insert(cr_key, reconcile_state_prime),
+                            external_lib_state: next_lib_state,
                             ..s
                         };
                         (s_prime, (Multiset::empty(), input.rest_id_allocator.allocate().0))

--- a/src/kubernetes_cluster/spec/controller/controller_runtime.rs
+++ b/src/kubernetes_cluster/spec/controller/controller_runtime.rs
@@ -25,7 +25,7 @@ pub open spec fn run_scheduled_reconcile<K: ResourceView, R: Reconciler<K>>() ->
             let initialized_ongoing_reconcile = OngoingReconcile {
                 triggering_cr: s.scheduled_reconciles[cr_key],
                 pending_req_msg: Option::None,
-                lib_response: Option::None,
+                pending_external_api_output: Option::None,
                 local_state: R::reconcile_init_state(),
             };
             let s_prime = ControllerState {
@@ -59,7 +59,7 @@ pub open spec fn continue_reconcile<K: ResourceView, R: Reconciler<K>>() -> Cont
                 // Note that if there is no pending request destined for kubernetes api, we have to require that
                 // the recv field of input is empty.
                 &&& if s.ongoing_reconciles[cr_key].pending_req_msg.is_Some() {
-                    &&& s.ongoing_reconciles[cr_key].lib_response.is_None() // The response from external library should have been consumed if ever exists
+                    &&& s.ongoing_reconciles[cr_key].pending_external_api_output.is_None() // The response from external library should have been consumed if ever exists
                     &&& input.recv.is_Some()
                     &&& input.recv.get_Some_0().content.is_APIResponse()
                     &&& resp_msg_matches_req_msg(input.recv.get_Some_0(), s.ongoing_reconciles[cr_key].pending_req_msg.get_Some_0())
@@ -76,8 +76,8 @@ pub open spec fn continue_reconcile<K: ResourceView, R: Reconciler<K>>() -> Cont
             let reconcile_state = s.ongoing_reconciles[cr_key];
             let resp_o = if input.recv.is_Some() {
                 Option::Some(ResponseView::KResponse(input.recv.get_Some_0().content.get_APIResponse_0()))
-            } else if reconcile_state.lib_response.is_Some() {
-                Option::Some(ResponseView::ExternalResponse(reconcile_state.lib_response.get_Some_0()))
+            } else if reconcile_state.pending_external_api_output.is_Some() {
+                Option::Some(ResponseView::ExternalResponse(reconcile_state.pending_external_api_output.get_Some_0()))
             } else {
                 Option::None
             };
@@ -89,7 +89,7 @@ pub open spec fn continue_reconcile<K: ResourceView, R: Reconciler<K>>() -> Cont
                             = (input.rest_id_allocator.allocate().0, Option::Some(controller_req_msg(req, input.rest_id_allocator.allocate().1)));
                         let reconcile_state_prime = OngoingReconcile {
                             pending_req_msg: pending_req_msg,
-                            lib_response: Option::None,
+                            pending_external_api_output: Option::None,
                             local_state: local_state_prime,
                             ..reconcile_state
                         };
@@ -101,16 +101,16 @@ pub open spec fn continue_reconcile<K: ResourceView, R: Reconciler<K>>() -> Cont
                     },
                     RequestView::ExternalRequest(req) => {
                         // Update the state by calling the external process method.
-                        let (lib_resp_opt, next_lib_state) = R::external_process(req, s.external_lib_state);
+                        let (lib_resp_opt, next_lib_state) = R::external_transition(req, s.external_state);
                         let reconcile_state_prime = OngoingReconcile {
                             pending_req_msg: Option::None,
-                            lib_response: lib_resp_opt,
+                            pending_external_api_output: lib_resp_opt,
                             local_state: local_state_prime,
                             ..reconcile_state
                         };
                         let s_prime = ControllerState {
                             ongoing_reconciles: s.ongoing_reconciles.insert(cr_key, reconcile_state_prime),
-                            external_lib_state: next_lib_state,
+                            external_state: next_lib_state,
                             ..s
                         };
                         (s_prime, (Multiset::empty(), input.rest_id_allocator.allocate().0))
@@ -119,7 +119,7 @@ pub open spec fn continue_reconcile<K: ResourceView, R: Reconciler<K>>() -> Cont
             } else {
                 let reconcile_state_prime = OngoingReconcile {
                     pending_req_msg: Option::None,
-                    lib_response: Option::None,
+                    pending_external_api_output: Option::None,
                     local_state: local_state_prime,
                     ..reconcile_state
                 };

--- a/src/reconciler/exec/external.rs
+++ b/src/reconciler/exec/external.rs
@@ -11,7 +11,7 @@ verus! {
 // Similarly, Output composes the Response<?> type of a reconciler.
 // Note that we can encapsulate all the required libraries here, so each reconciler only has one ExternalAPI type.
 pub trait ExternalAPI<Input: ToView, Output: ToView> {
-    fn process(input: Input) -> Option<Output>;
+    fn transition(input: Input) -> Option<Output>;
 }
 
 // An empty library that implements External Library.
@@ -20,7 +20,7 @@ pub trait ExternalAPI<Input: ToView, Output: ToView> {
 pub struct EmptyLib {}
 
 impl ExternalAPI<EmptyMsg, EmptyMsg> for EmptyLib {
-    fn process(input: EmptyMsg) -> Option<EmptyMsg> {
+    fn transition(input: EmptyMsg) -> Option<EmptyMsg> {
         Option::None
     }
 }

--- a/src/reconciler/exec/external.rs
+++ b/src/reconciler/exec/external.rs
@@ -7,11 +7,11 @@ verus! {
 
 // A trait for the external library of a reconciler.
 // Its core is a process method, and the developer should wrap all possible operations they may need in the function.
-// The InputType is the ? of Request<?> of the reconciler, i.e., it completes the request type of a reconciler.
-// Similarly, the OutputType composes the Response<?> type of a reconciler.
-// Note that we can encapsulate all the required libraries here, so each reconciler only has one ExternalLibrary type.
-pub trait ExternalLibrary<InputType: ToView, OutputType: ToView> {
-    fn process(input: InputType) -> Option<OutputType>;
+// Input is the ? of Request<?> of the reconciler, i.e., it completes the request type of a reconciler.
+// Similarly, Output composes the Response<?> type of a reconciler.
+// Note that we can encapsulate all the required libraries here, so each reconciler only has one ExternalAPI type.
+pub trait ExternalAPI<Input: ToView, Output: ToView> {
+    fn process(input: Input) -> Option<Output>;
 }
 
 // An empty library that implements External Library.
@@ -19,7 +19,7 @@ pub trait ExternalLibrary<InputType: ToView, OutputType: ToView> {
 // Users can define a reconciler as Reconciler<xx, xx, EmptyMsg, EmptyMsg, EmptyLib>.
 pub struct EmptyLib {}
 
-impl ExternalLibrary<EmptyMsg, EmptyMsg> for EmptyLib {
+impl ExternalAPI<EmptyMsg, EmptyMsg> for EmptyLib {
     fn process(input: EmptyMsg) -> Option<EmptyMsg> {
         Option::None
     }

--- a/src/reconciler/exec/io.rs
+++ b/src/reconciler/exec/io.rs
@@ -24,7 +24,7 @@ pub enum Request<T: ToView> {
 // The response type should be consistent with the Request type.
 // T: the output type of the third-party library of the reconciler which should be defined by the developer.
 // A safe and common way is to have an enum type which has the corresponding types of the input type in the Request.
-// Anyway, the process method in the ExternalLibrary, the input type in Request, output type in Response and the handling
+// Anyway, the process method in the ExternalAPI, the input type in Request, output type in Response and the handling
 // of external response in reconcile_core are correlative.
 // Developers have the freedom to define them in their own preferred way as long as they make them work well.
 #[is_variant]

--- a/src/reconciler/exec/reconciler.rs
+++ b/src/reconciler/exec/reconciler.rs
@@ -8,8 +8,8 @@ use vstd::prelude::*;
 
 verus! {
 
-pub trait Reconciler<R, T, ExternalAPIInput, ExternalAPIOutput, Lib>
-    where ExternalAPIInput: ToView, ExternalAPIOutput: ToView, Lib: ExternalAPI<ExternalAPIInput, ExternalAPIOutput>
+pub trait Reconciler<R, T, ExternalAPIInput, ExternalAPIOutput, ExternalAPIType>
+    where ExternalAPIInput: ToView, ExternalAPIOutput: ToView, ExternalAPIType: ExternalAPI<ExternalAPIInput, ExternalAPIOutput>
 {
     fn reconcile_init_state(&self) -> T;
     fn reconcile_core(&self, cr: &R, resp_o: Option<Response<ExternalAPIOutput>>, state: T) -> (T, Option<Request<ExternalAPIInput>>);

--- a/src/reconciler/exec/reconciler.rs
+++ b/src/reconciler/exec/reconciler.rs
@@ -8,11 +8,11 @@ use vstd::prelude::*;
 
 verus! {
 
-pub trait Reconciler<R, T, I, O, Lib>
-    where I: ToView, O: ToView, Lib: ExternalLibrary<I, O>
+pub trait Reconciler<R, T, ExternalAPIInput, ExternalAPIOutput, Lib>
+    where ExternalAPIInput: ToView, ExternalAPIOutput: ToView, Lib: ExternalAPI<ExternalAPIInput, ExternalAPIOutput>
 {
     fn reconcile_init_state(&self) -> T;
-    fn reconcile_core(&self, cr: &R, resp_o: Option<Response<O>>, state: T) -> (T, Option<Request<I>>);
+    fn reconcile_core(&self, cr: &R, resp_o: Option<Response<ExternalAPIOutput>>, state: T) -> (T, Option<Request<ExternalAPIInput>>);
     fn reconcile_done(&self, state: &T) -> bool;
     fn reconcile_error(&self, state: &T) -> bool;
 }

--- a/src/reconciler/spec/reconciler.rs
+++ b/src/reconciler/spec/reconciler.rs
@@ -13,13 +13,13 @@ verus! {
 pub trait Reconciler<#[verifier(maybe_negative)] K: ResourceView>: Sized {
     // Here are several internal associated types:
     // T: type of the reconciler state of the reconciler
-    // LibRequest: type of the request (input) to the external library
-    // LibResponse: type of the response (output) from the external library
-    // LibState: type of the state of the external library
+    // ExternalAPIInput: type of the request (input) to the external library
+    // ExternalAPIOutput: type of the response (output) from the external library
+    // ExternalState: type of the state of the external library
     type T;
-    type LibRequest;
-    type LibResponse;
-    type LibState;
+    type ExternalAPIInput;
+    type ExternalAPIOutput;
+    type ExternalState;
 
     // reconcile_init_state returns the initial local state that the reconciler starts
     // its reconcile function with.
@@ -31,8 +31,8 @@ pub trait Reconciler<#[verifier(maybe_negative)] K: ResourceView>: Sized {
     // reconcile_core describes the logic of reconcile function and is the key logic we want to verify.
     // Each reconcile_core should take the local state and a response of the previous request (if any) as input
     // and outputs the next local state and the request to send to Kubernetes API (if any).
-    open spec fn reconcile_core(cr: K, resp_o: Option<ResponseView<Self::LibResponse>>, state: Self::T)
-        -> (Self::T, Option<RequestView<Self::LibRequest>>);
+    open spec fn reconcile_core(cr: K, resp_o: Option<ResponseView<Self::ExternalAPIOutput>>, state: Self::T)
+        -> (Self::T, Option<RequestView<Self::ExternalAPIInput>>);
 
     // reconcile_done is used to tell the controller_runtime whether this reconcile round is done.
     // If it is true, controller_runtime will probably requeue the reconcile.
@@ -42,7 +42,7 @@ pub trait Reconciler<#[verifier(maybe_negative)] K: ResourceView>: Sized {
     // If it is true, controller_runtime will requeue the reconcile.
     open spec fn reconcile_error(state: Self::T) -> bool;
 
-    // external_process describes the logic of external libraries, which is a spec counterpart of Lib::process.
+    // external_transition describes the logic of external libraries, which is a spec counterpart of Lib::process.
     // An alternative way to achieve this is add Lib as a generic or associated type to this Reconciler trait. But since
     // Lib should contain method process, it should implement a trait (which should be the spec version of ExternalLibrary).
     // It must be a generic currently. This will cause another round of super annoying refactoring. So currently we just
@@ -51,9 +51,9 @@ pub trait Reconciler<#[verifier(maybe_negative)] K: ResourceView>: Sized {
     // library and produces the response and the next state of the library.
     // Use optional state here because: (1) it's easy to initialize since we don't have to require a default or init method,
     // (2) some libraries don't need a state to hold information, thus, optional state makes sense.
-    open spec fn external_process(input: Self::LibRequest, state: Self::LibState) -> (Option<Self::LibResponse>, Self::LibState);
+    open spec fn external_transition(input: Self::ExternalAPIInput, state: Self::ExternalState) -> (Option<Self::ExternalAPIOutput>, Self::ExternalState);
 
-    open spec fn library_init_state() -> Self::LibState;
+    open spec fn init_external_state() -> Self::ExternalState;
 }
 
 }

--- a/src/reconciler/spec/reconciler.rs
+++ b/src/reconciler/spec/reconciler.rs
@@ -13,13 +13,13 @@ verus! {
 pub trait Reconciler<#[verifier(maybe_negative)] K: ResourceView>: Sized {
     // Here are several internal associated types:
     // T: type of the reconciler state of the reconciler
-    // I: type of the request (input) to the external library
-    // O: type of the response (output) from the external library
-    // S: type of the state of the external library
+    // LibRequest: type of the request (input) to the external library
+    // LibResponse: type of the response (output) from the external library
+    // LibState: type of the state of the external library
     type T;
-    type I;
-    type O;
-    type S;
+    type LibRequest;
+    type LibResponse;
+    type LibState;
 
     // reconcile_init_state returns the initial local state that the reconciler starts
     // its reconcile function with.
@@ -31,8 +31,8 @@ pub trait Reconciler<#[verifier(maybe_negative)] K: ResourceView>: Sized {
     // reconcile_core describes the logic of reconcile function and is the key logic we want to verify.
     // Each reconcile_core should take the local state and a response of the previous request (if any) as input
     // and outputs the next local state and the request to send to Kubernetes API (if any).
-    open spec fn reconcile_core(cr: K, resp_o: Option<ResponseView<Self::O>>, state: Self::T)
-        -> (Self::T, Option<RequestView<Self::I>>);
+    open spec fn reconcile_core(cr: K, resp_o: Option<ResponseView<Self::LibResponse>>, state: Self::T)
+        -> (Self::T, Option<RequestView<Self::LibRequest>>);
 
     // reconcile_done is used to tell the controller_runtime whether this reconcile round is done.
     // If it is true, controller_runtime will probably requeue the reconcile.
@@ -43,15 +43,17 @@ pub trait Reconciler<#[verifier(maybe_negative)] K: ResourceView>: Sized {
     open spec fn reconcile_error(state: Self::T) -> bool;
 
     // external_process describes the logic of external libraries, which is a spec counterpart of Lib::process.
-    // An alternative way to achieve this is add Lib as a generic or associated type to this Reconciler trait. But since 
+    // An alternative way to achieve this is add Lib as a generic or associated type to this Reconciler trait. But since
     // Lib should contain method process, it should implement a trait (which should be the spec version of ExternalLibrary).
     // It must be a generic currently. This will cause another round of super annoying refactoring. So currently we just
     // add another method to this trait.
     // This method consumes the input (which should be computed by reconcile_core) and the current state of the external
     // library and produces the response and the next state of the library.
     // Use optional state here because: (1) it's easy to initialize since we don't have to require a default or init method,
-    // (2) some libraries don't need a state to hold information, thus, optional state makes sense. 
-    open spec fn external_process(input: Self::I, state: Option<Self::S>) -> (Option<Self::O>, Option<Self::S>);
+    // (2) some libraries don't need a state to hold information, thus, optional state makes sense.
+    open spec fn external_process(input: Self::LibRequest, state: Self::LibState) -> (Option<Self::LibResponse>, Self::LibState);
+
+    open spec fn library_init_state() -> Self::LibState;
 }
 
 }

--- a/src/reconciler/spec/reconciler.rs
+++ b/src/reconciler/spec/reconciler.rs
@@ -44,7 +44,7 @@ pub trait Reconciler<#[verifier(maybe_negative)] K: ResourceView>: Sized {
 
     // external_transition describes the logic of external libraries, which is a spec counterpart of Lib::process.
     // An alternative way to achieve this is add Lib as a generic or associated type to this Reconciler trait. But since
-    // Lib should contain method process, it should implement a trait (which should be the spec version of ExternalLibrary).
+    // Lib should contain method process, it should implement a trait (which should be the spec version of ExternalAPI).
     // It must be a generic currently. This will cause another round of super annoying refactoring. So currently we just
     // add another method to this trait.
     // This method consumes the input (which should be computed by reconcile_core) and the current state of the external

--- a/src/shim_layer/mod.rs
+++ b/src/shim_layer/mod.rs
@@ -42,7 +42,7 @@ where
     K::DynamicType: Default + Eq + Hash + Clone + Debug + Unpin,
     ResourceWrapperType: ResourceWrapper<K> + Send,
     ReconcilerType: Reconciler<ResourceWrapperType, ReconcileStateType, I, O, Lib> + Send + Sync + Default,
-    ReconcileStateType: Send, I: Send + ToView, O: Send + ToView, Lib: ExternalLibrary<I, O>,
+    ReconcileStateType: Send, I: Send + ToView, O: Send + ToView, Lib: ExternalAPI<I, O>,
 {
     let client = Client::try_default().await?;
     let crs = Api::<K>::all(client.clone());
@@ -87,7 +87,7 @@ where
     K: Clone + Resource<Scope = NamespaceResourceScope> + CustomResourceExt + DeserializeOwned + Debug + Serialize,
     K::DynamicType: Default + Clone + Debug,
     ResourceWrapperType: ResourceWrapper<K>,
-    I: ToView, O: ToView, Lib: ExternalLibrary<I, O>,
+    I: ToView, O: ToView, Lib: ExternalAPI<I, O>,
     ReconcilerType: Reconciler<ResourceWrapperType, ReconcileStateType, I, O, Lib>,
 {
     let client = &ctx.client;

--- a/src/zookeeper_controller.rs
+++ b/src/zookeeper_controller.rs
@@ -16,8 +16,8 @@ use builtin::*;
 use builtin_macros::*;
 
 use crate::zookeeper_controller::exec::reconciler::{ZookeeperReconcileState, ZookeeperReconciler};
-use crate::zookeeper_controller::exec::zookeepercluster::ZookeeperCluster;
 use crate::zookeeper_controller::exec::zookeeper_lib::lib::*;
+use crate::zookeeper_controller::exec::zookeepercluster::ZookeeperCluster;
 use deps_hack::anyhow::Result;
 use deps_hack::kube::CustomResourceExt;
 use deps_hack::serde_yaml;
@@ -39,7 +39,7 @@ async fn main() -> Result<()> {
     } else if cmd == String::from("run") {
         println!("running zookeeper-controller");
         run_controller::<deps_hack::ZookeeperCluster, ZookeeperCluster, ZookeeperReconciler, ZookeeperReconcileState,
-        ZKSupportInput, ZKSupportOutput, ZKSupport>().await?;
+        ZKAPIInput, ZKAPIOutput, ZKAPI>().await?;
         println!("controller terminated");
     } else {
         println!("wrong command; please use \"export\" or \"run\"");


### PR DESCRIPTION
The spec models the data stored in zookeeper as a map whose key is the zk node path. Calling the zk API to write to the zk node will insert the key-value pair into the map. The spec is highly simplified compared to the real zookeeper and is tailored for the use of the zookeeper controller.

There are still many important problems left for future PRs to deal with, such as: (1) what is our assumption on the external APIs? Do we assume they always return the result successfully, or they might return some transient error (and eventually get back to normal)? Or some other assumptions? (2) The external API's state and result might depend on the state of the k8s objects. Like, if the zk pods are not ready then the zk API won't work. Should we try to specify such dependencies?
