### PR TITLE
Port the fluent controller

### DIFF
--- a/deploy/fluent/crd.yaml
+++ b/deploy/fluent/crd.yaml
@@ -8,7 +8,8 @@ spec:
     categories: []
     kind: FluentBit
     plural: fluentbits
-    shortNames: []
+    shortNames:
+      - fb
     singular: fluentbit
   scope: Namespaced
   versions:
@@ -20,10 +21,13 @@ spec:
           properties:
             spec:
               properties:
-                config:
+                fluentBitConfig:
+                  type: string
+                parsersConfig:
                   type: string
               required:
-                - config
+                - fluentBitConfig
+                - parsersConfig
               type: object
           required:
             - spec

--- a/deploy/fluent/fluentbit.yaml
+++ b/deploy/fluent/fluentbit.yaml
@@ -4,4 +4,51 @@ metadata:
   name: fluent-bit
   namespace: default
 spec:
-  config: whatever
+  fluentBitConfig: |
+    [Service]
+        Parsers_File    parsers.conf
+    [Input]
+        Name    tail
+        Path    /var/log/containers/*.log
+        Exclude_Path    /var/log/containers/utils_default_utils-*.log
+        Refresh_Interval    10
+        Skip_Long_Lines    true
+        DB    /fluent-bit/tail/pos.db
+        DB.Sync    Normal
+        Mem_Buf_Limit    5MB
+        Parser    docker
+        Tag    kube.*
+    [Filter]
+        Name    kubernetes
+        Match    kube.*
+        Kube_URL    https://kubernetes.default.svc:443
+        Kube_CA_File    /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+        Kube_Token_File    /var/run/secrets/kubernetes.io/serviceaccount/token
+        Labels    false
+        Annotations    false
+    [Filter]
+        Name    nest
+        Match    kube.*
+        Operation    lift
+        Nested_under    kubernetes
+        Add_prefix    kubernetes_
+    [Filter]
+        Name    modify
+        Match    kube.*
+        Remove    stream
+        Remove    kubernetes_pod_id
+        Remove    kubernetes_host
+        Remove    kubernetes_container_hash
+    [Filter]
+        Name    nest
+        Match    kube.*
+        Operation    nest
+        Wildcard    kubernetes_*
+        Nest_under    kubernetes
+        Remove_prefix    kubernetes_
+    [Output]
+        Name    kafka
+        Match_Regex    (?:kube|service)\.(.*)
+        Brokers    my-cluster-kafka-brokers.kafka.svc:9092
+        Topics    fluent-log
+  parsersConfig: ""

--- a/src/controller_examples/fluent_controller/common/mod.rs
+++ b/src/controller_examples/fluent_controller/common/mod.rs
@@ -8,9 +8,9 @@ verus! {
 #[is_variant]
 pub enum FluentBitReconcileStep {
     Init,
-    AfterCreateClusterRole,
+    AfterCreateRole,
     AfterCreateServiceAccount,
-    AfterCreateClusterRoleBinding,
+    AfterCreateRoleBinding,
     AfterCreateSecret,
     AfterCreateDaemonSet,
     Done,

--- a/src/controller_examples/fluent_controller/common/mod.rs
+++ b/src/controller_examples/fluent_controller/common/mod.rs
@@ -1,0 +1,20 @@
+// Copyright 2022 VMware, Inc.
+// SPDX-License-Identifier: MIT
+#![allow(unused_imports)]
+use vstd::prelude::*;
+
+verus! {
+
+#[is_variant]
+pub enum FluentBitReconcileStep {
+    Init,
+    AfterCreateClusterRole,
+    AfterCreateServiceAccount,
+    AfterCreateClusterRoleBinding,
+    AfterCreateSecret,
+    AfterCreateDaemonSet,
+    Done,
+    Error,
+}
+
+}

--- a/src/controller_examples/fluent_controller/exec/fluentbit.rs
+++ b/src/controller_examples/fluent_controller/exec/fluentbit.rs
@@ -1,0 +1,117 @@
+// Copyright 2022 VMware, Inc.
+// SPDX-License-Identifier: MIT
+use crate::fluent_controller::spec::fluentbit::*;
+use crate::kubernetes_api_objects::error::ParseDynamicObjectError;
+use crate::kubernetes_api_objects::{
+    api_resource::*, common::*, dynamic::*, marshal::*, object_meta::*, resource::*,
+};
+use crate::pervasive_ext::string_view::*;
+use vstd::prelude::*;
+
+verus! {
+
+#[verifier(external_body)]
+pub struct FluentBit {
+    inner: deps_hack::FluentBit
+}
+
+impl FluentBit {
+    pub spec fn view(&self) -> FluentBitView;
+
+    #[verifier(external_body)]
+    pub fn metadata(&self) -> (metadata: ObjectMeta)
+        ensures
+            metadata@ == self@.metadata,
+    {
+        ObjectMeta::from_kube(self.inner.metadata.clone())
+    }
+
+    #[verifier(external_body)]
+    pub fn spec(&self) -> (spec: FluentBitSpec)
+        ensures
+            spec@ == self@.spec,
+    {
+        FluentBitSpec { inner: self.inner.spec.clone() }
+    }
+
+    #[verifier(external)]
+    pub fn into_kube(self) -> deps_hack::FluentBit {
+        self.inner
+    }
+
+    #[verifier(external_body)]
+    pub fn api_resource() -> (res: ApiResource)
+        ensures
+            res@.kind == FluentBitView::kind(),
+    {
+        ApiResource::from_kube(deps_hack::kube::api::ApiResource::erase::<deps_hack::FluentBit>(&()))
+    }
+
+    // NOTE: This function assumes serde_json::to_string won't fail!
+    #[verifier(external_body)]
+    pub fn to_dynamic_object(self) -> (obj: DynamicObject)
+        ensures
+            obj@ == self@.to_dynamic_object(),
+    {
+        // TODO: this might be unnecessarily slow
+        DynamicObject::from_kube(
+            deps_hack::k8s_openapi::serde_json::from_str(&deps_hack::k8s_openapi::serde_json::to_string(&self.inner).unwrap()).unwrap()
+        )
+    }
+
+    #[verifier(external_body)]
+    pub fn from_dynamic_object(obj: DynamicObject) -> (res: Result<FluentBit, ParseDynamicObjectError>)
+        ensures
+            res.is_Ok() == FluentBitView::from_dynamic_object(obj@).is_Ok(),
+            res.is_Ok() ==> res.get_Ok_0()@ == FluentBitView::from_dynamic_object(obj@).get_Ok_0(),
+    {
+        let parse_result = obj.into_kube().try_parse::<deps_hack::FluentBit>();
+        if parse_result.is_ok() {
+            let res = FluentBit { inner: parse_result.unwrap() };
+            Result::Ok(res)
+        } else {
+            Result::Err(ParseDynamicObjectError::ExecError)
+        }
+    }
+}
+
+impl ResourceWrapper<deps_hack::FluentBit> for FluentBit {
+    #[verifier(external)]
+    fn from_kube(inner: deps_hack::FluentBit) -> FluentBit {
+        FluentBit {
+            inner: inner
+        }
+    }
+
+    #[verifier(external)]
+    fn into_kube(self) -> deps_hack::FluentBit {
+        self.inner
+    }
+}
+
+#[verifier(external_body)]
+pub struct FluentBitSpec {
+    inner: deps_hack::FluentBitSpec,
+}
+
+impl FluentBitSpec {
+    pub spec fn view(&self) -> FluentBitSpecView;
+
+    #[verifier(external_body)]
+    pub fn fluentbit_config(&self) -> (fluentbit_config: String)
+        ensures
+            fluentbit_config@ == self@.fluentbit_config,
+    {
+        String::from_rust_string(self.inner.fluentbit_config.to_string())
+    }
+
+    #[verifier(external_body)]
+    pub fn parsers_config(&self) -> (parsers_config: String)
+        ensures
+            parsers_config@ == self@.parsers_config,
+    {
+        String::from_rust_string(self.inner.parsers_config.to_string())
+    }
+}
+
+}

--- a/src/controller_examples/fluent_controller/exec/mod.rs
+++ b/src/controller_examples/fluent_controller/exec/mod.rs
@@ -1,4 +1,4 @@
 // Copyright 2022 VMware, Inc.
 // SPDX-License-Identifier: MIT
 pub mod fluentbit;
-pub mod reconciler;
+// pub mod reconciler;

--- a/src/controller_examples/fluent_controller/exec/mod.rs
+++ b/src/controller_examples/fluent_controller/exec/mod.rs
@@ -1,4 +1,4 @@
 // Copyright 2022 VMware, Inc.
 // SPDX-License-Identifier: MIT
 pub mod fluentbit;
-// pub mod reconciler;
+pub mod reconciler;

--- a/src/controller_examples/fluent_controller/exec/reconciler.rs
+++ b/src/controller_examples/fluent_controller/exec/reconciler.rs
@@ -1,6 +1,7 @@
 // Copyright 2022 VMware, Inc.
 // SPDX-License-Identifier: MIT
 #![allow(unused_imports)]
+use crate::external_api::exec::*;
 use crate::fluent_controller::common::*;
 use crate::fluent_controller::exec::fluentbit::*;
 use crate::fluent_controller::spec::reconciler as fluent_spec;
@@ -12,7 +13,7 @@ use crate::kubernetes_api_objects::{
 };
 use crate::pervasive_ext::string_map::StringMap;
 use crate::pervasive_ext::string_view::*;
-use crate::reconciler::exec::{external::*, io::*, reconciler::*};
+use crate::reconciler::exec::{io::*, reconciler::*};
 use vstd::prelude::*;
 use vstd::seq_lib::*;
 use vstd::string::*;
@@ -41,12 +42,12 @@ impl FluentBitReconcileState {
 pub struct FluentBitReconciler {}
 
 #[verifier(external)]
-impl Reconciler<FluentBit, FluentBitReconcileState, EmptyMsg, EmptyMsg, EmptyLib> for FluentBitReconciler {
+impl Reconciler<FluentBit, FluentBitReconcileState, EmptyType, EmptyType, EmptyAPI> for FluentBitReconciler {
     fn reconcile_init_state(&self) -> FluentBitReconcileState {
         reconcile_init_state()
     }
 
-    fn reconcile_core(&self, fluentbit: &FluentBit, resp_o: Option<Response<EmptyMsg>>, state: FluentBitReconcileState) -> (FluentBitReconcileState, Option<Request<EmptyMsg>>) {
+    fn reconcile_core(&self, fluentbit: &FluentBit, resp_o: Option<Response<EmptyType>>, state: FluentBitReconcileState) -> (FluentBitReconcileState, Option<Request<EmptyType>>) {
         reconcile_core(fluentbit, resp_o, state)
     }
 
@@ -92,7 +93,7 @@ pub fn reconcile_error(state: &FluentBitReconcileState) -> (res: bool)
     }
 }
 
-pub fn reconcile_core(fluentbit: &FluentBit, resp_o: Option<Response<EmptyMsg>>, state: FluentBitReconcileState) -> (res: (FluentBitReconcileState, Option<Request<EmptyMsg>>))
+pub fn reconcile_core(fluentbit: &FluentBit, resp_o: Option<Response<EmptyType>>, state: FluentBitReconcileState) -> (res: (FluentBitReconcileState, Option<Request<EmptyType>>))
     requires
         fluentbit@.metadata.name.is_Some(),
         fluentbit@.metadata.namespace.is_Some(),

--- a/src/controller_examples/fluent_controller/mod.rs
+++ b/src/controller_examples/fluent_controller/mod.rs
@@ -1,0 +1,5 @@
+// Copyright 2022 VMware, Inc.
+// SPDX-License-Identifier: MIT
+pub mod common;
+// pub mod exec;
+pub mod spec;

--- a/src/controller_examples/fluent_controller/mod.rs
+++ b/src/controller_examples/fluent_controller/mod.rs
@@ -1,5 +1,5 @@
 // Copyright 2022 VMware, Inc.
 // SPDX-License-Identifier: MIT
 pub mod common;
-// pub mod exec;
+pub mod exec;
 pub mod spec;

--- a/src/controller_examples/fluent_controller/spec/fluentbit.rs
+++ b/src/controller_examples/fluent_controller/spec/fluentbit.rs
@@ -87,7 +87,7 @@ impl ResourceView for FluentBitView {
 }
 
 pub struct FluentBitSpecView {
-    pub fluent_bit_config: StringView,
+    pub fluentbit_config: StringView,
     pub parsers_config: StringView,
 }
 

--- a/src/controller_examples/fluent_controller/spec/fluentbit.rs
+++ b/src/controller_examples/fluent_controller/spec/fluentbit.rs
@@ -1,0 +1,108 @@
+// Copyright 2022 VMware, Inc.
+// SPDX-License-Identifier: MIT
+use crate::kubernetes_api_objects::error::ParseDynamicObjectError;
+use crate::kubernetes_api_objects::{
+    api_resource::*, common::*, dynamic::*, marshal::*, object_meta::*, resource::*,
+};
+use crate::pervasive_ext::string_view::*;
+use vstd::prelude::*;
+
+verus! {
+pub struct FluentBitView {
+    pub metadata: ObjectMetaView,
+    pub spec: FluentBitSpecView,
+}
+
+impl FluentBitView {
+    pub open spec fn well_formed(self) -> bool {
+        &&& self.metadata.name.is_Some()
+        &&& self.metadata.namespace.is_Some()
+    }
+
+    pub closed spec fn marshal_spec(s: FluentBitSpecView) -> Value;
+
+    pub closed spec fn unmarshal_spec(v: Value) -> Result<FluentBitSpecView, ParseDynamicObjectError>;
+
+    #[verifier(external_body)]
+    pub proof fn spec_integrity_is_preserved_by_marshal()
+        ensures
+            forall |s: FluentBitSpecView|
+                Self::unmarshal_spec(#[trigger] Self::marshal_spec(s)).is_Ok()
+                && s == Self::unmarshal_spec(Self::marshal_spec(s)).get_Ok_0() {}
+}
+
+impl ResourceView for FluentBitView {
+    type Spec = FluentBitSpecView;
+
+    open spec fn metadata(self) -> ObjectMetaView {
+        self.metadata
+    }
+
+    open spec fn kind() -> Kind {
+        Kind::CustomResourceKind
+    }
+
+    open spec fn object_ref(self) -> ObjectRef {
+        ObjectRef {
+            kind: Self::kind(),
+            name: self.metadata.name.get_Some_0(),
+            namespace: self.metadata.namespace.get_Some_0(),
+        }
+    }
+
+    proof fn object_ref_is_well_formed() {}
+
+    open spec fn spec(self) -> FluentBitSpecView {
+        self.spec
+    }
+
+    open spec fn to_dynamic_object(self) -> DynamicObjectView {
+        DynamicObjectView {
+            kind: Self::kind(),
+            metadata: self.metadata,
+            spec: FluentBitView::marshal_spec(self.spec)
+        }
+    }
+
+    open spec fn from_dynamic_object(obj: DynamicObjectView) -> Result<FluentBitView, ParseDynamicObjectError> {
+        if obj.kind != Self::kind() {
+            Result::Err(ParseDynamicObjectError::UnmarshalError)
+        } else if !FluentBitView::unmarshal_spec(obj.spec).is_Ok() {
+            Result::Err(ParseDynamicObjectError::UnmarshalError)
+        } else {
+            Result::Ok(FluentBitView {
+                metadata: obj.metadata,
+                spec: FluentBitView::unmarshal_spec(obj.spec).get_Ok_0(),
+            })
+        }
+    }
+
+    proof fn to_dynamic_preserves_integrity() {
+        FluentBitView::spec_integrity_is_preserved_by_marshal();
+    }
+
+    proof fn from_dynamic_preserves_metadata() {}
+
+    proof fn from_dynamic_preserves_kind() {}
+}
+
+pub struct FluentBitSpecView {
+    pub fluent_bit_config: StringView,
+    pub parsers_config: StringView,
+}
+
+impl FluentBitSpecView {}
+
+impl Marshalable for FluentBitSpecView {
+    spec fn marshal(self) -> Value;
+
+    spec fn unmarshal(value: Value) -> Result<Self, ParseDynamicObjectError>;
+
+    #[verifier(external_body)]
+    proof fn marshal_returns_non_null() {}
+
+    #[verifier(external_body)]
+    proof fn marshal_preserves_integrity() {}
+}
+
+}

--- a/src/controller_examples/fluent_controller/spec/mod.rs
+++ b/src/controller_examples/fluent_controller/spec/mod.rs
@@ -1,0 +1,5 @@
+// Copyright 2022 VMware, Inc.
+// SPDX-License-Identifier: MIT
+pub mod fluentbit;
+// pub mod exec;
+pub mod reconciler;

--- a/src/controller_examples/fluent_controller/spec/reconciler.rs
+++ b/src/controller_examples/fluent_controller/spec/reconciler.rs
@@ -241,7 +241,7 @@ pub open spec fn make_secret(fluentbit: FluentBitView) -> SecretView
         .set_metadata(ObjectMetaView::default()
             .set_name(make_secret_name(fluentbit.metadata.name.get_Some_0()))
         ).set_data(Map::empty()
-            .insert(new_strlit("fluent-bit.conf")@, fluentbit.spec.fluent_bit_config)
+            .insert(new_strlit("fluent-bit.conf")@, fluentbit.spec.fluentbit_config)
             .insert(new_strlit("parsers.conf")@, fluentbit.spec.parsers_config)
         )
 }

--- a/src/controller_examples/fluent_controller/spec/reconciler.rs
+++ b/src/controller_examples/fluent_controller/spec/reconciler.rs
@@ -1,0 +1,341 @@
+// Copyright 2022 VMware, Inc.
+// SPDX-License-Identifier: MIT
+#![allow(unused_imports)]
+use crate::fluent_controller::common::*;
+use crate::fluent_controller::spec::fluentbit::*;
+use crate::kubernetes_api_objects::{
+    api_method::*, cluster_role::*, cluster_role_binding::*, common::*, config_map::*,
+    daemon_set::*, label_selector::*, object_meta::*, persistent_volume_claim::*, pod::*,
+    pod_template_spec::*, resource::*, role::*, role_binding::*, secret::*, service::*,
+    service_account::*,
+};
+use crate::kubernetes_cluster::spec::message::*;
+use crate::pervasive_ext::string_view::*;
+use crate::reconciler::spec::{io::*, reconciler::*};
+use crate::state_machine::{action::*, state_machine::*};
+use crate::temporal_logic::defs::*;
+use vstd::prelude::*;
+use vstd::string::*;
+
+verus! {
+
+pub struct FluentBitReconcileState {
+    pub reconcile_step: FluentBitReconcileStep,
+}
+
+pub struct FluentBitReconciler {}
+
+impl Reconciler<FluentBitView> for FluentBitReconciler {
+    type T = FluentBitReconcileState;
+    type I = ();
+    type O = ();
+    open spec fn reconcile_init_state() -> FluentBitReconcileState {
+        reconcile_init_state()
+    }
+
+    open spec fn reconcile_core(
+        fluentbit: FluentBitView, resp_o: Option<ResponseView<()>>, state: FluentBitReconcileState
+    ) -> (FluentBitReconcileState, Option<RequestView<()>>) {
+        reconcile_core(fluentbit, resp_o, state)
+    }
+
+    open spec fn reconcile_done(state: FluentBitReconcileState) -> bool {
+        reconcile_done(state)
+    }
+
+    open spec fn reconcile_error(state: FluentBitReconcileState) -> bool {
+        reconcile_error(state)
+    }
+
+    open spec fn external_process(input: ()) -> Option<()> {
+        Option::None
+    }
+}
+
+pub open spec fn reconcile_init_state() -> FluentBitReconcileState {
+    FluentBitReconcileState {
+        reconcile_step: FluentBitReconcileStep::Init,
+    }
+}
+
+pub open spec fn reconcile_done(state: FluentBitReconcileState) -> bool {
+    match state.reconcile_step {
+        FluentBitReconcileStep::Done => true,
+        _ => false,
+    }
+}
+
+pub open spec fn reconcile_error(state: FluentBitReconcileState) -> bool {
+    match state.reconcile_step {
+        FluentBitReconcileStep::Error => true,
+        _ => false,
+    }
+}
+
+pub open spec fn reconcile_core(
+    fluentbit: FluentBitView, resp_o: Option<ResponseView<()>>, state: FluentBitReconcileState
+) -> (FluentBitReconcileState, Option<RequestView<()>>)
+    recommends
+        fluentbit.metadata.name.is_Some(),
+        fluentbit.metadata.namespace.is_Some(),
+{
+    let step = state.reconcile_step;
+    match step{
+        FluentBitReconcileStep::Init => {
+            let cluster_role = make_cluster_role(fluentbit);
+            let req_o = APIRequest::CreateRequest(CreateRequest{
+                namespace: fluentbit.metadata.namespace.get_Some_0(),
+                obj: cluster_role.to_dynamic_object(),
+            });
+            let state_prime = FluentBitReconcileState {
+                reconcile_step: FluentBitReconcileStep::AfterCreateClusterRole,
+                ..state
+            };
+            (state_prime, Option::Some(RequestView::KRequest(req_o)))
+        },
+        FluentBitReconcileStep::AfterCreateClusterRole => {
+            let service_account = make_service_account(fluentbit);
+            let req_o = APIRequest::CreateRequest(CreateRequest{
+                namespace: fluentbit.metadata.namespace.get_Some_0(),
+                obj: service_account.to_dynamic_object(),
+            });
+            let state_prime = FluentBitReconcileState {
+                reconcile_step: FluentBitReconcileStep::AfterCreateServiceAccount,
+                ..state
+            };
+            (state_prime, Option::Some(RequestView::KRequest(req_o)))
+        },
+        FluentBitReconcileStep::AfterCreateServiceAccount => {
+            let cluster_role_binding = make_cluster_role_binding(fluentbit);
+            let req_o = APIRequest::CreateRequest(CreateRequest{
+                namespace: fluentbit.metadata.namespace.get_Some_0(),
+                obj: cluster_role_binding.to_dynamic_object(),
+            });
+            let state_prime = FluentBitReconcileState {
+                reconcile_step: FluentBitReconcileStep::AfterCreateClusterRoleBinding,
+                ..state
+            };
+            (state_prime, Option::Some(RequestView::KRequest(req_o)))
+        },
+        FluentBitReconcileStep::AfterCreateClusterRoleBinding => {
+            let secret = make_secret(fluentbit);
+            let req_o = APIRequest::CreateRequest(CreateRequest{
+                namespace: fluentbit.metadata.namespace.get_Some_0(),
+                obj: secret.to_dynamic_object(),
+            });
+            let state_prime = FluentBitReconcileState {
+                reconcile_step: FluentBitReconcileStep::AfterCreateSecret,
+                ..state
+            };
+            (state_prime, Option::Some(RequestView::KRequest(req_o)))
+        },
+        FluentBitReconcileStep::AfterCreateSecret => {
+            let daemon_set = make_daemon_set(fluentbit);
+            let req_o = APIRequest::CreateRequest(CreateRequest{
+                namespace: fluentbit.metadata.namespace.get_Some_0(),
+                obj: daemon_set.to_dynamic_object(),
+            });
+            let state_prime = FluentBitReconcileState {
+                reconcile_step: FluentBitReconcileStep::AfterCreateDaemonSet,
+                ..state
+            };
+            (state_prime, Option::Some(RequestView::KRequest(req_o)))
+        },
+        FluentBitReconcileStep::AfterCreateDaemonSet => {
+            let state_prime = FluentBitReconcileState {
+                reconcile_step: FluentBitReconcileStep::Done,
+                ..state
+            };
+            (state_prime, Option::None)
+        },
+        _ => {
+            let state_prime = FluentBitReconcileState {
+                reconcile_step: step,
+                ..state
+            };
+            (state_prime, Option::None)
+        }
+
+    }
+}
+
+pub open spec fn reconcile_error_result(state: FluentBitReconcileState) -> (FluentBitReconcileState, Option<APIRequest>) {
+    let state_prime = FluentBitReconcileState {
+        reconcile_step: FluentBitReconcileStep::Error,
+        ..state
+    };
+    let req_o = Option::None;
+    (state_prime, req_o)
+}
+
+pub open spec fn make_cluster_role_name() -> StringView {
+    new_strlit("fluent-bit-role")@
+}
+
+pub open spec fn make_cluster_role(fluentbit: FluentBitView) -> ClusterRoleView
+    recommends
+        fluentbit.metadata.name.is_Some(),
+        fluentbit.metadata.namespace.is_Some(),
+{
+    ClusterRoleView::default()
+        .set_metadata(ObjectMetaView::default()
+            .set_name(make_cluster_role_name())
+        ).set_policy_rules(
+            seq![
+                PolicyRuleView::default()
+                    .set_api_groups(seq![new_strlit("")@])
+                    .set_resources(seq![new_strlit("pods")@])
+                    .set_verbs(seq![new_strlit("get")@])
+            ]
+        )
+}
+
+pub open spec fn make_service_account_name(fluentbit_name: StringView) -> StringView {
+    fluentbit_name
+}
+
+pub open spec fn make_service_account(fluentbit: FluentBitView) -> ServiceAccountView
+    recommends
+        fluentbit.metadata.name.is_Some(),
+        fluentbit.metadata.namespace.is_Some(),
+{
+    ServiceAccountView::default()
+        .set_metadata(ObjectMetaView::default()
+            .set_name(make_service_account_name(fluentbit.metadata.name.get_Some_0()))
+        )
+}
+
+pub open spec fn make_cluster_role_binding_name(fluentbit_name: StringView) -> StringView {
+    fluentbit_name + new_strlit("-role-binding")@
+}
+
+pub open spec fn make_cluster_role_binding(fluentbit: FluentBitView) -> ClusterRoleBindingView
+    recommends
+        fluentbit.metadata.name.is_Some(),
+        fluentbit.metadata.namespace.is_Some(),
+{
+    ClusterRoleBindingView::default()
+        .set_metadata(ObjectMetaView::default()
+            .set_name(make_cluster_role_binding_name(fluentbit.metadata.name.get_Some_0()))
+        ).set_role_ref(RoleRefView::default()
+            .set_api_group(new_strlit("rbac.authorization.k8s.io")@)
+            .set_kind(new_strlit("ClusterRole")@)
+            .set_name(make_cluster_role_name())
+        ).set_subjects(seq![SubjectView::default()
+            .set_kind(new_strlit("ServiceAccount")@)
+            .set_name(make_service_account_name(fluentbit.metadata.name.get_Some_0()))
+            .set_namespace(fluentbit.metadata.namespace.get_Some_0())
+        ])
+}
+
+pub open spec fn make_secret_name(fluentbit_name: StringView) -> StringView {
+    fluentbit_name + new_strlit("-config-secret")@
+}
+
+pub open spec fn make_secret(fluentbit: FluentBitView) -> SecretView
+    recommends
+        fluentbit.metadata.name.is_Some(),
+        fluentbit.metadata.namespace.is_Some(),
+{
+    SecretView::default()
+        .set_metadata(ObjectMetaView::default()
+            .set_name(make_secret_name(fluentbit.metadata.name.get_Some_0()))
+        ).set_data(Map::empty()
+            .insert(new_strlit("fluent-bit.conf")@, fluentbit.spec.fluent_bit_config)
+            .insert(new_strlit("parsers.conf")@, fluentbit.spec.parsers_config)
+        )
+}
+
+pub open spec fn make_daemon_set_name(fluentbit_name: StringView) -> StringView {
+    fluentbit_name
+}
+
+pub open spec fn make_daemon_set(fluentbit: FluentBitView) -> DaemonSetView
+    recommends
+        fluentbit.metadata.name.is_Some(),
+        fluentbit.metadata.namespace.is_Some(),
+{
+    let labels = Map::empty().insert(new_strlit("app")@, fluentbit.metadata.name.get_Some_0());
+    DaemonSetView::default()
+        .set_metadata(ObjectMetaView::default()
+            .set_name(make_daemon_set_name(fluentbit.metadata.name.get_Some_0()))
+            .set_labels(labels)
+        ).set_spec(DaemonSetSpecView::default()
+            .set_selector(LabelSelectorView::default().set_match_labels(labels))
+            .set_template(PodTemplateSpecView::default()
+                .set_metadata(ObjectMetaView::default()
+                    .set_labels(labels)
+                )
+                .set_spec(make_fluentbit_pod_spec(fluentbit))
+            )
+        )
+}
+
+pub open spec fn make_fluentbit_pod_spec(fluentbit: FluentBitView) -> PodSpecView
+    recommends
+        fluentbit.metadata.name.is_Some(),
+        fluentbit.metadata.namespace.is_Some(),
+{
+    PodSpecView::default()
+        .set_service_account_name(make_service_account_name(fluentbit.metadata.name.get_Some_0()))
+        .set_volumes(seq![
+            VolumeView::default()
+                .set_name(new_strlit("varlibcontainers")@)
+                .set_host_path(HostPathVolumeSourceView::default()
+                    .set_path(new_strlit("/containers")@)
+                ),
+            VolumeView::default()
+                .set_name(new_strlit("config")@)
+                .set_secret(SecretVolumeSourceView::default()
+                    .set_secret_name(make_secret_name(fluentbit.metadata.name.get_Some_0()))
+                ),
+            VolumeView::default()
+                .set_name(new_strlit("varlogs")@)
+                .set_host_path(HostPathVolumeSourceView::default()
+                    .set_path(new_strlit("/var/log")@)
+                ),
+            VolumeView::default()
+                .set_name(new_strlit("systemd")@)
+                .set_host_path(HostPathVolumeSourceView::default()
+                    .set_path(new_strlit("/var/log/journal")@)
+                ),
+            VolumeView::default()
+                .set_name(new_strlit("positions")@)
+                .set_host_path(HostPathVolumeSourceView::default()
+                    .set_path(new_strlit("/var/lib/fluent-bit/")@)
+                ),
+        ])
+        .set_containers(seq![
+            ContainerView::default()
+                .set_name(new_strlit("fluent-bit")@)
+                .set_image(new_strlit("kubesphere/fluent-bit:v2.1.7")@)
+                .set_volume_mounts(seq![
+                    VolumeMountView::default()
+                        .set_name(new_strlit("varlibcontainers")@)
+                        .set_read_only(true)
+                        .set_mount_path(new_strlit("/containers")@),
+                    VolumeMountView::default()
+                        .set_name(new_strlit("config")@)
+                        .set_read_only(true)
+                        .set_mount_path(new_strlit("/fluent-bit/config")@),
+                    VolumeMountView::default()
+                        .set_name(new_strlit("varlogs")@)
+                        .set_read_only(true)
+                        .set_mount_path(new_strlit("/var/log/")@),
+                    VolumeMountView::default()
+                        .set_name(new_strlit("systemd")@)
+                        .set_read_only(true)
+                        .set_mount_path(new_strlit("/var/log/journal")@),
+                    VolumeMountView::default()
+                        .set_name(new_strlit("positions")@)
+                        .set_mount_path(new_strlit("/fluent-bit/tail")@),
+                ])
+                .set_ports(seq![
+                    ContainerPortView::default()
+                        .set_name(new_strlit("metrics")@)
+                        .set_container_port(2020),
+                ])
+        ])
+}
+
+}

--- a/src/controller_examples/fluent_controller/spec/reconciler.rs
+++ b/src/controller_examples/fluent_controller/spec/reconciler.rs
@@ -1,6 +1,7 @@
 // Copyright 2022 VMware, Inc.
 // SPDX-License-Identifier: MIT
 #![allow(unused_imports)]
+use crate::external_api::spec::*;
 use crate::fluent_controller::common::*;
 use crate::fluent_controller::spec::fluentbit::*;
 use crate::kubernetes_api_objects::{
@@ -24,17 +25,16 @@ pub struct FluentBitReconcileState {
 
 pub struct FluentBitReconciler {}
 
-impl Reconciler<FluentBitView> for FluentBitReconciler {
+impl Reconciler<FluentBitView, EmptyAPI> for FluentBitReconciler {
     type T = FluentBitReconcileState;
-    type I = ();
-    type O = ();
+
     open spec fn reconcile_init_state() -> FluentBitReconcileState {
         reconcile_init_state()
     }
 
     open spec fn reconcile_core(
-        fluentbit: FluentBitView, resp_o: Option<ResponseView<()>>, state: FluentBitReconcileState
-    ) -> (FluentBitReconcileState, Option<RequestView<()>>) {
+        fluentbit: FluentBitView, resp_o: Option<ResponseView<EmptyTypeView>>, state: FluentBitReconcileState
+    ) -> (FluentBitReconcileState, Option<RequestView<EmptyTypeView>>) {
         reconcile_core(fluentbit, resp_o, state)
     }
 
@@ -44,10 +44,6 @@ impl Reconciler<FluentBitView> for FluentBitReconciler {
 
     open spec fn reconcile_error(state: FluentBitReconcileState) -> bool {
         reconcile_error(state)
-    }
-
-    open spec fn external_process(input: ()) -> Option<()> {
-        Option::None
     }
 }
 
@@ -72,8 +68,8 @@ pub open spec fn reconcile_error(state: FluentBitReconcileState) -> bool {
 }
 
 pub open spec fn reconcile_core(
-    fluentbit: FluentBitView, resp_o: Option<ResponseView<()>>, state: FluentBitReconcileState
-) -> (FluentBitReconcileState, Option<RequestView<()>>)
+    fluentbit: FluentBitView, resp_o: Option<ResponseView<EmptyTypeView>>, state: FluentBitReconcileState
+) -> (FluentBitReconcileState, Option<RequestView<EmptyTypeView>>)
     recommends
         fluentbit.metadata.name.is_Some(),
         fluentbit.metadata.namespace.is_Some(),

--- a/src/deps_hack/src/lib.rs
+++ b/src/deps_hack/src/lib.rs
@@ -52,14 +52,25 @@ pub struct RabbitmqClusterSpec {
     #[serde(rename = "rabbitmq", skip_serializing_if = "Option::is_none")]
     pub rabbitmq_config: Option<RabbitmqClusterConfigurationSpec>,
 }
+
 #[derive(Debug, Clone, serde::Deserialize, serde::Serialize, schemars::JsonSchema)]
 pub struct RabbitmqClusterConfigurationSpec {
-    // #[serde(rename = "additionalPlugins", skip_serializing_if = "Option::is_none")]
-    // pub additional_plugins: Option<Vec<String>>,
     #[serde(rename = "additionalConfig", skip_serializing_if = "Option::is_none")]
     pub additional_config: Option<String>,
     #[serde(rename = "advancedConfig", skip_serializing_if = "Option::is_none")]
     pub advanced_config: Option<String>,
     #[serde(rename = "envConfig", skip_serializing_if = "Option::is_none")]
     pub env_config: Option<String>,
+}
+
+#[derive(
+    kube::CustomResource, Debug, Clone, serde::Deserialize, serde::Serialize, schemars::JsonSchema,
+)]
+#[kube(group = "anvil.dev", version = "v1", kind = "FluentBit")]
+#[kube(shortname = "fb", namespaced)]
+pub struct FluentBitSpec {
+    #[serde(rename = "fluentBitConfig")]
+    pub fluent_bit_config: String,
+    #[serde(rename = "parsersConfig")]
+    pub parsers_config: String,
 }

--- a/src/deps_hack/src/lib.rs
+++ b/src/deps_hack/src/lib.rs
@@ -70,7 +70,7 @@ pub struct RabbitmqClusterConfigurationSpec {
 #[kube(shortname = "fb", namespaced)]
 pub struct FluentBitSpec {
     #[serde(rename = "fluentBitConfig")]
-    pub fluent_bit_config: String,
+    pub fluentbit_config: String,
     #[serde(rename = "parsersConfig")]
     pub parsers_config: String,
 }

--- a/src/fluent_controller.rs
+++ b/src/fluent_controller.rs
@@ -2,13 +2,13 @@
 // SPDX-License-Identifier: MIT
 #![allow(unused_imports)]
 
+pub mod external_api;
 #[path = "controller_examples/fluent_controller/mod.rs"]
 pub mod fluent_controller;
 pub mod kubernetes_api_objects;
 pub mod kubernetes_cluster;
 pub mod pervasive_ext;
 pub mod reconciler;
-pub mod external_api;
 pub mod shim_layer;
 pub mod state_machine;
 pub mod temporal_logic;
@@ -16,9 +16,9 @@ pub mod temporal_logic;
 use builtin::*;
 use builtin_macros::*;
 
+use crate::external_api::exec::*;
 use crate::fluent_controller::exec::fluentbit::FluentBit;
 use crate::fluent_controller::exec::reconciler::{FluentBitReconcileState, FluentBitReconciler};
-use crate::reconciler::exec::external::*;
 use deps_hack::anyhow::Result;
 use deps_hack::kube::CustomResourceExt;
 use deps_hack::serde_yaml;
@@ -39,7 +39,7 @@ async fn main() -> Result<()> {
         println!("{}", serde_yaml::to_string(&deps_hack::FluentBit::crd())?);
     } else if cmd == String::from("run") {
         println!("running fluent-controller");
-        run_controller::<deps_hack::FluentBit, FluentBit, FluentBitReconciler, FluentBitReconcileState, EmptyMsg, EmptyMsg, EmptyLib>().await?;
+        run_controller::<deps_hack::FluentBit, FluentBit, FluentBitReconciler, FluentBitReconcileState, EmptyType, EmptyType, EmptyAPI>().await?;
         println!("controller terminated");
     } else {
         println!("wrong command; please use \"export\" or \"run\"");

--- a/src/fluent_controller.rs
+++ b/src/fluent_controller.rs
@@ -1,6 +1,5 @@
 // Copyright 2022 VMware, Inc.
 // SPDX-License-Identifier: MIT
-
 #![allow(unused_imports)]
 
 #[path = "controller_examples/fluent_controller/mod.rs"]
@@ -14,5 +13,37 @@ pub mod shim_layer;
 pub mod state_machine;
 pub mod temporal_logic;
 
-// TODO(xudong): implement verified fluent-controller
-fn main() {}
+use builtin::*;
+use builtin_macros::*;
+
+use crate::fluent_controller::exec::fluentbit::FluentBit;
+use crate::fluent_controller::exec::reconciler::{FluentBitReconcileState, FluentBitReconciler};
+use crate::reconciler::exec::external::*;
+use deps_hack::anyhow::Result;
+use deps_hack::kube::CustomResourceExt;
+use deps_hack::serde_yaml;
+use deps_hack::tokio;
+use shim_layer::run_controller;
+use std::env;
+
+verus! {
+
+#[verifier(external)]
+#[tokio::main]
+async fn main() -> Result<()> {
+    let args: Vec<String> = env::args().collect();
+    let cmd = args[1].clone();
+
+    if cmd == String::from("export") {
+        println!("exporting custom resource definition");
+        println!("{}", serde_yaml::to_string(&deps_hack::FluentBit::crd())?);
+    } else if cmd == String::from("run") {
+        println!("running fluent-controller");
+        run_controller::<deps_hack::FluentBit, FluentBit, FluentBitReconciler, FluentBitReconcileState, EmptyMsg, EmptyMsg, EmptyLib>().await?;
+        println!("controller terminated");
+    } else {
+        println!("wrong command; please use \"export\" or \"run\"");
+    }
+    Ok(())
+}
+}

--- a/src/fluent_controller.rs
+++ b/src/fluent_controller.rs
@@ -3,6 +3,8 @@
 
 #![allow(unused_imports)]
 
+#[path = "controller_examples/fluent_controller/mod.rs"]
+pub mod fluent_controller;
 pub mod kubernetes_api_objects;
 pub mod kubernetes_cluster;
 pub mod pervasive_ext;

--- a/src/kubernetes_api_objects/pod.rs
+++ b/src/kubernetes_api_objects/pod.rs
@@ -419,6 +419,14 @@ impl VolumeMount {
     }
 
     #[verifier(external_body)]
+    pub fn set_read_only(&mut self, read_only: bool)
+        ensures
+            self@ == old(self)@.set_read_only(read_only),
+    {
+        self.inner.read_only = std::option::Option::Some(read_only);
+    }
+
+    #[verifier(external_body)]
     pub fn set_sub_path(&mut self, sub_path: String)
         ensures
             self@ == old(self)@.set_sub_path(sub_path@),
@@ -456,6 +464,14 @@ impl Volume {
             self@ == old(self)@.set_name(name@),
     {
         self.inner.name = name.into_rust_string();
+    }
+
+    #[verifier(external_body)]
+    pub fn set_host_path(&mut self, host_path: HostPathVolumeSource)
+        ensures
+            self@ == old(self)@.set_host_path(host_path@),
+    {
+        self.inner.host_path = std::option::Option::Some(host_path.into_kube());
     }
 
     #[verifier(external_body)]
@@ -573,6 +589,38 @@ impl LifecycleHandler {
 
     #[verifier(external)]
     pub fn into_kube(self) -> deps_hack::k8s_openapi::api::core::v1::LifecycleHandler {
+        self.inner
+    }
+}
+
+#[verifier(external_body)]
+pub struct HostPathVolumeSource {
+    inner: deps_hack::k8s_openapi::api::core::v1::HostPathVolumeSource,
+}
+
+impl HostPathVolumeSource {
+    pub spec fn view(&self) -> HostPathVolumeSourceView;
+
+    #[verifier(external_body)]
+    pub fn default() -> (host_path_volume_source: HostPathVolumeSource)
+        ensures
+            host_path_volume_source@ == HostPathVolumeSourceView::default(),
+    {
+        HostPathVolumeSource {
+            inner: deps_hack::k8s_openapi::api::core::v1::HostPathVolumeSource::default(),
+        }
+    }
+
+    #[verifier(external_body)]
+    pub fn set_path(&mut self, path: String)
+        ensures
+            self@ == old(self)@.set_path(path@),
+    {
+        self.inner.path = path.into_rust_string();
+    }
+
+    #[verifier(external)]
+    pub fn into_kube(self) -> deps_hack::k8s_openapi::api::core::v1::HostPathVolumeSource {
         self.inner
     }
 }
@@ -1184,9 +1232,7 @@ impl LifecycleView {
             ..self
         }
     }
-
 }
-
 
 pub struct LifecycleHandlerView {
     pub exec_: Option<Seq<StringView>>,
@@ -1251,6 +1297,7 @@ impl Marshalable for ContainerPortView {
 pub struct VolumeMountView {
     pub mount_path: StringView,
     pub name: StringView,
+    pub read_only: Option<bool>,
     pub sub_path: Option<StringView>,
 }
 
@@ -1259,6 +1306,7 @@ impl VolumeMountView {
         VolumeMountView {
             mount_path: new_strlit("")@,
             name: new_strlit("")@,
+            read_only: Option::Some(false),
             sub_path: Option::None,
         }
     }
@@ -1273,6 +1321,13 @@ impl VolumeMountView {
     pub open spec fn set_name(self, name: StringView) -> VolumeMountView {
         VolumeMountView {
             name: name,
+            ..self
+        }
+    }
+
+    pub open spec fn set_read_only(self, read_only: bool) -> VolumeMountView {
+        VolumeMountView {
+            read_only: Option::Some(read_only),
             ..self
         }
     }
@@ -1298,6 +1353,7 @@ impl Marshalable for VolumeMountView {
 }
 
 pub struct VolumeView {
+    pub host_path: Option<HostPathVolumeSourceView>,
     pub config_map: Option<ConfigMapVolumeSourceView>,
     pub name: StringView,
     pub projected: Option<ProjectedVolumeSourceView>,
@@ -1310,9 +1366,17 @@ impl VolumeView {
         VolumeView {
             name: new_strlit("")@,
             config_map: Option::None,
+            host_path: Option::None,
             projected: Option::None,
             secret: Option::None,
             downward_api: Option::None,
+        }
+    }
+
+    pub open spec fn set_host_path(self, host_path: HostPathVolumeSourceView) -> VolumeView {
+        VolumeView {
+            host_path: Option::Some(host_path),
+            ..self
         }
     }
 
@@ -1352,7 +1416,6 @@ impl VolumeView {
     }
 }
 
-
 impl Marshalable for VolumeView {
     spec fn marshal(self) -> Value;
 
@@ -1363,6 +1426,25 @@ impl Marshalable for VolumeView {
 
     #[verifier(external_body)]
     proof fn marshal_preserves_integrity() {}
+}
+
+pub struct HostPathVolumeSourceView {
+    pub path: StringView,
+}
+
+impl HostPathVolumeSourceView {
+    pub open spec fn default() -> HostPathVolumeSourceView {
+        HostPathVolumeSourceView {
+            path: new_strlit("")@,
+        }
+    }
+
+    pub open spec fn set_path(self, path: StringView) -> HostPathVolumeSourceView {
+        HostPathVolumeSourceView {
+            path: path,
+            ..self
+        }
+    }
 }
 
 pub struct ConfigMapVolumeSourceView {
@@ -1426,8 +1508,6 @@ impl Marshalable for SecretVolumeSourceView {
     #[verifier(external_body)]
     proof fn marshal_preserves_integrity() {}
 }
-
-
 
 pub struct ProjectedVolumeSourceView {
     pub sources: Option<Seq<VolumeProjectionView>>,

--- a/src/kubernetes_api_objects/pod.rs
+++ b/src/kubernetes_api_objects/pod.rs
@@ -168,6 +168,16 @@ impl PodSpec {
         self.inner.service_account_name = std::option::Option::Some(service_account.into_rust_string())
     }
 
+    #[verifier(external_body)]
+    pub fn set_tolerations(&mut self, tolerations: Vec<Toleration>)
+        ensures
+            self@ == old(self)@,
+    {
+        self.inner.tolerations = std::option::Option::Some(
+            tolerations.into_iter().map(|t: Toleration| t.into_kube()).collect()
+        )
+    }
+
     #[verifier(external)]
     pub fn into_kube(self) -> deps_hack::k8s_openapi::api::core::v1::PodSpec {
         self.inner
@@ -236,7 +246,7 @@ impl Container {
         self.inner.lifecycle = std::option::Option::Some(lifecycle.into_kube())
     }
 
-    /// Methods for the fields that Anvil currently does not reason about
+    // Methods for the fields that do not appear in spec
 
     #[verifier(external_body)]
     pub fn set_command(&mut self, command: Vec<String>)
@@ -284,6 +294,23 @@ impl Container {
 
     #[verifier(external)]
     pub fn into_kube(self) -> deps_hack::k8s_openapi::api::core::v1::Container {
+        self.inner
+    }
+}
+
+#[verifier(external_body)]
+pub struct Toleration {
+    inner: deps_hack::k8s_openapi::api::core::v1::Toleration,
+}
+
+impl Toleration {
+    #[verifier(external)]
+    pub fn from_kube(inner: deps_hack::k8s_openapi::api::core::v1::Toleration) -> Toleration {
+        Toleration { inner: inner }
+    }
+
+    #[verifier(external)]
+    pub fn into_kube(self) -> deps_hack::k8s_openapi::api::core::v1::Toleration {
         self.inner
     }
 }


### PR DESCRIPTION
The fluent controller, built on top of Anvil, behaves almost the same as the reference unverified fluent controller, except that: (1) The FluentBit configuration is passed to the controller through the CR's fields, and (2) The ported controller uses Role and RoleBinding, instead of Cluster and ClusterRoleBinding, because Anvil doesn't support cluster-scoped resources for now.