### PR TITLE
Allocate uid to each created object in k8s API state machine

### DIFF
--- a/src/kubernetes_api_objects/dynamic.rs
+++ b/src/kubernetes_api_objects/dynamic.rs
@@ -109,6 +109,16 @@ impl DynamicObjectView {
             ..self
         }
     }
+
+    pub open spec fn set_uid(self, uid: nat) -> DynamicObjectView {
+        DynamicObjectView {
+            metadata: ObjectMetaView {
+                uid: Option::Some(uid),
+                ..self.metadata
+            },
+            ..self
+        }
+    }
 }
 
 }

--- a/src/kubernetes_api_objects/object_meta.rs
+++ b/src/kubernetes_api_objects/object_meta.rs
@@ -64,18 +64,6 @@ impl ObjectMeta {
     }
 
     #[verifier(external_body)]
-    pub fn uid(&self) -> (uid: Option<String>)
-        ensures
-            self@.uid.is_Some() == uid.is_Some(),
-            uid.is_Some() ==> uid.get_Some_0()@ == self@.uid.get_Some_0(),
-    {
-        match &self.inner.uid {
-            std::option::Option::Some(n) => Option::Some(String::from_rust_string(n.to_string())),
-            std::option::Option::None => Option::None,
-        }
-    }
-
-    #[verifier(external_body)]
     pub fn resource_version(&self) -> (version: Option<u64>)
         ensures
             self@.resource_version.is_Some() == version.is_Some(),
@@ -86,7 +74,6 @@ impl ObjectMeta {
             std::option::Option::None => Option::None,
         }
     }
-
 
     #[verifier(external_body)]
     pub fn set_name(&mut self, name: String)
@@ -159,7 +146,7 @@ pub struct ObjectMetaView {
     pub namespace: Option<StringView>,
     pub generate_name: Option<StringView>,
     pub resource_version: Option<nat>, // make rv a nat so that it is easy to compare in spec/proof
-    pub uid: Option<StringView>,
+    pub uid: Option<nat>,
     pub labels: Option<Map<StringView, StringView>>,
     pub annotations: Option<Map<StringView, StringView>>,
     pub owner_references: Option<Seq<OwnerReferenceView>>,

--- a/src/kubernetes_api_objects/owner_reference.rs
+++ b/src/kubernetes_api_objects/owner_reference.rs
@@ -84,7 +84,6 @@ impl OwnerReference {
     {
         self.inner.uid = uid.into_rust_string();
     }
-
 }
 
 impl ResourceWrapper<deps_hack::k8s_openapi::apimachinery::pkg::apis::meta::v1::OwnerReference> for OwnerReference {

--- a/src/kubernetes_cluster/spec/kubernetes_api/common.rs
+++ b/src/kubernetes_cluster/spec/kubernetes_api/common.rs
@@ -12,9 +12,14 @@ verus! {
 
 pub type EtcdState = Map<ObjectRef, DynamicObjectView>;
 
+pub type Uid = nat;
+
+pub type ResourceVersion = nat;
+
 pub struct KubernetesAPIState {
-    pub resource_version_counter: nat,
     pub resources: EtcdState,
+    pub uid_counter: Uid,
+    pub resource_version_counter: ResourceVersion,
 }
 
 pub enum KubernetesAPIStep {

--- a/src/kubernetes_cluster/spec/kubernetes_api/state_machine.rs
+++ b/src/kubernetes_cluster/spec/kubernetes_api/state_machine.rs
@@ -48,6 +48,7 @@ pub open spec fn object_has_well_formed_spec(obj: DynamicObjectView) -> bool {
     &&& obj.kind == SecretView::kind() ==> SecretView::unmarshal_spec(obj.spec).is_Ok()
     &&& obj.kind == ServiceView::kind() ==> ServiceView::unmarshal_spec(obj.spec).is_Ok()
     &&& obj.kind == StatefulSetView::kind() ==> StatefulSetView::unmarshal_spec(obj.spec).is_Ok()
+    &&& obj.kind == ServiceAccountView::kind() ==> ServiceAccountView::unmarshal_spec(obj.spec).is_Ok()
     &&& obj.kind == K::kind() ==> K::unmarshal_spec(obj.spec).is_Ok()
 }
 


### PR DESCRIPTION
In Kubernetes, each object has an uid (unique id) which is used to differentiate it from any object that shares the same name and was previously deleted. For ease of specification and proof, we use nat, instead of a string (used in real implementation), to represent uid for each object.

Besides, we also simplify the state machine to make it easier to extend it with built-in controllers. The transition_by_etcd function now returns the new k8s api state and the output message. Built-in controllers later will be specified as other actions of the k8s api state machine (just like handle_request).