### PR TITLE
Set owner reference for the FluentBit controller

### DIFF
--- a/src/controller_examples/fluent_controller/exec/reconciler.rs
+++ b/src/controller_examples/fluent_controller/exec/reconciler.rs
@@ -8,7 +8,7 @@ use crate::fluent_controller::spec::reconciler as fluent_spec;
 use crate::kubernetes_api_objects::resource::ResourceWrapper;
 use crate::kubernetes_api_objects::{
     api_method::*, common::*, config_map::*, daemon_set::*, label_selector::*, object_meta::*,
-    persistent_volume_claim::*, pod::*, pod_template_spec::*, resource::*,
+    owner_reference::*, persistent_volume_claim::*, pod::*, pod_template_spec::*, resource::*,
     resource_requirements::*, role::*, role_binding::*, secret::*, service::*, service_account::*,
 };
 use crate::pervasive_ext::string_map::StringMap;
@@ -197,6 +197,17 @@ fn make_role(fluentbit: &FluentBit) -> (role: Role)
     role.set_metadata({
         let mut metadata = ObjectMeta::default();
         metadata.set_name(fluentbit.metadata().name().unwrap().concat(new_strlit("-role")));
+        metadata.set_owner_references({
+            let mut owner_references = Vec::new();
+            owner_references.push(fluentbit.controller_owner_ref());
+            proof {
+                assert_seqs_equal!(
+                    owner_references@.map_values(|owner_ref: OwnerReference| owner_ref@),
+                    fluent_spec::make_role(fluentbit@).metadata.owner_references.get_Some_0()
+                );
+            }
+            owner_references
+        });
         metadata
     });
     role.set_policy_rules({
@@ -260,6 +271,17 @@ fn make_service_account(fluentbit: &FluentBit) -> (service_account: ServiceAccou
     service_account.set_metadata({
         let mut metadata = ObjectMeta::default();
         metadata.set_name(fluentbit.metadata().name().unwrap());
+        metadata.set_owner_references({
+            let mut owner_references = Vec::new();
+            owner_references.push(fluentbit.controller_owner_ref());
+            proof {
+                assert_seqs_equal!(
+                    owner_references@.map_values(|owner_ref: OwnerReference| owner_ref@),
+                    fluent_spec::make_service_account(fluentbit@).metadata.owner_references.get_Some_0()
+                );
+            }
+            owner_references
+        });
         metadata
     });
 
@@ -277,6 +299,17 @@ fn make_role_binding(fluentbit: &FluentBit) -> (role_binding: RoleBinding)
     role_binding.set_metadata({
         let mut metadata = ObjectMeta::default();
         metadata.set_name(fluentbit.metadata().name().unwrap().concat(new_strlit("-role-binding")));
+        metadata.set_owner_references({
+            let mut owner_references = Vec::new();
+            owner_references.push(fluentbit.controller_owner_ref());
+            proof {
+                assert_seqs_equal!(
+                    owner_references@.map_values(|owner_ref: OwnerReference| owner_ref@),
+                    fluent_spec::make_role_binding(fluentbit@).metadata.owner_references.get_Some_0()
+                );
+            }
+            owner_references
+        });
         metadata
     });
     role_binding.set_role_ref({
@@ -318,6 +351,17 @@ pub fn make_secret(fluentbit: &FluentBit) -> (secret: Secret)
     secret.set_metadata({
         let mut metadata = ObjectMeta::default();
         metadata.set_name(fluentbit.metadata().name().unwrap().concat(new_strlit("-config-secret")));
+        metadata.set_owner_references({
+            let mut owner_references = Vec::new();
+            owner_references.push(fluentbit.controller_owner_ref());
+            proof {
+                assert_seqs_equal!(
+                    owner_references@.map_values(|owner_ref: OwnerReference| owner_ref@),
+                    fluent_spec::make_secret(fluentbit@).metadata.owner_references.get_Some_0()
+                );
+            }
+            owner_references
+        });
         metadata
     });
     secret.set_data({
@@ -344,6 +388,17 @@ fn make_daemon_set(fluentbit: &FluentBit) -> (daemon_set: DaemonSet)
             let mut labels = StringMap::empty();
             labels.insert(new_strlit("app").to_string(), fluentbit.metadata().name().unwrap());
             labels
+        });
+        metadata.set_owner_references({
+            let mut owner_references = Vec::new();
+            owner_references.push(fluentbit.controller_owner_ref());
+            proof {
+                assert_seqs_equal!(
+                    owner_references@.map_values(|owner_ref: OwnerReference| owner_ref@),
+                    fluent_spec::make_daemon_set(fluentbit@).metadata.owner_references.get_Some_0()
+                );
+            }
+            owner_references
         });
         metadata
     });

--- a/src/controller_examples/fluent_controller/spec/fluentbit.rs
+++ b/src/controller_examples/fluent_controller/spec/fluentbit.rs
@@ -2,8 +2,8 @@
 // SPDX-License-Identifier: MIT
 use crate::kubernetes_api_objects::error::ParseDynamicObjectError;
 use crate::kubernetes_api_objects::{
-    api_resource::*, common::*, dynamic::*, marshal::*, object_meta::*, resource::*,
-    resource_requirements::*,
+    api_resource::*, common::*, dynamic::*, marshal::*, object_meta::*, owner_reference::*,
+    resource::*, resource_requirements::*,
 };
 use crate::pervasive_ext::string_view::*;
 use vstd::prelude::*;
@@ -18,6 +18,16 @@ impl FluentBitView {
     pub open spec fn well_formed(self) -> bool {
         &&& self.metadata.name.is_Some()
         &&& self.metadata.namespace.is_Some()
+    }
+
+    pub open spec fn controller_owner_ref(self) -> OwnerReferenceView {
+        OwnerReferenceView {
+            block_owner_deletion: None,
+            controller: Some(true),
+            kind: Self::kind(),
+            name: self.metadata.name.get_Some_0(),
+            uid: self.metadata.uid.get_Some_0(),
+        }
     }
 }
 

--- a/src/controller_examples/fluent_controller/spec/reconciler.rs
+++ b/src/controller_examples/fluent_controller/spec/reconciler.rs
@@ -175,6 +175,7 @@ pub open spec fn make_role(fluentbit: FluentBitView) -> RoleView
     RoleView::default()
         .set_metadata(ObjectMetaView::default()
             .set_name(make_role_name(fluentbit.metadata.name.get_Some_0()))
+            .set_owner_references(seq![fluentbit.controller_owner_ref()])
         ).set_policy_rules(
             seq![
                 PolicyRuleView::default()
@@ -197,6 +198,7 @@ pub open spec fn make_service_account(fluentbit: FluentBitView) -> ServiceAccoun
     ServiceAccountView::default()
         .set_metadata(ObjectMetaView::default()
             .set_name(make_service_account_name(fluentbit.metadata.name.get_Some_0()))
+            .set_owner_references(seq![fluentbit.controller_owner_ref()])
         )
 }
 
@@ -212,6 +214,7 @@ pub open spec fn make_role_binding(fluentbit: FluentBitView) -> RoleBindingView
     RoleBindingView::default()
         .set_metadata(ObjectMetaView::default()
             .set_name(make_role_binding_name(fluentbit.metadata.name.get_Some_0()))
+            .set_owner_references(seq![fluentbit.controller_owner_ref()])
         ).set_role_ref(RoleRefView::default()
             .set_api_group(new_strlit("rbac.authorization.k8s.io")@)
             .set_kind(new_strlit("Role")@)
@@ -235,6 +238,7 @@ pub open spec fn make_secret(fluentbit: FluentBitView) -> SecretView
     SecretView::default()
         .set_metadata(ObjectMetaView::default()
             .set_name(make_secret_name(fluentbit.metadata.name.get_Some_0()))
+            .set_owner_references(seq![fluentbit.controller_owner_ref()])
         ).set_data(Map::empty()
             .insert(new_strlit("fluent-bit.conf")@, fluentbit.spec.fluentbit_config)
             .insert(new_strlit("parsers.conf")@, fluentbit.spec.parsers_config)
@@ -255,6 +259,7 @@ pub open spec fn make_daemon_set(fluentbit: FluentBitView) -> DaemonSetView
         .set_metadata(ObjectMetaView::default()
             .set_name(make_daemon_set_name(fluentbit.metadata.name.get_Some_0()))
             .set_labels(labels)
+            .set_owner_references(seq![fluentbit.controller_owner_ref()])
         ).set_spec(DaemonSetSpecView::default()
             .set_selector(LabelSelectorView::default().set_match_labels(labels))
             .set_template(PodTemplateSpecView::default()


### PR DESCRIPTION
With the owner reference that points to the FluentBit object, if the FluentBit is deleted, all the owned objects (role, service account, role binding, secret, and daemon set) will be automatically deleted by the garbage collector as well.