### PR TITLE
Prove all the invariants used for Rabbitmq controller liveness

### DIFF
--- a/src/controller_examples/rabbitmq_controller/proof/common.rs
+++ b/src/controller_examples/rabbitmq_controller/proof/common.rs
@@ -8,6 +8,7 @@ use crate::kubernetes_api_objects::{
 use crate::kubernetes_cluster::proof::controller_runtime::*;
 use crate::kubernetes_cluster::spec::{
     cluster::*,
+    cluster_state_machine::Step,
     controller::common::{controller_req_msg, ControllerActionInput, ControllerStep},
     message::*,
 };
@@ -17,6 +18,8 @@ use crate::temporal_logic::defs::*;
 use vstd::prelude::*;
 
 verus! {
+
+pub type RMQStep = Step<RabbitmqClusterView, EmptyAPI>;
 
 pub type RMQCluster = Cluster<RabbitmqClusterView, EmptyAPI, RabbitmqReconciler>;
 

--- a/src/controller_examples/rabbitmq_controller/proof/liveness/helper_invariants/invariants.rs
+++ b/src/controller_examples/rabbitmq_controller/proof/liveness/helper_invariants/invariants.rs
@@ -90,7 +90,7 @@ proof fn lemma_server_config_map_create_request_msg_implies_key_in_reconcile_equ
     let cr_key = step.get_ControllerStep_0().2.get_Some_0();
     // It's easy for the verifier to know that cr_key has the same kind and namespace as key.
 
-    // server_config_map_create_request_msg(key)(msg) requires the msg has a key with name key.name "-server-conf". So we 
+    // server_config_map_create_request_msg(key)(msg) requires the msg has a key with name key.name "-server-conf". So we
     // first show that in this action, cr_key is only possible to add "-server-conf" rather than "-plugins-conf" to reach
     // such a post state.
     assert_by(
@@ -311,7 +311,7 @@ proof fn lemma_always_sts_create_request_msg_is_valid(spec: TempPred<RMQCluster>
     init_invariant(spec, RMQCluster::init(), stronger_next,sts_create_request_msg_is_valid(key));
 }
 
-pub open spec fn create_cm_req_msg_in_flight_implies_at_after_create_cm_step(key: ObjectRef) -> StatePred<RMQCluster>
+pub open spec fn create_server_cm_req_msg_in_flight_implies_at_after_create_server_cm_step(key: ObjectRef) -> StatePred<RMQCluster>
     recommends
         key.kind.is_CustomResourceKind(),
 {
@@ -327,7 +327,7 @@ pub open spec fn create_cm_req_msg_in_flight_implies_at_after_create_cm_step(key
     }
 }
 
-pub proof fn lemma_true_leads_to_always_create_cm_req_msg_in_flight_implies_at_after_create_cm_step(spec: TempPred<RMQCluster>, key: ObjectRef)
+pub proof fn lemma_true_leads_to_always_create_server_cm_req_msg_in_flight_implies_at_after_create_server_cm_step(spec: TempPred<RMQCluster>, key: ObjectRef)
     requires
         spec.entails(tla_forall(|i| RMQCluster::kubernetes_api_next().weak_fairness(i))),
         spec.entails(always(lift_state(RMQCluster::every_in_flight_msg_has_lower_id_than_allocator()))),
@@ -339,7 +339,7 @@ pub proof fn lemma_true_leads_to_always_create_cm_req_msg_in_flight_implies_at_a
         key.kind.is_CustomResourceKind(),
     ensures
         spec.entails(
-            true_pred().leads_to(always(lift_state(create_cm_req_msg_in_flight_implies_at_after_create_cm_step(key))))
+            true_pred().leads_to(always(lift_state(create_server_cm_req_msg_in_flight_implies_at_after_create_server_cm_step(key))))
         ),
 {
     let requirements = |msg: Message, s: RMQCluster| {
@@ -382,10 +382,10 @@ pub proof fn lemma_true_leads_to_always_create_cm_req_msg_in_flight_implies_at_a
 
     RMQCluster::lemma_true_leads_to_always_every_in_flight_req_msg_satisfies(spec, requirements);
 
-    temp_pred_equality(lift_state(create_cm_req_msg_in_flight_implies_at_after_create_cm_step(key)), lift_state(RMQCluster::every_in_flight_req_msg_satisfies(requirements)));
+    temp_pred_equality(lift_state(create_server_cm_req_msg_in_flight_implies_at_after_create_server_cm_step(key)), lift_state(RMQCluster::every_in_flight_req_msg_satisfies(requirements)));
 }
 
-pub open spec fn update_cm_req_msg_in_flight_implies_at_after_update_cm_step(key: ObjectRef) -> StatePred<RMQCluster>
+pub open spec fn update_server_cm_req_msg_in_flight_implies_at_after_update_server_cm_step(key: ObjectRef) -> StatePred<RMQCluster>
     recommends
         key.kind.is_CustomResourceKind(),
 {
@@ -401,7 +401,7 @@ pub open spec fn update_cm_req_msg_in_flight_implies_at_after_update_cm_step(key
     }
 }
 
-pub proof fn lemma_true_leads_to_always_update_cm_req_msg_in_flight_implies_at_after_update_cm_step(spec: TempPred<RMQCluster>, key: ObjectRef)
+pub proof fn lemma_true_leads_to_always_update_server_cm_req_msg_in_flight_implies_at_after_update_server_cm_step(spec: TempPred<RMQCluster>, key: ObjectRef)
     requires
         spec.entails(tla_forall(|i| RMQCluster::kubernetes_api_next().weak_fairness(i))),
         spec.entails(always(lift_state(RMQCluster::every_in_flight_msg_has_lower_id_than_allocator()))),
@@ -413,7 +413,7 @@ pub proof fn lemma_true_leads_to_always_update_cm_req_msg_in_flight_implies_at_a
         key.kind.is_CustomResourceKind(),
     ensures
         spec.entails(
-            true_pred().leads_to(always(lift_state(update_cm_req_msg_in_flight_implies_at_after_update_cm_step(key))))
+            true_pred().leads_to(always(lift_state(update_server_cm_req_msg_in_flight_implies_at_after_update_server_cm_step(key))))
         ),
 {
     let requirements = |msg: Message, s: RMQCluster| {
@@ -469,11 +469,11 @@ pub proof fn lemma_true_leads_to_always_update_cm_req_msg_in_flight_implies_at_a
         lift_state(RMQCluster::every_in_flight_msg_has_unique_id())
     );
     RMQCluster::lemma_true_leads_to_always_every_in_flight_req_msg_satisfies(spec, requirements);
-    temp_pred_equality(lift_state(update_cm_req_msg_in_flight_implies_at_after_update_cm_step(key)), lift_state(RMQCluster::every_in_flight_req_msg_satisfies(requirements)));
+    temp_pred_equality(lift_state(update_server_cm_req_msg_in_flight_implies_at_after_update_server_cm_step(key)), lift_state(RMQCluster::every_in_flight_req_msg_satisfies(requirements)));
 }
 
 
-pub open spec fn every_update_cm_req_does_the_same(rabbitmq: RabbitmqClusterView) -> StatePred<RMQCluster>
+pub open spec fn every_update_server_cm_req_does_the_same(rabbitmq: RabbitmqClusterView) -> StatePred<RMQCluster>
     recommends
         rabbitmq.well_formed(),
 {
@@ -550,7 +550,7 @@ pub proof fn lemma_always_stateful_set_has_no_finalizers_or_timestamp_and_only_h
     init_invariant(spec, RMQCluster::init(), stronger_next, inv);
 }
 
-pub proof fn lemma_true_leads_to_always_every_update_cm_req_does_the_same(spec: TempPred<RMQCluster>, rabbitmq: RabbitmqClusterView)
+pub proof fn lemma_true_leads_to_always_every_update_server_cm_req_does_the_same(spec: TempPred<RMQCluster>, rabbitmq: RabbitmqClusterView)
     requires
         spec.entails(always(lift_state(RMQCluster::every_in_flight_msg_has_lower_id_than_allocator()))),
         spec.entails(always(lift_action(RMQCluster::next()))),
@@ -560,7 +560,7 @@ pub proof fn lemma_true_leads_to_always_every_update_cm_req_does_the_same(spec: 
         spec.entails(always(lift_state(RMQCluster::the_object_in_reconcile_has_spec_and_uid_as(rabbitmq)))),
     ensures
         spec.entails(
-            true_pred().leads_to(always(lift_state(every_update_cm_req_does_the_same(rabbitmq))))
+            true_pred().leads_to(always(lift_state(every_update_server_cm_req_does_the_same(rabbitmq))))
         ),
 {
     let requirements = |msg: Message, s: RMQCluster| {
@@ -597,7 +597,7 @@ pub proof fn lemma_true_leads_to_always_every_update_cm_req_does_the_same(spec: 
         lift_state(RMQCluster::the_object_in_reconcile_has_spec_and_uid_as(rabbitmq))
     );
     RMQCluster::lemma_true_leads_to_always_every_in_flight_req_msg_satisfies(spec, requirements);
-    temp_pred_equality(lift_state(every_update_cm_req_does_the_same(rabbitmq)), lift_state(RMQCluster::every_in_flight_req_msg_satisfies(requirements)));
+    temp_pred_equality(lift_state(every_update_server_cm_req_does_the_same(rabbitmq)), lift_state(RMQCluster::every_in_flight_req_msg_satisfies(requirements)));
 }
 
 pub proof fn lemma_true_leads_to_always_no_delete_cm_req_is_in_flight(spec: TempPred<RMQCluster>, rabbitmq: RabbitmqClusterView)
@@ -793,7 +793,7 @@ pub proof fn lemma_true_leads_to_always_every_create_sts_req_does_the_same(spec:
     temp_pred_equality(lift_state(every_create_sts_req_does_the_same(rabbitmq)), lift_state(RMQCluster::every_in_flight_req_msg_satisfies(requirements)));
 }
 
-pub open spec fn every_create_cm_req_does_the_same(rabbitmq: RabbitmqClusterView) -> StatePred<RMQCluster>
+pub open spec fn every_create_server_cm_req_does_the_same(rabbitmq: RabbitmqClusterView) -> StatePred<RMQCluster>
     recommends
         rabbitmq.well_formed(),
 {
@@ -806,7 +806,7 @@ pub open spec fn every_create_cm_req_does_the_same(rabbitmq: RabbitmqClusterView
     }
 }
 
-pub proof fn lemma_true_leads_to_always_every_create_cm_req_does_the_same(spec: TempPred<RMQCluster>, rabbitmq: RabbitmqClusterView)
+pub proof fn lemma_true_leads_to_always_every_create_server_cm_req_does_the_same(spec: TempPred<RMQCluster>, rabbitmq: RabbitmqClusterView)
     requires
         rabbitmq.well_formed(),
         spec.entails(always(lift_state(RMQCluster::every_in_flight_msg_has_lower_id_than_allocator()))),
@@ -817,7 +817,7 @@ pub proof fn lemma_true_leads_to_always_every_create_cm_req_does_the_same(spec: 
         spec.entails(always(lift_state(RMQCluster::the_object_in_reconcile_has_spec_and_uid_as(rabbitmq)))),
     ensures
         spec.entails(
-            true_pred().leads_to(always(lift_state(every_create_cm_req_does_the_same(rabbitmq))))
+            true_pred().leads_to(always(lift_state(every_create_server_cm_req_does_the_same(rabbitmq))))
         ),
 {
     let requirements = |msg: Message, s: RMQCluster| {
@@ -848,7 +848,7 @@ pub proof fn lemma_true_leads_to_always_every_create_cm_req_does_the_same(spec: 
         lift_state(RMQCluster::the_object_in_reconcile_has_spec_and_uid_as(rabbitmq))
     );
     RMQCluster::lemma_true_leads_to_always_every_in_flight_req_msg_satisfies(spec, requirements);
-    temp_pred_equality(lift_state(every_create_cm_req_does_the_same(rabbitmq)), lift_state(RMQCluster::every_in_flight_req_msg_satisfies(requirements)));
+    temp_pred_equality(lift_state(every_create_server_cm_req_does_the_same(rabbitmq)), lift_state(RMQCluster::every_in_flight_req_msg_satisfies(requirements)));
 }
 
 pub open spec fn create_sts_req_msg_in_flight_implies_at_after_create_sts_step(key: ObjectRef) -> StatePred<RMQCluster>

--- a/src/controller_examples/rabbitmq_controller/proof/liveness/helper_invariants/invariants.rs
+++ b/src/controller_examples/rabbitmq_controller/proof/liveness/helper_invariants/invariants.rs
@@ -12,7 +12,7 @@ use crate::kubernetes_cluster::spec::{
     controller::common::{controller_req_msg, ControllerActionInput, ControllerStep},
     message::*,
 };
-use crate::pervasive_ext::{multiset_lemmas, seq_lemmas};
+use crate::pervasive_ext::{multiset_lemmas, seq_lemmas, string_view::*};
 use crate::rabbitmq_controller::{
     common::*,
     proof::common::*,
@@ -38,6 +38,247 @@ pub open spec fn cm_update_request_msg(key: ObjectRef) -> FnSpec(Message) -> boo
         msg.dst.is_KubernetesAPI()
         && msg.content.is_update_request()
         && msg.content.get_update_request().key == make_server_config_map_key(key)
+}
+
+spec fn make_owner_references_with_name_and_uid(name: StringView, uid: nat) -> OwnerReferenceView {
+    OwnerReferenceView {
+        block_owner_deletion: None,
+        controller: Some(true),
+        kind: RabbitmqClusterView::kind(),
+        name: name,
+        uid: uid,
+    }
+}
+
+spec fn cm_create_request_msg_is_valid(key: ObjectRef) -> StatePred<RMQCluster> {
+    |s: RMQCluster| {
+        forall |msg: Message| {
+            #[trigger] s.message_in_flight(msg)
+            && cm_create_request_msg(key)(msg)
+            ==> msg.content.get_create_request().obj.metadata.finalizers.is_None()
+                && exists |uid: nat| #![auto]
+                    msg.content.get_create_request().obj.metadata.owner_references == Some(seq![
+                        make_owner_references_with_name_and_uid(key.name, uid)
+                    ])
+        }
+    }
+}
+
+// TODO: write a lemma to show that pending_req == cm_create_request ==> key == cr.object_ref()
+
+proof fn lemma_always_cm_create_request_msg_is_valid(spec: TempPred<RMQCluster>, key: ObjectRef)
+    requires
+        spec.entails(lift_state(RMQCluster::init())),
+        spec.entails(always(lift_action(RMQCluster::next()))),
+    ensures
+        spec.entails(always(lift_state(cm_create_request_msg_is_valid(key)))),
+{
+    let stronger_next = |s, s_prime| {
+        &&& RMQCluster::next()(s, s_prime)
+        &&& RMQCluster::each_object_in_reconcile_has_consistent_key_and_valid_metadata()(s)
+    };
+    RMQCluster::lemma_always_each_object_in_reconcile_has_consistent_key_and_valid_metadata(spec);
+    strengthen_next_n!(
+        stronger_next, spec,
+        lift_action(RMQCluster::next()),
+        lift_state(RMQCluster::each_object_in_reconcile_has_consistent_key_and_valid_metadata())
+    );
+    assert forall |s, s_prime| cm_create_request_msg_is_valid(key)(s) && #[trigger] stronger_next(s, s_prime) implies
+    cm_create_request_msg_is_valid(key)(s_prime) by {
+        assert forall |msg| #[trigger] s_prime.message_in_flight(msg) && cm_create_request_msg(key)(msg) implies
+        msg.content.get_create_request().obj.metadata.finalizers.is_None()
+        && exists |uid: nat| #![auto] msg.content.get_create_request().obj.metadata.owner_references
+            == Some(seq![make_owner_references_with_name_and_uid(key.name, uid)]) by {
+            if !s.message_in_flight(msg) {
+                let step = choose |step| RMQCluster::next_step(s, s_prime, step);
+                assert(step.is_ControllerStep());
+                let input = step.get_ControllerStep_0();
+                let other_key = input.2.get_Some_0();
+                assert_by(
+                    other_key.name + new_strlit("-plugins-conf")@ != key.name + new_strlit("-server-conf")@,
+                    {
+                        let str1 = key.name + new_strlit("-server-conf")@;
+                        let str2 = other_key.name + new_strlit("-plugins-conf")@;
+                        reveal_strlit("-server-conf");
+                        reveal_strlit("-plugins-conf");
+                        if str1.len() == str2.len() {
+                            assert(str1[str1.len() - 6] == 'r');
+                            assert(str2[str1.len() - 6] == 's');
+                        }
+                    }
+                );
+                seq_lemmas::seq_equal_preserved_by_add(key.name, other_key.name, new_strlit("-server-conf")@);
+                let cr = s.triggering_cr_of(other_key);
+                assert(cr.metadata.uid.is_Some());
+                assert(msg.content.get_create_request().obj.metadata.owner_references == Some(seq![
+                    make_owner_references_with_name_and_uid(key.name, cr.metadata.uid.get_Some_0())
+                ]));
+            }
+        }
+    }
+    init_invariant(spec, RMQCluster::init(), stronger_next, cm_create_request_msg_is_valid(key));
+}
+
+spec fn cm_update_request_msg_is_valid(key: ObjectRef) -> StatePred<RMQCluster> {
+    |s: RMQCluster| {
+        forall |msg: Message| {
+            #[trigger] s.message_in_flight(msg)
+            && cm_update_request_msg(key)(msg)
+            ==> msg.content.get_update_request().obj.metadata.finalizers.is_None()
+                && exists |uid: nat| #![auto]
+                    msg.content.get_update_request().obj.metadata.owner_references == Some(seq![
+                        make_owner_references_with_name_and_uid(key.name, uid)
+                    ])
+        }
+    }
+}
+
+proof fn lemma_always_cm_update_request_msg_is_valid(spec: TempPred<RMQCluster>, key: ObjectRef)
+    requires
+        spec.entails(lift_state(RMQCluster::init())),
+        spec.entails(always(lift_action(RMQCluster::next()))),
+    ensures
+        spec.entails(always(lift_state(cm_update_request_msg_is_valid(key)))),
+{
+    let stronger_next = |s, s_prime| {
+        &&& RMQCluster::next()(s, s_prime)
+        &&& RMQCluster::each_object_in_reconcile_has_consistent_key_and_valid_metadata()(s)
+    };
+    RMQCluster::lemma_always_each_object_in_reconcile_has_consistent_key_and_valid_metadata(spec);
+    strengthen_next_n!(
+        stronger_next, spec,
+        lift_action(RMQCluster::next()),
+        lift_state(RMQCluster::each_object_in_reconcile_has_consistent_key_and_valid_metadata())
+    );
+    assert forall |s, s_prime| cm_update_request_msg_is_valid(key)(s) && #[trigger] stronger_next(s, s_prime) implies
+    cm_update_request_msg_is_valid(key)(s_prime) by {
+        assert forall |msg| #[trigger] s_prime.message_in_flight(msg) && cm_update_request_msg(key)(msg) implies
+        msg.content.get_update_request().obj.metadata.finalizers.is_None()
+        && exists |uid: nat| #![auto] msg.content.get_update_request().obj.metadata.owner_references
+            == Some(seq![make_owner_references_with_name_and_uid(key.name, uid)]) by {
+            if !s.message_in_flight(msg) {
+                let step = choose |step| RMQCluster::next_step(s, s_prime, step);
+                assert(step.is_ControllerStep());
+                let input = step.get_ControllerStep_0();
+                let other_key = input.2.get_Some_0();
+                seq_lemmas::seq_equal_preserved_by_add(key.name, other_key.name, new_strlit("-server-conf")@);
+                let cr = s.triggering_cr_of(other_key);
+                assert(cr.metadata.uid.is_Some());
+                assert(msg.content.get_update_request().obj.metadata.owner_references == Some(seq![
+                    make_owner_references_with_name_and_uid(key.name, cr.metadata.uid.get_Some_0())
+                ]));
+            }
+        }
+    }
+    init_invariant(spec, RMQCluster::init(), stronger_next, cm_update_request_msg_is_valid(key));
+}
+
+spec fn sts_update_request_msg_is_valid(key: ObjectRef) -> StatePred<RMQCluster> {
+    |s: RMQCluster| {
+        forall |msg: Message| {
+            #[trigger] s.message_in_flight(msg)
+            && sts_update_request_msg(key)(msg)
+            ==> msg.content.get_update_request().obj.metadata.finalizers.is_None()
+                && exists |uid: nat| #![auto]
+                    msg.content.get_update_request().obj.metadata.owner_references == Some(seq![
+                        make_owner_references_with_name_and_uid(key.name, uid)
+                    ])
+        }
+    }
+}
+
+proof fn lemma_always_sts_update_request_msg_is_valid(spec: TempPred<RMQCluster>, key: ObjectRef)
+    requires
+        spec.entails(lift_state(RMQCluster::init())),
+        spec.entails(always(lift_action(RMQCluster::next()))),
+    ensures
+        spec.entails(always(lift_state(sts_update_request_msg_is_valid(key)))),
+{
+    let stronger_next = |s, s_prime| {
+        &&& RMQCluster::next()(s, s_prime)
+        &&& RMQCluster::each_object_in_reconcile_has_consistent_key_and_valid_metadata()(s)
+    };
+    RMQCluster::lemma_always_each_object_in_reconcile_has_consistent_key_and_valid_metadata(spec);
+    strengthen_next_n!(
+        stronger_next, spec,
+        lift_action(RMQCluster::next()),
+        lift_state(RMQCluster::each_object_in_reconcile_has_consistent_key_and_valid_metadata())
+    );
+    assert forall |s, s_prime| sts_update_request_msg_is_valid(key)(s) && #[trigger] stronger_next(s, s_prime) implies
+    sts_update_request_msg_is_valid(key)(s_prime) by {
+        assert forall |msg| #[trigger] s_prime.message_in_flight(msg) && sts_update_request_msg(key)(msg) implies
+        msg.content.get_update_request().obj.metadata.finalizers.is_None()
+        && exists |uid: nat| #![auto] msg.content.get_update_request().obj.metadata.owner_references
+            == Some(seq![make_owner_references_with_name_and_uid(key.name, uid)]) by {
+            if !s.message_in_flight(msg) {
+                let step = choose |step| RMQCluster::next_step(s, s_prime, step);
+                assert(step.is_ControllerStep());
+                let input = step.get_ControllerStep_0();
+                let other_key = input.2.get_Some_0();
+                seq_lemmas::seq_equal_preserved_by_add(key.name, other_key.name, new_strlit("-server")@);
+                let cr = s.triggering_cr_of(other_key);
+                assert(cr.metadata.uid.is_Some());
+                assert(msg.content.get_update_request().obj.metadata.owner_references == Some(seq![
+                    make_owner_references_with_name_and_uid(key.name, cr.metadata.uid.get_Some_0())
+                ]));
+            }
+        }
+    }
+    init_invariant(spec, RMQCluster::init(), stronger_next,sts_update_request_msg_is_valid(key));
+}
+
+spec fn sts_create_request_msg_is_valid(key: ObjectRef) -> StatePred<RMQCluster> {
+    |s: RMQCluster| {
+        forall |msg: Message| {
+            #[trigger] s.message_in_flight(msg)
+            && sts_create_request_msg(key)(msg)
+            ==> msg.content.get_create_request().obj.metadata.finalizers.is_None()
+                && exists |uid: nat| #![auto]
+                    msg.content.get_create_request().obj.metadata.owner_references == Some(seq![
+                        make_owner_references_with_name_and_uid(key.name, uid)
+                    ])
+        }
+    }
+}
+
+proof fn lemma_always_sts_create_request_msg_is_valid(spec: TempPred<RMQCluster>, key: ObjectRef)
+    requires
+        spec.entails(lift_state(RMQCluster::init())),
+        spec.entails(always(lift_action(RMQCluster::next()))),
+    ensures
+        spec.entails(always(lift_state(sts_create_request_msg_is_valid(key)))),
+{
+    let stronger_next = |s, s_prime| {
+        &&& RMQCluster::next()(s, s_prime)
+        &&& RMQCluster::each_object_in_reconcile_has_consistent_key_and_valid_metadata()(s)
+    };
+    RMQCluster::lemma_always_each_object_in_reconcile_has_consistent_key_and_valid_metadata(spec);
+    strengthen_next_n!(
+        stronger_next, spec,
+        lift_action(RMQCluster::next()),
+        lift_state(RMQCluster::each_object_in_reconcile_has_consistent_key_and_valid_metadata())
+    );
+    assert forall |s, s_prime| sts_create_request_msg_is_valid(key)(s) && #[trigger] stronger_next(s, s_prime) implies
+    sts_create_request_msg_is_valid(key)(s_prime) by {
+        assert forall |msg| #[trigger] s_prime.message_in_flight(msg) && sts_create_request_msg(key)(msg) implies
+        msg.content.get_create_request().obj.metadata.finalizers.is_None()
+        && exists |uid: nat| #![auto] msg.content.get_create_request().obj.metadata.owner_references
+            == Some(seq![make_owner_references_with_name_and_uid(key.name, uid)]) by {
+            if !s.message_in_flight(msg) {
+                let step = choose |step| RMQCluster::next_step(s, s_prime, step);
+                assert(step.is_ControllerStep());
+                let input = step.get_ControllerStep_0();
+                let other_key = input.2.get_Some_0();
+                seq_lemmas::seq_equal_preserved_by_add(key.name, other_key.name, new_strlit("-server")@);
+                let cr = s.triggering_cr_of(other_key);
+                assert(cr.metadata.uid.is_Some());
+                assert(msg.content.get_create_request().obj.metadata.owner_references == Some(seq![
+                    make_owner_references_with_name_and_uid(key.name, cr.metadata.uid.get_Some_0())
+                ]));
+            }
+        }
+    }
+    init_invariant(spec, RMQCluster::init(), stronger_next,sts_create_request_msg_is_valid(key));
 }
 
 pub open spec fn pending_msg_at_after_create_server_config_map_step_is_create_cm_req(
@@ -70,20 +311,20 @@ pub proof fn lemma_always_pending_msg_at_after_create_server_config_map_step_is_
     let init = RMQCluster::init();
     let stronger_next = |s, s_prime| {
         &&& RMQCluster::next()(s, s_prime)
-        &&& RMQCluster::each_key_in_reconcile_is_consistent_with_its_object()(s)
+        &&& RMQCluster::each_object_in_reconcile_has_consistent_key_and_valid_metadata()(s)
     };
 
-    RMQCluster::lemma_always_each_key_in_reconcile_is_consistent_with_its_object(spec);
+    RMQCluster::lemma_always_each_object_in_reconcile_has_consistent_key_and_valid_metadata(spec);
 
     entails_always_and_n!(
         spec,
         lift_action(RMQCluster::next()),
-        lift_state(RMQCluster::each_key_in_reconcile_is_consistent_with_its_object())
+        lift_state(RMQCluster::each_object_in_reconcile_has_consistent_key_and_valid_metadata())
     );
     temp_pred_equality(
         lift_action(stronger_next),
         lift_action(RMQCluster::next())
-        .and(lift_state(RMQCluster::each_key_in_reconcile_is_consistent_with_its_object()))
+        .and(lift_state(RMQCluster::each_object_in_reconcile_has_consistent_key_and_valid_metadata()))
     );
 
     init_invariant(spec, init, stronger_next, invariant);
@@ -119,20 +360,20 @@ pub proof fn lemma_always_pending_msg_at_after_update_server_config_map_step_is_
     let init = RMQCluster::init();
     let stronger_next = |s, s_prime| {
         &&& RMQCluster::next()(s, s_prime)
-        &&& RMQCluster::each_key_in_reconcile_is_consistent_with_its_object()(s)
+        &&& RMQCluster::each_object_in_reconcile_has_consistent_key_and_valid_metadata()(s)
     };
 
-    RMQCluster::lemma_always_each_key_in_reconcile_is_consistent_with_its_object(spec);
+    RMQCluster::lemma_always_each_object_in_reconcile_has_consistent_key_and_valid_metadata(spec);
 
     entails_always_and_n!(
         spec,
         lift_action(RMQCluster::next()),
-        lift_state(RMQCluster::each_key_in_reconcile_is_consistent_with_its_object())
+        lift_state(RMQCluster::each_object_in_reconcile_has_consistent_key_and_valid_metadata())
     );
     temp_pred_equality(
         lift_action(stronger_next),
         lift_action(RMQCluster::next())
-        .and(lift_state(RMQCluster::each_key_in_reconcile_is_consistent_with_its_object()))
+        .and(lift_state(RMQCluster::each_object_in_reconcile_has_consistent_key_and_valid_metadata()))
     );
 
     init_invariant(spec, init, stronger_next, invariant);
@@ -161,7 +402,7 @@ pub proof fn lemma_true_leads_to_always_at_most_one_create_cm_req_is_in_flight(s
         spec.entails(always(lift_action(RMQCluster::next()))),
         spec.entails(always(lift_state(RMQCluster::crash_disabled()))),
         spec.entails(always(lift_state(RMQCluster::busy_disabled()))),
-        spec.entails(always(lift_state(RMQCluster::each_key_in_reconcile_is_consistent_with_its_object()))),
+        spec.entails(always(lift_state(RMQCluster::each_object_in_reconcile_has_consistent_key_and_valid_metadata()))),
         spec.entails(always(lift_state(RMQCluster::every_in_flight_msg_has_unique_id()))),
         spec.entails(always(lift_state(pending_msg_at_after_create_server_config_map_step_is_create_cm_req(key)))),
         key.kind.is_CustomResourceKind(),
@@ -182,7 +423,7 @@ pub proof fn lemma_true_leads_to_always_at_most_one_create_cm_req_is_in_flight(s
         &&& RMQCluster::next()(s, s_prime)
         &&& RMQCluster::crash_disabled()(s)
         &&& RMQCluster::busy_disabled()(s)
-        &&& RMQCluster::each_key_in_reconcile_is_consistent_with_its_object()(s)
+        &&& RMQCluster::each_object_in_reconcile_has_consistent_key_and_valid_metadata()(s)
         &&& RMQCluster::every_in_flight_msg_has_unique_id()(s)
         &&& pending_msg_at_after_create_server_config_map_step_is_create_cm_req(key)(s)
     };
@@ -265,7 +506,7 @@ pub proof fn lemma_true_leads_to_always_at_most_one_create_cm_req_is_in_flight(s
     invariant_action_n!(
         spec, stronger_next, RMQCluster::every_new_req_msg_if_in_flight_then_satisfies(requirements),
         lift_action(RMQCluster::next()), lift_state(RMQCluster::crash_disabled()), lift_state(RMQCluster::busy_disabled()),
-        lift_state(RMQCluster::each_key_in_reconcile_is_consistent_with_its_object()),
+        lift_state(RMQCluster::each_object_in_reconcile_has_consistent_key_and_valid_metadata()),
         lift_state(RMQCluster::every_in_flight_msg_has_unique_id()),
         lift_state(pending_msg_at_after_create_server_config_map_step_is_create_cm_req(key))
     );
@@ -299,7 +540,7 @@ pub proof fn lemma_true_leads_to_always_at_most_one_update_cm_req_is_in_flight(s
         spec.entails(always(lift_state(RMQCluster::crash_disabled()))),
         spec.entails(always(lift_state(RMQCluster::busy_disabled()))),
         spec.entails(always(lift_state(pending_msg_at_after_update_server_config_map_step_is_update_cm_req(key)))),
-        spec.entails(always(lift_state(RMQCluster::each_key_in_reconcile_is_consistent_with_its_object()))),
+        spec.entails(always(lift_state(RMQCluster::each_object_in_reconcile_has_consistent_key_and_valid_metadata()))),
         spec.entails(always(lift_state(RMQCluster::every_in_flight_msg_has_unique_id()))),
         key.kind.is_CustomResourceKind(),
     ensures
@@ -320,7 +561,7 @@ pub proof fn lemma_true_leads_to_always_at_most_one_update_cm_req_is_in_flight(s
         &&& RMQCluster::crash_disabled()(s)
         &&& RMQCluster::busy_disabled()(s)
         &&& pending_msg_at_after_update_server_config_map_step_is_update_cm_req(key)(s)
-        &&& RMQCluster::each_key_in_reconcile_is_consistent_with_its_object()(s)
+        &&& RMQCluster::each_object_in_reconcile_has_consistent_key_and_valid_metadata()(s)
         &&& RMQCluster::every_in_flight_msg_has_unique_id()(s)
     };
     assert forall |s, s_prime| #[trigger] stronger_next(s, s_prime) implies RMQCluster::every_new_req_msg_if_in_flight_then_satisfies(requirements)(s, s_prime) by {
@@ -380,7 +621,7 @@ pub proof fn lemma_true_leads_to_always_at_most_one_update_cm_req_is_in_flight(s
         lift_state(RMQCluster::crash_disabled()),
         lift_state(RMQCluster::busy_disabled()),
         lift_state(pending_msg_at_after_update_server_config_map_step_is_update_cm_req(key)),
-        lift_state(RMQCluster::each_key_in_reconcile_is_consistent_with_its_object()),
+        lift_state(RMQCluster::each_object_in_reconcile_has_consistent_key_and_valid_metadata()),
         lift_state(RMQCluster::every_in_flight_msg_has_unique_id())
     );
     RMQCluster::lemma_true_leads_to_always_every_in_flight_req_msg_satisfies(spec, requirements);
@@ -418,8 +659,7 @@ pub open spec fn server_config_map_has_owner_reference_pointing_to_current_cr(ra
 pub open spec fn server_config_map_has_no_finalizers_or_timestamp_and_only_has_controller_owner_ref(rabbitmq: RabbitmqClusterView) -> StatePred<RMQCluster> {
     |s: RMQCluster| {
         s.resource_key_exists(make_server_config_map_key(rabbitmq.object_ref()))
-        ==>
-            s.resource_obj_of(make_server_config_map_key(rabbitmq.object_ref())).metadata.deletion_timestamp.is_None()
+        ==> s.resource_obj_of(make_server_config_map_key(rabbitmq.object_ref())).metadata.deletion_timestamp.is_None()
             && s.resource_obj_of(make_server_config_map_key(rabbitmq.object_ref())).metadata.finalizers.is_None()
             && exists |uid: nat| #![auto]
             s.resource_obj_of(make_server_config_map_key(rabbitmq.object_ref())).metadata.owner_references == Some(seq![OwnerReferenceView {
@@ -432,20 +672,34 @@ pub open spec fn server_config_map_has_no_finalizers_or_timestamp_and_only_has_c
     }
 }
 
-#[verifier(external_body)]
 pub proof fn lemma_always_server_config_map_has_no_finalizers_or_timestamp_and_only_has_controller_owner_ref(spec: TempPred<RMQCluster>, rabbitmq: RabbitmqClusterView)
     requires
         spec.entails(lift_state(RMQCluster::init())),
         spec.entails(always(lift_action(RMQCluster::next()))),
     ensures
         spec.entails(always(lift_state(server_config_map_has_no_finalizers_or_timestamp_and_only_has_controller_owner_ref(rabbitmq)))),
-{}
+{
+    let inv = server_config_map_has_no_finalizers_or_timestamp_and_only_has_controller_owner_ref(rabbitmq);
+    lemma_always_cm_create_request_msg_is_valid(spec, rabbitmq.object_ref());
+    lemma_always_cm_update_request_msg_is_valid(spec, rabbitmq.object_ref());
+    let stronger_next = |s, s_prime| {
+        &&& RMQCluster::next()(s, s_prime)
+        &&& cm_update_request_msg_is_valid(rabbitmq.object_ref())(s)
+        &&& cm_create_request_msg_is_valid(rabbitmq.object_ref())(s)
+    };
+    strengthen_next_n!(
+        stronger_next, spec,
+        lift_action(RMQCluster::next()),
+        lift_state(cm_update_request_msg_is_valid(rabbitmq.object_ref())),
+        lift_state(cm_create_request_msg_is_valid(rabbitmq.object_ref()))
+    );
+    init_invariant(spec, RMQCluster::init(), stronger_next, inv);
+}
 
 pub open spec fn stateful_set_has_no_finalizers_or_timestamp_and_only_has_controller_owner_ref(rabbitmq: RabbitmqClusterView) -> StatePred<RMQCluster> {
     |s: RMQCluster| {
         s.resource_key_exists(make_stateful_set_key(rabbitmq.object_ref()))
-        ==>
-            s.resource_obj_of(make_stateful_set_key(rabbitmq.object_ref())).metadata.deletion_timestamp.is_None()
+        ==> s.resource_obj_of(make_stateful_set_key(rabbitmq.object_ref())).metadata.deletion_timestamp.is_None()
             && s.resource_obj_of(make_stateful_set_key(rabbitmq.object_ref())).metadata.finalizers.is_None()
             && exists |uid: nat| #![auto]
             s.resource_obj_of(make_stateful_set_key(rabbitmq.object_ref())).metadata.owner_references == Some(seq![OwnerReferenceView {
@@ -458,7 +712,6 @@ pub open spec fn stateful_set_has_no_finalizers_or_timestamp_and_only_has_contro
     }
 }
 
-#[verifier(external_body)]
 pub proof fn lemma_always_stateful_set_has_no_finalizers_or_timestamp_and_only_has_controller_owner_ref(spec: TempPred<RMQCluster>, rabbitmq: RabbitmqClusterView)
     requires
         spec.entails(lift_state(RMQCluster::init())),
@@ -466,11 +719,21 @@ pub proof fn lemma_always_stateful_set_has_no_finalizers_or_timestamp_and_only_h
     ensures
         spec.entails(always(lift_state(stateful_set_has_no_finalizers_or_timestamp_and_only_has_controller_owner_ref(rabbitmq)))),
 {
-    let invariant = stateful_set_has_no_finalizers_or_timestamp_and_only_has_controller_owner_ref(rabbitmq);
-    assert forall |s, s_prime: RMQCluster| invariant(s) && #[trigger] RMQCluster::next()(s, s_prime) implies invariant(s_prime) by {
-
-    }
-    init_invariant(spec, RMQCluster::init(), RMQCluster::next(), invariant);
+    let inv = stateful_set_has_no_finalizers_or_timestamp_and_only_has_controller_owner_ref(rabbitmq);
+    lemma_always_sts_create_request_msg_is_valid(spec, rabbitmq.object_ref());
+    lemma_always_sts_update_request_msg_is_valid(spec, rabbitmq.object_ref());
+    let stronger_next = |s, s_prime| {
+        &&& RMQCluster::next()(s, s_prime)
+        &&& sts_update_request_msg_is_valid(rabbitmq.object_ref())(s)
+        &&& sts_create_request_msg_is_valid(rabbitmq.object_ref())(s)
+    };
+    strengthen_next_n!(
+        stronger_next, spec,
+        lift_action(RMQCluster::next()),
+        lift_state(sts_update_request_msg_is_valid(rabbitmq.object_ref())),
+        lift_state(sts_create_request_msg_is_valid(rabbitmq.object_ref()))
+    );
+    init_invariant(spec, RMQCluster::init(), stronger_next, inv);
 }
 
 pub proof fn lemma_true_leads_to_always_every_update_cm_req_does_the_same(spec: TempPred<RMQCluster>, rabbitmq: RabbitmqClusterView)
@@ -479,7 +742,7 @@ pub proof fn lemma_true_leads_to_always_every_update_cm_req_does_the_same(spec: 
         spec.entails(always(lift_action(RMQCluster::next()))),
         spec.entails(always(lift_state(RMQCluster::busy_disabled()))),
         spec.entails(tla_forall(|i| RMQCluster::kubernetes_api_next().weak_fairness(i))),
-        spec.entails(always(lift_state(RMQCluster::each_key_in_reconcile_is_consistent_with_its_object()))),
+        spec.entails(always(lift_state(RMQCluster::each_object_in_reconcile_has_consistent_key_and_valid_metadata()))),
         spec.entails(always(lift_state(RMQCluster::the_object_in_reconcile_has_spec_and_uid_as(rabbitmq)))),
     ensures
         spec.entails(
@@ -493,7 +756,7 @@ pub proof fn lemma_true_leads_to_always_every_update_cm_req_does_the_same(spec: 
     };
     let stronger_next = |s, s_prime| {
         &&& RMQCluster::next()(s, s_prime)
-        &&& RMQCluster::each_key_in_reconcile_is_consistent_with_its_object()(s)
+        &&& RMQCluster::each_object_in_reconcile_has_consistent_key_and_valid_metadata()(s)
         &&& RMQCluster::the_object_in_reconcile_has_spec_and_uid_as(rabbitmq)(s)
     };
     assert forall |s, s_prime| #[trigger] stronger_next(s, s_prime) implies RMQCluster::every_new_req_msg_if_in_flight_then_satisfies(requirements)(s, s_prime) by {
@@ -516,7 +779,7 @@ pub proof fn lemma_true_leads_to_always_every_update_cm_req_does_the_same(spec: 
     }
     invariant_action_n!(
         spec, stronger_next, RMQCluster::every_new_req_msg_if_in_flight_then_satisfies(requirements),
-        lift_action(RMQCluster::next()), lift_state(RMQCluster::each_key_in_reconcile_is_consistent_with_its_object()),
+        lift_action(RMQCluster::next()), lift_state(RMQCluster::each_object_in_reconcile_has_consistent_key_and_valid_metadata()),
         lift_state(RMQCluster::the_object_in_reconcile_has_spec_and_uid_as(rabbitmq))
     );
     RMQCluster::lemma_true_leads_to_always_every_in_flight_req_msg_satisfies(spec, requirements);
@@ -621,7 +884,7 @@ pub proof fn lemma_true_leads_to_always_every_update_sts_req_does_the_same(spec:
         spec.entails(always(lift_state(RMQCluster::busy_disabled()))),
         spec.entails(tla_forall(|i| RMQCluster::kubernetes_api_next().weak_fairness(i))),
         spec.entails(always(lift_action(RMQCluster::next()))),
-        spec.entails(always(lift_state(RMQCluster::each_key_in_reconcile_is_consistent_with_its_object()))),
+        spec.entails(always(lift_state(RMQCluster::each_object_in_reconcile_has_consistent_key_and_valid_metadata()))),
         spec.entails(always(lift_state(RMQCluster::the_object_in_reconcile_has_spec_and_uid_as(rabbitmq)))),
     ensures
         spec.entails(
@@ -635,7 +898,7 @@ pub proof fn lemma_true_leads_to_always_every_update_sts_req_does_the_same(spec:
     };
     let stronger_next = |s, s_prime| {
         &&& RMQCluster::next()(s, s_prime)
-        &&& RMQCluster::each_key_in_reconcile_is_consistent_with_its_object()(s)
+        &&& RMQCluster::each_object_in_reconcile_has_consistent_key_and_valid_metadata()(s)
         &&& RMQCluster::the_object_in_reconcile_has_spec_and_uid_as(rabbitmq)(s)
     };
     assert forall |s, s_prime| #[trigger] stronger_next(s, s_prime) implies RMQCluster::every_new_req_msg_if_in_flight_then_satisfies(requirements)(s, s_prime) by {
@@ -658,7 +921,7 @@ pub proof fn lemma_true_leads_to_always_every_update_sts_req_does_the_same(spec:
     }
     invariant_action_n!(
         spec, stronger_next, RMQCluster::every_new_req_msg_if_in_flight_then_satisfies(requirements),
-        lift_action(RMQCluster::next()), lift_state(RMQCluster::each_key_in_reconcile_is_consistent_with_its_object()),
+        lift_action(RMQCluster::next()), lift_state(RMQCluster::each_object_in_reconcile_has_consistent_key_and_valid_metadata()),
         lift_state(RMQCluster::the_object_in_reconcile_has_spec_and_uid_as(rabbitmq))
     );
     RMQCluster::lemma_true_leads_to_always_every_in_flight_req_msg_satisfies(spec, requirements);
@@ -684,7 +947,7 @@ pub proof fn lemma_true_leads_to_always_every_create_sts_req_does_the_same(spec:
         spec.entails(always(lift_state(RMQCluster::busy_disabled()))),
         spec.entails(tla_forall(|i| RMQCluster::kubernetes_api_next().weak_fairness(i))),
         spec.entails(always(lift_action(RMQCluster::next()))),
-        spec.entails(always(lift_state(RMQCluster::each_key_in_reconcile_is_consistent_with_its_object()))),
+        spec.entails(always(lift_state(RMQCluster::each_object_in_reconcile_has_consistent_key_and_valid_metadata()))),
         spec.entails(always(lift_state(RMQCluster::the_object_in_reconcile_has_spec_and_uid_as(rabbitmq)))),
     ensures
         spec.entails(
@@ -698,7 +961,7 @@ pub proof fn lemma_true_leads_to_always_every_create_sts_req_does_the_same(spec:
     };
     let stronger_next = |s, s_prime| {
         &&& RMQCluster::next()(s, s_prime)
-        &&& RMQCluster::each_key_in_reconcile_is_consistent_with_its_object()(s)
+        &&& RMQCluster::each_object_in_reconcile_has_consistent_key_and_valid_metadata()(s)
         &&& RMQCluster::the_object_in_reconcile_has_spec_and_uid_as(rabbitmq)(s)
     };
     assert forall |s, s_prime| #[trigger] stronger_next(s, s_prime) implies RMQCluster::every_new_req_msg_if_in_flight_then_satisfies(requirements)(s, s_prime) by {
@@ -721,7 +984,7 @@ pub proof fn lemma_true_leads_to_always_every_create_sts_req_does_the_same(spec:
     }
     invariant_action_n!(
         spec, stronger_next, RMQCluster::every_new_req_msg_if_in_flight_then_satisfies(requirements),
-        lift_action(RMQCluster::next()), lift_state(RMQCluster::each_key_in_reconcile_is_consistent_with_its_object()),
+        lift_action(RMQCluster::next()), lift_state(RMQCluster::each_object_in_reconcile_has_consistent_key_and_valid_metadata()),
         lift_state(RMQCluster::the_object_in_reconcile_has_spec_and_uid_as(rabbitmq))
     );
     RMQCluster::lemma_true_leads_to_always_every_in_flight_req_msg_satisfies(spec, requirements);
@@ -748,7 +1011,7 @@ pub proof fn lemma_true_leads_to_always_every_create_cm_req_does_the_same(spec: 
         spec.entails(always(lift_state(RMQCluster::busy_disabled()))),
         spec.entails(tla_forall(|i| RMQCluster::kubernetes_api_next().weak_fairness(i))),
         spec.entails(always(lift_action(RMQCluster::next()))),
-        spec.entails(always(lift_state(RMQCluster::each_key_in_reconcile_is_consistent_with_its_object()))),
+        spec.entails(always(lift_state(RMQCluster::each_object_in_reconcile_has_consistent_key_and_valid_metadata()))),
         spec.entails(always(lift_state(RMQCluster::the_object_in_reconcile_has_spec_and_uid_as(rabbitmq)))),
     ensures
         spec.entails(
@@ -762,7 +1025,7 @@ pub proof fn lemma_true_leads_to_always_every_create_cm_req_does_the_same(spec: 
     };
     let stronger_next = |s, s_prime| {
         &&& RMQCluster::next()(s, s_prime)
-        &&& RMQCluster::each_key_in_reconcile_is_consistent_with_its_object()(s)
+        &&& RMQCluster::each_object_in_reconcile_has_consistent_key_and_valid_metadata()(s)
         &&& RMQCluster::the_object_in_reconcile_has_spec_and_uid_as(rabbitmq)(s)
     };
     assert forall |s, s_prime| #[trigger] stronger_next(s, s_prime) implies RMQCluster::every_new_req_msg_if_in_flight_then_satisfies(requirements)(s, s_prime) by {
@@ -784,8 +1047,8 @@ pub proof fn lemma_true_leads_to_always_every_create_cm_req_does_the_same(spec: 
                         reveal_strlit("-server-conf");
                         reveal_strlit("-plugins-conf");
                         if str1.len() == str2.len() {
-                            assert(str1[str1.len() - 6] == 's');
-                            assert(str2[str1.len() - 6] == 'r');
+                            assert(str1[str1.len() - 6] == 'r');
+                            assert(str2[str1.len() - 6] == 's');
                         }
                     }
                 );
@@ -799,7 +1062,7 @@ pub proof fn lemma_true_leads_to_always_every_create_cm_req_does_the_same(spec: 
     }
     invariant_action_n!(
         spec, stronger_next, RMQCluster::every_new_req_msg_if_in_flight_then_satisfies(requirements),
-        lift_action(RMQCluster::next()), lift_state(RMQCluster::each_key_in_reconcile_is_consistent_with_its_object()),
+        lift_action(RMQCluster::next()), lift_state(RMQCluster::each_object_in_reconcile_has_consistent_key_and_valid_metadata()),
         lift_state(RMQCluster::the_object_in_reconcile_has_spec_and_uid_as(rabbitmq))
     );
     RMQCluster::lemma_true_leads_to_always_every_in_flight_req_msg_satisfies(spec, requirements);
@@ -836,20 +1099,20 @@ pub proof fn lemma_always_pending_msg_at_after_create_stateful_set_step_is_creat
     let init = RMQCluster::init();
     let stronger_next = |s, s_prime| {
         &&& RMQCluster::next()(s, s_prime)
-        &&& RMQCluster::each_key_in_reconcile_is_consistent_with_its_object()(s)
+        &&& RMQCluster::each_object_in_reconcile_has_consistent_key_and_valid_metadata()(s)
     };
 
-    RMQCluster::lemma_always_each_key_in_reconcile_is_consistent_with_its_object(spec);
+    RMQCluster::lemma_always_each_object_in_reconcile_has_consistent_key_and_valid_metadata(spec);
 
     entails_always_and_n!(
         spec,
         lift_action(RMQCluster::next()),
-        lift_state(RMQCluster::each_key_in_reconcile_is_consistent_with_its_object())
+        lift_state(RMQCluster::each_object_in_reconcile_has_consistent_key_and_valid_metadata())
     );
     temp_pred_equality(
         lift_action(stronger_next),
         lift_action(RMQCluster::next())
-        .and(lift_state(RMQCluster::each_key_in_reconcile_is_consistent_with_its_object()))
+        .and(lift_state(RMQCluster::each_object_in_reconcile_has_consistent_key_and_valid_metadata()))
     );
 
     init_invariant(spec, init, stronger_next, invariant);
@@ -885,20 +1148,20 @@ pub proof fn lemma_always_pending_msg_at_after_update_stateful_set_step_is_updat
     let init = RMQCluster::init();
     let stronger_next = |s, s_prime| {
         &&& RMQCluster::next()(s, s_prime)
-        &&& RMQCluster::each_key_in_reconcile_is_consistent_with_its_object()(s)
+        &&& RMQCluster::each_object_in_reconcile_has_consistent_key_and_valid_metadata()(s)
     };
 
-    RMQCluster::lemma_always_each_key_in_reconcile_is_consistent_with_its_object(spec);
+    RMQCluster::lemma_always_each_object_in_reconcile_has_consistent_key_and_valid_metadata(spec);
 
     entails_always_and_n!(
         spec,
         lift_action(RMQCluster::next()),
-        lift_state(RMQCluster::each_key_in_reconcile_is_consistent_with_its_object())
+        lift_state(RMQCluster::each_object_in_reconcile_has_consistent_key_and_valid_metadata())
     );
     temp_pred_equality(
         lift_action(stronger_next),
         lift_action(RMQCluster::next())
-        .and(lift_state(RMQCluster::each_key_in_reconcile_is_consistent_with_its_object()))
+        .and(lift_state(RMQCluster::each_object_in_reconcile_has_consistent_key_and_valid_metadata()))
     );
 
     init_invariant(spec, init, stronger_next, invariant);
@@ -928,7 +1191,7 @@ pub proof fn lemma_true_leads_to_always_at_most_one_create_sts_req_is_in_flight(
         spec.entails(always(lift_state(RMQCluster::crash_disabled()))),
         spec.entails(always(lift_state(RMQCluster::busy_disabled()))),
         spec.entails(always(lift_state(pending_msg_at_after_create_stateful_set_step_is_create_sts_req(key)))),
-        spec.entails(always(lift_state(RMQCluster::each_key_in_reconcile_is_consistent_with_its_object()))),
+        spec.entails(always(lift_state(RMQCluster::each_object_in_reconcile_has_consistent_key_and_valid_metadata()))),
         spec.entails(always(lift_state(RMQCluster::every_in_flight_msg_has_unique_id()))),
         key.kind.is_CustomResourceKind(),
     ensures
@@ -948,7 +1211,7 @@ pub proof fn lemma_true_leads_to_always_at_most_one_create_sts_req_is_in_flight(
         &&& RMQCluster::next()(s, s_prime)
         &&& RMQCluster::crash_disabled()(s)
         &&& RMQCluster::busy_disabled()(s)
-        &&& RMQCluster::each_key_in_reconcile_is_consistent_with_its_object()(s)
+        &&& RMQCluster::each_object_in_reconcile_has_consistent_key_and_valid_metadata()(s)
         &&& RMQCluster::every_in_flight_msg_has_unique_id()(s)
         &&& pending_msg_at_after_create_stateful_set_step_is_create_sts_req(key)(s)
     };
@@ -1005,7 +1268,7 @@ pub proof fn lemma_true_leads_to_always_at_most_one_create_sts_req_is_in_flight(
     invariant_action_n!(
         spec, stronger_next, RMQCluster::every_new_req_msg_if_in_flight_then_satisfies(requirements),
         lift_action(RMQCluster::next()), lift_state(RMQCluster::crash_disabled()), lift_state(RMQCluster::busy_disabled()),
-        lift_state(RMQCluster::each_key_in_reconcile_is_consistent_with_its_object()),
+        lift_state(RMQCluster::each_object_in_reconcile_has_consistent_key_and_valid_metadata()),
         lift_state(RMQCluster::every_in_flight_msg_has_unique_id()),
         lift_state(pending_msg_at_after_create_stateful_set_step_is_create_sts_req(key))
     );
@@ -1037,7 +1300,7 @@ pub proof fn lemma_true_leads_to_always_at_most_one_update_sts_req_is_in_flight(
         spec.entails(always(lift_action(RMQCluster::next()))),
         spec.entails(always(lift_state(RMQCluster::crash_disabled()))),
         spec.entails(always(lift_state(RMQCluster::busy_disabled()))),
-        spec.entails(always(lift_state(RMQCluster::each_key_in_reconcile_is_consistent_with_its_object()))),
+        spec.entails(always(lift_state(RMQCluster::each_object_in_reconcile_has_consistent_key_and_valid_metadata()))),
         spec.entails(always(lift_state(RMQCluster::every_in_flight_msg_has_unique_id()))),
         spec.entails(always(lift_state(pending_msg_at_after_update_stateful_set_step_is_update_sts_req(key)))),
         key.kind.is_CustomResourceKind(),
@@ -1058,7 +1321,7 @@ pub proof fn lemma_true_leads_to_always_at_most_one_update_sts_req_is_in_flight(
         &&& RMQCluster::next()(s, s_prime)
         &&& RMQCluster::crash_disabled()(s)
         &&& RMQCluster::busy_disabled()(s)
-        &&& RMQCluster::each_key_in_reconcile_is_consistent_with_its_object()(s)
+        &&& RMQCluster::each_object_in_reconcile_has_consistent_key_and_valid_metadata()(s)
         &&& RMQCluster::every_in_flight_msg_has_unique_id()(s)
         &&& pending_msg_at_after_update_stateful_set_step_is_update_sts_req(key)(s)
     };
@@ -1115,7 +1378,7 @@ pub proof fn lemma_true_leads_to_always_at_most_one_update_sts_req_is_in_flight(
     invariant_action_n!(
         spec, stronger_next, RMQCluster::every_new_req_msg_if_in_flight_then_satisfies(requirements),
         lift_action(RMQCluster::next()), lift_state(RMQCluster::crash_disabled()), lift_state(RMQCluster::busy_disabled()),
-        lift_state(RMQCluster::each_key_in_reconcile_is_consistent_with_its_object()),
+        lift_state(RMQCluster::each_object_in_reconcile_has_consistent_key_and_valid_metadata()),
         lift_state(RMQCluster::every_in_flight_msg_has_unique_id()),
         lift_state(pending_msg_at_after_update_stateful_set_step_is_update_sts_req(key))
     );

--- a/src/controller_examples/rabbitmq_controller/proof/liveness/helper_invariants/invariants.rs
+++ b/src/controller_examples/rabbitmq_controller/proof/liveness/helper_invariants/invariants.rs
@@ -1008,49 +1008,6 @@ pub proof fn lemma_true_leads_to_always_every_create_cm_req_does_the_same(spec: 
     temp_pred_equality(lift_state(every_create_cm_req_does_the_same(rabbitmq)), lift_state(RMQCluster::every_in_flight_req_msg_satisfies(requirements)));
 }
 
-pub open spec fn pending_msg_at_after_create_stateful_set_step_is_create_sts_req(
-    key: ObjectRef
-) -> StatePred<RMQCluster>
-    recommends
-        key.kind.is_CustomResourceKind(),
-{
-    |s: RMQCluster| {
-        at_rabbitmq_step(key, RabbitmqReconcileStep::AfterCreateStatefulSet)(s)
-        ==> {
-            &&& RMQCluster::pending_k8s_api_req_msg(s, key)
-            &&& sts_create_request_msg(key)(s.pending_req_of(key))
-        }
-    }
-}
-
-pub proof fn lemma_always_pending_msg_at_after_create_stateful_set_step_is_create_sts_req(
-    spec: TempPred<RMQCluster>, key: ObjectRef
-)
-    requires
-        spec.entails(lift_state(RMQCluster::init())),
-        spec.entails(always(lift_action(RMQCluster::next()))),
-    ensures
-        spec.entails(
-            always(lift_state(pending_msg_at_after_create_stateful_set_step_is_create_sts_req(key)))
-        ),
-{
-    let invariant = pending_msg_at_after_create_stateful_set_step_is_create_sts_req(key);
-    let init = RMQCluster::init();
-    let stronger_next = |s, s_prime| {
-        &&& RMQCluster::next()(s, s_prime)
-        &&& RMQCluster::each_object_in_reconcile_has_consistent_key_and_valid_metadata()(s)
-    };
-
-    RMQCluster::lemma_always_each_object_in_reconcile_has_consistent_key_and_valid_metadata(spec);
-
-    combine_spec_entails_always_n!(
-        spec, lift_action(stronger_next), lift_action(RMQCluster::next()),
-        lift_state(RMQCluster::each_object_in_reconcile_has_consistent_key_and_valid_metadata())
-    );
-
-    init_invariant(spec, init, stronger_next, invariant);
-}
-
 pub open spec fn pending_msg_at_after_update_stateful_set_step_is_update_sts_req(
     key: ObjectRef
 ) -> StatePred<RMQCluster>
@@ -1105,6 +1062,7 @@ pub open spec fn create_sts_req_msg_in_flight_implies_at_after_create_sts_step(k
             &&& sts_create_request_msg(key)(msg)
         } ==> {
             &&& at_rabbitmq_step(key, RabbitmqReconcileStep::AfterCreateStatefulSet)(s)
+            &&& RMQCluster::pending_k8s_api_req_msg(s, key)
             &&& msg == s.pending_req_of(key)
         }
     }
@@ -1117,7 +1075,6 @@ pub proof fn lemma_true_leads_to_always_create_sts_req_msg_in_flight_implies_at_
         spec.entails(always(lift_action(RMQCluster::next()))),
         spec.entails(always(lift_state(RMQCluster::crash_disabled()))),
         spec.entails(always(lift_state(RMQCluster::busy_disabled()))),
-        spec.entails(always(lift_state(pending_msg_at_after_create_stateful_set_step_is_create_sts_req(key)))),
         spec.entails(always(lift_state(RMQCluster::each_object_in_reconcile_has_consistent_key_and_valid_metadata()))),
         spec.entails(always(lift_state(RMQCluster::every_in_flight_msg_has_unique_id()))),
         key.kind.is_CustomResourceKind(),
@@ -1130,6 +1087,7 @@ pub proof fn lemma_true_leads_to_always_create_sts_req_msg_in_flight_implies_at_
         sts_create_request_msg(key)(msg)
         ==> {
             &&& at_rabbitmq_step(key, RabbitmqReconcileStep::AfterCreateStatefulSet)(s)
+            &&& RMQCluster::pending_k8s_api_req_msg(s, key)
             &&& msg == s.pending_req_of(key)
         }
     };
@@ -1139,7 +1097,6 @@ pub proof fn lemma_true_leads_to_always_create_sts_req_msg_in_flight_implies_at_
         &&& RMQCluster::busy_disabled()(s)
         &&& RMQCluster::each_object_in_reconcile_has_consistent_key_and_valid_metadata()(s)
         &&& RMQCluster::every_in_flight_msg_has_unique_id()(s)
-        &&& pending_msg_at_after_create_stateful_set_step_is_create_sts_req(key)(s)
     };
     assert forall |s, s_prime| #[trigger] stronger_next(s, s_prime)
     implies RMQCluster::every_new_req_msg_if_in_flight_then_satisfies(requirements)(s, s_prime) by {
@@ -1173,8 +1130,7 @@ pub proof fn lemma_true_leads_to_always_create_sts_req_msg_in_flight_implies_at_
         spec, lift_action(stronger_next), lift_action(RMQCluster::every_new_req_msg_if_in_flight_then_satisfies(requirements)),
         lift_action(RMQCluster::next()), lift_state(RMQCluster::crash_disabled()), lift_state(RMQCluster::busy_disabled()),
         lift_state(RMQCluster::each_object_in_reconcile_has_consistent_key_and_valid_metadata()),
-        lift_state(RMQCluster::every_in_flight_msg_has_unique_id()),
-        lift_state(pending_msg_at_after_create_stateful_set_step_is_create_sts_req(key))
+        lift_state(RMQCluster::every_in_flight_msg_has_unique_id())
     );
 
     RMQCluster::lemma_true_leads_to_always_every_in_flight_req_msg_satisfies(spec, requirements);

--- a/src/controller_examples/rabbitmq_controller/proof/liveness/helper_invariants/invariants.rs
+++ b/src/controller_examples/rabbitmq_controller/proof/liveness/helper_invariants/invariants.rs
@@ -78,8 +78,8 @@ proof fn lemma_always_cm_create_request_msg_is_valid(spec: TempPred<RMQCluster>,
         &&& RMQCluster::each_object_in_reconcile_has_consistent_key_and_valid_metadata()(s)
     };
     RMQCluster::lemma_always_each_object_in_reconcile_has_consistent_key_and_valid_metadata(spec);
-    strengthen_next_n!(
-        stronger_next, spec,
+    combine_spec_entails_always_n!(
+        spec, lift_action(stronger_next),
         lift_action(RMQCluster::next()),
         lift_state(RMQCluster::each_object_in_reconcile_has_consistent_key_and_valid_metadata())
     );
@@ -145,8 +145,8 @@ proof fn lemma_always_cm_update_request_msg_is_valid(spec: TempPred<RMQCluster>,
         &&& RMQCluster::each_object_in_reconcile_has_consistent_key_and_valid_metadata()(s)
     };
     RMQCluster::lemma_always_each_object_in_reconcile_has_consistent_key_and_valid_metadata(spec);
-    strengthen_next_n!(
-        stronger_next, spec,
+    combine_spec_entails_always_n!(
+        spec, lift_action(stronger_next),
         lift_action(RMQCluster::next()),
         lift_state(RMQCluster::each_object_in_reconcile_has_consistent_key_and_valid_metadata())
     );
@@ -199,8 +199,8 @@ proof fn lemma_always_sts_update_request_msg_is_valid(spec: TempPred<RMQCluster>
         &&& RMQCluster::each_object_in_reconcile_has_consistent_key_and_valid_metadata()(s)
     };
     RMQCluster::lemma_always_each_object_in_reconcile_has_consistent_key_and_valid_metadata(spec);
-    strengthen_next_n!(
-        stronger_next, spec,
+    combine_spec_entails_always_n!(
+        spec, lift_action(stronger_next),
         lift_action(RMQCluster::next()),
         lift_state(RMQCluster::each_object_in_reconcile_has_consistent_key_and_valid_metadata())
     );
@@ -253,8 +253,8 @@ proof fn lemma_always_sts_create_request_msg_is_valid(spec: TempPred<RMQCluster>
         &&& RMQCluster::each_object_in_reconcile_has_consistent_key_and_valid_metadata()(s)
     };
     RMQCluster::lemma_always_each_object_in_reconcile_has_consistent_key_and_valid_metadata(spec);
-    strengthen_next_n!(
-        stronger_next, spec,
+    combine_spec_entails_always_n!(
+        spec, lift_action(stronger_next),
         lift_action(RMQCluster::next()),
         lift_state(RMQCluster::each_object_in_reconcile_has_consistent_key_and_valid_metadata())
     );
@@ -316,15 +316,10 @@ pub proof fn lemma_always_pending_msg_at_after_create_server_config_map_step_is_
 
     RMQCluster::lemma_always_each_object_in_reconcile_has_consistent_key_and_valid_metadata(spec);
 
-    entails_always_and_n!(
-        spec,
+    combine_spec_entails_always_n!(
+        spec, lift_action(stronger_next),
         lift_action(RMQCluster::next()),
         lift_state(RMQCluster::each_object_in_reconcile_has_consistent_key_and_valid_metadata())
-    );
-    temp_pred_equality(
-        lift_action(stronger_next),
-        lift_action(RMQCluster::next())
-        .and(lift_state(RMQCluster::each_object_in_reconcile_has_consistent_key_and_valid_metadata()))
     );
 
     init_invariant(spec, init, stronger_next, invariant);
@@ -365,15 +360,10 @@ pub proof fn lemma_always_pending_msg_at_after_update_server_config_map_step_is_
 
     RMQCluster::lemma_always_each_object_in_reconcile_has_consistent_key_and_valid_metadata(spec);
 
-    entails_always_and_n!(
-        spec,
+    combine_spec_entails_always_n!(
+        spec, lift_action(stronger_next),
         lift_action(RMQCluster::next()),
         lift_state(RMQCluster::each_object_in_reconcile_has_consistent_key_and_valid_metadata())
-    );
-    temp_pred_equality(
-        lift_action(stronger_next),
-        lift_action(RMQCluster::next())
-        .and(lift_state(RMQCluster::each_object_in_reconcile_has_consistent_key_and_valid_metadata()))
     );
 
     init_invariant(spec, init, stronger_next, invariant);
@@ -503,8 +493,8 @@ pub proof fn lemma_true_leads_to_always_at_most_one_create_cm_req_is_in_flight(s
             }
         }
     }
-    invariant_action_n!(
-        spec, stronger_next, RMQCluster::every_new_req_msg_if_in_flight_then_satisfies(requirements),
+    invariant_n!(
+        spec, lift_action(stronger_next), lift_action(RMQCluster::every_new_req_msg_if_in_flight_then_satisfies(requirements)),
         lift_action(RMQCluster::next()), lift_state(RMQCluster::crash_disabled()), lift_state(RMQCluster::busy_disabled()),
         lift_state(RMQCluster::each_object_in_reconcile_has_consistent_key_and_valid_metadata()),
         lift_state(RMQCluster::every_in_flight_msg_has_unique_id()),
@@ -615,8 +605,8 @@ pub proof fn lemma_true_leads_to_always_at_most_one_update_cm_req_is_in_flight(s
         }
     }
 
-    invariant_action_n!(
-        spec, stronger_next, RMQCluster::every_new_req_msg_if_in_flight_then_satisfies(requirements),
+    invariant_n!(
+        spec, lift_action(stronger_next), lift_action(RMQCluster::every_new_req_msg_if_in_flight_then_satisfies(requirements)),
         lift_action(RMQCluster::next()),
         lift_state(RMQCluster::crash_disabled()),
         lift_state(RMQCluster::busy_disabled()),
@@ -687,8 +677,8 @@ pub proof fn lemma_always_server_config_map_has_no_finalizers_or_timestamp_and_o
         &&& cm_update_request_msg_is_valid(rabbitmq.object_ref())(s)
         &&& cm_create_request_msg_is_valid(rabbitmq.object_ref())(s)
     };
-    strengthen_next_n!(
-        stronger_next, spec,
+    combine_spec_entails_always_n!(
+        spec, lift_action(stronger_next),
         lift_action(RMQCluster::next()),
         lift_state(cm_update_request_msg_is_valid(rabbitmq.object_ref())),
         lift_state(cm_create_request_msg_is_valid(rabbitmq.object_ref()))
@@ -727,8 +717,8 @@ pub proof fn lemma_always_stateful_set_has_no_finalizers_or_timestamp_and_only_h
         &&& sts_update_request_msg_is_valid(rabbitmq.object_ref())(s)
         &&& sts_create_request_msg_is_valid(rabbitmq.object_ref())(s)
     };
-    strengthen_next_n!(
-        stronger_next, spec,
+    combine_spec_entails_always_n!(
+        spec, lift_action(stronger_next),
         lift_action(RMQCluster::next()),
         lift_state(sts_update_request_msg_is_valid(rabbitmq.object_ref())),
         lift_state(sts_create_request_msg_is_valid(rabbitmq.object_ref()))
@@ -777,8 +767,8 @@ pub proof fn lemma_true_leads_to_always_every_update_cm_req_does_the_same(spec: 
             }
         }
     }
-    invariant_action_n!(
-        spec, stronger_next, RMQCluster::every_new_req_msg_if_in_flight_then_satisfies(requirements),
+    invariant_n!(
+        spec, lift_action(stronger_next), lift_action(RMQCluster::every_new_req_msg_if_in_flight_then_satisfies(requirements)),
         lift_action(RMQCluster::next()), lift_state(RMQCluster::each_object_in_reconcile_has_consistent_key_and_valid_metadata()),
         lift_state(RMQCluster::the_object_in_reconcile_has_spec_and_uid_as(rabbitmq))
     );
@@ -838,8 +828,8 @@ pub proof fn lemma_true_leads_to_always_no_delete_cm_req_is_in_flight(spec: Temp
             }
         }
     }
-    invariant_action_n!(
-        spec, stronger_next, RMQCluster::every_new_req_msg_if_in_flight_then_satisfies(requirements),
+    invariant_n!(
+        spec, lift_action(stronger_next), lift_action(RMQCluster::every_new_req_msg_if_in_flight_then_satisfies(requirements)),
         lift_action(RMQCluster::next()), lift_state(RMQCluster::desired_state_is(rabbitmq)),
         lift_state(server_config_map_has_owner_reference_pointing_to_current_cr(rabbitmq)),
         lift_state(RMQCluster::each_object_in_etcd_is_well_formed())
@@ -919,8 +909,8 @@ pub proof fn lemma_true_leads_to_always_every_update_sts_req_does_the_same(spec:
             }
         }
     }
-    invariant_action_n!(
-        spec, stronger_next, RMQCluster::every_new_req_msg_if_in_flight_then_satisfies(requirements),
+    invariant_n!(
+        spec, lift_action(stronger_next), lift_action(RMQCluster::every_new_req_msg_if_in_flight_then_satisfies(requirements)),
         lift_action(RMQCluster::next()), lift_state(RMQCluster::each_object_in_reconcile_has_consistent_key_and_valid_metadata()),
         lift_state(RMQCluster::the_object_in_reconcile_has_spec_and_uid_as(rabbitmq))
     );
@@ -982,8 +972,8 @@ pub proof fn lemma_true_leads_to_always_every_create_sts_req_does_the_same(spec:
             }
         }
     }
-    invariant_action_n!(
-        spec, stronger_next, RMQCluster::every_new_req_msg_if_in_flight_then_satisfies(requirements),
+    invariant_n!(
+        spec, lift_action(stronger_next), lift_action(RMQCluster::every_new_req_msg_if_in_flight_then_satisfies(requirements)),
         lift_action(RMQCluster::next()), lift_state(RMQCluster::each_object_in_reconcile_has_consistent_key_and_valid_metadata()),
         lift_state(RMQCluster::the_object_in_reconcile_has_spec_and_uid_as(rabbitmq))
     );
@@ -1060,8 +1050,8 @@ pub proof fn lemma_true_leads_to_always_every_create_cm_req_does_the_same(spec: 
             }
         }
     }
-    invariant_action_n!(
-        spec, stronger_next, RMQCluster::every_new_req_msg_if_in_flight_then_satisfies(requirements),
+    invariant_n!(
+        spec, lift_action(stronger_next), lift_action(RMQCluster::every_new_req_msg_if_in_flight_then_satisfies(requirements)),
         lift_action(RMQCluster::next()), lift_state(RMQCluster::each_object_in_reconcile_has_consistent_key_and_valid_metadata()),
         lift_state(RMQCluster::the_object_in_reconcile_has_spec_and_uid_as(rabbitmq))
     );
@@ -1104,15 +1094,9 @@ pub proof fn lemma_always_pending_msg_at_after_create_stateful_set_step_is_creat
 
     RMQCluster::lemma_always_each_object_in_reconcile_has_consistent_key_and_valid_metadata(spec);
 
-    entails_always_and_n!(
-        spec,
-        lift_action(RMQCluster::next()),
+    combine_spec_entails_always_n!(
+        spec, lift_action(stronger_next), lift_action(RMQCluster::next()),
         lift_state(RMQCluster::each_object_in_reconcile_has_consistent_key_and_valid_metadata())
-    );
-    temp_pred_equality(
-        lift_action(stronger_next),
-        lift_action(RMQCluster::next())
-        .and(lift_state(RMQCluster::each_object_in_reconcile_has_consistent_key_and_valid_metadata()))
     );
 
     init_invariant(spec, init, stronger_next, invariant);
@@ -1153,15 +1137,10 @@ pub proof fn lemma_always_pending_msg_at_after_update_stateful_set_step_is_updat
 
     RMQCluster::lemma_always_each_object_in_reconcile_has_consistent_key_and_valid_metadata(spec);
 
-    entails_always_and_n!(
-        spec,
+    combine_spec_entails_always_n!(
+        spec, lift_action(stronger_next),
         lift_action(RMQCluster::next()),
         lift_state(RMQCluster::each_object_in_reconcile_has_consistent_key_and_valid_metadata())
-    );
-    temp_pred_equality(
-        lift_action(stronger_next),
-        lift_action(RMQCluster::next())
-        .and(lift_state(RMQCluster::each_object_in_reconcile_has_consistent_key_and_valid_metadata()))
     );
 
     init_invariant(spec, init, stronger_next, invariant);
@@ -1265,8 +1244,8 @@ pub proof fn lemma_true_leads_to_always_at_most_one_create_sts_req_is_in_flight(
             }
         }
     }
-    invariant_action_n!(
-        spec, stronger_next, RMQCluster::every_new_req_msg_if_in_flight_then_satisfies(requirements),
+    invariant_n!(
+        spec, lift_action(stronger_next), lift_action(RMQCluster::every_new_req_msg_if_in_flight_then_satisfies(requirements)),
         lift_action(RMQCluster::next()), lift_state(RMQCluster::crash_disabled()), lift_state(RMQCluster::busy_disabled()),
         lift_state(RMQCluster::each_object_in_reconcile_has_consistent_key_and_valid_metadata()),
         lift_state(RMQCluster::every_in_flight_msg_has_unique_id()),
@@ -1375,8 +1354,8 @@ pub proof fn lemma_true_leads_to_always_at_most_one_update_sts_req_is_in_flight(
             }
         }
     }
-    invariant_action_n!(
-        spec, stronger_next, RMQCluster::every_new_req_msg_if_in_flight_then_satisfies(requirements),
+    invariant_n!(
+        spec, lift_action(stronger_next), lift_action(RMQCluster::every_new_req_msg_if_in_flight_then_satisfies(requirements)),
         lift_action(RMQCluster::next()), lift_state(RMQCluster::crash_disabled()), lift_state(RMQCluster::busy_disabled()),
         lift_state(RMQCluster::each_object_in_reconcile_has_consistent_key_and_valid_metadata()),
         lift_state(RMQCluster::every_in_flight_msg_has_unique_id()),
@@ -1458,8 +1437,8 @@ pub proof fn lemma_true_leads_to_always_no_delete_sts_req_is_in_flight(spec: Tem
             }
         }
     }
-    invariant_action_n!(
-        spec, stronger_next, RMQCluster::every_new_req_msg_if_in_flight_then_satisfies(requirements),
+    invariant_n!(
+        spec, lift_action(stronger_next), lift_action(RMQCluster::every_new_req_msg_if_in_flight_then_satisfies(requirements)),
         lift_action(RMQCluster::next()), lift_state(RMQCluster::desired_state_is(rabbitmq)),
         lift_state(stateful_set_has_owner_reference_pointing_to_current_cr(rabbitmq)),
         lift_state(RMQCluster::each_object_in_etcd_is_well_formed())

--- a/src/controller_examples/rabbitmq_controller/proof/liveness/helper_invariants/invariants.rs
+++ b/src/controller_examples/rabbitmq_controller/proof/liveness/helper_invariants/invariants.rs
@@ -491,7 +491,7 @@ pub open spec fn every_update_cm_req_does_the_same(rabbitmq: RabbitmqClusterView
             &&& #[trigger] s.network_state.in_flight.contains(msg)
             &&& cm_update_request_msg(rabbitmq.object_ref())(msg)
         } ==> msg.content.get_update_request().obj.spec == ConfigMapView::marshal_spec((make_server_config_map(rabbitmq).data, ()))
-        && && msg.content.get_update_request().obj.metadata.owner_references == Some(seq![rabbitmq.controller_owner_ref()])
+            && msg.content.get_update_request().obj.metadata.owner_references == Some(seq![rabbitmq.controller_owner_ref()])
     }
 }
 

--- a/src/controller_examples/rabbitmq_controller/proof/liveness/helper_invariants/owner_ref.rs
+++ b/src/controller_examples/rabbitmq_controller/proof/liveness/helper_invariants/owner_ref.rs
@@ -51,7 +51,25 @@ pub proof fn lemma_eventually_only_valid_server_config_map_exists(spec: TempPred
         spec.entails(always(lift_state(every_create_cm_req_does_the_same(rabbitmq)))),
     ensures
         spec.entails(true_pred().leads_to(always(lift_state(server_config_map_has_owner_reference_pointing_to_current_cr(rabbitmq))))),
-{}
+{
+    let key = make_server_config_map_key(rabbitmq.object_ref());
+    let always_owner_ref = |owner_ref: Option<Seq<OwnerReferenceView>>| {
+        exists |uid: nat| #![auto]
+            owner_ref == Some(seq![OwnerReferenceView {
+                block_owner_deletion: None,
+                controller: Some(true),
+                kind: RabbitmqClusterView::kind(),
+                name: rabbitmq.metadata.name.get_Some_0(),
+                uid: uid,
+            }])
+    };
+    let eventual_owner_ref = |owner_ref: Option<Seq<OwnerReferenceView>>| {
+        owner_ref == Some(seq![rabbitmq.controller_owner_ref()])
+    };
+    // lemma_eventually_objects_owner_references_satisfies(
+    //     spec, key,
+    // );
+}
 
 /// The proof of spec |= true ~> all_objects_have_expected_owner_references consists of two parts:
 ///     1. spec |= true ~> (object_has_invalid_owner_reference ==> delete message in flight).
@@ -72,7 +90,7 @@ pub proof fn lemma_eventually_only_valid_server_config_map_exists(spec: TempPred
 ///     1. spec |= [](in_flight(update_msg_with(msg, key)) ==> expected(msg.obj.metadata.owner_references)).
 ///     2. spec |= [](in_flight(create_msg_with(msg, key)) ==> expected(msg.obj.metadata.owner_references)).
 ///     3. spec |= [](key_exists ==> resource_obj_of(key) has no finalizers or timestamp).
-///     3. spec |= [](invalid owner references must have deleted object or uid).
+///     3. spec |= [](!expected(owner_references) => deleted).
 pub proof fn lemma_eventually_only_valid_stateful_set_exists(spec: TempPred<RMQCluster>, rabbitmq: RabbitmqClusterView)
     requires
         rabbitmq.well_formed(),
@@ -265,6 +283,250 @@ proof fn lemma_delete_msg_in_flight_leads_to_only_valid_sts_exists(
         lift_state(pre),
         lift_state(key_exists_and_delete_msg_exists),
         lift_state(post)
+    );
+}
+
+pub open spec fn every_update_msg_sets_owner_references_as(
+    key: ObjectRef, requirements: FnSpec(Option<Seq<OwnerReferenceView>>) -> bool
+) -> StatePred<RMQCluster> {
+    |s: RMQCluster| {
+        forall |msg: Message| 
+            #[trigger] s.message_in_flight(msg)
+            && msg.dst.is_KubernetesAPI()
+            && msg.content.is_update_request()
+            && msg.content.get_update_request().key == key
+            ==> requirements(msg.content.get_update_request().obj.metadata.owner_references)
+    }
+}
+
+pub open spec fn every_create_msg_sets_owner_references_as(
+    key: ObjectRef, requirements: FnSpec(Option<Seq<OwnerReferenceView>>) -> bool
+) -> StatePred<RMQCluster> {
+    |s: RMQCluster| {
+        forall |msg: Message| 
+            #[trigger] s.message_in_flight(msg)
+            && msg.dst.is_KubernetesAPI()
+            && msg.content.is_create_request()
+            && msg.content.get_create_request().namespace == key.namespace
+            && msg.content.get_create_request().obj.metadata.name.get_Some_0() == key.name
+            && msg.content.get_create_request().obj.kind == key.kind
+            ==> requirements(msg.content.get_create_request().obj.metadata.owner_references)
+    }
+}
+
+pub open spec fn objects_owner_references_satisfies(key: ObjectRef, requirements: FnSpec(Option<Seq<OwnerReferenceView>>) -> bool) -> StatePred<RMQCluster> {
+    |s: RMQCluster| {
+        s.resource_key_exists(key) ==> requirements(s.resource_obj_of(key).metadata.owner_references)
+    }
+}
+
+pub open spec fn objects_owner_references_violates(key: ObjectRef, requirements: FnSpec(Option<Seq<OwnerReferenceView>>) -> bool) -> StatePred<RMQCluster> {
+    |s: RMQCluster| {
+        s.resource_key_exists(key) && !requirements(s.resource_obj_of(key).metadata.owner_references)
+    }
+}
+
+pub open spec fn object_has_no_finalizers_or_deletion_timestamp(key: ObjectRef) -> StatePred<RMQCluster> {
+    |s: RMQCluster| {
+        s.resource_key_exists(key) 
+        ==> s.resource_obj_of(key).metadata.deletion_timestamp.is_None()
+            && s.resource_obj_of(key).metadata.finalizers.is_None()
+    }
+}
+
+spec fn exists_delete_request_msg_in_flight_with_key(key: ObjectRef) -> StatePred<RMQCluster> {
+    |s: RMQCluster| {
+        exists |msg: Message| {
+            #[trigger] s.message_in_flight(msg)
+            && msg.dst.is_KubernetesAPI()
+            && msg.content.is_delete_request_with_key(key)
+        }
+    }
+}
+
+pub proof fn lemma_eventually_objects_owner_references_satisfies(
+    spec: TempPred<RMQCluster>, key: ObjectRef, eventual_owner_ref: FnSpec(Option<Seq<OwnerReferenceView>>) -> bool
+)
+    requires
+        spec.entails(always(lift_state(RMQCluster::busy_disabled()))),
+        spec.entails(always(lift_action(RMQCluster::next()))),
+        spec.entails(tla_forall(|i| RMQCluster::kubernetes_api_next().weak_fairness(i))),
+        spec.entails(tla_forall(|i| RMQCluster::builtin_controllers_next().weak_fairness(i))),
+        spec.entails(always(lift_state(every_create_msg_sets_owner_references_as(key, eventual_owner_ref)))),
+        spec.entails(always(lift_state(every_update_msg_sets_owner_references_as(key, eventual_owner_ref)))),
+        spec.entails(always(lift_state(object_has_no_finalizers_or_deletion_timestamp(key)))),
+        // If the current owner_references does not satisfy the eventual requirement, the gc action is enabled.
+        spec.entails(always(lift_state(objects_owner_references_violates(key, eventual_owner_ref)).implies(lift_state(RMQCluster::garbage_collector_deletion_enabled(key))))),
+    ensures
+        spec.entails(true_pred().leads_to(always(lift_state(objects_owner_references_satisfies(key, eventual_owner_ref))))),
+{
+    let pre = |s: RMQCluster| {
+        &&& objects_owner_references_violates(key, eventual_owner_ref)(s)
+        &&& RMQCluster::garbage_collector_deletion_enabled(key)(s)
+    };
+
+    let delete_msg_in_flight = |s: RMQCluster| {
+        objects_owner_references_violates(key, eventual_owner_ref)(s) ==> exists_delete_request_msg_in_flight_with_key(key)(s)
+    };
+    let post = objects_owner_references_satisfies(key, eventual_owner_ref);
+
+    let input = (BuiltinControllerChoice::GarbageCollector, key);
+    let stronger_next = |s, s_prime: RMQCluster| {
+        &&& RMQCluster::next()(s, s_prime)
+        &&& every_create_msg_sets_owner_references_as(key, eventual_owner_ref)(s)
+        &&& every_update_msg_sets_owner_references_as(key, eventual_owner_ref)(s)
+        &&& object_has_no_finalizers_or_deletion_timestamp(key)(s)
+        &&& objects_owner_references_violates(key, eventual_owner_ref)(s) ==> RMQCluster::garbage_collector_deletion_enabled(key)(s)
+        &&& objects_owner_references_violates(key, eventual_owner_ref)(s_prime) ==> RMQCluster::garbage_collector_deletion_enabled(key)(s_prime)
+    };
+    always_to_always_later(spec, lift_state(objects_owner_references_violates(key, eventual_owner_ref)).implies(lift_state(RMQCluster::garbage_collector_deletion_enabled(key))));
+    strengthen_next_n!(
+        stronger_next, spec,
+        lift_action(RMQCluster::next()),
+        lift_state(every_create_msg_sets_owner_references_as(key, eventual_owner_ref)),
+        lift_state(every_update_msg_sets_owner_references_as(key, eventual_owner_ref)),
+        lift_state(object_has_no_finalizers_or_deletion_timestamp(key)),
+        lift_state(objects_owner_references_violates(key, eventual_owner_ref)).implies(lift_state(RMQCluster::garbage_collector_deletion_enabled(key))),
+        later(lift_state(objects_owner_references_violates(key, eventual_owner_ref)).implies(lift_state(RMQCluster::garbage_collector_deletion_enabled(key))))
+    );
+
+    assert forall |s, s_prime: RMQCluster| pre(s) && #[trigger] stronger_next(s, s_prime) && RMQCluster::builtin_controllers_next().forward(input)(s, s_prime) implies delete_msg_in_flight(s_prime) by {
+        assert(RMQCluster::garbage_collector_deletion_enabled(key)(s));
+        let delete_req_msg = built_in_controller_req_msg(delete_req_msg_content(
+            key, s.rest_id_allocator.allocate().1
+        ));
+        assert(s_prime.message_in_flight(delete_req_msg));
+        assert(exists_delete_request_msg_in_flight_with_key(key)(s_prime));
+        assert(delete_msg_in_flight(s_prime));
+    }
+
+    assert forall |s, s_prime: RMQCluster| pre(s) && #[trigger] stronger_next(s, s_prime) implies pre(s_prime) || delete_msg_in_flight(s_prime) by {
+        let step = choose |step| RMQCluster::next_step(s, s_prime, step);
+        match step {
+            Step::BuiltinControllersStep(i) => {
+                if i == input {
+                    assert(RMQCluster::garbage_collector_deletion_enabled(key)(s));
+                    let delete_req_msg = built_in_controller_req_msg(delete_req_msg_content(
+                        key, s.rest_id_allocator.allocate().1
+                    ));
+                    assert(s_prime.message_in_flight(delete_req_msg));
+                    assert(exists_delete_request_msg_in_flight_with_key(key)(s_prime));
+                    assert(delete_msg_in_flight(s_prime));
+                } else {
+                    assert(pre(s_prime));
+                }
+            },
+            Step::KubernetesAPIStep(i) => {
+                if i.get_Some_0().content.is_update_request_with_key(key) {
+                    if RMQCluster::validate_update_request(i.get_Some_0().content.get_update_request(), s.kubernetes_api_state).is_Some()
+                    || RMQCluster::update_is_noop(i.get_Some_0().content.get_update_request().obj, s.resource_obj_of(key)) {
+                        assert(pre(s_prime));
+                    } else {
+                        assert(objects_owner_references_satisfies(key, eventual_owner_ref)(s_prime));
+                    }
+                } else if i.get_Some_0().content.is_delete_request_with_key(key) {
+                    assert(s.resource_obj_of(key).metadata.finalizers.is_None());
+                    assert(!s_prime.resource_key_exists(key));
+                } else {
+                    assert(pre(s_prime));
+                }
+            },
+            _ => {
+                assert(pre(s_prime) || delete_msg_in_flight(s_prime));
+            }
+        }
+    }
+
+    RMQCluster::lemma_pre_leads_to_post_by_builtin_controllers(
+        spec, input, stronger_next, RMQCluster::run_garbage_collector(), pre, delete_msg_in_flight
+    );
+
+    leads_to_self(post);
+
+    assert_by(
+        spec.entails(lift_state(objects_owner_references_violates(key, eventual_owner_ref)).leads_to(lift_state(post))),
+        {
+            lemma_delete_msg_in_flight_leads_to_owner_references_satisfies(spec, key, eventual_owner_ref);
+            or_leads_to_combine_temp(spec, lift_state(post), lift_state(exists_delete_request_msg_in_flight_with_key(key)), lift_state(post));
+            temp_pred_equality(lift_state(delete_msg_in_flight), lift_state(post).or(lift_state(exists_delete_request_msg_in_flight_with_key(key))));
+            leads_to_trans_n!(spec, lift_state(pre), lift_state(delete_msg_in_flight), lift_state(post));
+
+            temp_pred_equality(lift_state(objects_owner_references_violates(key, eventual_owner_ref)).implies(lift_state(RMQCluster::garbage_collector_deletion_enabled(key))), lift_state(objects_owner_references_violates(key, eventual_owner_ref)).implies(lift_state(pre)));
+            leads_to_weaken_temp(spec, lift_state(pre), lift_state(post), lift_state(objects_owner_references_violates(key, eventual_owner_ref)), lift_state(post));
+        }
+    );
+
+    or_leads_to_combine_temp(spec, lift_state(objects_owner_references_violates(key, eventual_owner_ref)), lift_state(post), lift_state(post));
+    temp_pred_equality(true_pred(), lift_state(objects_owner_references_violates(key, eventual_owner_ref)).or(lift_state(post)));
+
+    leads_to_stable(spec, stronger_next, |s: RMQCluster| true, post);
+}
+
+proof fn lemma_delete_msg_in_flight_leads_to_owner_references_satisfies(
+    spec: TempPred<RMQCluster>, key: ObjectRef, eventual_owner_ref: FnSpec(Option<Seq<OwnerReferenceView>>) -> bool
+)
+    requires
+        spec.entails(always(lift_state(RMQCluster::busy_disabled()))),
+        spec.entails(tla_forall(|i| RMQCluster::kubernetes_api_next().weak_fairness(i))),
+        spec.entails(always(lift_action(RMQCluster::next()))),
+        spec.entails(always(lift_state(every_update_msg_sets_owner_references_as(key, eventual_owner_ref)))),
+        spec.entails(always(lift_state(object_has_no_finalizers_or_deletion_timestamp(key)))),
+    ensures
+        spec.entails(
+            lift_state(exists_delete_request_msg_in_flight_with_key(key))
+            .leads_to(lift_state(objects_owner_references_satisfies(key, eventual_owner_ref)))
+        ),
+{
+    let pre = exists_delete_request_msg_in_flight_with_key(key);
+    let post = objects_owner_references_satisfies(key, eventual_owner_ref);
+    assert_by(
+        spec.entails(lift_state(pre).leads_to(lift_state(post))),
+        {
+            let msg_to_p = |msg: Message| {
+                lift_state(|s: RMQCluster| {
+                    &&& s.message_in_flight(msg)
+                    &&& msg.dst.is_KubernetesAPI()
+                    &&& msg.content.is_delete_request_with_key(key)
+                })
+            };
+            assert forall |msg: Message| spec.entails((#[trigger] msg_to_p(msg)).leads_to(lift_state(post))) by {
+                let input = Some(msg);
+                let msg_to_p_state = |s: RMQCluster| {
+                    &&& s.message_in_flight(msg)
+                    &&& msg.dst.is_KubernetesAPI()
+                    &&& msg.content.is_delete_request_with_key(key)
+                };
+                let stronger_next = |s, s_prime: RMQCluster| {
+                    &&& RMQCluster::next()(s, s_prime)
+                    &&& RMQCluster::busy_disabled()(s)
+                    &&& every_update_msg_sets_owner_references_as(key, eventual_owner_ref)(s)
+                    &&& object_has_no_finalizers_or_deletion_timestamp(key)(s)
+                };
+                strengthen_next_n!(
+                    stronger_next, spec,
+                    lift_action(RMQCluster::next()),
+                    lift_state(RMQCluster::busy_disabled()),
+                    lift_state(every_update_msg_sets_owner_references_as(key, eventual_owner_ref)),
+                    lift_state(object_has_no_finalizers_or_deletion_timestamp(key))
+                );
+                RMQCluster::lemma_pre_leads_to_post_by_kubernetes_api(spec, input, stronger_next, RMQCluster::handle_request(), msg_to_p_state, post);
+            }
+            leads_to_exists_intro(spec, msg_to_p, lift_state(post));
+            assert_by(
+                tla_exists(msg_to_p) == lift_state(pre),
+                {
+                    assert forall |ex| #[trigger] lift_state(pre).satisfied_by(ex) implies tla_exists(msg_to_p).satisfied_by(ex) by {
+                        let msg = choose |msg| {
+                            &&& #[trigger] ex.head().message_in_flight(msg)
+                            &&& msg.dst.is_KubernetesAPI()
+                            &&& msg.content.is_delete_request_with_key(key)
+                        };
+                        assert(msg_to_p(msg).satisfied_by(ex));
+                    }
+                    temp_pred_equality(tla_exists(msg_to_p), lift_state(pre));
+                }
+            )
+        }
     );
 }
 

--- a/src/controller_examples/rabbitmq_controller/proof/liveness/helper_invariants/owner_ref.rs
+++ b/src/controller_examples/rabbitmq_controller/proof/liveness/helper_invariants/owner_ref.rs
@@ -48,8 +48,8 @@ pub proof fn lemma_eventually_only_valid_server_config_map_exists(spec: TempPred
         RMQCluster::desired_state_is(rabbitmq)(s)
         && server_config_map_has_no_finalizers_or_timestamp_and_only_has_controller_owner_ref(rabbitmq)(s)
     };
-    invariant_state_n!(
-        spec, state, lift_state(RMQCluster::objects_owner_references_violates(key, eventual_owner_ref)).implies(lift_state(RMQCluster::garbage_collector_deletion_enabled(key))),
+    invariant_n!(
+        spec, lift_state(state), lift_state(RMQCluster::objects_owner_references_violates(key, eventual_owner_ref)).implies(lift_state(RMQCluster::garbage_collector_deletion_enabled(key))),
         lift_state(RMQCluster::desired_state_is(rabbitmq)),
         lift_state(server_config_map_has_no_finalizers_or_timestamp_and_only_has_controller_owner_ref(rabbitmq))
     );
@@ -84,8 +84,8 @@ pub proof fn lemma_eventually_only_valid_stateful_set_exists(spec: TempPred<RMQC
         RMQCluster::desired_state_is(rabbitmq)(s)
         && stateful_set_has_no_finalizers_or_timestamp_and_only_has_controller_owner_ref(rabbitmq)(s)
     };
-    invariant_state_n!(
-        spec, state, lift_state(RMQCluster::objects_owner_references_violates(key, eventual_owner_ref)).implies(lift_state(RMQCluster::garbage_collector_deletion_enabled(key))),
+    invariant_n!(
+        spec, lift_state(state), lift_state(RMQCluster::objects_owner_references_violates(key, eventual_owner_ref)).implies(lift_state(RMQCluster::garbage_collector_deletion_enabled(key))),
         lift_state(RMQCluster::desired_state_is(rabbitmq)),
         lift_state(stateful_set_has_no_finalizers_or_timestamp_and_only_has_controller_owner_ref(rabbitmq))
     );

--- a/src/controller_examples/rabbitmq_controller/proof/liveness/helper_invariants/owner_ref.rs
+++ b/src/controller_examples/rabbitmq_controller/proof/liveness/helper_invariants/owner_ref.rs
@@ -33,15 +33,15 @@ pub proof fn lemma_eventually_only_valid_server_config_map_exists(spec: TempPred
         spec.entails(tla_forall(|i| RMQCluster::builtin_controllers_next().weak_fairness(i))),
         spec.entails(always(lift_state(RMQCluster::desired_state_is(rabbitmq)))),
         spec.entails(always(lift_state(object_of_key_has_no_finalizers_or_timestamp_and_only_has_controller_owner_ref(make_server_config_map_key(rabbitmq.object_ref()), rabbitmq)))),
-        spec.entails(always(lift_state(every_update_cm_req_does_the_same(rabbitmq)))),
-        spec.entails(always(lift_state(every_create_cm_req_does_the_same(rabbitmq)))),
+        spec.entails(always(lift_state(every_update_server_cm_req_does_the_same(rabbitmq)))),
+        spec.entails(always(lift_state(every_create_server_cm_req_does_the_same(rabbitmq)))),
     ensures
         spec.entails(true_pred().leads_to(always(lift_state(object_of_key_only_has_owner_reference_pointing_to_current_cr(make_server_config_map_key(rabbitmq.object_ref()), rabbitmq))))),
 {
     let key = make_server_config_map_key(rabbitmq.object_ref());
     let eventual_owner_ref = |owner_ref: Option<Seq<OwnerReferenceView>>| {owner_ref == Some(seq![rabbitmq.controller_owner_ref()])};
-    always_weaken(spec, every_update_cm_req_does_the_same(rabbitmq), RMQCluster::every_update_msg_sets_owner_references_as(key, eventual_owner_ref));
-    always_weaken(spec, every_create_cm_req_does_the_same(rabbitmq), RMQCluster::every_create_msg_sets_owner_references_as(key, eventual_owner_ref));
+    always_weaken(spec, every_update_server_cm_req_does_the_same(rabbitmq), RMQCluster::every_update_msg_sets_owner_references_as(key, eventual_owner_ref));
+    always_weaken(spec, every_create_server_cm_req_does_the_same(rabbitmq), RMQCluster::every_create_msg_sets_owner_references_as(key, eventual_owner_ref));
     always_weaken(spec, object_of_key_has_no_finalizers_or_timestamp_and_only_has_controller_owner_ref(make_server_config_map_key(rabbitmq.object_ref()), rabbitmq), RMQCluster::object_has_no_finalizers(key));
 
     let state = |s: RMQCluster| {

--- a/src/controller_examples/rabbitmq_controller/proof/liveness/helper_invariants/owner_ref.rs
+++ b/src/controller_examples/rabbitmq_controller/proof/liveness/helper_invariants/owner_ref.rs
@@ -24,19 +24,6 @@ use vstd::prelude::*;
 
 verus! {
 
-spec fn sts_with_invalid_owner_ref_exists_implies_delete_msg_in_flight(rabbitmq: RabbitmqClusterView) -> StatePred<RMQCluster> {
-    let sts_key = make_stateful_set_key(rabbitmq.object_ref());
-    |s: RMQCluster| {
-        s.resource_key_exists(sts_key)
-        && s.resource_obj_of(sts_key).metadata.owner_references != Some(seq![rabbitmq.controller_owner_ref()])
-        ==> exists |msg: Message| {
-            #[trigger] s.message_in_flight(msg)
-            && msg.dst.is_KubernetesAPI()
-            && msg.content.is_delete_request_with_key(sts_key)
-        }
-    }
-}
-
 pub proof fn lemma_eventually_only_valid_server_config_map_exists(spec: TempPred<RMQCluster>, rabbitmq: RabbitmqClusterView)
     requires
         rabbitmq.well_formed(),
@@ -53,47 +40,26 @@ pub proof fn lemma_eventually_only_valid_server_config_map_exists(spec: TempPred
 {
     let key = make_server_config_map_key(rabbitmq.object_ref());
     let eventual_owner_ref = |owner_ref: Option<Seq<OwnerReferenceView>>| {owner_ref == Some(seq![rabbitmq.controller_owner_ref()])};
-    always_weaken(spec, every_update_cm_req_does_the_same(rabbitmq), every_update_msg_sets_owner_references_as(key, eventual_owner_ref));
-    always_weaken(spec, every_create_cm_req_does_the_same(rabbitmq), every_create_msg_sets_owner_references_as(key, eventual_owner_ref));
-    always_weaken(spec, server_config_map_has_no_finalizers_or_timestamp_and_only_has_controller_owner_ref(rabbitmq), object_has_no_finalizers_or_deletion_timestamp(key));
+    always_weaken(spec, every_update_cm_req_does_the_same(rabbitmq), RMQCluster::every_update_msg_sets_owner_references_as(key, eventual_owner_ref));
+    always_weaken(spec, every_create_cm_req_does_the_same(rabbitmq), RMQCluster::every_create_msg_sets_owner_references_as(key, eventual_owner_ref));
+    always_weaken(spec, server_config_map_has_no_finalizers_or_timestamp_and_only_has_controller_owner_ref(rabbitmq), RMQCluster::object_has_no_finalizers_or_deletion_timestamp(key));
 
     let state = |s: RMQCluster| {
         RMQCluster::desired_state_is(rabbitmq)(s)
         && server_config_map_has_no_finalizers_or_timestamp_and_only_has_controller_owner_ref(rabbitmq)(s)
     };
-    assert forall |s: RMQCluster| #[trigger] state(s) implies (objects_owner_references_violates(key, eventual_owner_ref)(s) ==> RMQCluster::garbage_collector_deletion_enabled(key)(s)) by {}
     invariant_state_n!(
-        spec, state, lift_state(objects_owner_references_violates(key, eventual_owner_ref)).implies(lift_state(RMQCluster::garbage_collector_deletion_enabled(key))),
+        spec, state, lift_state(RMQCluster::objects_owner_references_violates(key, eventual_owner_ref)).implies(lift_state(RMQCluster::garbage_collector_deletion_enabled(key))),
         lift_state(RMQCluster::desired_state_is(rabbitmq)),
         lift_state(server_config_map_has_no_finalizers_or_timestamp_and_only_has_controller_owner_ref(rabbitmq))
     );
-    lemma_eventually_objects_owner_references_satisfies(spec, key, eventual_owner_ref);
+    RMQCluster::lemma_eventually_objects_owner_references_satisfies(spec, key, eventual_owner_ref);
     temp_pred_equality(
         lift_state(server_config_map_has_owner_reference_pointing_to_current_cr(rabbitmq)),
-        lift_state(objects_owner_references_satisfies(key, eventual_owner_ref))
+        lift_state(RMQCluster::objects_owner_references_satisfies(key, eventual_owner_ref))
     );
 }
 
-/// The proof of spec |= true ~> all_objects_have_expected_owner_references consists of two parts:
-///     1. spec |= true ~> (object_has_invalid_owner_reference ==> delete message in flight).
-///     2. spec |= (object_has_invalid_owner_reference ==> delete message in flight) ~> all_objects_have_expected_owner_references.
-/// The first is primarily obtained by the weak fairness of the builtin controllers action (specifially, the garbage collector);
-/// and the second holds due to the weak fairness of kubernetes api.
-///
-/// To prove 1, we split `true` into three cases:
-///     a. The object has invalid owner references.
-///     b. The object has valid owner references.
-///     c. The object doesn't exist.
-/// For the last two cases, the post state ((object_has_invalid_owner_reference ==> delete message in flight)) is already reached.
-/// We only need to show spec |= case a ~> post. This is straightforward via the weak fairness of builtin controllers.
-///
-/// The proof of 2 is nothing new to previous proof about kubernetes api actions.
-///
-/// Several preconditions must be satisfied:
-///     1. spec |= [](in_flight(update_msg_with(msg, key)) ==> expected(msg.obj.metadata.owner_references)).
-///     2. spec |= [](in_flight(create_msg_with(msg, key)) ==> expected(msg.obj.metadata.owner_references)).
-///     3. spec |= [](key_exists ==> resource_obj_of(key) has no finalizers or timestamp).
-///     3. spec |= [](!expected(owner_references) => deleted).
 pub proof fn lemma_eventually_only_valid_stateful_set_exists(spec: TempPred<RMQCluster>, rabbitmq: RabbitmqClusterView)
     requires
         rabbitmq.well_formed(),
@@ -108,428 +74,25 @@ pub proof fn lemma_eventually_only_valid_stateful_set_exists(spec: TempPred<RMQC
     ensures
         spec.entails(true_pred().leads_to(always(lift_state(stateful_set_has_owner_reference_pointing_to_current_cr(rabbitmq))))),
 {
-    // TODO: make this lemma general without talking about stateful set or controller reference (only talking about what the owner
-    // references are like, whether they satisfy the precondition of gc action).
-    let sts_key = make_stateful_set_key(rabbitmq.object_ref());
+    let key = make_stateful_set_key(rabbitmq.object_ref());
+    let eventual_owner_ref = |owner_ref: Option<Seq<OwnerReferenceView>>| {owner_ref == Some(seq![rabbitmq.controller_owner_ref()])};
+    always_weaken(spec, every_update_sts_req_does_the_same(rabbitmq), RMQCluster::every_update_msg_sets_owner_references_as(key, eventual_owner_ref));
+    always_weaken(spec, every_create_sts_req_does_the_same(rabbitmq), RMQCluster::every_create_msg_sets_owner_references_as(key, eventual_owner_ref));
+    always_weaken(spec, stateful_set_has_no_finalizers_or_timestamp_and_only_has_controller_owner_ref(rabbitmq), RMQCluster::object_has_no_finalizers_or_deletion_timestamp(key));
 
-    let key_exists_and_old_ref = |s: RMQCluster| {
-        s.resource_key_exists(sts_key)
-        && exists |uid: nat| #![auto]
-        uid != rabbitmq.metadata.uid.get_Some_0() && s.resource_obj_of(sts_key).metadata.owner_references == Some(seq![OwnerReferenceView {
-            block_owner_deletion: None,
-            controller: Some(true),
-            kind: RabbitmqClusterView::kind(),
-            name: rabbitmq.metadata.name.get_Some_0(),
-            uid: uid,
-        }])
+    let state = |s: RMQCluster| {
+        RMQCluster::desired_state_is(rabbitmq)(s)
+        && stateful_set_has_no_finalizers_or_timestamp_and_only_has_controller_owner_ref(rabbitmq)(s)
     };
-    let delete_msg_in_flight = sts_with_invalid_owner_ref_exists_implies_delete_msg_in_flight(rabbitmq);
-    let post = stateful_set_has_owner_reference_pointing_to_current_cr(rabbitmq);
-    let input = (BuiltinControllerChoice::GarbageCollector, sts_key);
-    let stronger_next = |s, s_prime: RMQCluster| {
-        &&& RMQCluster::next()(s, s_prime)
-        &&& RMQCluster::desired_state_is(rabbitmq)(s)
-        &&& stateful_set_has_no_finalizers_or_timestamp_and_only_has_controller_owner_ref(rabbitmq)(s)
-        &&& every_update_sts_req_does_the_same(rabbitmq)(s)
-        &&& every_create_sts_req_does_the_same(rabbitmq)(s)
-    };
-    strengthen_next_n!(
-        stronger_next, spec,
-        lift_action(RMQCluster::next()),
+    invariant_state_n!(
+        spec, state, lift_state(RMQCluster::objects_owner_references_violates(key, eventual_owner_ref)).implies(lift_state(RMQCluster::garbage_collector_deletion_enabled(key))),
         lift_state(RMQCluster::desired_state_is(rabbitmq)),
-        lift_state(stateful_set_has_no_finalizers_or_timestamp_and_only_has_controller_owner_ref(rabbitmq)),
-        lift_state(every_update_sts_req_does_the_same(rabbitmq)),
-        lift_state(every_create_sts_req_does_the_same(rabbitmq))
+        lift_state(stateful_set_has_no_finalizers_or_timestamp_and_only_has_controller_owner_ref(rabbitmq))
     );
-
-    assert forall |s, s_prime: RMQCluster| key_exists_and_old_ref(s) && #[trigger] stronger_next(s, s_prime) && RMQCluster::builtin_controllers_next().forward(input)(s, s_prime) implies delete_msg_in_flight(s_prime) by {
-        let owner_references = s.resource_obj_of(sts_key).metadata.owner_references.get_Some_0();
-        assert(owner_references.len() == 1);
-        let new_delete_msg = built_in_controller_req_msg(delete_req_msg_content(
-            sts_key, s.rest_id_allocator.allocate().1
-        ));
-        assert(s_prime.resource_key_exists(sts_key));
-        assert(s_prime.message_in_flight(new_delete_msg));
-    }
-
-    assert forall |s, s_prime: RMQCluster| key_exists_and_old_ref(s) && #[trigger] stronger_next(s, s_prime) implies key_exists_and_old_ref(s_prime) || delete_msg_in_flight(s_prime) by {
-        let step = choose |step| RMQCluster::next_step(s, s_prime, step);
-        match step {
-            Step::BuiltinControllersStep(i) => {
-                if i == input {
-                    assert(delete_msg_in_flight(s_prime));
-                } else {
-                    assert(key_exists_and_old_ref(s_prime));
-                }
-            },
-            Step::KubernetesAPIStep(i) => {
-                if i.get_Some_0().content.is_update_request_with_key(sts_key) {
-                    if RMQCluster::validate_update_request(i.get_Some_0().content.get_update_request(), s.kubernetes_api_state).is_Some()
-                    || RMQCluster::updated_object(i.get_Some_0().content.get_update_request(), s.kubernetes_api_state) == s.resource_obj_of(sts_key) {
-                        assert(key_exists_and_old_ref(s_prime));
-                    } else {
-                        assert(i.get_Some_0().content.get_update_request().obj.metadata.owner_references == Some(seq![rabbitmq.controller_owner_ref()]));
-                        StatefulSetView::spec_integrity_is_preserved_by_marshal();
-                        assert(!s_prime.resource_key_exists(sts_key) || (s_prime.resource_key_exists(sts_key) && s_prime.resource_obj_of(sts_key).metadata.owner_references == Some(seq![rabbitmq.controller_owner_ref()])));
-                    }
-                } else if i.get_Some_0().content.is_delete_request_with_key(sts_key) {
-                    assert(s.resource_obj_of(sts_key).metadata.finalizers.is_None());
-                    assert(!s_prime.resource_key_exists(sts_key));
-                } else {
-                    assert(key_exists_and_old_ref(s_prime));
-                }
-            },
-            _ => {
-                assert(key_exists_and_old_ref(s_prime) || delete_msg_in_flight(s_prime));
-            }
-        }
-    }
-
-    RMQCluster::lemma_pre_leads_to_post_by_builtin_controllers(
-        spec, input, stronger_next, RMQCluster::run_garbage_collector(), key_exists_and_old_ref, delete_msg_in_flight
-    );
-    partial_implies_and_partial_leads_to_to_leads_to(
-        spec,
-        lift_state(stateful_set_has_no_finalizers_or_timestamp_and_only_has_controller_owner_ref(rabbitmq)),
-        true_pred(),
-        lift_state(key_exists_and_old_ref),
-        lift_state(delete_msg_in_flight)
-    );
-    lemma_delete_msg_in_flight_leads_to_only_valid_sts_exists(spec, rabbitmq);
-    leads_to_trans_n!(spec, true_pred(), lift_state(delete_msg_in_flight), lift_state(post));
-    leads_to_stable(spec, stronger_next, |s: RMQCluster| true, post);
-}
-
-proof fn lemma_delete_msg_in_flight_leads_to_only_valid_sts_exists(
-    spec: TempPred<RMQCluster>, rabbitmq: RabbitmqClusterView
-)
-    requires
-        rabbitmq.well_formed(),
-        spec.entails(always(lift_state(RMQCluster::busy_disabled()))),
-        spec.entails(always(lift_action(RMQCluster::next()))),
-        spec.entails(tla_forall(|i| RMQCluster::kubernetes_api_next().weak_fairness(i))),
-        spec.entails(tla_forall(|i| RMQCluster::builtin_controllers_next().weak_fairness(i))),
-        spec.entails(always(lift_state(RMQCluster::desired_state_is(rabbitmq)))),
-        spec.entails(always(lift_state(stateful_set_has_no_finalizers_or_timestamp_and_only_has_controller_owner_ref(rabbitmq)))),
-        spec.entails(always(lift_state(every_update_sts_req_does_the_same(rabbitmq)))),
-        spec.entails(always(lift_state(every_create_sts_req_does_the_same(rabbitmq)))),
-    ensures
-        spec.entails(lift_state(sts_with_invalid_owner_ref_exists_implies_delete_msg_in_flight(rabbitmq)).leads_to(lift_state(stateful_set_has_owner_reference_pointing_to_current_cr(rabbitmq)))),
-{
-    let pre = sts_with_invalid_owner_ref_exists_implies_delete_msg_in_flight(rabbitmq);
-    let post = stateful_set_has_owner_reference_pointing_to_current_cr(rabbitmq);
-    let sts_key = make_stateful_set_key(rabbitmq.object_ref());
-    let key_exists_and_delete_msg_exists = |s: RMQCluster| {
-        &&& s.resource_key_exists(sts_key)
-        &&& exists |msg: Message| {
-            #[trigger] s.message_in_flight(msg)
-            && msg.dst.is_KubernetesAPI()
-            && msg.content.is_delete_request_with_key(sts_key)
-        }
-    };
-
-    assert_by(
-        spec.entails(lift_state(key_exists_and_delete_msg_exists).leads_to(lift_state(post))),
-        {
-            let msg_to_p = |msg: Message| {
-                lift_state(|s: RMQCluster| {
-                    &&& s.resource_key_exists(sts_key)
-                    &&& s.message_in_flight(msg)
-                    &&& msg.dst.is_KubernetesAPI()
-                    &&& msg.content.is_delete_request_with_key(sts_key)
-                })
-            };
-            assert forall |msg: Message| spec.entails((#[trigger] msg_to_p(msg)).leads_to(lift_state(post))) by {
-                let input = Some(msg);
-                let msg_to_p_state = |s: RMQCluster| {
-                    &&& s.resource_key_exists(sts_key)
-                    &&& s.message_in_flight(msg)
-                    &&& msg.dst.is_KubernetesAPI()
-                    &&& msg.content.is_delete_request_with_key(sts_key)
-                };
-                let stronger_next = |s, s_prime: RMQCluster| {
-                    &&& RMQCluster::next()(s, s_prime)
-                    &&& RMQCluster::busy_disabled()(s)
-                    &&& stateful_set_has_no_finalizers_or_timestamp_and_only_has_controller_owner_ref(rabbitmq)(s)
-                    &&& every_update_sts_req_does_the_same(rabbitmq)(s)
-                };
-                strengthen_next_n!(
-                    stronger_next, spec,
-                    lift_action(RMQCluster::next()),
-                    lift_state(RMQCluster::busy_disabled()),
-                    lift_state(stateful_set_has_no_finalizers_or_timestamp_and_only_has_controller_owner_ref(rabbitmq)),
-                    lift_state(every_update_sts_req_does_the_same(rabbitmq))
-                );
-                RMQCluster::lemma_pre_leads_to_post_by_kubernetes_api(spec, input, stronger_next, RMQCluster::handle_request(), msg_to_p_state, post);
-            }
-            leads_to_exists_intro(spec, msg_to_p, lift_state(post));
-            assert_by(
-                tla_exists(msg_to_p) == lift_state(key_exists_and_delete_msg_exists),
-                {
-                    assert forall |ex| #[trigger] lift_state(key_exists_and_delete_msg_exists).satisfied_by(ex) implies tla_exists(msg_to_p).satisfied_by(ex) by {
-                        assert(ex.head().resource_key_exists(sts_key));
-                        let msg = choose |msg| {
-                            &&& #[trigger] ex.head().message_in_flight(msg)
-                            &&& msg.dst.is_KubernetesAPI()
-                            &&& msg.content.is_delete_request_with_key(sts_key)
-                        };
-                        assert(msg_to_p(msg).satisfied_by(ex));
-                    }
-                    temp_pred_equality(tla_exists(msg_to_p), lift_state(key_exists_and_delete_msg_exists));
-                }
-            )
-        }
-    );
-    partial_implies_and_partial_leads_to_to_leads_to(
-        spec,
-        true_pred(),
-        lift_state(pre),
-        lift_state(key_exists_and_delete_msg_exists),
-        lift_state(post)
-    );
-}
-
-pub open spec fn every_update_msg_sets_owner_references_as(
-    key: ObjectRef, requirements: FnSpec(Option<Seq<OwnerReferenceView>>) -> bool
-) -> StatePred<RMQCluster> {
-    |s: RMQCluster| {
-        forall |msg: Message| 
-            #[trigger] s.message_in_flight(msg)
-            && msg.dst.is_KubernetesAPI()
-            && msg.content.is_update_request()
-            && msg.content.get_update_request().key == key
-            ==> requirements(msg.content.get_update_request().obj.metadata.owner_references)
-    }
-}
-
-pub open spec fn every_create_msg_sets_owner_references_as(
-    key: ObjectRef, requirements: FnSpec(Option<Seq<OwnerReferenceView>>) -> bool
-) -> StatePred<RMQCluster> {
-    |s: RMQCluster| {
-        forall |msg: Message| 
-            #[trigger] s.message_in_flight(msg)
-            && msg.dst.is_KubernetesAPI()
-            && msg.content.is_create_request()
-            && msg.content.get_create_request().namespace == key.namespace
-            && msg.content.get_create_request().obj.metadata.name.get_Some_0() == key.name
-            && msg.content.get_create_request().obj.kind == key.kind
-            ==> requirements(msg.content.get_create_request().obj.metadata.owner_references)
-    }
-}
-
-pub open spec fn objects_owner_references_satisfies(key: ObjectRef, requirements: FnSpec(Option<Seq<OwnerReferenceView>>) -> bool) -> StatePred<RMQCluster> {
-    |s: RMQCluster| {
-        s.resource_key_exists(key) ==> requirements(s.resource_obj_of(key).metadata.owner_references)
-    }
-}
-
-pub open spec fn objects_owner_references_violates(key: ObjectRef, requirements: FnSpec(Option<Seq<OwnerReferenceView>>) -> bool) -> StatePred<RMQCluster> {
-    |s: RMQCluster| {
-        s.resource_key_exists(key) && !requirements(s.resource_obj_of(key).metadata.owner_references)
-    }
-}
-
-pub open spec fn object_has_no_finalizers_or_deletion_timestamp(key: ObjectRef) -> StatePred<RMQCluster> {
-    |s: RMQCluster| {
-        s.resource_key_exists(key) 
-        ==> s.resource_obj_of(key).metadata.deletion_timestamp.is_None()
-            && s.resource_obj_of(key).metadata.finalizers.is_None()
-    }
-}
-
-spec fn exists_delete_request_msg_in_flight_with_key(key: ObjectRef) -> StatePred<RMQCluster> {
-    |s: RMQCluster| {
-        exists |msg: Message| {
-            #[trigger] s.message_in_flight(msg)
-            && msg.dst.is_KubernetesAPI()
-            && msg.content.is_delete_request_with_key(key)
-        }
-    }
-}
-
-pub proof fn lemma_eventually_objects_owner_references_satisfies(
-    spec: TempPred<RMQCluster>, key: ObjectRef, eventual_owner_ref: FnSpec(Option<Seq<OwnerReferenceView>>) -> bool
-)
-    requires
-        spec.entails(always(lift_state(RMQCluster::busy_disabled()))),
-        spec.entails(always(lift_action(RMQCluster::next()))),
-        spec.entails(tla_forall(|i| RMQCluster::kubernetes_api_next().weak_fairness(i))),
-        spec.entails(tla_forall(|i| RMQCluster::builtin_controllers_next().weak_fairness(i))),
-        spec.entails(always(lift_state(every_create_msg_sets_owner_references_as(key, eventual_owner_ref)))),
-        spec.entails(always(lift_state(every_update_msg_sets_owner_references_as(key, eventual_owner_ref)))),
-        spec.entails(always(lift_state(object_has_no_finalizers_or_deletion_timestamp(key)))),
-        // If the current owner_references does not satisfy the eventual requirement, the gc action is enabled.
-        spec.entails(always(lift_state(objects_owner_references_violates(key, eventual_owner_ref)).implies(lift_state(RMQCluster::garbage_collector_deletion_enabled(key))))),
-    ensures
-        spec.entails(true_pred().leads_to(always(lift_state(objects_owner_references_satisfies(key, eventual_owner_ref))))),
-{
-    let pre = |s: RMQCluster| {
-        &&& objects_owner_references_violates(key, eventual_owner_ref)(s)
-        &&& RMQCluster::garbage_collector_deletion_enabled(key)(s)
-    };
-
-    let delete_msg_in_flight = |s: RMQCluster| {
-        objects_owner_references_violates(key, eventual_owner_ref)(s) ==> exists_delete_request_msg_in_flight_with_key(key)(s)
-    };
-    let post = objects_owner_references_satisfies(key, eventual_owner_ref);
-
-    let input = (BuiltinControllerChoice::GarbageCollector, key);
-    let stronger_next = |s, s_prime: RMQCluster| {
-        &&& RMQCluster::next()(s, s_prime)
-        &&& every_create_msg_sets_owner_references_as(key, eventual_owner_ref)(s)
-        &&& every_update_msg_sets_owner_references_as(key, eventual_owner_ref)(s)
-        &&& object_has_no_finalizers_or_deletion_timestamp(key)(s)
-        &&& objects_owner_references_violates(key, eventual_owner_ref)(s) ==> RMQCluster::garbage_collector_deletion_enabled(key)(s)
-        &&& objects_owner_references_violates(key, eventual_owner_ref)(s_prime) ==> RMQCluster::garbage_collector_deletion_enabled(key)(s_prime)
-    };
-    always_to_always_later(spec, lift_state(objects_owner_references_violates(key, eventual_owner_ref)).implies(lift_state(RMQCluster::garbage_collector_deletion_enabled(key))));
-    strengthen_next_n!(
-        stronger_next, spec,
-        lift_action(RMQCluster::next()),
-        lift_state(every_create_msg_sets_owner_references_as(key, eventual_owner_ref)),
-        lift_state(every_update_msg_sets_owner_references_as(key, eventual_owner_ref)),
-        lift_state(object_has_no_finalizers_or_deletion_timestamp(key)),
-        lift_state(objects_owner_references_violates(key, eventual_owner_ref)).implies(lift_state(RMQCluster::garbage_collector_deletion_enabled(key))),
-        later(lift_state(objects_owner_references_violates(key, eventual_owner_ref)).implies(lift_state(RMQCluster::garbage_collector_deletion_enabled(key))))
-    );
-
-    assert forall |s, s_prime: RMQCluster| pre(s) && #[trigger] stronger_next(s, s_prime) && RMQCluster::builtin_controllers_next().forward(input)(s, s_prime) implies delete_msg_in_flight(s_prime) by {
-        assert(RMQCluster::garbage_collector_deletion_enabled(key)(s));
-        let delete_req_msg = built_in_controller_req_msg(delete_req_msg_content(
-            key, s.rest_id_allocator.allocate().1
-        ));
-        assert(s_prime.message_in_flight(delete_req_msg));
-        assert(exists_delete_request_msg_in_flight_with_key(key)(s_prime));
-        assert(delete_msg_in_flight(s_prime));
-    }
-
-    assert forall |s, s_prime: RMQCluster| pre(s) && #[trigger] stronger_next(s, s_prime) implies pre(s_prime) || delete_msg_in_flight(s_prime) by {
-        let step = choose |step| RMQCluster::next_step(s, s_prime, step);
-        match step {
-            Step::BuiltinControllersStep(i) => {
-                if i == input {
-                    assert(RMQCluster::garbage_collector_deletion_enabled(key)(s));
-                    let delete_req_msg = built_in_controller_req_msg(delete_req_msg_content(
-                        key, s.rest_id_allocator.allocate().1
-                    ));
-                    assert(s_prime.message_in_flight(delete_req_msg));
-                    assert(exists_delete_request_msg_in_flight_with_key(key)(s_prime));
-                    assert(delete_msg_in_flight(s_prime));
-                } else {
-                    assert(pre(s_prime));
-                }
-            },
-            Step::KubernetesAPIStep(i) => {
-                if i.get_Some_0().content.is_update_request_with_key(key) {
-                    if RMQCluster::validate_update_request(i.get_Some_0().content.get_update_request(), s.kubernetes_api_state).is_Some()
-                    || RMQCluster::update_is_noop(i.get_Some_0().content.get_update_request().obj, s.resource_obj_of(key)) {
-                        assert(pre(s_prime));
-                    } else {
-                        assert(objects_owner_references_satisfies(key, eventual_owner_ref)(s_prime));
-                    }
-                } else if i.get_Some_0().content.is_delete_request_with_key(key) {
-                    assert(s.resource_obj_of(key).metadata.finalizers.is_None());
-                    assert(!s_prime.resource_key_exists(key));
-                } else {
-                    assert(pre(s_prime));
-                }
-            },
-            _ => {
-                assert(pre(s_prime) || delete_msg_in_flight(s_prime));
-            }
-        }
-    }
-
-    RMQCluster::lemma_pre_leads_to_post_by_builtin_controllers(
-        spec, input, stronger_next, RMQCluster::run_garbage_collector(), pre, delete_msg_in_flight
-    );
-
-    leads_to_self(post);
-
-    assert_by(
-        spec.entails(lift_state(objects_owner_references_violates(key, eventual_owner_ref)).leads_to(lift_state(post))),
-        {
-            lemma_delete_msg_in_flight_leads_to_owner_references_satisfies(spec, key, eventual_owner_ref);
-            or_leads_to_combine_temp(spec, lift_state(post), lift_state(exists_delete_request_msg_in_flight_with_key(key)), lift_state(post));
-            temp_pred_equality(lift_state(delete_msg_in_flight), lift_state(post).or(lift_state(exists_delete_request_msg_in_flight_with_key(key))));
-            leads_to_trans_n!(spec, lift_state(pre), lift_state(delete_msg_in_flight), lift_state(post));
-
-            temp_pred_equality(lift_state(objects_owner_references_violates(key, eventual_owner_ref)).implies(lift_state(RMQCluster::garbage_collector_deletion_enabled(key))), lift_state(objects_owner_references_violates(key, eventual_owner_ref)).implies(lift_state(pre)));
-            leads_to_weaken_temp(spec, lift_state(pre), lift_state(post), lift_state(objects_owner_references_violates(key, eventual_owner_ref)), lift_state(post));
-        }
-    );
-
-    or_leads_to_combine_temp(spec, lift_state(objects_owner_references_violates(key, eventual_owner_ref)), lift_state(post), lift_state(post));
-    temp_pred_equality(true_pred(), lift_state(objects_owner_references_violates(key, eventual_owner_ref)).or(lift_state(post)));
-
-    leads_to_stable(spec, stronger_next, |s: RMQCluster| true, post);
-}
-
-proof fn lemma_delete_msg_in_flight_leads_to_owner_references_satisfies(
-    spec: TempPred<RMQCluster>, key: ObjectRef, eventual_owner_ref: FnSpec(Option<Seq<OwnerReferenceView>>) -> bool
-)
-    requires
-        spec.entails(always(lift_state(RMQCluster::busy_disabled()))),
-        spec.entails(tla_forall(|i| RMQCluster::kubernetes_api_next().weak_fairness(i))),
-        spec.entails(always(lift_action(RMQCluster::next()))),
-        spec.entails(always(lift_state(every_update_msg_sets_owner_references_as(key, eventual_owner_ref)))),
-        spec.entails(always(lift_state(object_has_no_finalizers_or_deletion_timestamp(key)))),
-    ensures
-        spec.entails(
-            lift_state(exists_delete_request_msg_in_flight_with_key(key))
-            .leads_to(lift_state(objects_owner_references_satisfies(key, eventual_owner_ref)))
-        ),
-{
-    let pre = exists_delete_request_msg_in_flight_with_key(key);
-    let post = objects_owner_references_satisfies(key, eventual_owner_ref);
-    assert_by(
-        spec.entails(lift_state(pre).leads_to(lift_state(post))),
-        {
-            let msg_to_p = |msg: Message| {
-                lift_state(|s: RMQCluster| {
-                    &&& s.message_in_flight(msg)
-                    &&& msg.dst.is_KubernetesAPI()
-                    &&& msg.content.is_delete_request_with_key(key)
-                })
-            };
-            assert forall |msg: Message| spec.entails((#[trigger] msg_to_p(msg)).leads_to(lift_state(post))) by {
-                let input = Some(msg);
-                let msg_to_p_state = |s: RMQCluster| {
-                    &&& s.message_in_flight(msg)
-                    &&& msg.dst.is_KubernetesAPI()
-                    &&& msg.content.is_delete_request_with_key(key)
-                };
-                let stronger_next = |s, s_prime: RMQCluster| {
-                    &&& RMQCluster::next()(s, s_prime)
-                    &&& RMQCluster::busy_disabled()(s)
-                    &&& every_update_msg_sets_owner_references_as(key, eventual_owner_ref)(s)
-                    &&& object_has_no_finalizers_or_deletion_timestamp(key)(s)
-                };
-                strengthen_next_n!(
-                    stronger_next, spec,
-                    lift_action(RMQCluster::next()),
-                    lift_state(RMQCluster::busy_disabled()),
-                    lift_state(every_update_msg_sets_owner_references_as(key, eventual_owner_ref)),
-                    lift_state(object_has_no_finalizers_or_deletion_timestamp(key))
-                );
-                RMQCluster::lemma_pre_leads_to_post_by_kubernetes_api(spec, input, stronger_next, RMQCluster::handle_request(), msg_to_p_state, post);
-            }
-            leads_to_exists_intro(spec, msg_to_p, lift_state(post));
-            assert_by(
-                tla_exists(msg_to_p) == lift_state(pre),
-                {
-                    assert forall |ex| #[trigger] lift_state(pre).satisfied_by(ex) implies tla_exists(msg_to_p).satisfied_by(ex) by {
-                        let msg = choose |msg| {
-                            &&& #[trigger] ex.head().message_in_flight(msg)
-                            &&& msg.dst.is_KubernetesAPI()
-                            &&& msg.content.is_delete_request_with_key(key)
-                        };
-                        assert(msg_to_p(msg).satisfied_by(ex));
-                    }
-                    temp_pred_equality(tla_exists(msg_to_p), lift_state(pre));
-                }
-            )
-        }
+    RMQCluster::lemma_eventually_objects_owner_references_satisfies(spec, key, eventual_owner_ref);
+    temp_pred_equality(
+        lift_state(stateful_set_has_owner_reference_pointing_to_current_cr(rabbitmq)),
+        lift_state(RMQCluster::objects_owner_references_satisfies(key, eventual_owner_ref))
     );
 }
 

--- a/src/controller_examples/rabbitmq_controller/proof/liveness/helper_invariants/owner_ref.rs
+++ b/src/controller_examples/rabbitmq_controller/proof/liveness/helper_invariants/owner_ref.rs
@@ -42,7 +42,7 @@ pub proof fn lemma_eventually_only_valid_server_config_map_exists(spec: TempPred
     let eventual_owner_ref = |owner_ref: Option<Seq<OwnerReferenceView>>| {owner_ref == Some(seq![rabbitmq.controller_owner_ref()])};
     always_weaken(spec, every_update_cm_req_does_the_same(rabbitmq), RMQCluster::every_update_msg_sets_owner_references_as(key, eventual_owner_ref));
     always_weaken(spec, every_create_cm_req_does_the_same(rabbitmq), RMQCluster::every_create_msg_sets_owner_references_as(key, eventual_owner_ref));
-    always_weaken(spec, server_config_map_has_no_finalizers_or_timestamp_and_only_has_controller_owner_ref(rabbitmq), RMQCluster::object_has_no_finalizers_or_deletion_timestamp(key));
+    always_weaken(spec, server_config_map_has_no_finalizers_or_timestamp_and_only_has_controller_owner_ref(rabbitmq), RMQCluster::object_has_no_finalizers(key));
 
     let state = |s: RMQCluster| {
         RMQCluster::desired_state_is(rabbitmq)(s)
@@ -78,7 +78,7 @@ pub proof fn lemma_eventually_only_valid_stateful_set_exists(spec: TempPred<RMQC
     let eventual_owner_ref = |owner_ref: Option<Seq<OwnerReferenceView>>| {owner_ref == Some(seq![rabbitmq.controller_owner_ref()])};
     always_weaken(spec, every_update_sts_req_does_the_same(rabbitmq), RMQCluster::every_update_msg_sets_owner_references_as(key, eventual_owner_ref));
     always_weaken(spec, every_create_sts_req_does_the_same(rabbitmq), RMQCluster::every_create_msg_sets_owner_references_as(key, eventual_owner_ref));
-    always_weaken(spec, stateful_set_has_no_finalizers_or_timestamp_and_only_has_controller_owner_ref(rabbitmq), RMQCluster::object_has_no_finalizers_or_deletion_timestamp(key));
+    always_weaken(spec, stateful_set_has_no_finalizers_or_timestamp_and_only_has_controller_owner_ref(rabbitmq), RMQCluster::object_has_no_finalizers(key));
 
     let state = |s: RMQCluster| {
         RMQCluster::desired_state_is(rabbitmq)(s)

--- a/src/controller_examples/rabbitmq_controller/proof/liveness/helper_invariants/owner_ref.rs
+++ b/src/controller_examples/rabbitmq_controller/proof/liveness/helper_invariants/owner_ref.rs
@@ -32,30 +32,30 @@ pub proof fn lemma_eventually_only_valid_server_config_map_exists(spec: TempPred
         spec.entails(tla_forall(|i| RMQCluster::kubernetes_api_next().weak_fairness(i))),
         spec.entails(tla_forall(|i| RMQCluster::builtin_controllers_next().weak_fairness(i))),
         spec.entails(always(lift_state(RMQCluster::desired_state_is(rabbitmq)))),
-        spec.entails(always(lift_state(server_config_map_has_no_finalizers_or_timestamp_and_only_has_controller_owner_ref(rabbitmq)))),
+        spec.entails(always(lift_state(object_of_key_has_no_finalizers_or_timestamp_and_only_has_controller_owner_ref(make_server_config_map_key(rabbitmq.object_ref()), rabbitmq)))),
         spec.entails(always(lift_state(every_update_cm_req_does_the_same(rabbitmq)))),
         spec.entails(always(lift_state(every_create_cm_req_does_the_same(rabbitmq)))),
     ensures
-        spec.entails(true_pred().leads_to(always(lift_state(server_config_map_has_owner_reference_pointing_to_current_cr(rabbitmq))))),
+        spec.entails(true_pred().leads_to(always(lift_state(object_of_key_only_has_owner_reference_pointing_to_current_cr(make_server_config_map_key(rabbitmq.object_ref()), rabbitmq))))),
 {
     let key = make_server_config_map_key(rabbitmq.object_ref());
     let eventual_owner_ref = |owner_ref: Option<Seq<OwnerReferenceView>>| {owner_ref == Some(seq![rabbitmq.controller_owner_ref()])};
     always_weaken(spec, every_update_cm_req_does_the_same(rabbitmq), RMQCluster::every_update_msg_sets_owner_references_as(key, eventual_owner_ref));
     always_weaken(spec, every_create_cm_req_does_the_same(rabbitmq), RMQCluster::every_create_msg_sets_owner_references_as(key, eventual_owner_ref));
-    always_weaken(spec, server_config_map_has_no_finalizers_or_timestamp_and_only_has_controller_owner_ref(rabbitmq), RMQCluster::object_has_no_finalizers(key));
+    always_weaken(spec, object_of_key_has_no_finalizers_or_timestamp_and_only_has_controller_owner_ref(make_server_config_map_key(rabbitmq.object_ref()), rabbitmq), RMQCluster::object_has_no_finalizers(key));
 
     let state = |s: RMQCluster| {
         RMQCluster::desired_state_is(rabbitmq)(s)
-        && server_config_map_has_no_finalizers_or_timestamp_and_only_has_controller_owner_ref(rabbitmq)(s)
+        && object_of_key_has_no_finalizers_or_timestamp_and_only_has_controller_owner_ref(make_server_config_map_key(rabbitmq.object_ref()), rabbitmq)(s)
     };
     invariant_n!(
         spec, lift_state(state), lift_state(RMQCluster::objects_owner_references_violates(key, eventual_owner_ref)).implies(lift_state(RMQCluster::garbage_collector_deletion_enabled(key))),
         lift_state(RMQCluster::desired_state_is(rabbitmq)),
-        lift_state(server_config_map_has_no_finalizers_or_timestamp_and_only_has_controller_owner_ref(rabbitmq))
+        lift_state(object_of_key_has_no_finalizers_or_timestamp_and_only_has_controller_owner_ref(make_server_config_map_key(rabbitmq.object_ref()), rabbitmq))
     );
     RMQCluster::lemma_eventually_objects_owner_references_satisfies(spec, key, eventual_owner_ref);
     temp_pred_equality(
-        lift_state(server_config_map_has_owner_reference_pointing_to_current_cr(rabbitmq)),
+        lift_state(object_of_key_only_has_owner_reference_pointing_to_current_cr(make_server_config_map_key(rabbitmq.object_ref()), rabbitmq)),
         lift_state(RMQCluster::objects_owner_references_satisfies(key, eventual_owner_ref))
     );
 }
@@ -68,30 +68,30 @@ pub proof fn lemma_eventually_only_valid_stateful_set_exists(spec: TempPred<RMQC
         spec.entails(tla_forall(|i| RMQCluster::kubernetes_api_next().weak_fairness(i))),
         spec.entails(tla_forall(|i| RMQCluster::builtin_controllers_next().weak_fairness(i))),
         spec.entails(always(lift_state(RMQCluster::desired_state_is(rabbitmq)))),
-        spec.entails(always(lift_state(stateful_set_has_no_finalizers_or_timestamp_and_only_has_controller_owner_ref(rabbitmq)))),
+        spec.entails(always(lift_state(object_of_key_has_no_finalizers_or_timestamp_and_only_has_controller_owner_ref(make_stateful_set_key(rabbitmq.object_ref()), rabbitmq)))),
         spec.entails(always(lift_state(every_update_sts_req_does_the_same(rabbitmq)))),
         spec.entails(always(lift_state(every_create_sts_req_does_the_same(rabbitmq)))),
     ensures
-        spec.entails(true_pred().leads_to(always(lift_state(stateful_set_has_owner_reference_pointing_to_current_cr(rabbitmq))))),
+        spec.entails(true_pred().leads_to(always(lift_state(object_of_key_only_has_owner_reference_pointing_to_current_cr(make_stateful_set_key(rabbitmq.object_ref()), rabbitmq))))),
 {
     let key = make_stateful_set_key(rabbitmq.object_ref());
     let eventual_owner_ref = |owner_ref: Option<Seq<OwnerReferenceView>>| {owner_ref == Some(seq![rabbitmq.controller_owner_ref()])};
     always_weaken(spec, every_update_sts_req_does_the_same(rabbitmq), RMQCluster::every_update_msg_sets_owner_references_as(key, eventual_owner_ref));
     always_weaken(spec, every_create_sts_req_does_the_same(rabbitmq), RMQCluster::every_create_msg_sets_owner_references_as(key, eventual_owner_ref));
-    always_weaken(spec, stateful_set_has_no_finalizers_or_timestamp_and_only_has_controller_owner_ref(rabbitmq), RMQCluster::object_has_no_finalizers(key));
+    always_weaken(spec, object_of_key_has_no_finalizers_or_timestamp_and_only_has_controller_owner_ref(make_stateful_set_key(rabbitmq.object_ref()), rabbitmq), RMQCluster::object_has_no_finalizers(key));
 
     let state = |s: RMQCluster| {
         RMQCluster::desired_state_is(rabbitmq)(s)
-        && stateful_set_has_no_finalizers_or_timestamp_and_only_has_controller_owner_ref(rabbitmq)(s)
+        && object_of_key_has_no_finalizers_or_timestamp_and_only_has_controller_owner_ref(make_stateful_set_key(rabbitmq.object_ref()), rabbitmq)(s)
     };
     invariant_n!(
         spec, lift_state(state), lift_state(RMQCluster::objects_owner_references_violates(key, eventual_owner_ref)).implies(lift_state(RMQCluster::garbage_collector_deletion_enabled(key))),
         lift_state(RMQCluster::desired_state_is(rabbitmq)),
-        lift_state(stateful_set_has_no_finalizers_or_timestamp_and_only_has_controller_owner_ref(rabbitmq))
+        lift_state(object_of_key_has_no_finalizers_or_timestamp_and_only_has_controller_owner_ref(make_stateful_set_key(rabbitmq.object_ref()), rabbitmq))
     );
     RMQCluster::lemma_eventually_objects_owner_references_satisfies(spec, key, eventual_owner_ref);
     temp_pred_equality(
-        lift_state(stateful_set_has_owner_reference_pointing_to_current_cr(rabbitmq)),
+        lift_state(object_of_key_only_has_owner_reference_pointing_to_current_cr(make_stateful_set_key(rabbitmq.object_ref()), rabbitmq)),
         lift_state(RMQCluster::objects_owner_references_satisfies(key, eventual_owner_ref))
     );
 }

--- a/src/controller_examples/rabbitmq_controller/proof/liveness/liveness.rs
+++ b/src/controller_examples/rabbitmq_controller/proof/liveness/liveness.rs
@@ -317,6 +317,14 @@ proof fn liveness_proof(rabbitmq: RabbitmqClusterView)
     invariants_since_phase_II_is_stable(rabbitmq);
     invariants_since_phase_III_is_stable(rabbitmq);
     invariants_since_phase_IV_is_stable(rabbitmq);
+    stable_and_n!(
+        invariants(rabbitmq),
+        always(lift_state(RMQCluster::desired_state_is(rabbitmq))),
+        invariants_since_phase_I(rabbitmq),
+        invariants_since_phase_II(rabbitmq),
+        invariants_since_phase_III(rabbitmq),
+        invariants_since_phase_IV(rabbitmq)
+    );
     // Eliminate all the invariants by phase.
     assert_by(
         invariants(rabbitmq).and(always(lift_state(RMQCluster::desired_state_is(rabbitmq)))).and(invariants_since_phase_I(rabbitmq)).and(invariants_since_phase_II(rabbitmq)).and(invariants_since_phase_III(rabbitmq)).and(invariants_since_phase_IV(rabbitmq))
@@ -325,14 +333,6 @@ proof fn liveness_proof(rabbitmq: RabbitmqClusterView)
         ),
         {
             let spec = invariants(rabbitmq).and(always(lift_state(RMQCluster::desired_state_is(rabbitmq)))).and(invariants_since_phase_I(rabbitmq)).and(invariants_since_phase_II(rabbitmq)).and(invariants_since_phase_III(rabbitmq)).and(invariants_since_phase_IV(rabbitmq));
-            stable_and_n!(
-                invariants(rabbitmq),
-                always(lift_state(RMQCluster::desired_state_is(rabbitmq))),
-                invariants_since_phase_I(rabbitmq),
-                invariants_since_phase_II(rabbitmq),
-                invariants_since_phase_III(rabbitmq),
-                invariants_since_phase_IV(rabbitmq)
-            );
             unpack_conditions_from_spec(spec, invariants_since_phase_V(rabbitmq), true_pred(), always(current_state_matches(rabbitmq)));
             temp_pred_equality(true_pred().and(invariants_since_phase_V(rabbitmq)), invariants_since_phase_V(rabbitmq));
             eliminate_always(spec, lift_state(RMQCluster::every_in_flight_msg_has_lower_id_than_allocator()));
@@ -353,13 +353,6 @@ proof fn liveness_proof(rabbitmq: RabbitmqClusterView)
         ),
         {
             let spec = invariants(rabbitmq).and(always(lift_state(RMQCluster::desired_state_is(rabbitmq)))).and(invariants_since_phase_I(rabbitmq)).and(invariants_since_phase_II(rabbitmq)).and(invariants_since_phase_III(rabbitmq));
-            stable_and_n!(
-                invariants(rabbitmq),
-                always(lift_state(RMQCluster::desired_state_is(rabbitmq))),
-                invariants_since_phase_I(rabbitmq),
-                invariants_since_phase_II(rabbitmq),
-                invariants_since_phase_III(rabbitmq)
-            );
             unpack_conditions_from_spec(spec, invariants_since_phase_IV(rabbitmq), true_pred(), always(current_state_matches(rabbitmq)));
             temp_pred_equality(true_pred().and(invariants_since_phase_IV(rabbitmq)), invariants_since_phase_IV(rabbitmq));
             helper_invariants::lemma_eventually_only_valid_stateful_set_exists(spec, rabbitmq);
@@ -378,20 +371,8 @@ proof fn liveness_proof(rabbitmq: RabbitmqClusterView)
         ),
         {
             let spec = invariants(rabbitmq).and(always(lift_state(RMQCluster::desired_state_is(rabbitmq)))).and(invariants_since_phase_I(rabbitmq)).and(invariants_since_phase_II(rabbitmq));
-            stable_and_n!(
-                invariants(rabbitmq),
-                always(lift_state(RMQCluster::desired_state_is(rabbitmq))),
-                invariants_since_phase_I(rabbitmq),
-                invariants_since_phase_II(rabbitmq)
-            );
             unpack_conditions_from_spec(spec, invariants_since_phase_III(rabbitmq), true_pred(), always(current_state_matches(rabbitmq)));
             temp_pred_equality(true_pred().and(invariants_since_phase_III(rabbitmq)), invariants_since_phase_III(rabbitmq));
-
-            eliminate_always(spec, lift_state(RMQCluster::every_in_flight_msg_has_lower_id_than_allocator()));
-            eliminate_always(spec, lift_state(helper_invariants::pending_msg_at_after_create_server_config_map_step_is_create_cm_req(rabbitmq.object_ref())));
-            eliminate_always(spec, lift_state(helper_invariants::pending_msg_at_after_update_server_config_map_step_is_update_cm_req(rabbitmq.object_ref())));
-            eliminate_always(spec, lift_state(helper_invariants::pending_msg_at_after_create_stateful_set_step_is_create_sts_req(rabbitmq.object_ref())));
-            eliminate_always(spec, lift_state(helper_invariants::pending_msg_at_after_update_stateful_set_step_is_update_sts_req(rabbitmq.object_ref())));
 
             helper_invariants::lemma_true_leads_to_always_at_most_one_create_cm_req_is_in_flight(spec, rabbitmq.object_ref());
             helper_invariants::lemma_true_leads_to_always_at_most_one_update_cm_req_is_in_flight(spec, rabbitmq.object_ref());
@@ -423,11 +404,6 @@ proof fn liveness_proof(rabbitmq: RabbitmqClusterView)
         ),
         {
             let spec = invariants(rabbitmq).and(always(lift_state(RMQCluster::desired_state_is(rabbitmq)))).and(invariants_since_phase_I(rabbitmq));
-            stable_and_n!(
-                invariants(rabbitmq),
-                always(lift_state(RMQCluster::desired_state_is(rabbitmq))),
-                invariants_since_phase_I(rabbitmq)
-            );
             unpack_conditions_from_spec(spec, invariants_since_phase_II(rabbitmq), true_pred(), always(current_state_matches(rabbitmq)));
             temp_pred_equality(true_pred().and(invariants_since_phase_II(rabbitmq)), invariants_since_phase_II(rabbitmq));
 
@@ -445,10 +421,6 @@ proof fn liveness_proof(rabbitmq: RabbitmqClusterView)
         ),
         {
             let spec = invariants(rabbitmq).and(always(lift_state(RMQCluster::desired_state_is(rabbitmq))));
-            stable_and_n!(
-                invariants(rabbitmq),
-                always(lift_state(RMQCluster::desired_state_is(rabbitmq)))
-            );
             unpack_conditions_from_spec(spec, invariants_since_phase_I(rabbitmq), true_pred(), always(current_state_matches(rabbitmq)));
             temp_pred_equality(true_pred().and(invariants_since_phase_I(rabbitmq)), invariants_since_phase_I(rabbitmq));
 

--- a/src/controller_examples/rabbitmq_controller/proof/liveness/liveness.rs
+++ b/src/controller_examples/rabbitmq_controller/proof/liveness/liveness.rs
@@ -233,10 +233,10 @@ proof fn invariants_since_phase_II_is_stable(rabbitmq: RabbitmqClusterView)
 /// After we know that the spec and uid of object in reconcile, we can obtain the following invariants about messages. This is
 /// because the create and update request messages are derived from the custom resource object in reconcile (i.e, triggering_cr).
 spec fn invariants_since_phase_III(rabbitmq: RabbitmqClusterView) -> TempPred<RMQCluster> {
-    always(lift_state(helper_invariants::create_cm_req_msg_in_flight_implies_at_after_create_cm_step(rabbitmq.object_ref())))
-    .and(always(lift_state(helper_invariants::update_cm_req_msg_in_flight_implies_at_after_update_cm_step(rabbitmq.object_ref()))))
-    .and(always(lift_state(helper_invariants::every_update_cm_req_does_the_same(rabbitmq))))
-    .and(always(lift_state(helper_invariants::every_create_cm_req_does_the_same(rabbitmq))))
+    always(lift_state(helper_invariants::create_server_cm_req_msg_in_flight_implies_at_after_create_server_cm_step(rabbitmq.object_ref())))
+    .and(always(lift_state(helper_invariants::update_server_cm_req_msg_in_flight_implies_at_after_update_server_cm_step(rabbitmq.object_ref()))))
+    .and(always(lift_state(helper_invariants::every_update_server_cm_req_does_the_same(rabbitmq))))
+    .and(always(lift_state(helper_invariants::every_create_server_cm_req_does_the_same(rabbitmq))))
     .and(always(lift_state(helper_invariants::create_sts_req_msg_in_flight_implies_at_after_create_sts_step(rabbitmq.object_ref()))))
     .and(always(lift_state(helper_invariants::update_sts_req_msg_in_flight_implies_at_after_update_sts_step(rabbitmq.object_ref()))))
     .and(always(lift_state(helper_invariants::every_update_sts_req_does_the_same(rabbitmq))))
@@ -248,10 +248,10 @@ proof fn invariants_since_phase_III_is_stable(rabbitmq: RabbitmqClusterView)
         valid(stable(invariants_since_phase_III(rabbitmq))),
 {
     stable_and_always_n!(
-        lift_state(helper_invariants::create_cm_req_msg_in_flight_implies_at_after_create_cm_step(rabbitmq.object_ref())),
-        lift_state(helper_invariants::update_cm_req_msg_in_flight_implies_at_after_update_cm_step(rabbitmq.object_ref())),
-        lift_state(helper_invariants::every_update_cm_req_does_the_same(rabbitmq)),
-        lift_state(helper_invariants::every_create_cm_req_does_the_same(rabbitmq)),
+        lift_state(helper_invariants::create_server_cm_req_msg_in_flight_implies_at_after_create_server_cm_step(rabbitmq.object_ref())),
+        lift_state(helper_invariants::update_server_cm_req_msg_in_flight_implies_at_after_update_server_cm_step(rabbitmq.object_ref())),
+        lift_state(helper_invariants::every_update_server_cm_req_does_the_same(rabbitmq)),
+        lift_state(helper_invariants::every_create_server_cm_req_does_the_same(rabbitmq)),
         lift_state(helper_invariants::create_sts_req_msg_in_flight_implies_at_after_create_sts_step(rabbitmq.object_ref())),
         lift_state(helper_invariants::update_sts_req_msg_in_flight_implies_at_after_update_sts_step(rabbitmq.object_ref())),
         lift_state(helper_invariants::every_update_sts_req_does_the_same(rabbitmq)),
@@ -366,10 +366,10 @@ proof fn liveness_proof(rabbitmq: RabbitmqClusterView)
             unpack_conditions_from_spec(spec, invariants_since_phase_III(rabbitmq), true_pred(), always(current_state_matches(rabbitmq)));
             temp_pred_equality(true_pred().and(invariants_since_phase_III(rabbitmq)), invariants_since_phase_III(rabbitmq));
 
-            helper_invariants::lemma_true_leads_to_always_create_cm_req_msg_in_flight_implies_at_after_create_cm_step(spec, rabbitmq.object_ref());
-            helper_invariants::lemma_true_leads_to_always_update_cm_req_msg_in_flight_implies_at_after_update_cm_step(spec, rabbitmq.object_ref());
-            helper_invariants::lemma_true_leads_to_always_every_update_cm_req_does_the_same(spec, rabbitmq);
-            helper_invariants::lemma_true_leads_to_always_every_create_cm_req_does_the_same(spec, rabbitmq);
+            helper_invariants::lemma_true_leads_to_always_create_server_cm_req_msg_in_flight_implies_at_after_create_server_cm_step(spec, rabbitmq.object_ref());
+            helper_invariants::lemma_true_leads_to_always_update_server_cm_req_msg_in_flight_implies_at_after_update_server_cm_step(spec, rabbitmq.object_ref());
+            helper_invariants::lemma_true_leads_to_always_every_update_server_cm_req_does_the_same(spec, rabbitmq);
+            helper_invariants::lemma_true_leads_to_always_every_create_server_cm_req_does_the_same(spec, rabbitmq);
             helper_invariants::lemma_true_leads_to_always_create_sts_req_msg_in_flight_implies_at_after_create_sts_step(spec, rabbitmq.object_ref());
             helper_invariants::lemma_true_leads_to_always_update_sts_req_msg_in_flight_implies_at_after_update_sts_step(spec, rabbitmq.object_ref());
             helper_invariants::lemma_true_leads_to_always_every_update_sts_req_does_the_same(spec, rabbitmq);
@@ -377,10 +377,10 @@ proof fn liveness_proof(rabbitmq: RabbitmqClusterView)
 
             leads_to_always_combine_n!(
                 spec, true_pred(),
-                lift_state(helper_invariants::create_cm_req_msg_in_flight_implies_at_after_create_cm_step(rabbitmq.object_ref())),
-                lift_state(helper_invariants::update_cm_req_msg_in_flight_implies_at_after_update_cm_step(rabbitmq.object_ref())),
-                lift_state(helper_invariants::every_update_cm_req_does_the_same(rabbitmq)),
-                lift_state(helper_invariants::every_create_cm_req_does_the_same(rabbitmq)),
+                lift_state(helper_invariants::create_server_cm_req_msg_in_flight_implies_at_after_create_server_cm_step(rabbitmq.object_ref())),
+                lift_state(helper_invariants::update_server_cm_req_msg_in_flight_implies_at_after_update_server_cm_step(rabbitmq.object_ref())),
+                lift_state(helper_invariants::every_update_server_cm_req_does_the_same(rabbitmq)),
+                lift_state(helper_invariants::every_create_server_cm_req_does_the_same(rabbitmq)),
                 lift_state(helper_invariants::create_sts_req_msg_in_flight_implies_at_after_create_sts_step(rabbitmq.object_ref())),
                 lift_state(helper_invariants::update_sts_req_msg_in_flight_implies_at_after_update_sts_step(rabbitmq.object_ref())),
                 lift_state(helper_invariants::every_update_sts_req_does_the_same(rabbitmq)),
@@ -1710,7 +1710,7 @@ proof fn lemma_receives_not_found_resp_at_after_get_server_config_map_step_with_
         spec.entails(always(lift_state(RMQCluster::crash_disabled()))),
         spec.entails(always(lift_state(RMQCluster::busy_disabled()))),
         spec.entails(always(lift_state(RMQCluster::every_in_flight_msg_has_unique_id()))),
-        spec.entails(always(lift_state(helper_invariants::create_cm_req_msg_in_flight_implies_at_after_create_cm_step(rabbitmq.object_ref())))),
+        spec.entails(always(lift_state(helper_invariants::create_server_cm_req_msg_in_flight_implies_at_after_create_server_cm_step(rabbitmq.object_ref())))),
         rabbitmq.well_formed(),
     ensures
         spec.entails(
@@ -1741,7 +1741,7 @@ proof fn lemma_receives_not_found_resp_at_after_get_server_config_map_step_with_
         &&& RMQCluster::crash_disabled()(s)
         &&& RMQCluster::busy_disabled()(s)
         &&& RMQCluster::every_in_flight_msg_has_unique_id()(s)
-        &&& helper_invariants::create_cm_req_msg_in_flight_implies_at_after_create_cm_step(rabbitmq.object_ref())(s)
+        &&& helper_invariants::create_server_cm_req_msg_in_flight_implies_at_after_create_server_cm_step(rabbitmq.object_ref())(s)
     };
     combine_spec_entails_always_n!(
         spec, lift_action(stronger_next),
@@ -1749,7 +1749,7 @@ proof fn lemma_receives_not_found_resp_at_after_get_server_config_map_step_with_
         lift_state(RMQCluster::crash_disabled()),
         lift_state(RMQCluster::busy_disabled()),
         lift_state(RMQCluster::every_in_flight_msg_has_unique_id()),
-        lift_state(helper_invariants::create_cm_req_msg_in_flight_implies_at_after_create_cm_step(rabbitmq.object_ref()))
+        lift_state(helper_invariants::create_server_cm_req_msg_in_flight_implies_at_after_create_server_cm_step(rabbitmq.object_ref()))
     );
 
     assert forall |s, s_prime| pre(s) && #[trigger] stronger_next(s, s_prime) implies pre(s_prime) || post(s_prime) by {
@@ -1796,7 +1796,7 @@ proof fn lemma_from_after_get_server_config_map_step_to_after_create_server_conf
         spec.entails(always(lift_state(RMQCluster::every_in_flight_msg_has_unique_id()))),
         spec.entails(always(lift_state(RMQCluster::each_resp_matches_at_most_one_pending_req(rabbitmq.object_ref())))),
         spec.entails(always(lift_state(RMQCluster::each_resp_if_matches_pending_req_then_no_other_resp_matches(rabbitmq.object_ref())))),
-        spec.entails(always(lift_state(helper_invariants::create_cm_req_msg_in_flight_implies_at_after_create_cm_step(rabbitmq.object_ref())))),
+        spec.entails(always(lift_state(helper_invariants::create_server_cm_req_msg_in_flight_implies_at_after_create_server_cm_step(rabbitmq.object_ref())))),
         rabbitmq.well_formed(),
     ensures
         spec.entails(
@@ -1828,7 +1828,7 @@ proof fn lemma_from_after_get_server_config_map_step_to_after_create_server_conf
         &&& RMQCluster::every_in_flight_msg_has_unique_id()(s)
         &&& RMQCluster::each_resp_matches_at_most_one_pending_req(rabbitmq.object_ref())(s)
         &&& RMQCluster::each_resp_if_matches_pending_req_then_no_other_resp_matches(rabbitmq.object_ref())(s)
-        &&& helper_invariants::create_cm_req_msg_in_flight_implies_at_after_create_cm_step(rabbitmq.object_ref())(s)
+        &&& helper_invariants::create_server_cm_req_msg_in_flight_implies_at_after_create_server_cm_step(rabbitmq.object_ref())(s)
     };
 
     combine_spec_entails_always_n!(
@@ -1838,7 +1838,7 @@ proof fn lemma_from_after_get_server_config_map_step_to_after_create_server_conf
         lift_state(RMQCluster::every_in_flight_msg_has_unique_id()),
         lift_state(RMQCluster::each_resp_matches_at_most_one_pending_req(rabbitmq.object_ref())),
         lift_state(RMQCluster::each_resp_if_matches_pending_req_then_no_other_resp_matches(rabbitmq.object_ref())),
-        lift_state(helper_invariants::create_cm_req_msg_in_flight_implies_at_after_create_cm_step(rabbitmq.object_ref()))
+        lift_state(helper_invariants::create_server_cm_req_msg_in_flight_implies_at_after_create_server_cm_step(rabbitmq.object_ref()))
     );
 
     RMQCluster::lemma_pre_leads_to_post_by_controller(
@@ -1856,7 +1856,7 @@ proof fn lemma_cm_is_created_at_after_create_server_config_map_step_with_rabbitm
         spec.entails(always(lift_state(RMQCluster::crash_disabled()))),
         spec.entails(always(lift_state(RMQCluster::busy_disabled()))),
         spec.entails(always(lift_state(RMQCluster::every_in_flight_msg_has_unique_id()))),
-        spec.entails(always(lift_state(helper_invariants::create_cm_req_msg_in_flight_implies_at_after_create_cm_step(rabbitmq.object_ref())))),
+        spec.entails(always(lift_state(helper_invariants::create_server_cm_req_msg_in_flight_implies_at_after_create_server_cm_step(rabbitmq.object_ref())))),
         rabbitmq.well_formed(),
     ensures
         spec.entails(
@@ -1889,7 +1889,7 @@ proof fn lemma_cm_is_created_at_after_create_server_config_map_step_with_rabbitm
         &&& RMQCluster::crash_disabled()(s)
         &&& RMQCluster::busy_disabled()(s)
         &&& RMQCluster::every_in_flight_msg_has_unique_id()(s)
-        &&& helper_invariants::create_cm_req_msg_in_flight_implies_at_after_create_cm_step(rabbitmq.object_ref())(s)
+        &&& helper_invariants::create_server_cm_req_msg_in_flight_implies_at_after_create_server_cm_step(rabbitmq.object_ref())(s)
     };
     combine_spec_entails_always_n!(
         spec, lift_action(stronger_next),
@@ -1897,7 +1897,7 @@ proof fn lemma_cm_is_created_at_after_create_server_config_map_step_with_rabbitm
         lift_state(RMQCluster::crash_disabled()),
         lift_state(RMQCluster::busy_disabled()),
         lift_state(RMQCluster::every_in_flight_msg_has_unique_id()),
-        lift_state(helper_invariants::create_cm_req_msg_in_flight_implies_at_after_create_cm_step(rabbitmq.object_ref()))
+        lift_state(helper_invariants::create_server_cm_req_msg_in_flight_implies_at_after_create_server_cm_step(rabbitmq.object_ref()))
     );
 
     assert forall |s, s_prime| pre(s) && #[trigger] stronger_next(s, s_prime) implies pre(s_prime) || post(s_prime) by {
@@ -2325,7 +2325,7 @@ proof fn lemma_receives_ok_resp_at_after_get_server_config_map_step_with_rabbitm
         spec.entails(always(lift_state(RMQCluster::crash_disabled()))),
         spec.entails(always(lift_state(RMQCluster::busy_disabled()))),
         spec.entails(always(lift_state(RMQCluster::every_in_flight_msg_has_unique_id()))),
-        spec.entails(always(lift_state(helper_invariants::update_cm_req_msg_in_flight_implies_at_after_update_cm_step(rabbitmq.object_ref())))),
+        spec.entails(always(lift_state(helper_invariants::update_server_cm_req_msg_in_flight_implies_at_after_update_server_cm_step(rabbitmq.object_ref())))),
         spec.entails(always(lift_state(helper_invariants::no_delete_request_msg_in_flight_with_key(make_server_config_map_key(rabbitmq.object_ref()))))),
         rabbitmq.well_formed(),
     ensures
@@ -2361,7 +2361,7 @@ proof fn lemma_receives_ok_resp_at_after_get_server_config_map_step_with_rabbitm
         &&& RMQCluster::crash_disabled()(s)
         &&& RMQCluster::busy_disabled()(s)
         &&& RMQCluster::every_in_flight_msg_has_unique_id()(s)
-        &&& helper_invariants::update_cm_req_msg_in_flight_implies_at_after_update_cm_step(rabbitmq.object_ref())(s)
+        &&& helper_invariants::update_server_cm_req_msg_in_flight_implies_at_after_update_server_cm_step(rabbitmq.object_ref())(s)
         &&& helper_invariants::no_delete_request_msg_in_flight_with_key(make_server_config_map_key(rabbitmq.object_ref()))(s)
     };
     combine_spec_entails_always_n!(
@@ -2370,7 +2370,7 @@ proof fn lemma_receives_ok_resp_at_after_get_server_config_map_step_with_rabbitm
         lift_state(RMQCluster::crash_disabled()),
         lift_state(RMQCluster::busy_disabled()),
         lift_state(RMQCluster::every_in_flight_msg_has_unique_id()),
-        lift_state(helper_invariants::update_cm_req_msg_in_flight_implies_at_after_update_cm_step(rabbitmq.object_ref())),
+        lift_state(helper_invariants::update_server_cm_req_msg_in_flight_implies_at_after_update_server_cm_step(rabbitmq.object_ref())),
         lift_state(helper_invariants::no_delete_request_msg_in_flight_with_key(make_server_config_map_key(rabbitmq.object_ref())))
     );
 
@@ -2419,7 +2419,7 @@ proof fn lemma_cm_is_updated_at_after_update_server_config_map_step_with_rabbitm
         spec.entails(always(lift_state(RMQCluster::every_in_flight_msg_has_unique_id()))),
         spec.entails(always(lift_state(RMQCluster::each_object_in_etcd_is_well_formed()))),
         spec.entails(always(lift_state(RMQCluster::every_in_flight_msg_has_unique_id()))),
-        spec.entails(always(lift_state(helper_invariants::update_cm_req_msg_in_flight_implies_at_after_update_cm_step(rabbitmq.object_ref())))),
+        spec.entails(always(lift_state(helper_invariants::update_server_cm_req_msg_in_flight_implies_at_after_update_server_cm_step(rabbitmq.object_ref())))),
         spec.entails(always(lift_state(helper_invariants::no_delete_request_msg_in_flight_with_key(make_server_config_map_key(rabbitmq.object_ref()))))),
         spec.entails(always(lift_state(helper_invariants::object_of_key_has_no_finalizers_or_timestamp_and_only_has_controller_owner_ref(make_server_config_map_key(rabbitmq.object_ref()), rabbitmq)))),
         rabbitmq.well_formed(),
@@ -2459,7 +2459,7 @@ proof fn lemma_cm_is_updated_at_after_update_server_config_map_step_with_rabbitm
         &&& RMQCluster::every_in_flight_msg_has_unique_id()(s)
         &&& RMQCluster::each_object_in_etcd_is_well_formed()(s)
         &&& RMQCluster::every_in_flight_msg_has_unique_id()(s)
-        &&& helper_invariants::update_cm_req_msg_in_flight_implies_at_after_update_cm_step(rabbitmq.object_ref())(s)
+        &&& helper_invariants::update_server_cm_req_msg_in_flight_implies_at_after_update_server_cm_step(rabbitmq.object_ref())(s)
         &&& helper_invariants::no_delete_request_msg_in_flight_with_key(make_server_config_map_key(rabbitmq.object_ref()))(s)
         &&& helper_invariants::object_of_key_has_no_finalizers_or_timestamp_and_only_has_controller_owner_ref(make_server_config_map_key(rabbitmq.object_ref()), rabbitmq)(s)
     };
@@ -2471,7 +2471,7 @@ proof fn lemma_cm_is_updated_at_after_update_server_config_map_step_with_rabbitm
         lift_state(RMQCluster::every_in_flight_msg_has_unique_id()),
         lift_state(RMQCluster::each_object_in_etcd_is_well_formed()),
         lift_state(RMQCluster::every_in_flight_msg_has_unique_id()),
-        lift_state(helper_invariants::update_cm_req_msg_in_flight_implies_at_after_update_cm_step(rabbitmq.object_ref())),
+        lift_state(helper_invariants::update_server_cm_req_msg_in_flight_implies_at_after_update_server_cm_step(rabbitmq.object_ref())),
         lift_state(helper_invariants::no_delete_request_msg_in_flight_with_key(make_server_config_map_key(rabbitmq.object_ref()))),
         lift_state(helper_invariants::object_of_key_has_no_finalizers_or_timestamp_and_only_has_controller_owner_ref(make_server_config_map_key(rabbitmq.object_ref()), rabbitmq))
     );
@@ -2508,7 +2508,7 @@ proof fn lemma_from_after_get_server_config_map_step_to_after_update_server_conf
         spec.entails(always(lift_state(RMQCluster::each_resp_if_matches_pending_req_then_no_other_resp_matches(rabbitmq.object_ref())))),
         spec.entails(always(lift_state(RMQCluster::each_object_in_etcd_is_well_formed()))),
         spec.entails(always(lift_state(RMQCluster::every_in_flight_msg_has_unique_id()))),
-        spec.entails(always(lift_state(helper_invariants::update_cm_req_msg_in_flight_implies_at_after_update_cm_step(rabbitmq.object_ref())))),
+        spec.entails(always(lift_state(helper_invariants::update_server_cm_req_msg_in_flight_implies_at_after_update_server_cm_step(rabbitmq.object_ref())))),
         spec.entails(always(lift_state(helper_invariants::no_delete_request_msg_in_flight_with_key(make_server_config_map_key(rabbitmq.object_ref()))))),
         rabbitmq.well_formed(),
     ensures
@@ -2548,7 +2548,7 @@ proof fn lemma_from_after_get_server_config_map_step_to_after_update_server_conf
         &&& RMQCluster::each_resp_if_matches_pending_req_then_no_other_resp_matches(rabbitmq.object_ref())(s)
         &&& RMQCluster::each_object_in_etcd_is_well_formed()(s)
         &&& RMQCluster::every_in_flight_msg_has_unique_id()(s)
-        &&& helper_invariants::update_cm_req_msg_in_flight_implies_at_after_update_cm_step(rabbitmq.object_ref())(s)
+        &&& helper_invariants::update_server_cm_req_msg_in_flight_implies_at_after_update_server_cm_step(rabbitmq.object_ref())(s)
         &&& helper_invariants::no_delete_request_msg_in_flight_with_key(make_server_config_map_key(rabbitmq.object_ref()))(s)
     };
 
@@ -2561,7 +2561,7 @@ proof fn lemma_from_after_get_server_config_map_step_to_after_update_server_conf
         lift_state(RMQCluster::each_resp_if_matches_pending_req_then_no_other_resp_matches(rabbitmq.object_ref())),
         lift_state(RMQCluster::each_object_in_etcd_is_well_formed()),
         lift_state(RMQCluster::every_in_flight_msg_has_unique_id()),
-        lift_state(helper_invariants::update_cm_req_msg_in_flight_implies_at_after_update_cm_step(rabbitmq.object_ref())),
+        lift_state(helper_invariants::update_server_cm_req_msg_in_flight_implies_at_after_update_server_cm_step(rabbitmq.object_ref())),
         lift_state(helper_invariants::no_delete_request_msg_in_flight_with_key(make_server_config_map_key(rabbitmq.object_ref())))
     );
 
@@ -2579,7 +2579,7 @@ proof fn lemma_server_config_map_is_stable(
         spec.entails(p.leads_to(lift_state(current_config_map_matches(rabbitmq)))),
         spec.entails(always(lift_action(RMQCluster::next()))),
         spec.entails(always(lift_state(helper_invariants::no_delete_request_msg_in_flight_with_key(make_server_config_map_key(rabbitmq.object_ref()))))),
-        spec.entails(always(lift_state(helper_invariants::every_update_cm_req_does_the_same(rabbitmq)))),
+        spec.entails(always(lift_state(helper_invariants::every_update_server_cm_req_does_the_same(rabbitmq)))),
         spec.entails(always(lift_state(helper_invariants::object_of_key_has_no_finalizers_or_timestamp_and_only_has_controller_owner_ref(make_server_config_map_key(rabbitmq.object_ref()), rabbitmq)))),
     ensures
         spec.entails(p.leads_to(always(lift_state(current_config_map_matches(rabbitmq))))),
@@ -2588,14 +2588,14 @@ proof fn lemma_server_config_map_is_stable(
     let stronger_next = |s, s_prime: RMQCluster| {
         &&& RMQCluster::next()(s, s_prime)
         &&& helper_invariants::no_delete_request_msg_in_flight_with_key(make_server_config_map_key(rabbitmq.object_ref()))(s)
-        &&& helper_invariants::every_update_cm_req_does_the_same(rabbitmq)(s)
+        &&& helper_invariants::every_update_server_cm_req_does_the_same(rabbitmq)(s)
         &&& helper_invariants::object_of_key_has_no_finalizers_or_timestamp_and_only_has_controller_owner_ref(make_server_config_map_key(rabbitmq.object_ref()), rabbitmq)(s)
     };
     combine_spec_entails_always_n!(
         spec, lift_action(stronger_next),
         lift_action(RMQCluster::next()),
         lift_state(helper_invariants::no_delete_request_msg_in_flight_with_key(make_server_config_map_key(rabbitmq.object_ref()))),
-        lift_state(helper_invariants::every_update_cm_req_does_the_same(rabbitmq)),
+        lift_state(helper_invariants::every_update_server_cm_req_does_the_same(rabbitmq)),
         lift_state(helper_invariants::object_of_key_has_no_finalizers_or_timestamp_and_only_has_controller_owner_ref(make_server_config_map_key(rabbitmq.object_ref()), rabbitmq))
     );
 

--- a/src/controller_examples/rabbitmq_controller/proof/liveness/liveness.rs
+++ b/src/controller_examples/rabbitmq_controller/proof/liveness/liveness.rs
@@ -241,12 +241,12 @@ proof fn invariants_since_phase_II_is_stable(rabbitmq: RabbitmqClusterView)
 /// After we know that the spec and uid of object in reconcile, we can obtain the following invariants about messages. This is
 /// because the create and update request messages are derived from the custom resource object in reconcile (i.e, triggering_cr).
 spec fn invariants_since_phase_III(rabbitmq: RabbitmqClusterView) -> TempPred<RMQCluster> {
-    always(lift_state(helper_invariants::at_most_one_create_cm_req_is_in_flight(rabbitmq.object_ref())))
-    .and(always(lift_state(helper_invariants::at_most_one_update_cm_req_is_in_flight(rabbitmq.object_ref()))))
+    always(lift_state(helper_invariants::create_cm_req_msg_in_flight_implies_at_after_create_cm_step(rabbitmq.object_ref())))
+    .and(always(lift_state(helper_invariants::update_cm_req_msg_in_flight_implies_at_after_update_cm_step(rabbitmq.object_ref()))))
     .and(always(lift_state(helper_invariants::every_update_cm_req_does_the_same(rabbitmq))))
     .and(always(lift_state(helper_invariants::every_create_cm_req_does_the_same(rabbitmq))))
-    .and(always(lift_state(helper_invariants::at_most_one_create_sts_req_is_in_flight(rabbitmq.object_ref()))))
-    .and(always(lift_state(helper_invariants::at_most_one_update_sts_req_is_in_flight(rabbitmq.object_ref()))))
+    .and(always(lift_state(helper_invariants::create_sts_req_msg_in_flight_implies_at_after_create_sts_step(rabbitmq.object_ref()))))
+    .and(always(lift_state(helper_invariants::update_sts_req_msg_in_flight_implies_at_after_update_sts_step(rabbitmq.object_ref()))))
     .and(always(lift_state(helper_invariants::every_update_sts_req_does_the_same(rabbitmq))))
     .and(always(lift_state(helper_invariants::every_create_sts_req_does_the_same(rabbitmq))))
 }
@@ -256,12 +256,12 @@ proof fn invariants_since_phase_III_is_stable(rabbitmq: RabbitmqClusterView)
         valid(stable(invariants_since_phase_III(rabbitmq))),
 {
     stable_and_always_n!(
-        lift_state(helper_invariants::at_most_one_create_cm_req_is_in_flight(rabbitmq.object_ref())),
-        lift_state(helper_invariants::at_most_one_update_cm_req_is_in_flight(rabbitmq.object_ref())),
+        lift_state(helper_invariants::create_cm_req_msg_in_flight_implies_at_after_create_cm_step(rabbitmq.object_ref())),
+        lift_state(helper_invariants::update_cm_req_msg_in_flight_implies_at_after_update_cm_step(rabbitmq.object_ref())),
         lift_state(helper_invariants::every_update_cm_req_does_the_same(rabbitmq)),
         lift_state(helper_invariants::every_create_cm_req_does_the_same(rabbitmq)),
-        lift_state(helper_invariants::at_most_one_create_sts_req_is_in_flight(rabbitmq.object_ref())),
-        lift_state(helper_invariants::at_most_one_update_sts_req_is_in_flight(rabbitmq.object_ref())),
+        lift_state(helper_invariants::create_sts_req_msg_in_flight_implies_at_after_create_sts_step(rabbitmq.object_ref())),
+        lift_state(helper_invariants::update_sts_req_msg_in_flight_implies_at_after_update_sts_step(rabbitmq.object_ref())),
         lift_state(helper_invariants::every_update_sts_req_does_the_same(rabbitmq)),
         lift_state(helper_invariants::every_create_sts_req_does_the_same(rabbitmq))
     );
@@ -374,23 +374,23 @@ proof fn liveness_proof(rabbitmq: RabbitmqClusterView)
             unpack_conditions_from_spec(spec, invariants_since_phase_III(rabbitmq), true_pred(), always(current_state_matches(rabbitmq)));
             temp_pred_equality(true_pred().and(invariants_since_phase_III(rabbitmq)), invariants_since_phase_III(rabbitmq));
 
-            helper_invariants::lemma_true_leads_to_always_at_most_one_create_cm_req_is_in_flight(spec, rabbitmq.object_ref());
-            helper_invariants::lemma_true_leads_to_always_at_most_one_update_cm_req_is_in_flight(spec, rabbitmq.object_ref());
+            helper_invariants::lemma_true_leads_to_always_create_cm_req_msg_in_flight_implies_at_after_create_cm_step(spec, rabbitmq.object_ref());
+            helper_invariants::lemma_true_leads_to_always_update_cm_req_msg_in_flight_implies_at_after_update_cm_step(spec, rabbitmq.object_ref());
             helper_invariants::lemma_true_leads_to_always_every_update_cm_req_does_the_same(spec, rabbitmq);
             helper_invariants::lemma_true_leads_to_always_every_create_cm_req_does_the_same(spec, rabbitmq);
-            helper_invariants::lemma_true_leads_to_always_at_most_one_create_sts_req_is_in_flight(spec, rabbitmq.object_ref());
-            helper_invariants::lemma_true_leads_to_always_at_most_one_update_sts_req_is_in_flight(spec, rabbitmq.object_ref());
+            helper_invariants::lemma_true_leads_to_always_create_sts_req_msg_in_flight_implies_at_after_create_sts_step(spec, rabbitmq.object_ref());
+            helper_invariants::lemma_true_leads_to_always_update_sts_req_msg_in_flight_implies_at_after_update_sts_step(spec, rabbitmq.object_ref());
             helper_invariants::lemma_true_leads_to_always_every_update_sts_req_does_the_same(spec, rabbitmq);
             helper_invariants::lemma_true_leads_to_always_every_create_sts_req_does_the_same(spec, rabbitmq);
 
             leads_to_always_combine_n!(
                 spec, true_pred(),
-                lift_state(helper_invariants::at_most_one_create_cm_req_is_in_flight(rabbitmq.object_ref())),
-                lift_state(helper_invariants::at_most_one_update_cm_req_is_in_flight(rabbitmq.object_ref())),
+                lift_state(helper_invariants::create_cm_req_msg_in_flight_implies_at_after_create_cm_step(rabbitmq.object_ref())),
+                lift_state(helper_invariants::update_cm_req_msg_in_flight_implies_at_after_update_cm_step(rabbitmq.object_ref())),
                 lift_state(helper_invariants::every_update_cm_req_does_the_same(rabbitmq)),
                 lift_state(helper_invariants::every_create_cm_req_does_the_same(rabbitmq)),
-                lift_state(helper_invariants::at_most_one_create_sts_req_is_in_flight(rabbitmq.object_ref())),
-                lift_state(helper_invariants::at_most_one_update_sts_req_is_in_flight(rabbitmq.object_ref())),
+                lift_state(helper_invariants::create_sts_req_msg_in_flight_implies_at_after_create_sts_step(rabbitmq.object_ref())),
+                lift_state(helper_invariants::update_sts_req_msg_in_flight_implies_at_after_update_sts_step(rabbitmq.object_ref())),
                 lift_state(helper_invariants::every_update_sts_req_does_the_same(rabbitmq)),
                 lift_state(helper_invariants::every_create_sts_req_does_the_same(rabbitmq))
             );
@@ -1333,7 +1333,7 @@ proof fn lemma_from_after_get_stateful_set_and_key_exists_to_rabbitmq_matches(ra
         spec, pre.and(lift_state(helper_invariants::stateful_set_has_owner_reference_pointing_to_current_cr(rabbitmq))), tla_exists(pre_with_object)
     );
     borrow_conditions_from_spec(
-        spec, lift_state(helper_invariants::stateful_set_has_owner_reference_pointing_to_current_cr(rabbitmq)), 
+        spec, lift_state(helper_invariants::stateful_set_has_owner_reference_pointing_to_current_cr(rabbitmq)),
         pre, tla_exists(pre_with_object)
     );
     leads_to_trans_temp(spec, pre, tla_exists(pre_with_object), lift_state(current_stateful_set_matches(rabbitmq)));
@@ -1348,7 +1348,7 @@ proof fn lemma_receives_ok_resp_at_after_get_stateful_set_step_with_rabbitmq(
         spec.entails(always(lift_state(RMQCluster::crash_disabled()))),
         spec.entails(always(lift_state(RMQCluster::busy_disabled()))),
         spec.entails(always(lift_state(RMQCluster::every_in_flight_msg_has_unique_id()))),
-        spec.entails(always(lift_state(helper_invariants::at_most_one_update_sts_req_is_in_flight(rabbitmq.object_ref())))),
+        spec.entails(always(lift_state(helper_invariants::update_sts_req_msg_in_flight_implies_at_after_update_sts_step(rabbitmq.object_ref())))),
         spec.entails(always(lift_state(helper_invariants::no_delete_sts_req_is_in_flight(rabbitmq.object_ref())))),
         rabbitmq.well_formed(),
     ensures
@@ -1389,7 +1389,7 @@ proof fn lemma_receives_ok_resp_at_after_get_stateful_set_step_with_rabbitmq(
         &&& RMQCluster::crash_disabled()(s)
         &&& RMQCluster::busy_disabled()(s)
         &&& RMQCluster::every_in_flight_msg_has_unique_id()(s)
-        &&& helper_invariants::at_most_one_update_sts_req_is_in_flight(rabbitmq.object_ref())(s)
+        &&& helper_invariants::update_sts_req_msg_in_flight_implies_at_after_update_sts_step(rabbitmq.object_ref())(s)
         &&& helper_invariants::no_delete_sts_req_is_in_flight(rabbitmq.object_ref())(s)
     };
     combine_spec_entails_always_n!(
@@ -1398,7 +1398,7 @@ proof fn lemma_receives_ok_resp_at_after_get_stateful_set_step_with_rabbitmq(
         lift_state(RMQCluster::crash_disabled()),
         lift_state(RMQCluster::busy_disabled()),
         lift_state(RMQCluster::every_in_flight_msg_has_unique_id()),
-        lift_state(helper_invariants::at_most_one_update_sts_req_is_in_flight(rabbitmq.object_ref())),
+        lift_state(helper_invariants::update_sts_req_msg_in_flight_implies_at_after_update_sts_step(rabbitmq.object_ref())),
         lift_state(helper_invariants::no_delete_sts_req_is_in_flight(rabbitmq.object_ref()))
     );
 
@@ -1449,7 +1449,8 @@ proof fn lemma_from_after_get_stateful_set_step_to_after_update_stateful_set_ste
         spec.entails(always(lift_state(RMQCluster::each_resp_matches_at_most_one_pending_req(rabbitmq.object_ref())))),
         spec.entails(always(lift_state(RMQCluster::each_resp_if_matches_pending_req_then_no_other_resp_matches(rabbitmq.object_ref())))),
         spec.entails(always(lift_state(RMQCluster::each_object_in_etcd_is_well_formed()))),
-        spec.entails(always(lift_state(helper_invariants::at_most_one_update_sts_req_is_in_flight(rabbitmq.object_ref())))),
+        spec.entails(always(lift_state(RMQCluster::every_in_flight_msg_has_unique_id()))),
+        spec.entails(always(lift_state(helper_invariants::update_sts_req_msg_in_flight_implies_at_after_update_sts_step(rabbitmq.object_ref())))),
         spec.entails(always(lift_state(helper_invariants::no_delete_sts_req_is_in_flight(rabbitmq.object_ref())))),
         rabbitmq.well_formed(),
     ensures
@@ -1490,7 +1491,8 @@ proof fn lemma_from_after_get_stateful_set_step_to_after_update_stateful_set_ste
         &&& RMQCluster::each_resp_matches_at_most_one_pending_req(rabbitmq.object_ref())(s)
         &&& RMQCluster::each_resp_if_matches_pending_req_then_no_other_resp_matches(rabbitmq.object_ref())(s)
         &&& RMQCluster::each_object_in_etcd_is_well_formed()(s)
-        &&& helper_invariants::at_most_one_update_sts_req_is_in_flight(rabbitmq.object_ref())(s)
+        &&& RMQCluster::every_in_flight_msg_has_unique_id()(s)
+        &&& helper_invariants::update_sts_req_msg_in_flight_implies_at_after_update_sts_step(rabbitmq.object_ref())(s)
         &&& helper_invariants::no_delete_sts_req_is_in_flight(rabbitmq.object_ref())(s)
     };
 
@@ -1502,7 +1504,8 @@ proof fn lemma_from_after_get_stateful_set_step_to_after_update_stateful_set_ste
         lift_state(RMQCluster::each_resp_matches_at_most_one_pending_req(rabbitmq.object_ref())),
         lift_state(RMQCluster::each_resp_if_matches_pending_req_then_no_other_resp_matches(rabbitmq.object_ref())),
         lift_state(RMQCluster::each_object_in_etcd_is_well_formed()),
-        lift_state(helper_invariants::at_most_one_update_sts_req_is_in_flight(rabbitmq.object_ref())),
+        lift_state(RMQCluster::every_in_flight_msg_has_unique_id()),
+        lift_state(helper_invariants::update_sts_req_msg_in_flight_implies_at_after_update_sts_step(rabbitmq.object_ref())),
         lift_state(helper_invariants::no_delete_sts_req_is_in_flight(rabbitmq.object_ref()))
     );
 
@@ -1519,7 +1522,8 @@ proof fn lemma_sts_is_updated_at_after_update_stateful_set_step_with_rabbitmq(
         spec.entails(always(lift_state(RMQCluster::busy_disabled()))),
         spec.entails(always(lift_state(RMQCluster::every_in_flight_msg_has_unique_id()))),
         spec.entails(always(lift_state(RMQCluster::each_object_in_etcd_is_well_formed()))),
-        spec.entails(always(lift_state(helper_invariants::at_most_one_update_sts_req_is_in_flight(rabbitmq.object_ref())))),
+        spec.entails(always(lift_state(RMQCluster::every_in_flight_msg_has_unique_id()))),
+        spec.entails(always(lift_state(helper_invariants::update_sts_req_msg_in_flight_implies_at_after_update_sts_step(rabbitmq.object_ref())))),
         spec.entails(always(lift_state(helper_invariants::no_delete_sts_req_is_in_flight(rabbitmq.object_ref())))),
         spec.entails(always(lift_state(helper_invariants::stateful_set_has_no_finalizers_or_timestamp_and_only_has_controller_owner_ref(rabbitmq)))),
         rabbitmq.well_formed(),
@@ -1558,7 +1562,8 @@ proof fn lemma_sts_is_updated_at_after_update_stateful_set_step_with_rabbitmq(
         &&& RMQCluster::busy_disabled()(s)
         &&& RMQCluster::every_in_flight_msg_has_unique_id()(s)
         &&& RMQCluster::each_object_in_etcd_is_well_formed()(s)
-        &&& helper_invariants::at_most_one_update_sts_req_is_in_flight(rabbitmq.object_ref())(s)
+        &&& RMQCluster::every_in_flight_msg_has_unique_id()(s)
+        &&& helper_invariants::update_sts_req_msg_in_flight_implies_at_after_update_sts_step(rabbitmq.object_ref())(s)
         &&& helper_invariants::no_delete_sts_req_is_in_flight(rabbitmq.object_ref())(s)
         &&& helper_invariants::stateful_set_has_no_finalizers_or_timestamp_and_only_has_controller_owner_ref(rabbitmq)(s)
     };
@@ -1569,7 +1574,8 @@ proof fn lemma_sts_is_updated_at_after_update_stateful_set_step_with_rabbitmq(
         lift_state(RMQCluster::busy_disabled()),
         lift_state(RMQCluster::every_in_flight_msg_has_unique_id()),
         lift_state(RMQCluster::each_object_in_etcd_is_well_formed()),
-        lift_state(helper_invariants::at_most_one_update_sts_req_is_in_flight(rabbitmq.object_ref())),
+        lift_state(RMQCluster::every_in_flight_msg_has_unique_id()),
+        lift_state(helper_invariants::update_sts_req_msg_in_flight_implies_at_after_update_sts_step(rabbitmq.object_ref())),
         lift_state(helper_invariants::no_delete_sts_req_is_in_flight(rabbitmq.object_ref())),
         lift_state(helper_invariants::stateful_set_has_no_finalizers_or_timestamp_and_only_has_controller_owner_ref(rabbitmq))
     );
@@ -1723,7 +1729,7 @@ proof fn lemma_receives_not_found_resp_at_after_get_server_config_map_step_with_
         spec.entails(always(lift_state(RMQCluster::crash_disabled()))),
         spec.entails(always(lift_state(RMQCluster::busy_disabled()))),
         spec.entails(always(lift_state(RMQCluster::every_in_flight_msg_has_unique_id()))),
-        spec.entails(always(lift_state(helper_invariants::at_most_one_create_cm_req_is_in_flight(rabbitmq.object_ref())))),
+        spec.entails(always(lift_state(helper_invariants::create_cm_req_msg_in_flight_implies_at_after_create_cm_step(rabbitmq.object_ref())))),
         rabbitmq.well_formed(),
     ensures
         spec.entails(
@@ -1755,7 +1761,7 @@ proof fn lemma_receives_not_found_resp_at_after_get_server_config_map_step_with_
         &&& RMQCluster::crash_disabled()(s)
         &&& RMQCluster::busy_disabled()(s)
         &&& RMQCluster::every_in_flight_msg_has_unique_id()(s)
-        &&& helper_invariants::at_most_one_create_cm_req_is_in_flight(rabbitmq.object_ref())(s)
+        &&& helper_invariants::create_cm_req_msg_in_flight_implies_at_after_create_cm_step(rabbitmq.object_ref())(s)
     };
     combine_spec_entails_always_n!(
         spec, lift_action(stronger_next),
@@ -1763,7 +1769,7 @@ proof fn lemma_receives_not_found_resp_at_after_get_server_config_map_step_with_
         lift_state(RMQCluster::crash_disabled()),
         lift_state(RMQCluster::busy_disabled()),
         lift_state(RMQCluster::every_in_flight_msg_has_unique_id()),
-        lift_state(helper_invariants::at_most_one_create_cm_req_is_in_flight(rabbitmq.object_ref()))
+        lift_state(helper_invariants::create_cm_req_msg_in_flight_implies_at_after_create_cm_step(rabbitmq.object_ref()))
     );
 
     assert forall |s, s_prime| pre(s) && #[trigger] stronger_next(s, s_prime) implies pre(s_prime) || post(s_prime) by {
@@ -1807,9 +1813,10 @@ proof fn lemma_from_after_get_server_config_map_step_to_after_create_server_conf
         spec.entails(always(lift_action(RMQCluster::next()))),
         spec.entails(tla_forall(|i| RMQCluster::controller_next().weak_fairness(i))),
         spec.entails(always(lift_state(RMQCluster::crash_disabled()))),
+        spec.entails(always(lift_state(RMQCluster::every_in_flight_msg_has_unique_id()))),
         spec.entails(always(lift_state(RMQCluster::each_resp_matches_at_most_one_pending_req(rabbitmq.object_ref())))),
         spec.entails(always(lift_state(RMQCluster::each_resp_if_matches_pending_req_then_no_other_resp_matches(rabbitmq.object_ref())))),
-        spec.entails(always(lift_state(helper_invariants::at_most_one_create_cm_req_is_in_flight(rabbitmq.object_ref())))),
+        spec.entails(always(lift_state(helper_invariants::create_cm_req_msg_in_flight_implies_at_after_create_cm_step(rabbitmq.object_ref())))),
         rabbitmq.well_formed(),
     ensures
         spec.entails(
@@ -1839,18 +1846,20 @@ proof fn lemma_from_after_get_server_config_map_step_to_after_create_server_conf
     let stronger_next = |s, s_prime: RMQCluster| {
         &&& RMQCluster::next()(s, s_prime)
         &&& RMQCluster::crash_disabled()(s)
+        &&& RMQCluster::every_in_flight_msg_has_unique_id()(s)
         &&& RMQCluster::each_resp_matches_at_most_one_pending_req(rabbitmq.object_ref())(s)
         &&& RMQCluster::each_resp_if_matches_pending_req_then_no_other_resp_matches(rabbitmq.object_ref())(s)
-        &&& helper_invariants::at_most_one_create_cm_req_is_in_flight(rabbitmq.object_ref())(s)
+        &&& helper_invariants::create_cm_req_msg_in_flight_implies_at_after_create_cm_step(rabbitmq.object_ref())(s)
     };
 
     combine_spec_entails_always_n!(
         spec, lift_action(stronger_next),
         lift_action(RMQCluster::next()),
         lift_state(RMQCluster::crash_disabled()),
+        lift_state(RMQCluster::every_in_flight_msg_has_unique_id()),
         lift_state(RMQCluster::each_resp_matches_at_most_one_pending_req(rabbitmq.object_ref())),
         lift_state(RMQCluster::each_resp_if_matches_pending_req_then_no_other_resp_matches(rabbitmq.object_ref())),
-        lift_state(helper_invariants::at_most_one_create_cm_req_is_in_flight(rabbitmq.object_ref()))
+        lift_state(helper_invariants::create_cm_req_msg_in_flight_implies_at_after_create_cm_step(rabbitmq.object_ref()))
     );
 
     RMQCluster::lemma_pre_leads_to_post_by_controller(
@@ -1868,7 +1877,7 @@ proof fn lemma_cm_is_created_at_after_create_server_config_map_step_with_rabbitm
         spec.entails(always(lift_state(RMQCluster::crash_disabled()))),
         spec.entails(always(lift_state(RMQCluster::busy_disabled()))),
         spec.entails(always(lift_state(RMQCluster::every_in_flight_msg_has_unique_id()))),
-        spec.entails(always(lift_state(helper_invariants::at_most_one_create_cm_req_is_in_flight(rabbitmq.object_ref())))),
+        spec.entails(always(lift_state(helper_invariants::create_cm_req_msg_in_flight_implies_at_after_create_cm_step(rabbitmq.object_ref())))),
         rabbitmq.well_formed(),
     ensures
         spec.entails(
@@ -1902,7 +1911,7 @@ proof fn lemma_cm_is_created_at_after_create_server_config_map_step_with_rabbitm
         &&& RMQCluster::crash_disabled()(s)
         &&& RMQCluster::busy_disabled()(s)
         &&& RMQCluster::every_in_flight_msg_has_unique_id()(s)
-        &&& helper_invariants::at_most_one_create_cm_req_is_in_flight(rabbitmq.object_ref())(s)
+        &&& helper_invariants::create_cm_req_msg_in_flight_implies_at_after_create_cm_step(rabbitmq.object_ref())(s)
     };
     combine_spec_entails_always_n!(
         spec, lift_action(stronger_next),
@@ -1910,7 +1919,7 @@ proof fn lemma_cm_is_created_at_after_create_server_config_map_step_with_rabbitm
         lift_state(RMQCluster::crash_disabled()),
         lift_state(RMQCluster::busy_disabled()),
         lift_state(RMQCluster::every_in_flight_msg_has_unique_id()),
-        lift_state(helper_invariants::at_most_one_create_cm_req_is_in_flight(rabbitmq.object_ref()))
+        lift_state(helper_invariants::create_cm_req_msg_in_flight_implies_at_after_create_cm_step(rabbitmq.object_ref()))
     );
 
     assert forall |s, s_prime| pre(s) && #[trigger] stronger_next(s, s_prime) implies pre(s_prime) || post(s_prime) by {
@@ -1942,7 +1951,7 @@ proof fn lemma_receives_not_found_resp_at_after_get_stateful_set_step_with_rabbi
         spec.entails(always(lift_state(RMQCluster::crash_disabled()))),
         spec.entails(always(lift_state(RMQCluster::busy_disabled()))),
         spec.entails(always(lift_state(RMQCluster::every_in_flight_msg_has_unique_id()))),
-        spec.entails(always(lift_state(helper_invariants::at_most_one_create_sts_req_is_in_flight(rabbitmq.object_ref())))),
+        spec.entails(always(lift_state(helper_invariants::create_sts_req_msg_in_flight_implies_at_after_create_sts_step(rabbitmq.object_ref())))),
         rabbitmq.well_formed(),
     ensures
         spec.entails(
@@ -1974,7 +1983,7 @@ proof fn lemma_receives_not_found_resp_at_after_get_stateful_set_step_with_rabbi
         &&& RMQCluster::crash_disabled()(s)
         &&& RMQCluster::busy_disabled()(s)
         &&& RMQCluster::every_in_flight_msg_has_unique_id()(s)
-        &&& helper_invariants::at_most_one_create_sts_req_is_in_flight(rabbitmq.object_ref())(s)
+        &&& helper_invariants::create_sts_req_msg_in_flight_implies_at_after_create_sts_step(rabbitmq.object_ref())(s)
     };
     combine_spec_entails_always_n!(
         spec, lift_action(stronger_next),
@@ -1982,7 +1991,7 @@ proof fn lemma_receives_not_found_resp_at_after_get_stateful_set_step_with_rabbi
         lift_state(RMQCluster::crash_disabled()),
         lift_state(RMQCluster::busy_disabled()),
         lift_state(RMQCluster::every_in_flight_msg_has_unique_id()),
-        lift_state(helper_invariants::at_most_one_create_sts_req_is_in_flight(rabbitmq.object_ref()))
+        lift_state(helper_invariants::create_sts_req_msg_in_flight_implies_at_after_create_sts_step(rabbitmq.object_ref()))
     );
 
     assert forall |s, s_prime| pre(s) && #[trigger] stronger_next(s, s_prime) implies pre(s_prime) || post(s_prime) by {
@@ -2026,9 +2035,10 @@ proof fn lemma_from_after_get_stateful_set_step_to_after_create_stateful_set_ste
         spec.entails(always(lift_action(RMQCluster::next()))),
         spec.entails(tla_forall(|i| RMQCluster::controller_next().weak_fairness(i))),
         spec.entails(always(lift_state(RMQCluster::crash_disabled()))),
+        spec.entails(always(lift_state(RMQCluster::every_in_flight_msg_has_unique_id()))),
         spec.entails(always(lift_state(RMQCluster::each_resp_matches_at_most_one_pending_req(rabbitmq.object_ref())))),
         spec.entails(always(lift_state(RMQCluster::each_resp_if_matches_pending_req_then_no_other_resp_matches(rabbitmq.object_ref())))),
-        spec.entails(always(lift_state(helper_invariants::at_most_one_create_sts_req_is_in_flight(rabbitmq.object_ref())))),
+        spec.entails(always(lift_state(helper_invariants::create_sts_req_msg_in_flight_implies_at_after_create_sts_step(rabbitmq.object_ref())))),
         rabbitmq.well_formed(),
     ensures
         spec.entails(
@@ -2058,18 +2068,20 @@ proof fn lemma_from_after_get_stateful_set_step_to_after_create_stateful_set_ste
     let stronger_next = |s, s_prime: RMQCluster| {
         &&& RMQCluster::next()(s, s_prime)
         &&& RMQCluster::crash_disabled()(s)
+        &&& RMQCluster::every_in_flight_msg_has_unique_id()(s)
         &&& RMQCluster::each_resp_matches_at_most_one_pending_req(rabbitmq.object_ref())(s)
         &&& RMQCluster::each_resp_if_matches_pending_req_then_no_other_resp_matches(rabbitmq.object_ref())(s)
-        &&& helper_invariants::at_most_one_create_sts_req_is_in_flight(rabbitmq.object_ref())(s)
+        &&& helper_invariants::create_sts_req_msg_in_flight_implies_at_after_create_sts_step(rabbitmq.object_ref())(s)
     };
 
     combine_spec_entails_always_n!(
         spec, lift_action(stronger_next),
         lift_action(RMQCluster::next()),
         lift_state(RMQCluster::crash_disabled()),
+        lift_state(RMQCluster::every_in_flight_msg_has_unique_id()),
         lift_state(RMQCluster::each_resp_matches_at_most_one_pending_req(rabbitmq.object_ref())),
         lift_state(RMQCluster::each_resp_if_matches_pending_req_then_no_other_resp_matches(rabbitmq.object_ref())),
-        lift_state(helper_invariants::at_most_one_create_sts_req_is_in_flight(rabbitmq.object_ref()))
+        lift_state(helper_invariants::create_sts_req_msg_in_flight_implies_at_after_create_sts_step(rabbitmq.object_ref()))
     );
 
     RMQCluster::lemma_pre_leads_to_post_by_controller(
@@ -2087,7 +2099,7 @@ proof fn lemma_sts_is_created_at_after_create_stateful_set_step_with_rabbitmq(
         spec.entails(always(lift_state(RMQCluster::crash_disabled()))),
         spec.entails(always(lift_state(RMQCluster::busy_disabled()))),
         spec.entails(always(lift_state(RMQCluster::every_in_flight_msg_has_unique_id()))),
-        spec.entails(always(lift_state(helper_invariants::at_most_one_create_sts_req_is_in_flight(rabbitmq.object_ref())))),
+        spec.entails(always(lift_state(helper_invariants::create_sts_req_msg_in_flight_implies_at_after_create_sts_step(rabbitmq.object_ref())))),
         rabbitmq.well_formed(),
     ensures
         spec.entails(
@@ -2121,7 +2133,7 @@ proof fn lemma_sts_is_created_at_after_create_stateful_set_step_with_rabbitmq(
         &&& RMQCluster::crash_disabled()(s)
         &&& RMQCluster::busy_disabled()(s)
         &&& RMQCluster::every_in_flight_msg_has_unique_id()(s)
-        &&& helper_invariants::at_most_one_create_sts_req_is_in_flight(rabbitmq.object_ref())(s)
+        &&& helper_invariants::create_sts_req_msg_in_flight_implies_at_after_create_sts_step(rabbitmq.object_ref())(s)
     };
     combine_spec_entails_always_n!(
         spec, lift_action(stronger_next),
@@ -2129,7 +2141,7 @@ proof fn lemma_sts_is_created_at_after_create_stateful_set_step_with_rabbitmq(
         lift_state(RMQCluster::crash_disabled()),
         lift_state(RMQCluster::busy_disabled()),
         lift_state(RMQCluster::every_in_flight_msg_has_unique_id()),
-        lift_state(helper_invariants::at_most_one_create_sts_req_is_in_flight(rabbitmq.object_ref()))
+        lift_state(helper_invariants::create_sts_req_msg_in_flight_implies_at_after_create_sts_step(rabbitmq.object_ref()))
     );
 
     assert forall |s, s_prime| pre(s) && #[trigger] stronger_next(s, s_prime) implies pre(s_prime) || post(s_prime) by {
@@ -2338,7 +2350,7 @@ proof fn lemma_receives_ok_resp_at_after_get_server_config_map_step_with_rabbitm
         spec.entails(always(lift_state(RMQCluster::crash_disabled()))),
         spec.entails(always(lift_state(RMQCluster::busy_disabled()))),
         spec.entails(always(lift_state(RMQCluster::every_in_flight_msg_has_unique_id()))),
-        spec.entails(always(lift_state(helper_invariants::at_most_one_update_cm_req_is_in_flight(rabbitmq.object_ref())))),
+        spec.entails(always(lift_state(helper_invariants::update_cm_req_msg_in_flight_implies_at_after_update_cm_step(rabbitmq.object_ref())))),
         spec.entails(always(lift_state(helper_invariants::no_delete_cm_req_is_in_flight(rabbitmq.object_ref())))),
         rabbitmq.well_formed(),
     ensures
@@ -2375,7 +2387,7 @@ proof fn lemma_receives_ok_resp_at_after_get_server_config_map_step_with_rabbitm
         &&& RMQCluster::crash_disabled()(s)
         &&& RMQCluster::busy_disabled()(s)
         &&& RMQCluster::every_in_flight_msg_has_unique_id()(s)
-        &&& helper_invariants::at_most_one_update_cm_req_is_in_flight(rabbitmq.object_ref())(s)
+        &&& helper_invariants::update_cm_req_msg_in_flight_implies_at_after_update_cm_step(rabbitmq.object_ref())(s)
         &&& helper_invariants::no_delete_cm_req_is_in_flight(rabbitmq.object_ref())(s)
     };
     combine_spec_entails_always_n!(
@@ -2384,7 +2396,7 @@ proof fn lemma_receives_ok_resp_at_after_get_server_config_map_step_with_rabbitm
         lift_state(RMQCluster::crash_disabled()),
         lift_state(RMQCluster::busy_disabled()),
         lift_state(RMQCluster::every_in_flight_msg_has_unique_id()),
-        lift_state(helper_invariants::at_most_one_update_cm_req_is_in_flight(rabbitmq.object_ref())),
+        lift_state(helper_invariants::update_cm_req_msg_in_flight_implies_at_after_update_cm_step(rabbitmq.object_ref())),
         lift_state(helper_invariants::no_delete_cm_req_is_in_flight(rabbitmq.object_ref()))
     );
 
@@ -2432,7 +2444,8 @@ proof fn lemma_cm_is_updated_at_after_update_server_config_map_step_with_rabbitm
         spec.entails(always(lift_state(RMQCluster::busy_disabled()))),
         spec.entails(always(lift_state(RMQCluster::every_in_flight_msg_has_unique_id()))),
         spec.entails(always(lift_state(RMQCluster::each_object_in_etcd_is_well_formed()))),
-        spec.entails(always(lift_state(helper_invariants::at_most_one_update_cm_req_is_in_flight(rabbitmq.object_ref())))),
+        spec.entails(always(lift_state(RMQCluster::every_in_flight_msg_has_unique_id()))),
+        spec.entails(always(lift_state(helper_invariants::update_cm_req_msg_in_flight_implies_at_after_update_cm_step(rabbitmq.object_ref())))),
         spec.entails(always(lift_state(helper_invariants::no_delete_cm_req_is_in_flight(rabbitmq.object_ref())))),
         spec.entails(always(lift_state(helper_invariants::server_config_map_has_no_finalizers_or_timestamp_and_only_has_controller_owner_ref(rabbitmq)))),
         rabbitmq.well_formed(),
@@ -2471,7 +2484,8 @@ proof fn lemma_cm_is_updated_at_after_update_server_config_map_step_with_rabbitm
         &&& RMQCluster::busy_disabled()(s)
         &&& RMQCluster::every_in_flight_msg_has_unique_id()(s)
         &&& RMQCluster::each_object_in_etcd_is_well_formed()(s)
-        &&& helper_invariants::at_most_one_update_cm_req_is_in_flight(rabbitmq.object_ref())(s)
+        &&& RMQCluster::every_in_flight_msg_has_unique_id()(s)
+        &&& helper_invariants::update_cm_req_msg_in_flight_implies_at_after_update_cm_step(rabbitmq.object_ref())(s)
         &&& helper_invariants::no_delete_cm_req_is_in_flight(rabbitmq.object_ref())(s)
         &&& helper_invariants::server_config_map_has_no_finalizers_or_timestamp_and_only_has_controller_owner_ref(rabbitmq)(s)
     };
@@ -2482,7 +2496,8 @@ proof fn lemma_cm_is_updated_at_after_update_server_config_map_step_with_rabbitm
         lift_state(RMQCluster::busy_disabled()),
         lift_state(RMQCluster::every_in_flight_msg_has_unique_id()),
         lift_state(RMQCluster::each_object_in_etcd_is_well_formed()),
-        lift_state(helper_invariants::at_most_one_update_cm_req_is_in_flight(rabbitmq.object_ref())),
+        lift_state(RMQCluster::every_in_flight_msg_has_unique_id()),
+        lift_state(helper_invariants::update_cm_req_msg_in_flight_implies_at_after_update_cm_step(rabbitmq.object_ref())),
         lift_state(helper_invariants::no_delete_cm_req_is_in_flight(rabbitmq.object_ref())),
         lift_state(helper_invariants::server_config_map_has_no_finalizers_or_timestamp_and_only_has_controller_owner_ref(rabbitmq))
     );
@@ -2518,7 +2533,8 @@ proof fn lemma_from_after_get_server_config_map_step_to_after_update_server_conf
         spec.entails(always(lift_state(RMQCluster::each_resp_matches_at_most_one_pending_req(rabbitmq.object_ref())))),
         spec.entails(always(lift_state(RMQCluster::each_resp_if_matches_pending_req_then_no_other_resp_matches(rabbitmq.object_ref())))),
         spec.entails(always(lift_state(RMQCluster::each_object_in_etcd_is_well_formed()))),
-        spec.entails(always(lift_state(helper_invariants::at_most_one_update_cm_req_is_in_flight(rabbitmq.object_ref())))),
+        spec.entails(always(lift_state(RMQCluster::every_in_flight_msg_has_unique_id()))),
+        spec.entails(always(lift_state(helper_invariants::update_cm_req_msg_in_flight_implies_at_after_update_cm_step(rabbitmq.object_ref())))),
         spec.entails(always(lift_state(helper_invariants::no_delete_cm_req_is_in_flight(rabbitmq.object_ref())))),
         rabbitmq.well_formed(),
     ensures
@@ -2557,7 +2573,8 @@ proof fn lemma_from_after_get_server_config_map_step_to_after_update_server_conf
         &&& RMQCluster::each_resp_matches_at_most_one_pending_req(rabbitmq.object_ref())(s)
         &&& RMQCluster::each_resp_if_matches_pending_req_then_no_other_resp_matches(rabbitmq.object_ref())(s)
         &&& RMQCluster::each_object_in_etcd_is_well_formed()(s)
-        &&& helper_invariants::at_most_one_update_cm_req_is_in_flight(rabbitmq.object_ref())(s)
+        &&& RMQCluster::every_in_flight_msg_has_unique_id()(s)
+        &&& helper_invariants::update_cm_req_msg_in_flight_implies_at_after_update_cm_step(rabbitmq.object_ref())(s)
         &&& helper_invariants::no_delete_cm_req_is_in_flight(rabbitmq.object_ref())(s)
     };
 
@@ -2569,7 +2586,8 @@ proof fn lemma_from_after_get_server_config_map_step_to_after_update_server_conf
         lift_state(RMQCluster::each_resp_matches_at_most_one_pending_req(rabbitmq.object_ref())),
         lift_state(RMQCluster::each_resp_if_matches_pending_req_then_no_other_resp_matches(rabbitmq.object_ref())),
         lift_state(RMQCluster::each_object_in_etcd_is_well_formed()),
-        lift_state(helper_invariants::at_most_one_update_cm_req_is_in_flight(rabbitmq.object_ref())),
+        lift_state(RMQCluster::every_in_flight_msg_has_unique_id()),
+        lift_state(helper_invariants::update_cm_req_msg_in_flight_implies_at_after_update_cm_step(rabbitmq.object_ref())),
         lift_state(helper_invariants::no_delete_cm_req_is_in_flight(rabbitmq.object_ref()))
     );
 

--- a/src/controller_examples/rabbitmq_controller/proof/liveness/liveness.rs
+++ b/src/controller_examples/rabbitmq_controller/proof/liveness/liveness.rs
@@ -343,10 +343,6 @@ proof fn liveness_proof(rabbitmq: RabbitmqClusterView)
                 lift_state(helper_invariants::no_delete_sts_req_is_in_flight(rabbitmq.object_ref())),
                 lift_state(helper_invariants::no_delete_cm_req_is_in_flight(rabbitmq.object_ref()))
             );
-            always_and_equality(
-                lift_state(helper_invariants::no_delete_sts_req_is_in_flight(rabbitmq.object_ref())),
-                lift_state(helper_invariants::no_delete_cm_req_is_in_flight(rabbitmq.object_ref()))
-            );
             leads_to_trans_temp(spec, true_pred(), invariants_since_phase_V(rabbitmq), always(current_state_matches(rabbitmq)));
         }
     );
@@ -370,10 +366,6 @@ proof fn liveness_proof(rabbitmq: RabbitmqClusterView)
             helper_invariants::lemma_eventually_only_valid_server_config_map_exists(spec, rabbitmq);
             leads_to_always_combine_temp(
                 spec, true_pred(),
-                lift_state(helper_invariants::stateful_set_has_owner_reference_pointing_to_current_cr(rabbitmq)),
-                lift_state(helper_invariants::server_config_map_has_owner_reference_pointing_to_current_cr(rabbitmq))
-            );
-            always_and_equality(
                 lift_state(helper_invariants::stateful_set_has_owner_reference_pointing_to_current_cr(rabbitmq)),
                 lift_state(helper_invariants::server_config_map_has_owner_reference_pointing_to_current_cr(rabbitmq))
             );
@@ -412,17 +404,6 @@ proof fn liveness_proof(rabbitmq: RabbitmqClusterView)
 
             leads_to_always_combine_n!(
                 spec, true_pred(),
-                lift_state(helper_invariants::at_most_one_create_cm_req_is_in_flight(rabbitmq.object_ref())),
-                lift_state(helper_invariants::at_most_one_update_cm_req_is_in_flight(rabbitmq.object_ref())),
-                lift_state(helper_invariants::every_update_cm_req_does_the_same(rabbitmq)),
-                lift_state(helper_invariants::every_create_cm_req_does_the_same(rabbitmq)),
-                lift_state(helper_invariants::at_most_one_create_sts_req_is_in_flight(rabbitmq.object_ref())),
-                lift_state(helper_invariants::at_most_one_update_sts_req_is_in_flight(rabbitmq.object_ref())),
-                lift_state(helper_invariants::every_update_sts_req_does_the_same(rabbitmq)),
-                lift_state(helper_invariants::every_create_sts_req_does_the_same(rabbitmq))
-            );
-
-            always_and_equality_n!(
                 lift_state(helper_invariants::at_most_one_create_cm_req_is_in_flight(rabbitmq.object_ref())),
                 lift_state(helper_invariants::at_most_one_update_cm_req_is_in_flight(rabbitmq.object_ref())),
                 lift_state(helper_invariants::every_update_cm_req_does_the_same(rabbitmq)),
@@ -477,11 +458,6 @@ proof fn liveness_proof(rabbitmq: RabbitmqClusterView)
             leads_to_always_combine_n!(
                 spec,
                 true_pred(),
-                lift_state(RMQCluster::crash_disabled()),
-                lift_state(RMQCluster::busy_disabled()),
-                lift_state(RMQCluster::the_object_in_schedule_has_spec_and_uid_as(rabbitmq))
-            );
-            always_and_equality_n!(
                 lift_state(RMQCluster::crash_disabled()),
                 lift_state(RMQCluster::busy_disabled()),
                 lift_state(RMQCluster::the_object_in_schedule_has_spec_and_uid_as(rabbitmq))

--- a/src/controller_examples/rabbitmq_controller/proof/liveness/liveness.rs
+++ b/src/controller_examples/rabbitmq_controller/proof/liveness/liveness.rs
@@ -123,7 +123,6 @@ spec fn derived_invariants_since_beginning(rabbitmq: RabbitmqClusterView) -> Tem
     .and(always(lift_state(helper_invariants::server_config_map_has_no_finalizers_or_timestamp_and_only_has_controller_owner_ref(rabbitmq))))
     .and(always(lift_state(helper_invariants::pending_msg_at_after_create_server_config_map_step_is_create_cm_req(rabbitmq.object_ref()))))
     .and(always(lift_state(helper_invariants::pending_msg_at_after_update_server_config_map_step_is_update_cm_req(rabbitmq.object_ref()))))
-    .and(always(lift_state(helper_invariants::pending_msg_at_after_create_stateful_set_step_is_create_sts_req(rabbitmq.object_ref()))))
     .and(always(lift_state(helper_invariants::pending_msg_at_after_update_stateful_set_step_is_update_sts_req(rabbitmq.object_ref()))))
     .and(always(lift_state(RMQCluster::no_pending_req_msg_or_external_api_input_at_reconcile_state(rabbitmq.object_ref(), at_step_closure(RabbitmqReconcileStep::Init)))))
     .and(always(lift_state(RMQCluster::pending_req_in_flight_or_resp_in_flight_at_reconcile_state(rabbitmq.object_ref(), at_step_closure(RabbitmqReconcileStep::AfterCreateHeadlessService)))))
@@ -158,7 +157,6 @@ proof fn derived_invariants_since_beginning_is_stable(rabbitmq: RabbitmqClusterV
         lift_state(helper_invariants::server_config_map_has_no_finalizers_or_timestamp_and_only_has_controller_owner_ref(rabbitmq)),
         lift_state(helper_invariants::pending_msg_at_after_create_server_config_map_step_is_create_cm_req(rabbitmq.object_ref())),
         lift_state(helper_invariants::pending_msg_at_after_update_server_config_map_step_is_update_cm_req(rabbitmq.object_ref())),
-        lift_state(helper_invariants::pending_msg_at_after_create_stateful_set_step_is_create_sts_req(rabbitmq.object_ref())),
         lift_state(helper_invariants::pending_msg_at_after_update_stateful_set_step_is_update_sts_req(rabbitmq.object_ref())),
         lift_state(RMQCluster::no_pending_req_msg_or_external_api_input_at_reconcile_state(rabbitmq.object_ref(), at_step_closure(RabbitmqReconcileStep::Init))),
         lift_state(RMQCluster::pending_req_in_flight_or_resp_in_flight_at_reconcile_state(rabbitmq.object_ref(), at_step_closure(RabbitmqReconcileStep::AfterCreateHeadlessService))),
@@ -476,7 +474,6 @@ proof fn sm_spec_entails_all_invariants(rabbitmq: RabbitmqClusterView)
     helper_invariants::lemma_always_server_config_map_has_no_finalizers_or_timestamp_and_only_has_controller_owner_ref(spec, rabbitmq);
     helper_invariants::lemma_always_pending_msg_at_after_create_server_config_map_step_is_create_cm_req(spec, rabbitmq.object_ref());
     helper_invariants::lemma_always_pending_msg_at_after_update_server_config_map_step_is_update_cm_req(spec, rabbitmq.object_ref());
-    helper_invariants::lemma_always_pending_msg_at_after_create_stateful_set_step_is_create_sts_req(spec, rabbitmq.object_ref());
     helper_invariants::lemma_always_pending_msg_at_after_update_stateful_set_step_is_update_sts_req(spec, rabbitmq.object_ref());
     RMQCluster::lemma_always_no_pending_req_msg_or_external_api_input_at_reconcile_state(spec, rabbitmq.object_ref(), at_step_closure(RabbitmqReconcileStep::Init));
     RMQCluster::lemma_always_pending_req_in_flight_or_resp_in_flight_at_reconcile_state(
@@ -534,7 +531,6 @@ proof fn sm_spec_entails_all_invariants(rabbitmq: RabbitmqClusterView)
         lift_state(helper_invariants::server_config_map_has_no_finalizers_or_timestamp_and_only_has_controller_owner_ref(rabbitmq)),
         lift_state(helper_invariants::pending_msg_at_after_create_server_config_map_step_is_create_cm_req(rabbitmq.object_ref())),
         lift_state(helper_invariants::pending_msg_at_after_update_server_config_map_step_is_update_cm_req(rabbitmq.object_ref())),
-        lift_state(helper_invariants::pending_msg_at_after_create_stateful_set_step_is_create_sts_req(rabbitmq.object_ref())),
         lift_state(helper_invariants::pending_msg_at_after_update_stateful_set_step_is_update_sts_req(rabbitmq.object_ref())),
         lift_state(RMQCluster::no_pending_req_msg_or_external_api_input_at_reconcile_state(rabbitmq.object_ref(), at_step_closure(RabbitmqReconcileStep::Init))),
         lift_state(RMQCluster::pending_req_in_flight_or_resp_in_flight_at_reconcile_state(rabbitmq.object_ref(), at_step_closure(RabbitmqReconcileStep::AfterCreateHeadlessService))),

--- a/src/controller_examples/rabbitmq_controller/proof/liveness/liveness.rs
+++ b/src/controller_examples/rabbitmq_controller/proof/liveness/liveness.rs
@@ -117,8 +117,8 @@ spec fn derived_invariants_since_beginning(rabbitmq: RabbitmqClusterView) -> Tem
     .and(always(lift_state(RMQCluster::each_resp_if_matches_pending_req_then_no_other_resp_matches(rabbitmq.object_ref()))))
     .and(always(lift_state(RMQCluster::every_in_flight_msg_has_lower_id_than_allocator())))
     .and(always(lift_state(RMQCluster::each_object_in_etcd_is_well_formed())))
-    .and(always(lift_state(RMQCluster::each_scheduled_key_is_consistent_with_its_object())))
-    .and(always(lift_state(RMQCluster::each_key_in_reconcile_is_consistent_with_its_object())))
+    .and(always(lift_state(RMQCluster::each_scheduled_object_has_consistent_key_and_valid_metadata())))
+    .and(always(lift_state(RMQCluster::each_object_in_reconcile_has_consistent_key_and_valid_metadata())))
     .and(always(lift_state(helper_invariants::stateful_set_has_no_finalizers_or_timestamp_and_only_has_controller_owner_ref(rabbitmq))))
     .and(always(lift_state(helper_invariants::server_config_map_has_no_finalizers_or_timestamp_and_only_has_controller_owner_ref(rabbitmq))))
     .and(always(lift_state(helper_invariants::pending_msg_at_after_create_server_config_map_step_is_create_cm_req(rabbitmq.object_ref()))))
@@ -152,8 +152,8 @@ proof fn derived_invariants_since_beginning_is_stable(rabbitmq: RabbitmqClusterV
         lift_state(RMQCluster::each_resp_if_matches_pending_req_then_no_other_resp_matches(rabbitmq.object_ref())),
         lift_state(RMQCluster::every_in_flight_msg_has_lower_id_than_allocator()),
         lift_state(RMQCluster::each_object_in_etcd_is_well_formed()),
-        lift_state(RMQCluster::each_scheduled_key_is_consistent_with_its_object()),
-        lift_state(RMQCluster::each_key_in_reconcile_is_consistent_with_its_object()),
+        lift_state(RMQCluster::each_scheduled_object_has_consistent_key_and_valid_metadata()),
+        lift_state(RMQCluster::each_object_in_reconcile_has_consistent_key_and_valid_metadata()),
         lift_state(helper_invariants::stateful_set_has_no_finalizers_or_timestamp_and_only_has_controller_owner_ref(rabbitmq)),
         lift_state(helper_invariants::server_config_map_has_no_finalizers_or_timestamp_and_only_has_controller_owner_ref(rabbitmq)),
         lift_state(helper_invariants::pending_msg_at_after_create_server_config_map_step_is_create_cm_req(rabbitmq.object_ref())),
@@ -180,7 +180,7 @@ proof fn derived_invariants_since_beginning_is_stable(rabbitmq: RabbitmqClusterV
 
 /// This predicate combines all the possible actions (next), weak fairness and invariants that hold throughout the execution.
 /// We name it invariants here because these predicates are never violated, thus they can all be seen as some kind of invariants.
-/// 
+///
 /// The final goal of our proof is to show init /\ invariants |= []desired_state_is(cr) ~> []current_state_matches(cr).
 /// init /\ invariants is equivalent to init /\ next /\ weak_fairness, so we get cluster_spec() |= []desired_state_is(cr) ~> []current_state_matches(cr).
 spec fn invariants(rabbitmq: RabbitmqClusterView) -> TempPred<RMQCluster> {
@@ -202,7 +202,7 @@ proof fn invariants_is_stable(rabbitmq: RabbitmqClusterView)
 
 /// The first notable phase comes when crash and k8s busy are always disabled and the object in schedule always has the same
 /// spec and uid as the cr we provide.
-/// 
+///
 /// Note that don't try to find any connections between those invariants -- they are put together because they don't have to
 /// wait for another of them to first be satisfied.
 spec fn invariants_since_phase_I(rabbitmq: RabbitmqClusterView) -> TempPred<RMQCluster> {
@@ -223,7 +223,7 @@ proof fn invariants_since_phase_I_is_stable(rabbitmq: RabbitmqClusterView)
 }
 
 /// For now, phase II only contains one invariant, which is the object in reconcile has the same spec and uid as rabbitmq.
-/// 
+///
 /// It is alone because it relies on the invariant the_object_in_schedule_has_spec_and_uid_as (in phase I) and every invariant
 /// in phase III relies on it.
 spec fn invariants_since_phase_II(rabbitmq: RabbitmqClusterView) -> TempPred<RMQCluster> {
@@ -522,8 +522,8 @@ proof fn sm_spec_entails_all_invariants(rabbitmq: RabbitmqClusterView)
     RMQCluster::lemma_always_each_resp_if_matches_pending_req_then_no_other_resp_matches(rabbitmq.object_ref());
     RMQCluster::lemma_always_every_in_flight_msg_has_lower_id_than_allocator();
     RMQCluster::lemma_always_each_object_in_etcd_is_well_formed(spec);
-    RMQCluster::lemma_always_each_scheduled_key_is_consistent_with_its_object(spec);
-    RMQCluster::lemma_always_each_key_in_reconcile_is_consistent_with_its_object(spec);
+    RMQCluster::lemma_always_each_scheduled_object_has_consistent_key_and_valid_metadata(spec);
+    RMQCluster::lemma_always_each_object_in_reconcile_has_consistent_key_and_valid_metadata(spec);
     helper_invariants::lemma_always_stateful_set_has_no_finalizers_or_timestamp_and_only_has_controller_owner_ref(spec, rabbitmq);
     helper_invariants::lemma_always_server_config_map_has_no_finalizers_or_timestamp_and_only_has_controller_owner_ref(spec, rabbitmq);
     helper_invariants::lemma_always_pending_msg_at_after_create_server_config_map_step_is_create_cm_req(spec, rabbitmq.object_ref());
@@ -580,8 +580,8 @@ proof fn sm_spec_entails_all_invariants(rabbitmq: RabbitmqClusterView)
         lift_state(RMQCluster::each_resp_if_matches_pending_req_then_no_other_resp_matches(rabbitmq.object_ref())),
         lift_state(RMQCluster::every_in_flight_msg_has_lower_id_than_allocator()),
         lift_state(RMQCluster::each_object_in_etcd_is_well_formed()),
-        lift_state(RMQCluster::each_scheduled_key_is_consistent_with_its_object()),
-        lift_state(RMQCluster::each_key_in_reconcile_is_consistent_with_its_object()),
+        lift_state(RMQCluster::each_scheduled_object_has_consistent_key_and_valid_metadata()),
+        lift_state(RMQCluster::each_object_in_reconcile_has_consistent_key_and_valid_metadata()),
         lift_state(helper_invariants::stateful_set_has_no_finalizers_or_timestamp_and_only_has_controller_owner_ref(rabbitmq)),
         lift_state(helper_invariants::server_config_map_has_no_finalizers_or_timestamp_and_only_has_controller_owner_ref(rabbitmq)),
         lift_state(helper_invariants::pending_msg_at_after_create_server_config_map_step_is_create_cm_req(rabbitmq.object_ref())),
@@ -729,7 +729,7 @@ proof fn lemma_from_scheduled_to_init_step(spec: TempPred<RMQCluster>, rabbitmq:
         spec.entails(always(lift_action(RMQCluster::next()))),
         spec.entails(tla_forall(|i| RMQCluster::controller_next().weak_fairness(i))),
         spec.entails(always(lift_state(RMQCluster::crash_disabled()))),
-        spec.entails(always(lift_state(RMQCluster::each_scheduled_key_is_consistent_with_its_object()))),
+        spec.entails(always(lift_state(RMQCluster::each_scheduled_object_has_consistent_key_and_valid_metadata()))),
         spec.entails(always(lift_state(RMQCluster::the_object_in_schedule_has_spec_and_uid_as(rabbitmq)))),
         rabbitmq.well_formed(),
     ensures
@@ -750,21 +750,21 @@ proof fn lemma_from_scheduled_to_init_step(spec: TempPred<RMQCluster>, rabbitmq:
     let stronger_next = |s, s_prime: RMQCluster| {
         &&& RMQCluster::next()(s, s_prime)
         &&& RMQCluster::crash_disabled()(s)
-        &&& RMQCluster::each_scheduled_key_is_consistent_with_its_object()(s)
+        &&& RMQCluster::each_scheduled_object_has_consistent_key_and_valid_metadata()(s)
         &&& RMQCluster::the_object_in_schedule_has_spec_and_uid_as(rabbitmq)(s)
     };
     entails_always_and_n!(
         spec,
         lift_action(RMQCluster::next()),
         lift_state(RMQCluster::crash_disabled()),
-        lift_state(RMQCluster::each_scheduled_key_is_consistent_with_its_object()),
+        lift_state(RMQCluster::each_scheduled_object_has_consistent_key_and_valid_metadata()),
         lift_state(RMQCluster::the_object_in_schedule_has_spec_and_uid_as(rabbitmq))
     );
     temp_pred_equality(
         lift_action(stronger_next),
         lift_action(RMQCluster::next())
         .and(lift_state(RMQCluster::crash_disabled()))
-        .and(lift_state(RMQCluster::each_scheduled_key_is_consistent_with_its_object()))
+        .and(lift_state(RMQCluster::each_scheduled_object_has_consistent_key_and_valid_metadata()))
         .and(lift_state(RMQCluster::the_object_in_schedule_has_spec_and_uid_as(rabbitmq)))
     );
 

--- a/src/controller_examples/rabbitmq_controller/proof/liveness/liveness.rs
+++ b/src/controller_examples/rabbitmq_controller/proof/liveness/liveness.rs
@@ -121,9 +121,6 @@ spec fn derived_invariants_since_beginning(rabbitmq: RabbitmqClusterView) -> Tem
     .and(always(lift_state(RMQCluster::each_object_in_reconcile_has_consistent_key_and_valid_metadata())))
     .and(always(lift_state(helper_invariants::stateful_set_has_no_finalizers_or_timestamp_and_only_has_controller_owner_ref(rabbitmq))))
     .and(always(lift_state(helper_invariants::server_config_map_has_no_finalizers_or_timestamp_and_only_has_controller_owner_ref(rabbitmq))))
-    .and(always(lift_state(helper_invariants::pending_msg_at_after_create_server_config_map_step_is_create_cm_req(rabbitmq.object_ref()))))
-    .and(always(lift_state(helper_invariants::pending_msg_at_after_update_server_config_map_step_is_update_cm_req(rabbitmq.object_ref()))))
-    .and(always(lift_state(helper_invariants::pending_msg_at_after_update_stateful_set_step_is_update_sts_req(rabbitmq.object_ref()))))
     .and(always(lift_state(RMQCluster::no_pending_req_msg_or_external_api_input_at_reconcile_state(rabbitmq.object_ref(), at_step_closure(RabbitmqReconcileStep::Init)))))
     .and(always(lift_state(RMQCluster::pending_req_in_flight_or_resp_in_flight_at_reconcile_state(rabbitmq.object_ref(), at_step_closure(RabbitmqReconcileStep::AfterCreateHeadlessService)))))
     .and(always(lift_state(RMQCluster::pending_req_in_flight_or_resp_in_flight_at_reconcile_state(rabbitmq.object_ref(), at_step_closure(RabbitmqReconcileStep::AfterCreateService)))))
@@ -155,9 +152,6 @@ proof fn derived_invariants_since_beginning_is_stable(rabbitmq: RabbitmqClusterV
         lift_state(RMQCluster::each_object_in_reconcile_has_consistent_key_and_valid_metadata()),
         lift_state(helper_invariants::stateful_set_has_no_finalizers_or_timestamp_and_only_has_controller_owner_ref(rabbitmq)),
         lift_state(helper_invariants::server_config_map_has_no_finalizers_or_timestamp_and_only_has_controller_owner_ref(rabbitmq)),
-        lift_state(helper_invariants::pending_msg_at_after_create_server_config_map_step_is_create_cm_req(rabbitmq.object_ref())),
-        lift_state(helper_invariants::pending_msg_at_after_update_server_config_map_step_is_update_cm_req(rabbitmq.object_ref())),
-        lift_state(helper_invariants::pending_msg_at_after_update_stateful_set_step_is_update_sts_req(rabbitmq.object_ref())),
         lift_state(RMQCluster::no_pending_req_msg_or_external_api_input_at_reconcile_state(rabbitmq.object_ref(), at_step_closure(RabbitmqReconcileStep::Init))),
         lift_state(RMQCluster::pending_req_in_flight_or_resp_in_flight_at_reconcile_state(rabbitmq.object_ref(), at_step_closure(RabbitmqReconcileStep::AfterCreateHeadlessService))),
         lift_state(RMQCluster::pending_req_in_flight_or_resp_in_flight_at_reconcile_state(rabbitmq.object_ref(), at_step_closure(RabbitmqReconcileStep::AfterCreateService))),
@@ -472,9 +466,6 @@ proof fn sm_spec_entails_all_invariants(rabbitmq: RabbitmqClusterView)
     RMQCluster::lemma_always_each_object_in_reconcile_has_consistent_key_and_valid_metadata(spec);
     helper_invariants::lemma_always_stateful_set_has_no_finalizers_or_timestamp_and_only_has_controller_owner_ref(spec, rabbitmq);
     helper_invariants::lemma_always_server_config_map_has_no_finalizers_or_timestamp_and_only_has_controller_owner_ref(spec, rabbitmq);
-    helper_invariants::lemma_always_pending_msg_at_after_create_server_config_map_step_is_create_cm_req(spec, rabbitmq.object_ref());
-    helper_invariants::lemma_always_pending_msg_at_after_update_server_config_map_step_is_update_cm_req(spec, rabbitmq.object_ref());
-    helper_invariants::lemma_always_pending_msg_at_after_update_stateful_set_step_is_update_sts_req(spec, rabbitmq.object_ref());
     RMQCluster::lemma_always_no_pending_req_msg_or_external_api_input_at_reconcile_state(spec, rabbitmq.object_ref(), at_step_closure(RabbitmqReconcileStep::Init));
     RMQCluster::lemma_always_pending_req_in_flight_or_resp_in_flight_at_reconcile_state(
         spec, rabbitmq.object_ref(), at_step_closure(RabbitmqReconcileStep::AfterCreateHeadlessService)
@@ -529,9 +520,6 @@ proof fn sm_spec_entails_all_invariants(rabbitmq: RabbitmqClusterView)
         lift_state(RMQCluster::each_object_in_reconcile_has_consistent_key_and_valid_metadata()),
         lift_state(helper_invariants::stateful_set_has_no_finalizers_or_timestamp_and_only_has_controller_owner_ref(rabbitmq)),
         lift_state(helper_invariants::server_config_map_has_no_finalizers_or_timestamp_and_only_has_controller_owner_ref(rabbitmq)),
-        lift_state(helper_invariants::pending_msg_at_after_create_server_config_map_step_is_create_cm_req(rabbitmq.object_ref())),
-        lift_state(helper_invariants::pending_msg_at_after_update_server_config_map_step_is_update_cm_req(rabbitmq.object_ref())),
-        lift_state(helper_invariants::pending_msg_at_after_update_stateful_set_step_is_update_sts_req(rabbitmq.object_ref())),
         lift_state(RMQCluster::no_pending_req_msg_or_external_api_input_at_reconcile_state(rabbitmq.object_ref(), at_step_closure(RabbitmqReconcileStep::Init))),
         lift_state(RMQCluster::pending_req_in_flight_or_resp_in_flight_at_reconcile_state(rabbitmq.object_ref(), at_step_closure(RabbitmqReconcileStep::AfterCreateHeadlessService))),
         lift_state(RMQCluster::pending_req_in_flight_or_resp_in_flight_at_reconcile_state(rabbitmq.object_ref(), at_step_closure(RabbitmqReconcileStep::AfterCreateService))),

--- a/src/controller_examples/rabbitmq_controller/proof/liveness/liveness.rs
+++ b/src/controller_examples/rabbitmq_controller/proof/liveness/liveness.rs
@@ -1344,8 +1344,7 @@ proof fn lemma_receives_ok_resp_at_after_get_stateful_set_step_with_rabbitmq(
                     &&& object.metadata.owner_references_only_contains(rabbitmq.controller_owner_ref())
                     &&& req_msg_is_the_in_flight_pending_req_at_rabbitmq_step_with_rabbitmq(RabbitmqReconcileStep::AfterGetStatefulSet, rabbitmq, req_msg)(s)
                 }
-            )
-            .leads_to(lift_state(
+            ).leads_to(lift_state(
                 |s: RMQCluster| {
                     &&& s.resource_key_exists(make_stateful_set_key(rabbitmq.object_ref()))
                     &&& s.resource_obj_of(make_stateful_set_key(rabbitmq.object_ref())) == object
@@ -1446,8 +1445,7 @@ proof fn lemma_from_after_get_stateful_set_step_to_after_update_stateful_set_ste
                 &&& resp_msg.content.get_get_response().res.is_Ok()
                 &&& resp_msg.content.get_get_response().res.get_Ok_0() == object
                 &&& object.metadata.owner_references_only_contains(rabbitmq.controller_owner_ref())
-            })
-            .leads_to(lift_state(|s: RMQCluster| {
+            }).leads_to(lift_state(|s: RMQCluster| {
                 &&& s.resource_key_exists(make_stateful_set_key(rabbitmq.object_ref()))
                 &&& s.resource_obj_of(make_stateful_set_key(rabbitmq.object_ref())) == object
                 &&& pending_req_with_object_in_flight_at_rabbitmq_step_with_rabbitmq(RabbitmqReconcileStep::AfterUpdateStatefulSet, rabbitmq, object)(s)
@@ -1519,8 +1517,7 @@ proof fn lemma_sts_is_updated_at_after_update_stateful_set_step_with_rabbitmq(
                     &&& s.resource_obj_of(make_stateful_set_key(rabbitmq.object_ref())) == object
                     &&& req_msg_is_the_in_flight_pending_req_with_object_at_rabbitmq_step_with_rabbitmq(RabbitmqReconcileStep::AfterUpdateStatefulSet, rabbitmq, req_msg, object)(s)
                 }
-            )
-            .leads_to(lift_state(
+            ).leads_to(lift_state(
                 |s: RMQCluster| {
                     &&& s.resource_key_exists(make_stateful_set_key(rabbitmq.object_ref()))
                     &&& StatefulSetView::from_dynamic_object(s.resource_obj_of(make_stateful_set_key(rabbitmq.object_ref()))).is_Ok()
@@ -1722,8 +1719,7 @@ proof fn lemma_receives_not_found_resp_at_after_get_server_config_map_step_with_
                     &&& !s.resource_key_exists(make_server_config_map_key(rabbitmq.object_ref()))
                     &&& req_msg_is_the_in_flight_pending_req_at_rabbitmq_step_with_rabbitmq(RabbitmqReconcileStep::AfterGetServerConfigMap, rabbitmq, req_msg)(s)
                 }
-            )
-            .leads_to(lift_state(
+            ).leads_to(lift_state(
                 |s: RMQCluster| {
                     &&& !s.resource_key_exists(make_server_config_map_key(rabbitmq.object_ref()))
                     &&& at_after_get_server_config_map_step_with_rabbitmq_and_exists_not_found_resp_in_flight(rabbitmq)(s)
@@ -1809,11 +1805,10 @@ proof fn lemma_from_after_get_server_config_map_step_to_after_create_server_conf
                 &&& resp_msg_is_the_in_flight_resp_at_rabbitmq_step_with_rabbitmq(RabbitmqReconcileStep::AfterGetServerConfigMap, rabbitmq, resp_msg)(s)
                 &&& resp_msg.content.get_get_response().res.is_Err()
                 &&& resp_msg.content.get_get_response().res.get_Err_0().is_ObjectNotFound()
-            })
-                .leads_to(lift_state(|s: RMQCluster| {
-                    &&& !s.resource_key_exists(make_server_config_map_key(rabbitmq.object_ref()))
-                    &&& pending_req_in_flight_at_rabbitmq_step_with_rabbitmq(RabbitmqReconcileStep::AfterCreateServerConfigMap, rabbitmq)(s)
-                }))
+            }).leads_to(lift_state(|s: RMQCluster| {
+                &&& !s.resource_key_exists(make_server_config_map_key(rabbitmq.object_ref()))
+                &&& pending_req_in_flight_at_rabbitmq_step_with_rabbitmq(RabbitmqReconcileStep::AfterCreateServerConfigMap, rabbitmq)(s)
+            }))
         ),
 {
     let pre = |s: RMQCluster| {
@@ -1870,14 +1865,13 @@ proof fn lemma_cm_is_created_at_after_create_server_config_map_step_with_rabbitm
                     &&& !s.resource_key_exists(make_server_config_map_key(rabbitmq.object_ref()))
                     &&& req_msg_is_the_in_flight_pending_req_at_rabbitmq_step_with_rabbitmq(RabbitmqReconcileStep::AfterCreateServerConfigMap, rabbitmq, req_msg)(s)
                 }
-            )
-                .leads_to(lift_state(
-                    |s: RMQCluster| {
-                        &&& s.resource_key_exists(make_server_config_map_key(rabbitmq.object_ref()))
-                        &&& ConfigMapView::from_dynamic_object(s.resource_obj_of(make_server_config_map_key(rabbitmq.object_ref()))).is_Ok()
-                        &&& ConfigMapView::from_dynamic_object(s.resource_obj_of(make_server_config_map_key(rabbitmq.object_ref()))).get_Ok_0().data == make_server_config_map(rabbitmq).data
-                    }
-                ))
+            ).leads_to(lift_state(
+                |s: RMQCluster| {
+                    &&& s.resource_key_exists(make_server_config_map_key(rabbitmq.object_ref()))
+                    &&& ConfigMapView::from_dynamic_object(s.resource_obj_of(make_server_config_map_key(rabbitmq.object_ref()))).is_Ok()
+                    &&& ConfigMapView::from_dynamic_object(s.resource_obj_of(make_server_config_map_key(rabbitmq.object_ref()))).get_Ok_0().data == make_server_config_map(rabbitmq).data
+                }
+            ))
         ),
 {
     let pre = |s: RMQCluster| {
@@ -1944,8 +1938,7 @@ proof fn lemma_receives_not_found_resp_at_after_get_stateful_set_step_with_rabbi
                     &&& !s.resource_key_exists(make_stateful_set_key(rabbitmq.object_ref()))
                     &&& req_msg_is_the_in_flight_pending_req_at_rabbitmq_step_with_rabbitmq(RabbitmqReconcileStep::AfterGetStatefulSet, rabbitmq, req_msg)(s)
                 }
-            )
-            .leads_to(lift_state(
+            ).leads_to(lift_state(
                 |s: RMQCluster| {
                     &&& !s.resource_key_exists(make_stateful_set_key(rabbitmq.object_ref()))
                     &&& at_after_get_stateful_set_step_with_rabbitmq_and_exists_not_found_resp_in_flight(rabbitmq)(s)
@@ -2031,11 +2024,10 @@ proof fn lemma_from_after_get_stateful_set_step_to_after_create_stateful_set_ste
                 &&& resp_msg_is_the_in_flight_resp_at_rabbitmq_step_with_rabbitmq(RabbitmqReconcileStep::AfterGetStatefulSet, rabbitmq, resp_msg)(s)
                 &&& resp_msg.content.get_get_response().res.is_Err()
                 &&& resp_msg.content.get_get_response().res.get_Err_0().is_ObjectNotFound()
-            })
-                .leads_to(lift_state(|s: RMQCluster| {
-                    &&& !s.resource_key_exists(make_stateful_set_key(rabbitmq.object_ref()))
-                    &&& pending_req_in_flight_at_rabbitmq_step_with_rabbitmq(RabbitmqReconcileStep::AfterCreateStatefulSet, rabbitmq)(s)
-                }))
+            }).leads_to(lift_state(|s: RMQCluster| {
+                &&& !s.resource_key_exists(make_stateful_set_key(rabbitmq.object_ref()))
+                &&& pending_req_in_flight_at_rabbitmq_step_with_rabbitmq(RabbitmqReconcileStep::AfterCreateStatefulSet, rabbitmq)(s)
+            }))
         ),
 {
     let pre = |s: RMQCluster| {
@@ -2092,14 +2084,13 @@ proof fn lemma_sts_is_created_at_after_create_stateful_set_step_with_rabbitmq(
                     &&& !s.resource_key_exists(make_stateful_set_key(rabbitmq.object_ref()))
                     &&& req_msg_is_the_in_flight_pending_req_at_rabbitmq_step_with_rabbitmq(RabbitmqReconcileStep::AfterCreateStatefulSet, rabbitmq, req_msg)(s)
                 }
-            )
-                .leads_to(lift_state(
-                    |s: RMQCluster| {
-                        &&& s.resource_key_exists(make_stateful_set_key(rabbitmq.object_ref()))
-                        &&& StatefulSetView::from_dynamic_object(s.resource_obj_of(make_stateful_set_key(rabbitmq.object_ref()))).is_Ok()
-                        &&& StatefulSetView::from_dynamic_object(s.resource_obj_of(make_stateful_set_key(rabbitmq.object_ref()))).get_Ok_0().spec == make_stateful_set(rabbitmq).spec
-                    }
-                ))
+            ).leads_to(lift_state(
+                |s: RMQCluster| {
+                    &&& s.resource_key_exists(make_stateful_set_key(rabbitmq.object_ref()))
+                    &&& StatefulSetView::from_dynamic_object(s.resource_obj_of(make_stateful_set_key(rabbitmq.object_ref()))).is_Ok()
+                    &&& StatefulSetView::from_dynamic_object(s.resource_obj_of(make_stateful_set_key(rabbitmq.object_ref()))).get_Ok_0().spec == make_stateful_set(rabbitmq).spec
+                }
+            ))
         ),
 {
     let pre = |s: RMQCluster| {
@@ -2345,14 +2336,13 @@ proof fn lemma_receives_ok_resp_at_after_get_server_config_map_step_with_rabbitm
                     &&& s.resource_obj_of(make_server_config_map_key(rabbitmq.object_ref())) == object
                     &&& req_msg_is_the_in_flight_pending_req_at_rabbitmq_step_with_rabbitmq(RabbitmqReconcileStep::AfterGetServerConfigMap, rabbitmq, req_msg)(s)
                 }
-            )
-                .leads_to(lift_state(
-                    |s: RMQCluster| {
-                        &&& s.resource_key_exists(make_server_config_map_key(rabbitmq.object_ref()))
-                        &&& s.resource_obj_of(make_server_config_map_key(rabbitmq.object_ref())) == object
-                        &&& at_after_get_server_config_map_step_with_rabbitmq_and_exists_ok_resp_in_flight(rabbitmq, object)(s)
-                    }
-                ))
+            ).leads_to(lift_state(
+                |s: RMQCluster| {
+                    &&& s.resource_key_exists(make_server_config_map_key(rabbitmq.object_ref()))
+                    &&& s.resource_obj_of(make_server_config_map_key(rabbitmq.object_ref())) == object
+                    &&& at_after_get_server_config_map_step_with_rabbitmq_and_exists_ok_resp_in_flight(rabbitmq, object)(s)
+                }
+            ))
         ),
 {
     let pre = |s: RMQCluster| {

--- a/src/controller_examples/rabbitmq_controller/proof/liveness/liveness.rs
+++ b/src/controller_examples/rabbitmq_controller/proof/liveness/liveness.rs
@@ -753,19 +753,12 @@ proof fn lemma_from_scheduled_to_init_step(spec: TempPred<RMQCluster>, rabbitmq:
         &&& RMQCluster::each_scheduled_object_has_consistent_key_and_valid_metadata()(s)
         &&& RMQCluster::the_object_in_schedule_has_spec_and_uid_as(rabbitmq)(s)
     };
-    entails_always_and_n!(
-        spec,
+    combine_spec_entails_always_n!(
+        spec, lift_action(stronger_next),
         lift_action(RMQCluster::next()),
         lift_state(RMQCluster::crash_disabled()),
         lift_state(RMQCluster::each_scheduled_object_has_consistent_key_and_valid_metadata()),
         lift_state(RMQCluster::the_object_in_schedule_has_spec_and_uid_as(rabbitmq))
-    );
-    temp_pred_equality(
-        lift_action(stronger_next),
-        lift_action(RMQCluster::next())
-        .and(lift_state(RMQCluster::crash_disabled()))
-        .and(lift_state(RMQCluster::each_scheduled_object_has_consistent_key_and_valid_metadata()))
-        .and(lift_state(RMQCluster::the_object_in_schedule_has_spec_and_uid_as(rabbitmq)))
     );
 
     RMQCluster::lemma_pre_leads_to_post_by_controller(
@@ -795,15 +788,10 @@ proof fn lemma_from_init_step_to_after_create_headless_service_step(
         &&& RMQCluster::next()(s, s_prime)
         &&& RMQCluster::crash_disabled()(s)
     };
-    entails_always_and_n!(
-        spec,
+    combine_spec_entails_always_n!(
+        spec, lift_action(stronger_next),
         lift_action(RMQCluster::next()),
         lift_state(RMQCluster::crash_disabled())
-    );
-    temp_pred_equality(
-        lift_action(stronger_next),
-        lift_action(RMQCluster::next())
-        .and(lift_state(RMQCluster::crash_disabled()))
     );
 
     assert forall |s, s_prime| pre(s) && #[trigger] stronger_next(s, s_prime) implies pre(s_prime) || post(s_prime) by {
@@ -965,19 +953,12 @@ proof fn lemma_receives_some_resp_at_rabbitmq_step_with_rabbitmq(
         &&& RMQCluster::busy_disabled()(s)
         &&& RMQCluster::every_in_flight_msg_has_unique_id()(s)
     };
-    entails_always_and_n!(
-        spec,
+    combine_spec_entails_always_n!(
+        spec, lift_action(stronger_next),
         lift_action(RMQCluster::next()),
         lift_state(RMQCluster::crash_disabled()),
         lift_state(RMQCluster::busy_disabled()),
         lift_state(RMQCluster::every_in_flight_msg_has_unique_id())
-    );
-    temp_pred_equality(
-        lift_action(stronger_next),
-        lift_action(RMQCluster::next())
-        .and(lift_state(RMQCluster::crash_disabled()))
-        .and(lift_state(RMQCluster::busy_disabled()))
-        .and(lift_state(RMQCluster::every_in_flight_msg_has_unique_id()))
     );
 
     assert forall |s, s_prime| pre(s) && #[trigger] stronger_next(s, s_prime) && RMQCluster::kubernetes_api_next().forward(input)(s, s_prime)
@@ -1044,19 +1025,12 @@ proof fn lemma_from_resp_in_flight_at_some_step_to_pending_req_in_flight_at_next
         &&& RMQCluster::each_resp_matches_at_most_one_pending_req(rabbitmq.object_ref())(s)
     };
 
-    entails_always_and_n!(
-        spec,
+    combine_spec_entails_always_n!(
+        spec, lift_action(stronger_next),
         lift_action(RMQCluster::next()),
         lift_state(RMQCluster::crash_disabled()),
         lift_state(RMQCluster::busy_disabled()),
         lift_state(RMQCluster::each_resp_matches_at_most_one_pending_req(rabbitmq.object_ref()))
-    );
-    temp_pred_equality(
-        lift_action(stronger_next),
-        lift_action(RMQCluster::next())
-        .and(lift_state(RMQCluster::crash_disabled()))
-        .and(lift_state(RMQCluster::busy_disabled()))
-        .and(lift_state(RMQCluster::each_resp_matches_at_most_one_pending_req(rabbitmq.object_ref())))
     );
 
     assert forall |s, s_prime| pre(s) && #[trigger] stronger_next(s, s_prime) implies pre(s_prime) || post(s_prime) by {
@@ -1466,23 +1440,14 @@ proof fn lemma_receives_ok_resp_at_after_get_stateful_set_step_with_rabbitmq(
         &&& helper_invariants::at_most_one_update_sts_req_is_in_flight(rabbitmq.object_ref())(s)
         &&& helper_invariants::no_delete_sts_req_is_in_flight(rabbitmq.object_ref())(s)
     };
-    entails_always_and_n!(
-        spec,
+    combine_spec_entails_always_n!(
+        spec, lift_action(stronger_next),
         lift_action(RMQCluster::next()),
         lift_state(RMQCluster::crash_disabled()),
         lift_state(RMQCluster::busy_disabled()),
         lift_state(RMQCluster::every_in_flight_msg_has_unique_id()),
         lift_state(helper_invariants::at_most_one_update_sts_req_is_in_flight(rabbitmq.object_ref())),
         lift_state(helper_invariants::no_delete_sts_req_is_in_flight(rabbitmq.object_ref()))
-    );
-    temp_pred_equality(
-        lift_action(stronger_next),
-        lift_action(RMQCluster::next())
-        .and(lift_state(RMQCluster::crash_disabled()))
-        .and(lift_state(RMQCluster::busy_disabled()))
-        .and(lift_state(RMQCluster::every_in_flight_msg_has_unique_id()))
-        .and(lift_state(helper_invariants::at_most_one_update_sts_req_is_in_flight(rabbitmq.object_ref())))
-        .and(lift_state(helper_invariants::no_delete_sts_req_is_in_flight(rabbitmq.object_ref())))
     );
 
     assert forall |s, s_prime| pre(s) && #[trigger] stronger_next(s, s_prime) implies pre(s_prime) || post(s_prime) by {
@@ -1577,8 +1542,8 @@ proof fn lemma_from_after_get_stateful_set_step_to_after_update_stateful_set_ste
         &&& helper_invariants::no_delete_sts_req_is_in_flight(rabbitmq.object_ref())(s)
     };
 
-    entails_always_and_n!(
-        spec,
+    combine_spec_entails_always_n!(
+        spec, lift_action(stronger_next),
         lift_action(RMQCluster::next()),
         lift_state(RMQCluster::crash_disabled()),
         lift_state(RMQCluster::busy_disabled()),
@@ -1587,17 +1552,6 @@ proof fn lemma_from_after_get_stateful_set_step_to_after_update_stateful_set_ste
         lift_state(RMQCluster::each_object_in_etcd_is_well_formed()),
         lift_state(helper_invariants::at_most_one_update_sts_req_is_in_flight(rabbitmq.object_ref())),
         lift_state(helper_invariants::no_delete_sts_req_is_in_flight(rabbitmq.object_ref()))
-    );
-    temp_pred_equality(
-        lift_action(stronger_next),
-        lift_action(RMQCluster::next())
-        .and(lift_state(RMQCluster::crash_disabled()))
-        .and(lift_state(RMQCluster::busy_disabled()))
-        .and(lift_state(RMQCluster::each_resp_matches_at_most_one_pending_req(rabbitmq.object_ref())))
-        .and(lift_state(RMQCluster::each_resp_if_matches_pending_req_then_no_other_resp_matches(rabbitmq.object_ref())))
-        .and(lift_state(RMQCluster::each_object_in_etcd_is_well_formed()))
-        .and(lift_state(helper_invariants::at_most_one_update_sts_req_is_in_flight(rabbitmq.object_ref())))
-        .and(lift_state(helper_invariants::no_delete_sts_req_is_in_flight(rabbitmq.object_ref())))
     );
 
     RMQCluster::lemma_pre_leads_to_post_by_controller(spec, input, stronger_next, RMQCluster::continue_reconcile(), pre, post);
@@ -1656,8 +1610,8 @@ proof fn lemma_sts_is_updated_at_after_update_stateful_set_step_with_rabbitmq(
         &&& helper_invariants::no_delete_sts_req_is_in_flight(rabbitmq.object_ref())(s)
         &&& helper_invariants::stateful_set_has_no_finalizers_or_timestamp_and_only_has_controller_owner_ref(rabbitmq)(s)
     };
-    entails_always_and_n!(
-        spec,
+    combine_spec_entails_always_n!(
+        spec, lift_action(stronger_next),
         lift_action(RMQCluster::next()),
         lift_state(RMQCluster::crash_disabled()),
         lift_state(RMQCluster::busy_disabled()),
@@ -1666,17 +1620,6 @@ proof fn lemma_sts_is_updated_at_after_update_stateful_set_step_with_rabbitmq(
         lift_state(helper_invariants::at_most_one_update_sts_req_is_in_flight(rabbitmq.object_ref())),
         lift_state(helper_invariants::no_delete_sts_req_is_in_flight(rabbitmq.object_ref())),
         lift_state(helper_invariants::stateful_set_has_no_finalizers_or_timestamp_and_only_has_controller_owner_ref(rabbitmq))
-    );
-    temp_pred_equality(
-        lift_action(stronger_next),
-        lift_action(RMQCluster::next())
-        .and(lift_state(RMQCluster::crash_disabled()))
-        .and(lift_state(RMQCluster::busy_disabled()))
-        .and(lift_state(RMQCluster::every_in_flight_msg_has_unique_id()))
-        .and(lift_state(RMQCluster::each_object_in_etcd_is_well_formed()))
-        .and(lift_state(helper_invariants::at_most_one_update_sts_req_is_in_flight(rabbitmq.object_ref())))
-        .and(lift_state(helper_invariants::no_delete_sts_req_is_in_flight(rabbitmq.object_ref())))
-        .and(lift_state(helper_invariants::stateful_set_has_no_finalizers_or_timestamp_and_only_has_controller_owner_ref(rabbitmq)))
     );
 
     assert forall |s, s_prime| pre(s) && #[trigger] stronger_next(s, s_prime) implies pre(s_prime) || post(s_prime) by {
@@ -1862,21 +1805,13 @@ proof fn lemma_receives_not_found_resp_at_after_get_server_config_map_step_with_
         &&& RMQCluster::every_in_flight_msg_has_unique_id()(s)
         &&& helper_invariants::at_most_one_create_cm_req_is_in_flight(rabbitmq.object_ref())(s)
     };
-    entails_always_and_n!(
-        spec,
+    combine_spec_entails_always_n!(
+        spec, lift_action(stronger_next),
         lift_action(RMQCluster::next()),
         lift_state(RMQCluster::crash_disabled()),
         lift_state(RMQCluster::busy_disabled()),
         lift_state(RMQCluster::every_in_flight_msg_has_unique_id()),
         lift_state(helper_invariants::at_most_one_create_cm_req_is_in_flight(rabbitmq.object_ref()))
-    );
-    temp_pred_equality(
-        lift_action(stronger_next),
-        lift_action(RMQCluster::next())
-        .and(lift_state(RMQCluster::crash_disabled()))
-        .and(lift_state(RMQCluster::busy_disabled()))
-        .and(lift_state(RMQCluster::every_in_flight_msg_has_unique_id()))
-        .and(lift_state(helper_invariants::at_most_one_create_cm_req_is_in_flight(rabbitmq.object_ref())))
     );
 
     assert forall |s, s_prime| pre(s) && #[trigger] stronger_next(s, s_prime) implies pre(s_prime) || post(s_prime) by {
@@ -1957,21 +1892,13 @@ proof fn lemma_from_after_get_server_config_map_step_to_after_create_server_conf
         &&& helper_invariants::at_most_one_create_cm_req_is_in_flight(rabbitmq.object_ref())(s)
     };
 
-    entails_always_and_n!(
-        spec,
+    combine_spec_entails_always_n!(
+        spec, lift_action(stronger_next),
         lift_action(RMQCluster::next()),
         lift_state(RMQCluster::crash_disabled()),
         lift_state(RMQCluster::each_resp_matches_at_most_one_pending_req(rabbitmq.object_ref())),
         lift_state(RMQCluster::each_resp_if_matches_pending_req_then_no_other_resp_matches(rabbitmq.object_ref())),
         lift_state(helper_invariants::at_most_one_create_cm_req_is_in_flight(rabbitmq.object_ref()))
-    );
-    temp_pred_equality(
-        lift_action(stronger_next),
-        lift_action(RMQCluster::next())
-        .and(lift_state(RMQCluster::crash_disabled()))
-        .and(lift_state(RMQCluster::each_resp_matches_at_most_one_pending_req(rabbitmq.object_ref())))
-        .and(lift_state(RMQCluster::each_resp_if_matches_pending_req_then_no_other_resp_matches(rabbitmq.object_ref())))
-        .and(lift_state(helper_invariants::at_most_one_create_cm_req_is_in_flight(rabbitmq.object_ref())))
     );
 
     RMQCluster::lemma_pre_leads_to_post_by_controller(
@@ -2025,21 +1952,13 @@ proof fn lemma_cm_is_created_at_after_create_server_config_map_step_with_rabbitm
         &&& RMQCluster::every_in_flight_msg_has_unique_id()(s)
         &&& helper_invariants::at_most_one_create_cm_req_is_in_flight(rabbitmq.object_ref())(s)
     };
-    entails_always_and_n!(
-        spec,
+    combine_spec_entails_always_n!(
+        spec, lift_action(stronger_next),
         lift_action(RMQCluster::next()),
         lift_state(RMQCluster::crash_disabled()),
         lift_state(RMQCluster::busy_disabled()),
         lift_state(RMQCluster::every_in_flight_msg_has_unique_id()),
         lift_state(helper_invariants::at_most_one_create_cm_req_is_in_flight(rabbitmq.object_ref()))
-    );
-    temp_pred_equality(
-        lift_action(stronger_next),
-        lift_action(RMQCluster::next())
-        .and(lift_state(RMQCluster::crash_disabled()))
-        .and(lift_state(RMQCluster::busy_disabled()))
-        .and(lift_state(RMQCluster::every_in_flight_msg_has_unique_id()))
-        .and(lift_state(helper_invariants::at_most_one_create_cm_req_is_in_flight(rabbitmq.object_ref())))
     );
 
     assert forall |s, s_prime| pre(s) && #[trigger] stronger_next(s, s_prime) implies pre(s_prime) || post(s_prime) by {
@@ -2105,21 +2024,13 @@ proof fn lemma_receives_not_found_resp_at_after_get_stateful_set_step_with_rabbi
         &&& RMQCluster::every_in_flight_msg_has_unique_id()(s)
         &&& helper_invariants::at_most_one_create_sts_req_is_in_flight(rabbitmq.object_ref())(s)
     };
-    entails_always_and_n!(
-        spec,
+    combine_spec_entails_always_n!(
+        spec, lift_action(stronger_next),
         lift_action(RMQCluster::next()),
         lift_state(RMQCluster::crash_disabled()),
         lift_state(RMQCluster::busy_disabled()),
         lift_state(RMQCluster::every_in_flight_msg_has_unique_id()),
         lift_state(helper_invariants::at_most_one_create_sts_req_is_in_flight(rabbitmq.object_ref()))
-    );
-    temp_pred_equality(
-        lift_action(stronger_next),
-        lift_action(RMQCluster::next())
-        .and(lift_state(RMQCluster::crash_disabled()))
-        .and(lift_state(RMQCluster::busy_disabled()))
-        .and(lift_state(RMQCluster::every_in_flight_msg_has_unique_id()))
-        .and(lift_state(helper_invariants::at_most_one_create_sts_req_is_in_flight(rabbitmq.object_ref())))
     );
 
     assert forall |s, s_prime| pre(s) && #[trigger] stronger_next(s, s_prime) implies pre(s_prime) || post(s_prime) by {
@@ -2200,21 +2111,13 @@ proof fn lemma_from_after_get_stateful_set_step_to_after_create_stateful_set_ste
         &&& helper_invariants::at_most_one_create_sts_req_is_in_flight(rabbitmq.object_ref())(s)
     };
 
-    entails_always_and_n!(
-        spec,
+    combine_spec_entails_always_n!(
+        spec, lift_action(stronger_next),
         lift_action(RMQCluster::next()),
         lift_state(RMQCluster::crash_disabled()),
         lift_state(RMQCluster::each_resp_matches_at_most_one_pending_req(rabbitmq.object_ref())),
         lift_state(RMQCluster::each_resp_if_matches_pending_req_then_no_other_resp_matches(rabbitmq.object_ref())),
         lift_state(helper_invariants::at_most_one_create_sts_req_is_in_flight(rabbitmq.object_ref()))
-    );
-    temp_pred_equality(
-        lift_action(stronger_next),
-        lift_action(RMQCluster::next())
-        .and(lift_state(RMQCluster::crash_disabled()))
-        .and(lift_state(RMQCluster::each_resp_matches_at_most_one_pending_req(rabbitmq.object_ref())))
-        .and(lift_state(RMQCluster::each_resp_if_matches_pending_req_then_no_other_resp_matches(rabbitmq.object_ref())))
-        .and(lift_state(helper_invariants::at_most_one_create_sts_req_is_in_flight(rabbitmq.object_ref())))
     );
 
     RMQCluster::lemma_pre_leads_to_post_by_controller(
@@ -2268,21 +2171,13 @@ proof fn lemma_sts_is_created_at_after_create_stateful_set_step_with_rabbitmq(
         &&& RMQCluster::every_in_flight_msg_has_unique_id()(s)
         &&& helper_invariants::at_most_one_create_sts_req_is_in_flight(rabbitmq.object_ref())(s)
     };
-    entails_always_and_n!(
-        spec,
+    combine_spec_entails_always_n!(
+        spec, lift_action(stronger_next),
         lift_action(RMQCluster::next()),
         lift_state(RMQCluster::crash_disabled()),
         lift_state(RMQCluster::busy_disabled()),
         lift_state(RMQCluster::every_in_flight_msg_has_unique_id()),
         lift_state(helper_invariants::at_most_one_create_sts_req_is_in_flight(rabbitmq.object_ref()))
-    );
-    temp_pred_equality(
-        lift_action(stronger_next),
-        lift_action(RMQCluster::next())
-        .and(lift_state(RMQCluster::crash_disabled()))
-        .and(lift_state(RMQCluster::busy_disabled()))
-        .and(lift_state(RMQCluster::every_in_flight_msg_has_unique_id()))
-        .and(lift_state(helper_invariants::at_most_one_create_sts_req_is_in_flight(rabbitmq.object_ref())))
     );
 
     assert forall |s, s_prime| pre(s) && #[trigger] stronger_next(s, s_prime) implies pre(s_prime) || post(s_prime) by {
@@ -2531,23 +2426,14 @@ proof fn lemma_receives_ok_resp_at_after_get_server_config_map_step_with_rabbitm
         &&& helper_invariants::at_most_one_update_cm_req_is_in_flight(rabbitmq.object_ref())(s)
         &&& helper_invariants::no_delete_cm_req_is_in_flight(rabbitmq.object_ref())(s)
     };
-    entails_always_and_n!(
-        spec,
+    combine_spec_entails_always_n!(
+        spec, lift_action(stronger_next),
         lift_action(RMQCluster::next()),
         lift_state(RMQCluster::crash_disabled()),
         lift_state(RMQCluster::busy_disabled()),
         lift_state(RMQCluster::every_in_flight_msg_has_unique_id()),
         lift_state(helper_invariants::at_most_one_update_cm_req_is_in_flight(rabbitmq.object_ref())),
         lift_state(helper_invariants::no_delete_cm_req_is_in_flight(rabbitmq.object_ref()))
-    );
-    temp_pred_equality(
-        lift_action(stronger_next),
-        lift_action(RMQCluster::next())
-        .and(lift_state(RMQCluster::crash_disabled()))
-        .and(lift_state(RMQCluster::busy_disabled()))
-        .and(lift_state(RMQCluster::every_in_flight_msg_has_unique_id()))
-        .and(lift_state(helper_invariants::at_most_one_update_cm_req_is_in_flight(rabbitmq.object_ref())))
-        .and(lift_state(helper_invariants::no_delete_cm_req_is_in_flight(rabbitmq.object_ref())))
     );
 
     assert forall |s, s_prime| pre(s) && #[trigger] stronger_next(s, s_prime) implies pre(s_prime) || post(s_prime) by {
@@ -2637,8 +2523,8 @@ proof fn lemma_cm_is_updated_at_after_update_server_config_map_step_with_rabbitm
         &&& helper_invariants::no_delete_cm_req_is_in_flight(rabbitmq.object_ref())(s)
         &&& helper_invariants::server_config_map_has_no_finalizers_or_timestamp_and_only_has_controller_owner_ref(rabbitmq)(s)
     };
-    entails_always_and_n!(
-        spec,
+    combine_spec_entails_always_n!(
+        spec, lift_action(stronger_next),
         lift_action(RMQCluster::next()),
         lift_state(RMQCluster::crash_disabled()),
         lift_state(RMQCluster::busy_disabled()),
@@ -2647,17 +2533,6 @@ proof fn lemma_cm_is_updated_at_after_update_server_config_map_step_with_rabbitm
         lift_state(helper_invariants::at_most_one_update_cm_req_is_in_flight(rabbitmq.object_ref())),
         lift_state(helper_invariants::no_delete_cm_req_is_in_flight(rabbitmq.object_ref())),
         lift_state(helper_invariants::server_config_map_has_no_finalizers_or_timestamp_and_only_has_controller_owner_ref(rabbitmq))
-    );
-    temp_pred_equality(
-        lift_action(stronger_next),
-        lift_action(RMQCluster::next())
-        .and(lift_state(RMQCluster::crash_disabled()))
-        .and(lift_state(RMQCluster::busy_disabled()))
-        .and(lift_state(RMQCluster::every_in_flight_msg_has_unique_id()))
-        .and(lift_state(RMQCluster::each_object_in_etcd_is_well_formed()))
-        .and(lift_state(helper_invariants::at_most_one_update_cm_req_is_in_flight(rabbitmq.object_ref())))
-        .and(lift_state(helper_invariants::no_delete_cm_req_is_in_flight(rabbitmq.object_ref())))
-        .and(lift_state(helper_invariants::server_config_map_has_no_finalizers_or_timestamp_and_only_has_controller_owner_ref(rabbitmq)))
     );
 
     assert forall |s, s_prime| pre(s) && #[trigger] stronger_next(s, s_prime) implies pre(s_prime) || post(s_prime) by {
@@ -2734,8 +2609,8 @@ proof fn lemma_from_after_get_server_config_map_step_to_after_update_server_conf
         &&& helper_invariants::no_delete_cm_req_is_in_flight(rabbitmq.object_ref())(s)
     };
 
-    entails_always_and_n!(
-        spec,
+    combine_spec_entails_always_n!(
+        spec, lift_action(stronger_next),
         lift_action(RMQCluster::next()),
         lift_state(RMQCluster::crash_disabled()),
         lift_state(RMQCluster::busy_disabled()),
@@ -2744,17 +2619,6 @@ proof fn lemma_from_after_get_server_config_map_step_to_after_update_server_conf
         lift_state(RMQCluster::each_object_in_etcd_is_well_formed()),
         lift_state(helper_invariants::at_most_one_update_cm_req_is_in_flight(rabbitmq.object_ref())),
         lift_state(helper_invariants::no_delete_cm_req_is_in_flight(rabbitmq.object_ref()))
-    );
-    temp_pred_equality(
-        lift_action(stronger_next),
-        lift_action(RMQCluster::next())
-        .and(lift_state(RMQCluster::crash_disabled()))
-        .and(lift_state(RMQCluster::busy_disabled()))
-        .and(lift_state(RMQCluster::each_resp_matches_at_most_one_pending_req(rabbitmq.object_ref())))
-        .and(lift_state(RMQCluster::each_resp_if_matches_pending_req_then_no_other_resp_matches(rabbitmq.object_ref())))
-        .and(lift_state(RMQCluster::each_object_in_etcd_is_well_formed()))
-        .and(lift_state(helper_invariants::at_most_one_update_cm_req_is_in_flight(rabbitmq.object_ref())))
-        .and(lift_state(helper_invariants::no_delete_cm_req_is_in_flight(rabbitmq.object_ref())))
     );
 
     RMQCluster::lemma_pre_leads_to_post_by_controller(
@@ -2783,19 +2647,12 @@ proof fn lemma_server_config_map_is_stable(
         &&& helper_invariants::every_update_cm_req_does_the_same(rabbitmq)(s)
         &&& helper_invariants::server_config_map_has_no_finalizers_or_timestamp_and_only_has_controller_owner_ref(rabbitmq)(s)
     };
-    entails_always_and_n!(
-        spec,
+    combine_spec_entails_always_n!(
+        spec, lift_action(stronger_next),
         lift_action(RMQCluster::next()),
         lift_state(helper_invariants::no_delete_cm_req_is_in_flight(rabbitmq.object_ref())),
         lift_state(helper_invariants::every_update_cm_req_does_the_same(rabbitmq)),
         lift_state(helper_invariants::server_config_map_has_no_finalizers_or_timestamp_and_only_has_controller_owner_ref(rabbitmq))
-    );
-    temp_pred_equality(
-        lift_action(stronger_next),
-        lift_action(RMQCluster::next())
-        .and(lift_state(helper_invariants::no_delete_cm_req_is_in_flight(rabbitmq.object_ref())))
-        .and(lift_state(helper_invariants::every_update_cm_req_does_the_same(rabbitmq)))
-        .and(lift_state(helper_invariants::server_config_map_has_no_finalizers_or_timestamp_and_only_has_controller_owner_ref(rabbitmq)))
     );
 
     assert forall |s, s_prime| post(s) && #[trigger] stronger_next(s, s_prime) implies post(s_prime) by {
@@ -2824,19 +2681,12 @@ proof fn lemma_stateful_set_is_stable(
         &&& helper_invariants::every_update_sts_req_does_the_same(rabbitmq)(s)
         &&& helper_invariants::stateful_set_has_no_finalizers_or_timestamp_and_only_has_controller_owner_ref(rabbitmq)(s)
     };
-    entails_always_and_n!(
-        spec,
+    combine_spec_entails_always_n!(
+        spec, lift_action(stronger_next),
         lift_action(RMQCluster::next()),
         lift_state(helper_invariants::no_delete_sts_req_is_in_flight(rabbitmq.object_ref())),
         lift_state(helper_invariants::every_update_sts_req_does_the_same(rabbitmq)),
         lift_state(helper_invariants::stateful_set_has_no_finalizers_or_timestamp_and_only_has_controller_owner_ref(rabbitmq))
-    );
-    temp_pred_equality(
-        lift_action(stronger_next),
-        lift_action(RMQCluster::next())
-        .and(lift_state(helper_invariants::no_delete_sts_req_is_in_flight(rabbitmq.object_ref())))
-        .and(lift_state(helper_invariants::every_update_sts_req_does_the_same(rabbitmq)))
-        .and(lift_state(helper_invariants::stateful_set_has_no_finalizers_or_timestamp_and_only_has_controller_owner_ref(rabbitmq)))
     );
 
     assert forall |s, s_prime| post(s) && #[trigger] stronger_next(s, s_prime) implies post(s_prime) by {

--- a/src/controller_examples/rabbitmq_controller/proof/liveness/liveness.rs
+++ b/src/controller_examples/rabbitmq_controller/proof/liveness/liveness.rs
@@ -1370,7 +1370,7 @@ proof fn lemma_from_after_get_stateful_set_and_key_exists_to_rabbitmq_matches(ra
     }
     leads_to_exists_intro(spec, pre_with_object, lift_state(current_stateful_set_matches(rabbitmq)));
     assert_by(
-        lift_state(helper_invariants::stateful_set_has_owner_reference_pointing_to_current_cr(rabbitmq)).entails(pre.implies(tla_exists(pre_with_object))),
+        pre.and(lift_state(helper_invariants::stateful_set_has_owner_reference_pointing_to_current_cr(rabbitmq))).entails(tla_exists(pre_with_object)),
         {
             assert forall |ex| #[trigger] lift_state(helper_invariants::stateful_set_has_owner_reference_pointing_to_current_cr(rabbitmq)).satisfied_by(ex) implies pre.implies(tla_exists(pre_with_object)).satisfied_by(ex) by {
                 if pre.satisfied_by(ex) {
@@ -1381,10 +1381,14 @@ proof fn lemma_from_after_get_stateful_set_and_key_exists_to_rabbitmq_matches(ra
             }
         }
     );
-    implies_with_spec_to_leads_to(
-        spec, lift_state(helper_invariants::stateful_set_has_owner_reference_pointing_to_current_cr(rabbitmq)),
-        pre, tla_exists(pre_with_object), lift_state(current_stateful_set_matches(rabbitmq))
+    valid_implies_implies_leads_to(
+        spec, pre.and(lift_state(helper_invariants::stateful_set_has_owner_reference_pointing_to_current_cr(rabbitmq))), tla_exists(pre_with_object)
     );
+    borrow_conditions_from_spec(
+        spec, lift_state(helper_invariants::stateful_set_has_owner_reference_pointing_to_current_cr(rabbitmq)), 
+        pre, tla_exists(pre_with_object)
+    );
+    leads_to_trans_temp(spec, pre, tla_exists(pre_with_object), lift_state(current_stateful_set_matches(rabbitmq)));
 }
 
 proof fn lemma_receives_ok_resp_at_after_get_stateful_set_step_with_rabbitmq(

--- a/src/controller_examples/rabbitmq_controller/proof/liveness/terminate.rs
+++ b/src/controller_examples/rabbitmq_controller/proof/liveness/terminate.rs
@@ -58,23 +58,17 @@ pub proof fn reconcile_eventually_terminates(spec: TempPred<RMQCluster>, rabbitm
     );
     RMQCluster::lemma_from_some_state_to_arbitrary_next_state_to_reconcile_idle(spec, rabbitmq, at_step_closure(RabbitmqReconcileStep::AfterUpdateStatefulSet), at_step_closure(RabbitmqReconcileStep::Done));
     RMQCluster::lemma_from_some_state_to_arbitrary_next_state_to_reconcile_idle(spec, rabbitmq, at_step_closure(RabbitmqReconcileStep::AfterCreateStatefulSet), at_step_closure(RabbitmqReconcileStep::Done));
-    or_leads_to_combine_n!(
-        spec,
-        lift_state(at_step_state_pred(rabbitmq, RabbitmqReconcileStep::AfterUpdateStatefulSet)),
-        lift_state(at_step_state_pred(rabbitmq, RabbitmqReconcileStep::AfterCreateStatefulSet)),
-        lift_state(at_step_state_pred(rabbitmq, RabbitmqReconcileStep::Error));
-        lift_state(|s: RMQCluster| { !s.reconcile_state_contains(rabbitmq.object_ref()) })
-    );
     let next_state = |s: RabbitmqReconcileState| {
         s.reconcile_step == RabbitmqReconcileStep::AfterUpdateStatefulSet
         || s.reconcile_step == RabbitmqReconcileStep::AfterCreateStatefulSet
         || s.reconcile_step == RabbitmqReconcileStep::Error
     };
-    temp_pred_equality(
-        lift_state(at_step_state_pred(rabbitmq, RabbitmqReconcileStep::AfterUpdateStatefulSet))
-        .or(lift_state(at_step_state_pred(rabbitmq, RabbitmqReconcileStep::AfterCreateStatefulSet)))
-        .or(lift_state(at_step_state_pred(rabbitmq, RabbitmqReconcileStep::Error))),
-        lift_state(RMQCluster::at_expected_reconcile_states(rabbitmq.object_ref(), next_state))
+    or_leads_to_combine_and_equality!(
+        spec, lift_state(RMQCluster::at_expected_reconcile_states(rabbitmq.object_ref(), next_state)),
+        lift_state(at_step_state_pred(rabbitmq, RabbitmqReconcileStep::AfterUpdateStatefulSet)),
+        lift_state(at_step_state_pred(rabbitmq, RabbitmqReconcileStep::AfterCreateStatefulSet)),
+        lift_state(at_step_state_pred(rabbitmq, RabbitmqReconcileStep::Error));
+        lift_state(|s: RMQCluster| { !s.reconcile_state_contains(rabbitmq.object_ref()) })
     );
     RMQCluster::lemma_from_some_state_to_arbitrary_next_state_to_reconcile_idle(
         spec, rabbitmq, at_step_closure(RabbitmqReconcileStep::AfterGetStatefulSet), next_state
@@ -85,23 +79,17 @@ pub proof fn reconcile_eventually_terminates(spec: TempPred<RMQCluster>, rabbitm
     RMQCluster::lemma_from_some_state_to_arbitrary_next_state_to_reconcile_idle(spec, rabbitmq, at_step_closure(RabbitmqReconcileStep::AfterCreateServerConfigMap), at_step_closure(RabbitmqReconcileStep::AfterCreateServiceAccount));
     RMQCluster::lemma_from_some_state_to_arbitrary_next_state_to_reconcile_idle(spec, rabbitmq, at_step_closure(RabbitmqReconcileStep::AfterUpdateServerConfigMap), at_step_closure(RabbitmqReconcileStep::AfterCreateServiceAccount));
 
-    or_leads_to_combine_n!(
-        spec,
-        lift_state(at_step_state_pred(rabbitmq, RabbitmqReconcileStep::AfterUpdateServerConfigMap)),
-        lift_state(at_step_state_pred(rabbitmq, RabbitmqReconcileStep::AfterCreateServerConfigMap)),
-        lift_state(at_step_state_pred(rabbitmq, RabbitmqReconcileStep::Error));
-        lift_state(|s: RMQCluster| { !s.reconcile_state_contains(rabbitmq.object_ref()) })
-    );
     let next_state_1 = |s: RabbitmqReconcileState| {
         s.reconcile_step == RabbitmqReconcileStep::AfterUpdateServerConfigMap
         || s.reconcile_step == RabbitmqReconcileStep::AfterCreateServerConfigMap
         || s.reconcile_step == RabbitmqReconcileStep::Error
     };
-    temp_pred_equality(
-        lift_state(at_step_state_pred(rabbitmq, RabbitmqReconcileStep::AfterUpdateServerConfigMap))
-        .or(lift_state(at_step_state_pred(rabbitmq, RabbitmqReconcileStep::AfterCreateServerConfigMap)))
-        .or(lift_state(at_step_state_pred(rabbitmq, RabbitmqReconcileStep::Error))),
-        lift_state(RMQCluster::at_expected_reconcile_states(rabbitmq.object_ref(), next_state_1))
+    or_leads_to_combine_and_equality!(
+        spec, lift_state(RMQCluster::at_expected_reconcile_states(rabbitmq.object_ref(), next_state_1)),
+        lift_state(at_step_state_pred(rabbitmq, RabbitmqReconcileStep::AfterUpdateServerConfigMap)),
+        lift_state(at_step_state_pred(rabbitmq, RabbitmqReconcileStep::AfterCreateServerConfigMap)),
+        lift_state(at_step_state_pred(rabbitmq, RabbitmqReconcileStep::Error));
+        lift_state(|s: RMQCluster| { !s.reconcile_state_contains(rabbitmq.object_ref()) })
     );
     RMQCluster::lemma_from_some_state_to_arbitrary_next_state_to_reconcile_idle(
         spec, rabbitmq, at_step_closure(RabbitmqReconcileStep::AfterGetServerConfigMap), next_state_1

--- a/src/controller_examples/simple_controller/proof/liveness.rs
+++ b/src/controller_examples/simple_controller/proof/liveness.rs
@@ -269,17 +269,12 @@ proof fn lemma_reconcile_ongoing_leads_to_cm_exists(cr: SimpleCRView)
             .leads_to(lift_state(cm_exists(cr)))
         ),
 {
-    temp_pred_equality::<State<SimpleReconcileState>>(
-        lift_state(|s: State<SimpleReconcileState>| s.reconcile_state_contains(cr.object_ref())),
-        lift_state(reconciler_reconcile_error(cr))
-            .or(lift_state(reconciler_at_init_pc(cr)))
-            .or(lift_state(reconciler_at_after_get_cr_pc(cr)))
-            .or(lift_state(reconciler_at_after_create_cm_pc(cr))));
     lemma_error_pc_leads_to_cm_exists(cr);
     lemma_init_pc_leads_to_cm_exists(cr);
     lemma_after_get_cr_pc_leads_to_cm_exists(cr);
     lemma_after_create_cm_pc_leads_to_cm_exists(cr);
-    or_leads_to_combine_n!(partial_spec_with_invariants_and_assumptions(cr),
+    or_leads_to_combine_and_equality!(
+        partial_spec_with_invariants_and_assumptions(cr), lift_state(|s: State<SimpleReconcileState>| s.reconcile_state_contains(cr.object_ref())),
         lift_state(reconciler_reconcile_error(cr)),
         lift_state(reconciler_at_init_pc(cr)),
         lift_state(reconciler_at_after_get_cr_pc(cr)),

--- a/src/controller_examples/simple_controller/proof/liveness.rs
+++ b/src/controller_examples/simple_controller/proof/liveness.rs
@@ -520,13 +520,9 @@ proof fn lemma_init_pc_and_no_pending_req_leads_to_after_get_cr_pc_and_exists_pe
         &&& !s.crash_enabled
         &&& every_in_flight_msg_has_lower_id_than_allocator::<SimpleReconcileState>()(s)
     };
-    entails_always_and_n!(partial_spec_with_invariants_and_assumptions(cr),
+    combine_spec_entails_always_n!(partial_spec_with_invariants_and_assumptions(cr), lift_action(stronger_next)
         lift_action(next(simple_reconciler())), lift_state(crash_disabled::<SimpleReconcileState>()),
         lift_state(every_in_flight_msg_has_lower_id_than_allocator::<SimpleReconcileState>()));
-    temp_pred_equality(lift_action(stronger_next),
-        lift_action(next(simple_reconciler()))
-        .and(lift_state(crash_disabled::<SimpleReconcileState>()))
-        .and(lift_state(every_in_flight_msg_has_lower_id_than_allocator::<SimpleReconcileState>())));
     assert forall |s, s_prime| reconciler_init_and_no_pending_req(simple_reconciler(), cr.object_ref())(s) && #[trigger] stronger_next(s, s_prime) implies
     reconciler_init_and_no_pending_req(simple_reconciler(), cr.object_ref())(s_prime)
     || reconciler_at_after_get_cr_pc_and_exists_pending_req_and_req_in_flight_and_no_resp_in_flight(cr)(s_prime) by {

--- a/src/controller_examples/simple_controller/proof/liveness.rs
+++ b/src/controller_examples/simple_controller/proof/liveness.rs
@@ -87,7 +87,6 @@ proof fn liveness_proof(cr: SimpleCRView)
     leads_to_self_temp::<State<SimpleReconcileState>>(always(cr_exists(cr)));
     leads_to_always_combine_temp::<State<SimpleReconcileState>>(sm_spec(simple_reconciler()), always(cr_exists(cr)),
         cr_exists(cr), lift_state(crash_disabled::<SimpleReconcileState>()));
-    always_and_equality::<State<SimpleReconcileState>>(cr_exists(cr), lift_state(crash_disabled::<SimpleReconcileState>()));
     lemma_sm_spec_entails_cr_always_exists_and_crash_always_disabled_leads_to_cm_always_exists(cr);
     // Step (7)
     leads_to_trans_temp::<State<SimpleReconcileState>>(sm_spec(simple_reconciler()), always(cr_exists(cr)),

--- a/src/controller_examples/zookeeper_controller/proof/liveness/helper_invariants.rs
+++ b/src/controller_examples/zookeeper_controller/proof/liveness/helper_invariants.rs
@@ -67,20 +67,20 @@ pub proof fn lemma_always_pending_msg_at_after_create_stateful_set_step_is_creat
     let init = ZKCluster::init();
     let stronger_next = |s, s_prime| {
         &&& ZKCluster::next()(s, s_prime)
-        &&& ZKCluster::each_key_in_reconcile_is_consistent_with_its_object()(s)
+        &&& ZKCluster::each_object_in_reconcile_has_consistent_key_and_valid_metadata()(s)
     };
 
-    ZKCluster::lemma_always_each_key_in_reconcile_is_consistent_with_its_object(spec);
+    ZKCluster::lemma_always_each_object_in_reconcile_has_consistent_key_and_valid_metadata(spec);
 
     entails_always_and_n!(
         spec,
         lift_action(ZKCluster::next()),
-        lift_state(ZKCluster::each_key_in_reconcile_is_consistent_with_its_object())
+        lift_state(ZKCluster::each_object_in_reconcile_has_consistent_key_and_valid_metadata())
     );
     temp_pred_equality(
         lift_action(stronger_next),
         lift_action(ZKCluster::next())
-        .and(lift_state(ZKCluster::each_key_in_reconcile_is_consistent_with_its_object()))
+        .and(lift_state(ZKCluster::each_object_in_reconcile_has_consistent_key_and_valid_metadata()))
     );
 
     init_invariant(spec, init, stronger_next, invariant);
@@ -115,7 +115,7 @@ proof fn lemma_always_filtered_create_sts_req_len_is_at_most_one(
         spec.entails(always(lift_state(ZKCluster::crash_disabled()))),
         spec.entails(always(lift_state(ZKCluster::busy_disabled()))),
         spec.entails(always(lift_state(pending_msg_at_after_create_stateful_set_step_is_create_sts_req(key)))),
-        spec.entails(always(lift_state(ZKCluster::each_key_in_reconcile_is_consistent_with_its_object()))),
+        spec.entails(always(lift_state(ZKCluster::each_object_in_reconcile_has_consistent_key_and_valid_metadata()))),
         spec.entails(always(lift_state(ZKCluster::rest_id_counter_is_no_smaller_than(rest_id)))),
         spec.entails(always(lift_state(ZKCluster::every_in_flight_msg_has_unique_id()))),
         key.kind.is_CustomResourceKind(),
@@ -134,7 +134,7 @@ proof fn lemma_always_filtered_create_sts_req_len_is_at_most_one(
         &&& ZKCluster::crash_disabled()(s)
         &&& ZKCluster::busy_disabled()(s)
         &&& pending_msg_at_after_create_stateful_set_step_is_create_sts_req(key)(s)
-        &&& ZKCluster::each_key_in_reconcile_is_consistent_with_its_object()(s)
+        &&& ZKCluster::each_object_in_reconcile_has_consistent_key_and_valid_metadata()(s)
         &&& ZKCluster::rest_id_counter_is_no_smaller_than(rest_id)(s)
         &&& ZKCluster::every_in_flight_msg_has_unique_id()(s)
     };
@@ -159,7 +159,7 @@ proof fn lemma_always_filtered_create_sts_req_len_is_at_most_one(
         lift_state(ZKCluster::crash_disabled()),
         lift_state(ZKCluster::busy_disabled()),
         lift_state(pending_msg_at_after_create_stateful_set_step_is_create_sts_req(key)),
-        lift_state(ZKCluster::each_key_in_reconcile_is_consistent_with_its_object()),
+        lift_state(ZKCluster::each_object_in_reconcile_has_consistent_key_and_valid_metadata()),
         lift_state(ZKCluster::rest_id_counter_is_no_smaller_than(rest_id)),
         lift_state(ZKCluster::every_in_flight_msg_has_unique_id())
     );
@@ -169,7 +169,7 @@ proof fn lemma_always_filtered_create_sts_req_len_is_at_most_one(
         .and(lift_state(ZKCluster::crash_disabled()))
         .and(lift_state(ZKCluster::busy_disabled()))
         .and(lift_state(pending_msg_at_after_create_stateful_set_step_is_create_sts_req(key)))
-        .and(lift_state(ZKCluster::each_key_in_reconcile_is_consistent_with_its_object()))
+        .and(lift_state(ZKCluster::each_object_in_reconcile_has_consistent_key_and_valid_metadata()))
         .and(lift_state(ZKCluster::rest_id_counter_is_no_smaller_than(rest_id)))
         .and(lift_state(ZKCluster::every_in_flight_msg_has_unique_id()))
     );
@@ -249,7 +249,7 @@ proof fn lemma_always_filtered_create_sts_req_len_is_at_most_one(
                     // It is trivial because of the isolation between different reconcilers:
                     // each reconciler does not touch other reconcilers' resources.
                     // The isolation property comes from the way each reconciler names its owned resources.
-                    // Note that here we implicitly use each_key_in_reconcile_is_consistent_with_its_object
+                    // Note that here we implicitly use each_object_in_reconcile_has_consistent_key_and_valid_metadata
                     // because the reconciler uses zk, instead of the key of zk, when naming the resources.
                     assert(sts_create_req_multiset =~= sts_create_req_multiset_prime);
                 }
@@ -296,7 +296,7 @@ pub proof fn lemma_always_at_most_one_create_sts_req_since_rest_id_is_in_flight(
         spec.entails(always(lift_state(ZKCluster::crash_disabled()))),
         spec.entails(always(lift_state(ZKCluster::busy_disabled()))),
         spec.entails(always(lift_state(pending_msg_at_after_create_stateful_set_step_is_create_sts_req(key)))),
-        spec.entails(always(lift_state(ZKCluster::each_key_in_reconcile_is_consistent_with_its_object()))),
+        spec.entails(always(lift_state(ZKCluster::each_object_in_reconcile_has_consistent_key_and_valid_metadata()))),
         spec.entails(always(lift_state(ZKCluster::rest_id_counter_is_no_smaller_than(rest_id)))),
         spec.entails(always(lift_state(ZKCluster::every_in_flight_msg_has_unique_id()))),
         key.kind.is_CustomResourceKind(),
@@ -378,20 +378,20 @@ pub proof fn lemma_always_pending_msg_at_after_update_stateful_set_step_is_updat
     let init = ZKCluster::init();
     let stronger_next = |s, s_prime| {
         &&& ZKCluster::next()(s, s_prime)
-        &&& ZKCluster::each_key_in_reconcile_is_consistent_with_its_object()(s)
+        &&& ZKCluster::each_object_in_reconcile_has_consistent_key_and_valid_metadata()(s)
     };
 
-    ZKCluster::lemma_always_each_key_in_reconcile_is_consistent_with_its_object(spec);
+    ZKCluster::lemma_always_each_object_in_reconcile_has_consistent_key_and_valid_metadata(spec);
 
     entails_always_and_n!(
         spec,
         lift_action(ZKCluster::next()),
-        lift_state(ZKCluster::each_key_in_reconcile_is_consistent_with_its_object())
+        lift_state(ZKCluster::each_object_in_reconcile_has_consistent_key_and_valid_metadata())
     );
     temp_pred_equality(
         lift_action(stronger_next),
         lift_action(ZKCluster::next())
-        .and(lift_state(ZKCluster::each_key_in_reconcile_is_consistent_with_its_object()))
+        .and(lift_state(ZKCluster::each_object_in_reconcile_has_consistent_key_and_valid_metadata()))
     );
 
     init_invariant(spec, init, stronger_next, invariant);
@@ -426,7 +426,7 @@ proof fn lemma_always_filtered_update_sts_req_len_is_at_most_one(
         spec.entails(always(lift_state(ZKCluster::crash_disabled()))),
         spec.entails(always(lift_state(ZKCluster::busy_disabled()))),
         spec.entails(always(lift_state(pending_msg_at_after_update_stateful_set_step_is_update_sts_req(key)))),
-        spec.entails(always(lift_state(ZKCluster::each_key_in_reconcile_is_consistent_with_its_object()))),
+        spec.entails(always(lift_state(ZKCluster::each_object_in_reconcile_has_consistent_key_and_valid_metadata()))),
         spec.entails(always(lift_state(ZKCluster::rest_id_counter_is_no_smaller_than(rest_id)))),
         spec.entails(always(lift_state(ZKCluster::every_in_flight_msg_has_unique_id()))),
         key.kind.is_CustomResourceKind(),
@@ -445,7 +445,7 @@ proof fn lemma_always_filtered_update_sts_req_len_is_at_most_one(
         &&& ZKCluster::crash_disabled()(s)
         &&& ZKCluster::busy_disabled()(s)
         &&& pending_msg_at_after_update_stateful_set_step_is_update_sts_req(key)(s)
-        &&& ZKCluster::each_key_in_reconcile_is_consistent_with_its_object()(s)
+        &&& ZKCluster::each_object_in_reconcile_has_consistent_key_and_valid_metadata()(s)
         &&& ZKCluster::rest_id_counter_is_no_smaller_than(rest_id)(s)
         &&& ZKCluster::every_in_flight_msg_has_unique_id()(s)
     };
@@ -470,7 +470,7 @@ proof fn lemma_always_filtered_update_sts_req_len_is_at_most_one(
         lift_state(ZKCluster::crash_disabled()),
         lift_state(ZKCluster::busy_disabled()),
         lift_state(pending_msg_at_after_update_stateful_set_step_is_update_sts_req(key)),
-        lift_state(ZKCluster::each_key_in_reconcile_is_consistent_with_its_object()),
+        lift_state(ZKCluster::each_object_in_reconcile_has_consistent_key_and_valid_metadata()),
         lift_state(ZKCluster::rest_id_counter_is_no_smaller_than(rest_id)),
         lift_state(ZKCluster::every_in_flight_msg_has_unique_id())
     );
@@ -480,7 +480,7 @@ proof fn lemma_always_filtered_update_sts_req_len_is_at_most_one(
         .and(lift_state(ZKCluster::crash_disabled()))
         .and(lift_state(ZKCluster::busy_disabled()))
         .and(lift_state(pending_msg_at_after_update_stateful_set_step_is_update_sts_req(key)))
-        .and(lift_state(ZKCluster::each_key_in_reconcile_is_consistent_with_its_object()))
+        .and(lift_state(ZKCluster::each_object_in_reconcile_has_consistent_key_and_valid_metadata()))
         .and(lift_state(ZKCluster::rest_id_counter_is_no_smaller_than(rest_id)))
         .and(lift_state(ZKCluster::every_in_flight_msg_has_unique_id()))
     );
@@ -560,7 +560,7 @@ proof fn lemma_always_filtered_update_sts_req_len_is_at_most_one(
                     // It is trivial because of the isolation between different reconcilers:
                     // each reconciler does not touch other reconcilers' resources.
                     // The isolation property comes from the way each reconciler names its owned resources.
-                    // Note that here we implicitly use each_key_in_reconcile_is_consistent_with_its_object
+                    // Note that here we implicitly use each_object_in_reconcile_has_consistent_key_and_valid_metadata
                     // because the reconciler uses zk, instead of the key of zk, when naming the resources.
                     assert(sts_update_req_multiset =~= sts_update_req_multiset_prime);
                 }
@@ -607,7 +607,7 @@ pub proof fn lemma_always_at_most_one_update_sts_req_since_rest_id_is_in_flight(
         spec.entails(always(lift_state(ZKCluster::crash_disabled()))),
         spec.entails(always(lift_state(ZKCluster::busy_disabled()))),
         spec.entails(always(lift_state(pending_msg_at_after_update_stateful_set_step_is_update_sts_req(key)))),
-        spec.entails(always(lift_state(ZKCluster::each_key_in_reconcile_is_consistent_with_its_object()))),
+        spec.entails(always(lift_state(ZKCluster::each_object_in_reconcile_has_consistent_key_and_valid_metadata()))),
         spec.entails(always(lift_state(ZKCluster::rest_id_counter_is_no_smaller_than(rest_id)))),
         spec.entails(always(lift_state(ZKCluster::every_in_flight_msg_has_unique_id()))),
         key.kind.is_CustomResourceKind(),
@@ -667,7 +667,7 @@ pub proof fn lemma_always_every_update_sts_req_since_rest_id_does_the_same(
         spec.entails(lift_state(ZKCluster::rest_id_counter_is(rest_id))),
         spec.entails(lift_state(ZKCluster::every_in_flight_msg_has_lower_id_than_allocator())),
         spec.entails(always(lift_action(ZKCluster::next()))),
-        spec.entails(always(lift_state(ZKCluster::each_key_in_reconcile_is_consistent_with_its_object()))),
+        spec.entails(always(lift_state(ZKCluster::each_object_in_reconcile_has_consistent_key_and_valid_metadata()))),
         spec.entails(always(lift_state(ZKCluster::rest_id_counter_is_no_smaller_than(rest_id)))),
         spec.entails(always(lift_state(ZKCluster::the_object_in_reconcile_has_spec_and_uid_as(zk)))),
     ensures
@@ -679,7 +679,7 @@ pub proof fn lemma_always_every_update_sts_req_since_rest_id_does_the_same(
     };
     let stronger_next = |s, s_prime: ZKCluster| {
         &&& ZKCluster::next()(s, s_prime)
-        &&& ZKCluster::each_key_in_reconcile_is_consistent_with_its_object()(s)
+        &&& ZKCluster::each_object_in_reconcile_has_consistent_key_and_valid_metadata()(s)
         &&& ZKCluster::rest_id_counter_is_no_smaller_than(rest_id)(s)
         &&& ZKCluster::the_object_in_reconcile_has_spec_and_uid_as(zk)(s)
     };
@@ -699,14 +699,14 @@ pub proof fn lemma_always_every_update_sts_req_since_rest_id_does_the_same(
     entails_always_and_n!(
         spec,
         lift_action(ZKCluster::next()),
-        lift_state(ZKCluster::each_key_in_reconcile_is_consistent_with_its_object()),
+        lift_state(ZKCluster::each_object_in_reconcile_has_consistent_key_and_valid_metadata()),
         lift_state(ZKCluster::rest_id_counter_is_no_smaller_than(rest_id)),
         lift_state(ZKCluster::the_object_in_reconcile_has_spec_and_uid_as(zk))
     );
     temp_pred_equality(
         lift_action(stronger_next),
         lift_action(ZKCluster::next())
-        .and(lift_state(ZKCluster::each_key_in_reconcile_is_consistent_with_its_object()))
+        .and(lift_state(ZKCluster::each_object_in_reconcile_has_consistent_key_and_valid_metadata()))
         .and(lift_state(ZKCluster::rest_id_counter_is_no_smaller_than(rest_id)))
         .and(lift_state(ZKCluster::the_object_in_reconcile_has_spec_and_uid_as(zk)))
     );

--- a/src/controller_examples/zookeeper_controller/proof/liveness/liveness_property.rs
+++ b/src/controller_examples/zookeeper_controller/proof/liveness/liveness_property.rs
@@ -591,15 +591,11 @@ proof fn lemma_true_leads_to_always_current_state_matches_zk_under_eventual_inva
                 scheduled_and_not_in_reconcile,
                 lift_state(no_pending_req_at_zookeeper_step_with_zk(zk, ZookeeperReconcileStep::Init))
             );
-            or_leads_to_combine_temp(
-                spec,
+            or_leads_to_combine_and_equality!(
+                spec, lift_state(|s: ZKCluster| !s.reconcile_state_contains(zk.object_ref())),
                 unscheduled_and_not_in_reconcile,
-                scheduled_and_not_in_reconcile,
+                scheduled_and_not_in_reconcile;
                 lift_state(no_pending_req_at_zookeeper_step_with_zk(zk, ZookeeperReconcileStep::Init))
-            );
-            temp_pred_equality(
-                lift_state(|s: ZKCluster| !s.reconcile_state_contains(zk.object_ref())),
-                unscheduled_and_not_in_reconcile.or(scheduled_and_not_in_reconcile)
             );
         }
     );
@@ -892,8 +888,10 @@ proof fn lemma_true_leads_to_always_current_state_matches_zk_under_eventual_inva
                 &&& s.resource_key_exists(make_stateful_set_key(zk.object_ref()))
                 &&& pending_req_in_flight_at_zookeeper_step_with_zk(ZookeeperReconcileStep::AfterGetStatefulSet, zk, arbitrary())(s)
             });
-            or_leads_to_combine_temp(spec, p1, p2, lift_state(current_state_matches(zk)));
-            temp_pred_equality(p1.or(p2), lift_state(pending_req_in_flight_at_zookeeper_step_with_zk(ZookeeperReconcileStep::AfterGetStatefulSet, zk, arbitrary())));
+            or_leads_to_combine_and_equality!(
+                spec, lift_state(pending_req_in_flight_at_zookeeper_step_with_zk(ZookeeperReconcileStep::AfterGetStatefulSet, zk, arbitrary())),
+                p1, p2; lift_state(current_state_matches(zk))
+            );
         }
     );
 

--- a/src/controller_examples/zookeeper_controller/proof/liveness/liveness_property.rs
+++ b/src/controller_examples/zookeeper_controller/proof/liveness/liveness_property.rs
@@ -347,7 +347,7 @@ proof fn liveness_proof(zk: ZookeeperClusterView)
 
             ZKCluster::lemma_true_leads_to_crash_always_disabled(spec);
             ZKCluster::lemma_true_leads_to_busy_always_disabled(spec);
-            leads_to_always_combine_temp(
+            _temp(
                 spec,
                 true_pred(),
                 lift_state(ZKCluster::crash_disabled()),

--- a/src/controller_examples/zookeeper_controller/proof/liveness/terminate.rs
+++ b/src/controller_examples/zookeeper_controller/proof/liveness/terminate.rs
@@ -96,17 +96,8 @@ pub proof fn reconcile_eventually_terminates(spec: TempPred<ZKCluster>, zk: Zook
         spec, zk, |s: ZookeeperReconcileState| s.reconcile_step == ZookeeperReconcileStep::AfterSetZKNode,
         |s: ZookeeperReconcileState| {s.reconcile_step == ZookeeperReconcileStep::AfterUpdateStatefulSet || s.reconcile_step == ZookeeperReconcileStep::Error}
     );
-    or_leads_to_combine_n!(
+    or_leads_to_combine_and_equality!(
         spec,
-        lift_state(at_step(zk, ZookeeperReconcileStep::AfterCreateStatefulSet)),
-        lift_state(at_step(zk, ZookeeperReconcileStep::AfterSetZKNode)),
-        lift_state(at_step(zk, ZookeeperReconcileStep::Error));
-        lift_state(reconcile_idle)
-    );
-    temp_pred_equality(
-        lift_state(at_step(zk, ZookeeperReconcileStep::AfterCreateStatefulSet))
-        .or(lift_state(at_step(zk, ZookeeperReconcileStep::AfterSetZKNode)))
-        .or(lift_state(at_step(zk, ZookeeperReconcileStep::Error))),
         lift_state(ZKCluster::at_expected_reconcile_states(
             zk.object_ref(),
             |s: ZookeeperReconcileState| {
@@ -114,7 +105,11 @@ pub proof fn reconcile_eventually_terminates(spec: TempPred<ZKCluster>, zk: Zook
                 || s.reconcile_step == ZookeeperReconcileStep::AfterSetZKNode
                 || s.reconcile_step == ZookeeperReconcileStep::Error
             }
-        ))
+        )),
+        lift_state(at_step(zk, ZookeeperReconcileStep::AfterCreateStatefulSet)),
+        lift_state(at_step(zk, ZookeeperReconcileStep::AfterUpdateZKNode)),
+        lift_state(at_step(zk, ZookeeperReconcileStep::Error));
+        lift_state(reconcile_idle)
     );
     ZKCluster::lemma_from_some_state_to_arbitrary_next_state_to_reconcile_idle(
         spec, zk, |s: ZookeeperReconcileState| s.reconcile_step == ZookeeperReconcileStep::AfterGetStatefulSet,

--- a/src/kubernetes_api_objects/object_meta.rs
+++ b/src/kubernetes_api_objects/object_meta.rs
@@ -295,6 +295,13 @@ impl ObjectMetaView {
             ..self
         }
     }
+
+    pub open spec fn well_formed(self) -> bool {
+        &&& self.name.is_Some()
+        &&& self.namespace.is_Some()
+        &&& self.resource_version.is_Some()
+        &&& self.uid.is_Some()
+    }
 }
 
 impl Marshalable for ObjectMetaView {

--- a/src/kubernetes_cluster/proof/builtin_controllers.rs
+++ b/src/kubernetes_cluster/proof/builtin_controllers.rs
@@ -1,0 +1,289 @@
+// Copyright 2022 VMware, Inc.
+// SPDX-License-Identifier: MIT
+#![allow(unused_imports)]
+use crate::external_api::spec::*;
+use crate::kubernetes_api_objects::{
+    api_method::*, common::*, config_map::*, dynamic::*, owner_reference::*, resource::*,
+    stateful_set::*,
+};
+use crate::kubernetes_cluster::spec::{
+    builtin_controllers::types::{built_in_controller_req_msg, BuiltinControllerChoice},
+    cluster::*,
+    cluster_state_machine::Step,
+    controller::common::{controller_req_msg, ControllerActionInput, ControllerStep},
+    message::*,
+};
+use crate::reconciler::spec::reconciler::Reconciler;
+use crate::temporal_logic::{defs::*, rules::*};
+use vstd::prelude::*;
+
+verus! {
+
+impl <K: ResourceView, E: ExternalAPI, R: Reconciler<K, E>> Cluster<K, E, R> {
+
+pub open spec fn every_update_msg_sets_owner_references_as(
+    key: ObjectRef, requirements: FnSpec(Option<Seq<OwnerReferenceView>>) -> bool
+) -> StatePred<Self> {
+    |s: Self| {
+        forall |msg: Message|
+            #[trigger] s.message_in_flight(msg)
+            && msg.dst.is_KubernetesAPI()
+            && msg.content.is_update_request()
+            && msg.content.get_update_request().key == key
+            ==> requirements(msg.content.get_update_request().obj.metadata.owner_references)
+    }
+}
+
+pub open spec fn every_create_msg_sets_owner_references_as(
+    key: ObjectRef, requirements: FnSpec(Option<Seq<OwnerReferenceView>>) -> bool
+) -> StatePred<Self> {
+    |s: Self| {
+        forall |msg: Message|
+            #[trigger] s.message_in_flight(msg)
+            && msg.dst.is_KubernetesAPI()
+            && msg.content.is_create_request()
+            && msg.content.get_create_request().namespace == key.namespace
+            && msg.content.get_create_request().obj.metadata.name.get_Some_0() == key.name
+            && msg.content.get_create_request().obj.kind == key.kind
+            ==> requirements(msg.content.get_create_request().obj.metadata.owner_references)
+    }
+}
+
+pub open spec fn objects_owner_references_satisfies(key: ObjectRef, requirements: FnSpec(Option<Seq<OwnerReferenceView>>) -> bool) -> StatePred<Self> {
+    |s: Self| {
+        s.resource_key_exists(key) ==> requirements(s.resource_obj_of(key).metadata.owner_references)
+    }
+}
+
+pub open spec fn objects_owner_references_violates(key: ObjectRef, requirements: FnSpec(Option<Seq<OwnerReferenceView>>) -> bool) -> StatePred<Self> {
+    |s: Self| {
+        s.resource_key_exists(key) && !requirements(s.resource_obj_of(key).metadata.owner_references)
+    }
+}
+
+pub open spec fn object_has_no_finalizers_or_deletion_timestamp(key: ObjectRef) -> StatePred<Self> {
+    |s: Self| {
+        s.resource_key_exists(key)
+        ==> s.resource_obj_of(key).metadata.deletion_timestamp.is_None()
+            && s.resource_obj_of(key).metadata.finalizers.is_None()
+    }
+}
+
+spec fn exists_delete_request_msg_in_flight_with_key(key: ObjectRef) -> StatePred<Self> {
+    |s: Self| {
+        exists |msg: Message| {
+            #[trigger] s.message_in_flight(msg)
+            && msg.dst.is_KubernetesAPI()
+            && msg.content.is_delete_request_with_key(key)
+        }
+    }
+}
+
+/// This lemma requires the following preconditions:
+///     1. spec |= [](in_flight(update_msg_with(msg, key)) ==> satisfies(msg.obj.metadata.owner_references, eventual_owner_ref)).
+///     2. spec |= [](in_flight(create_msg_with(msg, key)) ==> satisfies(msg.obj.metadata.owner_references, eventual_owner_ref)).
+///     3. spec |= [](key_exists(key) ==> resource_obj_of(key) has no finalizers or deletion_timestamp).
+///     4. spec |= [](!expected(owner_references) => deleted).
+/// In 3, no finalizers ensures the stability: once the desired state reaches, every update request
+/// 
+/// The proof of spec |= true ~> objects_owner_references_satisfies(eventual_owner_ref) consists of two parts:
+///     1. spec |= true ~> (object_has_invalid_owner_reference ==> delete message in flight).
+///     2. spec |= (object_has_invalid_owner_reference ==> delete message in flight) ~> all_objects_have_expected_owner_references.
+/// The first is primarily obtained by the weak fairness of the builtin controllers action (specifially, the garbage collector);
+/// and the second holds due to the weak fairness of kubernetes api.
+/// 
+/// To prove 1, we split `true` into three cases:
+///     a. The object's.
+///     b. The object has valid owner references.
+///     c. The object doesn't exist.
+/// For the last two cases, the post state ((object_has_invalid_owner_reference ==> delete message in flight)) is already reached. 
+/// We only need to show spec |= case a ~> post. This is straightforward via the weak fairness of builtin controllers.
+pub proof fn lemma_eventually_objects_owner_references_satisfies(
+    spec: TempPred<Self>, key: ObjectRef, eventual_owner_ref: FnSpec(Option<Seq<OwnerReferenceView>>) -> bool
+)
+    requires
+        spec.entails(always(lift_state(Self::busy_disabled()))),
+        spec.entails(always(lift_action(Self::next()))),
+        spec.entails(tla_forall(|i| Self::kubernetes_api_next().weak_fairness(i))),
+        spec.entails(tla_forall(|i| Self::builtin_controllers_next().weak_fairness(i))),
+        spec.entails(always(lift_state(Self::every_create_msg_sets_owner_references_as(key, eventual_owner_ref)))),
+        spec.entails(always(lift_state(Self::every_update_msg_sets_owner_references_as(key, eventual_owner_ref)))),
+        spec.entails(always(lift_state(Self::object_has_no_finalizers_or_deletion_timestamp(key)))),
+        // If the current owner_references does not satisfy the eventual requirement, the gc action is enabled.
+        spec.entails(always(lift_state(Self::objects_owner_references_violates(key, eventual_owner_ref)).implies(lift_state(Self::garbage_collector_deletion_enabled(key))))),
+    ensures
+        spec.entails(true_pred().leads_to(always(lift_state(Self::objects_owner_references_satisfies(key, eventual_owner_ref))))),
+{
+    let pre = |s: Self| {
+        &&& Self::objects_owner_references_violates(key, eventual_owner_ref)(s)
+        &&& Self::garbage_collector_deletion_enabled(key)(s)
+    };
+
+    let delete_msg_in_flight = |s: Self| {
+        Self::objects_owner_references_violates(key, eventual_owner_ref)(s) ==> Self::exists_delete_request_msg_in_flight_with_key(key)(s)
+    };
+    let post = Self::objects_owner_references_satisfies(key, eventual_owner_ref);
+
+    let input = (BuiltinControllerChoice::GarbageCollector, key);
+    let stronger_next = |s, s_prime: Self| {
+        &&& Self::next()(s, s_prime)
+        &&& Self::every_create_msg_sets_owner_references_as(key, eventual_owner_ref)(s)
+        &&& Self::every_update_msg_sets_owner_references_as(key, eventual_owner_ref)(s)
+        &&& Self::object_has_no_finalizers_or_deletion_timestamp(key)(s)
+        &&& Self::objects_owner_references_violates(key, eventual_owner_ref)(s) ==> Self::garbage_collector_deletion_enabled(key)(s)
+        &&& Self::objects_owner_references_violates(key, eventual_owner_ref)(s_prime) ==> Self::garbage_collector_deletion_enabled(key)(s_prime)
+    };
+    always_to_always_later(spec, lift_state(Self::objects_owner_references_violates(key, eventual_owner_ref)).implies(lift_state(Self::garbage_collector_deletion_enabled(key))));
+    strengthen_next_n!(
+        stronger_next, spec,
+        lift_action(Self::next()),
+        lift_state(Self::every_create_msg_sets_owner_references_as(key, eventual_owner_ref)),
+        lift_state(Self::every_update_msg_sets_owner_references_as(key, eventual_owner_ref)),
+        lift_state(Self::object_has_no_finalizers_or_deletion_timestamp(key)),
+        lift_state(Self::objects_owner_references_violates(key, eventual_owner_ref)).implies(lift_state(Self::garbage_collector_deletion_enabled(key))),
+        later(lift_state(Self::objects_owner_references_violates(key, eventual_owner_ref)).implies(lift_state(Self::garbage_collector_deletion_enabled(key))))
+    );
+
+    assert forall |s, s_prime: Self| pre(s) && #[trigger] stronger_next(s, s_prime) && Self::builtin_controllers_next().forward(input)(s, s_prime) implies delete_msg_in_flight(s_prime) by {
+        assert(Self::garbage_collector_deletion_enabled(key)(s));
+        let delete_req_msg = built_in_controller_req_msg(delete_req_msg_content(
+            key, s.rest_id_allocator.allocate().1
+        ));
+        assert(s_prime.message_in_flight(delete_req_msg));
+        assert(Self::exists_delete_request_msg_in_flight_with_key(key)(s_prime));
+        assert(delete_msg_in_flight(s_prime));
+    }
+
+    assert forall |s, s_prime: Self| pre(s) && #[trigger] stronger_next(s, s_prime) implies pre(s_prime) || delete_msg_in_flight(s_prime) by {
+        let step = choose |step| Self::next_step(s, s_prime, step);
+        match step {
+            Step::BuiltinControllersStep(i) => {
+                if i == input {
+                    assert(Self::garbage_collector_deletion_enabled(key)(s));
+                    let delete_req_msg = built_in_controller_req_msg(delete_req_msg_content(
+                        key, s.rest_id_allocator.allocate().1
+                    ));
+                    assert(s_prime.message_in_flight(delete_req_msg));
+                    assert(Self::exists_delete_request_msg_in_flight_with_key(key)(s_prime));
+                    assert(delete_msg_in_flight(s_prime));
+                } else {
+                    assert(pre(s_prime));
+                }
+            },
+            Step::KubernetesAPIStep(i) => {
+                if i.get_Some_0().content.is_update_request_with_key(key) {
+                    if Self::validate_update_request(i.get_Some_0().content.get_update_request(), s.kubernetes_api_state).is_Some()
+                    || Self::update_is_noop(i.get_Some_0().content.get_update_request().obj, s.resource_obj_of(key)) {
+                        assert(pre(s_prime));
+                    } else {
+                        assert(Self::objects_owner_references_satisfies(key, eventual_owner_ref)(s_prime));
+                    }
+                } else if i.get_Some_0().content.is_delete_request_with_key(key) {
+                    assert(s.resource_obj_of(key).metadata.finalizers.is_None());
+                    assert(!s_prime.resource_key_exists(key));
+                } else {
+                    assert(pre(s_prime));
+                }
+            },
+            _ => {
+                assert(pre(s_prime) || delete_msg_in_flight(s_prime));
+            }
+        }
+    }
+
+    Self::lemma_pre_leads_to_post_by_builtin_controllers(
+        spec, input, stronger_next, Self::run_garbage_collector(), pre, delete_msg_in_flight
+    );
+
+    leads_to_self(post);
+
+    assert_by(
+        spec.entails(lift_state(Self::objects_owner_references_violates(key, eventual_owner_ref)).leads_to(lift_state(post))),
+        {
+            Self::lemma_delete_msg_in_flight_leads_to_owner_references_satisfies(spec, key, eventual_owner_ref);
+            or_leads_to_combine_temp(spec, lift_state(post), lift_state(Self::exists_delete_request_msg_in_flight_with_key(key)), lift_state(post));
+            temp_pred_equality(lift_state(delete_msg_in_flight), lift_state(post).or(lift_state(Self::exists_delete_request_msg_in_flight_with_key(key))));
+            leads_to_trans_n!(spec, lift_state(pre), lift_state(delete_msg_in_flight), lift_state(post));
+
+            temp_pred_equality(lift_state(Self::objects_owner_references_violates(key, eventual_owner_ref)).implies(lift_state(Self::garbage_collector_deletion_enabled(key))), lift_state(Self::objects_owner_references_violates(key, eventual_owner_ref)).implies(lift_state(pre)));
+            leads_to_weaken_temp(spec, lift_state(pre), lift_state(post), lift_state(Self::objects_owner_references_violates(key, eventual_owner_ref)), lift_state(post));
+        }
+    );
+
+    or_leads_to_combine_temp(spec, lift_state(Self::objects_owner_references_violates(key, eventual_owner_ref)), lift_state(post), lift_state(post));
+    temp_pred_equality(true_pred(), lift_state(Self::objects_owner_references_violates(key, eventual_owner_ref)).or(lift_state(post)));
+
+    leads_to_stable(spec, stronger_next, |s: Self| true, post);
+}
+
+proof fn lemma_delete_msg_in_flight_leads_to_owner_references_satisfies(
+    spec: TempPred<Self>, key: ObjectRef, eventual_owner_ref: FnSpec(Option<Seq<OwnerReferenceView>>) -> bool
+)
+    requires
+        spec.entails(always(lift_state(Self::busy_disabled()))),
+        spec.entails(tla_forall(|i| Self::kubernetes_api_next().weak_fairness(i))),
+        spec.entails(always(lift_action(Self::next()))),
+        spec.entails(always(lift_state(Self::every_update_msg_sets_owner_references_as(key, eventual_owner_ref)))),
+        spec.entails(always(lift_state(Self::object_has_no_finalizers_or_deletion_timestamp(key)))),
+    ensures
+        spec.entails(
+            lift_state(Self::exists_delete_request_msg_in_flight_with_key(key))
+            .leads_to(lift_state(Self::objects_owner_references_satisfies(key, eventual_owner_ref)))
+        ),
+{
+    let pre = Self::exists_delete_request_msg_in_flight_with_key(key);
+    let post = Self::objects_owner_references_satisfies(key, eventual_owner_ref);
+    assert_by(
+        spec.entails(lift_state(pre).leads_to(lift_state(post))),
+        {
+            let msg_to_p = |msg: Message| {
+                lift_state(|s: Self| {
+                    &&& s.message_in_flight(msg)
+                    &&& msg.dst.is_KubernetesAPI()
+                    &&& msg.content.is_delete_request_with_key(key)
+                })
+            };
+            assert forall |msg: Message| spec.entails((#[trigger] msg_to_p(msg)).leads_to(lift_state(post))) by {
+                let input = Some(msg);
+                let msg_to_p_state = |s: Self| {
+                    &&& s.message_in_flight(msg)
+                    &&& msg.dst.is_KubernetesAPI()
+                    &&& msg.content.is_delete_request_with_key(key)
+                };
+                let stronger_next = |s, s_prime: Self| {
+                    &&& Self::next()(s, s_prime)
+                    &&& Self::busy_disabled()(s)
+                    &&& Self::every_update_msg_sets_owner_references_as(key, eventual_owner_ref)(s)
+                    &&& Self::object_has_no_finalizers_or_deletion_timestamp(key)(s)
+                };
+                strengthen_next_n!(
+                    stronger_next, spec,
+                    lift_action(Self::next()),
+                    lift_state(Self::busy_disabled()),
+                    lift_state(Self::every_update_msg_sets_owner_references_as(key, eventual_owner_ref)),
+                    lift_state(Self::object_has_no_finalizers_or_deletion_timestamp(key))
+                );
+                Self::lemma_pre_leads_to_post_by_kubernetes_api(spec, input, stronger_next, Self::handle_request(), msg_to_p_state, post);
+            }
+            leads_to_exists_intro(spec, msg_to_p, lift_state(post));
+            assert_by(
+                tla_exists(msg_to_p) == lift_state(pre),
+                {
+                    assert forall |ex| #[trigger] lift_state(pre).satisfied_by(ex) implies tla_exists(msg_to_p).satisfied_by(ex) by {
+                        let msg = choose |msg| {
+                            &&& #[trigger] ex.head().message_in_flight(msg)
+                            &&& msg.dst.is_KubernetesAPI()
+                            &&& msg.content.is_delete_request_with_key(key)
+                        };
+                        assert(msg_to_p(msg).satisfied_by(ex));
+                    }
+                    temp_pred_equality(tla_exists(msg_to_p), lift_state(pre));
+                }
+            )
+        }
+    );
+}
+
+}
+
+}

--- a/src/kubernetes_cluster/proof/builtin_controllers.rs
+++ b/src/kubernetes_cluster/proof/builtin_controllers.rs
@@ -149,7 +149,7 @@ pub proof fn lemma_eventually_objects_owner_references_satisfies(
     };
     always_to_always_later(spec, lift_state(Self::objects_owner_references_violates(key, eventual_owner_ref)).implies(lift_state(Self::garbage_collector_deletion_enabled(key))));
     combine_spec_entails_always_n!(
-        spec, lift_action(stronger_next), 
+        spec, lift_action(stronger_next),
         lift_action(Self::next()),
         lift_state(Self::every_create_msg_sets_owner_references_as(key, eventual_owner_ref)),
         lift_state(Self::every_update_msg_sets_owner_references_as(key, eventual_owner_ref)),
@@ -194,8 +194,7 @@ pub proof fn lemma_eventually_objects_owner_references_satisfies(
         spec.entails(lift_state(Self::objects_owner_references_violates(key, eventual_owner_ref)).leads_to(lift_state(post))),
         {
             Self::lemma_delete_msg_in_flight_leads_to_owner_references_satisfies(spec, key, eventual_owner_ref);
-            or_leads_to_combine_temp(spec, lift_state(post), lift_state(Self::exists_delete_request_msg_in_flight_with_key(key)), lift_state(post));
-            temp_pred_equality(lift_state(delete_msg_in_flight), lift_state(post).or(lift_state(Self::exists_delete_request_msg_in_flight_with_key(key))));
+            or_leads_to_combine_and_equality!(spec, lift_state(delete_msg_in_flight), lift_state(post), lift_state(Self::exists_delete_request_msg_in_flight_with_key(key)); lift_state(post));
             leads_to_trans_n!(spec, lift_state(pre), lift_state(delete_msg_in_flight), lift_state(post));
 
             temp_pred_equality(lift_state(Self::objects_owner_references_violates(key, eventual_owner_ref)).implies(lift_state(Self::garbage_collector_deletion_enabled(key))), lift_state(Self::objects_owner_references_violates(key, eventual_owner_ref)).implies(lift_state(pre)));
@@ -203,8 +202,7 @@ pub proof fn lemma_eventually_objects_owner_references_satisfies(
         }
     );
 
-    or_leads_to_combine_temp(spec, lift_state(Self::objects_owner_references_violates(key, eventual_owner_ref)), lift_state(post), lift_state(post));
-    temp_pred_equality(true_pred(), lift_state(Self::objects_owner_references_violates(key, eventual_owner_ref)).or(lift_state(post)));
+    or_leads_to_combine_and_equality!(spec, true_pred(), lift_state(Self::objects_owner_references_violates(key, eventual_owner_ref)), lift_state(post); lift_state(post));
 
     leads_to_stable(spec, stronger_next, |s: Self| true, post);
 }
@@ -250,7 +248,7 @@ proof fn lemma_delete_msg_in_flight_leads_to_owner_references_satisfies(
                     &&& Self::object_has_no_finalizers(key)(s)
                 };
                 combine_spec_entails_always_n!(
-                    spec, lift_action(stronger_next), 
+                    spec, lift_action(stronger_next),
                     lift_action(Self::next()),
                     lift_state(Self::busy_disabled()),
                     lift_state(Self::every_update_msg_sets_owner_references_as(key, eventual_owner_ref)),

--- a/src/kubernetes_cluster/proof/cluster_safety.rs
+++ b/src/kubernetes_cluster/proof/cluster_safety.rs
@@ -3,8 +3,9 @@
 #![allow(unused_imports)]
 use crate::external_api::spec::ExternalAPI;
 use crate::kubernetes_api_objects::{
-    api_method::*, common::*, config_map::*, persistent_volume_claim::*, pod::*, resource::*,
-    role::*, role_binding::*, secret::*, service::*, service_account::*, stateful_set::*,
+    api_method::*, common::*, config_map::*, object_meta::*, persistent_volume_claim::*, pod::*,
+    resource::*, role::*, role_binding::*, secret::*, service::*, service_account::*,
+    stateful_set::*,
 };
 use crate::kubernetes_cluster::spec::{cluster::*, cluster_state_machine::Step, message::*};
 use crate::reconciler::spec::reconciler::Reconciler;
@@ -28,13 +29,17 @@ pub proof fn lemma_always_has_rest_id_counter_no_smaller_than(
     init_invariant::<Self>(spec, Self::rest_id_counter_is(rest_id), Self::next(), invariant);
 }
 
-pub open spec fn object_is_well_formed(key: ObjectRef) -> StatePred<Self> {
+pub open spec fn metadata_is_well_formed(metadata: ObjectMetaView) -> bool {
+    &&& metadata.name.is_Some()
+    &&& metadata.namespace.is_Some()
+    &&& metadata.resource_version.is_Some()
+    &&& metadata.uid.is_Some()
+}
+
+pub open spec fn etcd_object_is_well_formed(key: ObjectRef) -> StatePred<Self> {
     |s: Self| {
         &&& s.resource_obj_of(key).object_ref() == key
-        &&& s.resource_obj_of(key).metadata.name.is_Some()
-        &&& s.resource_obj_of(key).metadata.namespace.is_Some()
-        &&& s.resource_obj_of(key).metadata.resource_version.is_Some()
-        &&& s.resource_obj_of(key).metadata.uid.is_Some()
+        &&& Self::metadata_is_well_formed(s.resource_obj_of(key).metadata)
         &&& {
             &&& key.kind == ConfigMapView::kind() ==> ConfigMapView::from_dynamic_object(s.resource_obj_of(key)).is_Ok()
             &&& key.kind == PersistentVolumeClaimView::kind() ==> PersistentVolumeClaimView::from_dynamic_object(s.resource_obj_of(key)).is_Ok()
@@ -51,7 +56,8 @@ pub open spec fn object_is_well_formed(key: ObjectRef) -> StatePred<Self> {
 pub open spec fn each_object_in_etcd_is_well_formed() -> StatePred<Self> {
     |s: Self| {
         forall |key: ObjectRef|
-            #[trigger] s.resource_key_exists(key) ==> Self::object_is_well_formed(key)(s)
+            #[trigger] s.resource_key_exists(key)
+                ==> Self::etcd_object_is_well_formed(key)(s)
     }
 }
 
@@ -67,7 +73,7 @@ pub proof fn lemma_always_each_object_in_etcd_is_well_formed(spec: TempPred<Self
     assert forall |s, s_prime: Self| invariant(s) && #[trigger] Self::next()(s, s_prime)
     implies invariant(s_prime) by {
         assert forall |key: ObjectRef| #[trigger] s_prime.resource_key_exists(key)
-        implies Self::object_is_well_formed(key)(s_prime) by {
+        implies Self::etcd_object_is_well_formed(key)(s_prime) by {
             if s.resource_key_exists(key) {} else {}
         }
     }
@@ -75,24 +81,25 @@ pub proof fn lemma_always_each_object_in_etcd_is_well_formed(spec: TempPred<Self
     init_invariant(spec, Self::init(), Self::next(), invariant);
 }
 
-pub open spec fn each_scheduled_key_is_consistent_with_its_object() -> StatePred<Self> {
+pub open spec fn each_scheduled_object_has_consistent_key_and_valid_metadata() -> StatePred<Self> {
     |s: Self| {
         forall |key: ObjectRef|
             #[trigger] s.reconcile_scheduled_for(key)
                 ==> s.reconcile_scheduled_obj_of(key).object_ref() == key
+                    && Self::metadata_is_well_formed(s.reconcile_scheduled_obj_of(key).metadata())
     }
 }
 
-pub proof fn lemma_always_each_scheduled_key_is_consistent_with_its_object(
+pub proof fn lemma_always_each_scheduled_object_has_consistent_key_and_valid_metadata(
     spec: TempPred<Self>
 )
     requires
         spec.entails(lift_state(Self::init())),
         spec.entails(always(lift_action(Self::next()))),
     ensures
-        spec.entails(always(lift_state(Self::each_scheduled_key_is_consistent_with_its_object()))),
+        spec.entails(always(lift_state(Self::each_scheduled_object_has_consistent_key_and_valid_metadata()))),
 {
-    let invariant = Self::each_scheduled_key_is_consistent_with_its_object();
+    let invariant = Self::each_scheduled_object_has_consistent_key_and_valid_metadata();
 
     Self::lemma_always_each_object_in_etcd_is_well_formed(spec);
 
@@ -105,24 +112,23 @@ pub proof fn lemma_always_each_scheduled_key_is_consistent_with_its_object(
 
     assert forall |s, s_prime: Self| invariant(s) && #[trigger] stronger_next(s, s_prime)
     implies invariant(s_prime) by {
-        let step = choose |step| Self::next_step(s, s_prime, step);
-        match step {
-            Step::ScheduleControllerReconcileStep(input) => {
-                assert forall |key: ObjectRef| #[trigger] s_prime.reconcile_scheduled_for(key)
-                implies s_prime.reconcile_scheduled_obj_of(key).object_ref() == key by {
-                    if input == key {
-                        K::from_dynamic_preserves_metadata();
-                        K::from_dynamic_preserves_kind();
-                        K::object_ref_is_well_formed();
-                    } else {
+        assert forall |key: ObjectRef| #[trigger] s_prime.reconcile_scheduled_for(key)
+        implies s_prime.reconcile_scheduled_obj_of(key).object_ref() == key
+        && Self::metadata_is_well_formed(s_prime.reconcile_scheduled_obj_of(key).metadata()) by {
+            let step = choose |step| Self::next_step(s, s_prime, step);
+            match step {
+                Step::ScheduleControllerReconcileStep(input) => {
+
+                        if input == key {
+                            K::from_dynamic_preserves_metadata();
+                            K::from_dynamic_preserves_kind();
+                            K::object_ref_is_well_formed();
+                        } else {
+                            assert(s.reconcile_scheduled_for(key));
+                        }
+                },
+                _ => {
                         assert(s.reconcile_scheduled_for(key));
-                    }
-                }
-            },
-            _ => {
-                assert forall |key: ObjectRef| #[trigger] s_prime.reconcile_scheduled_for(key)
-                implies s_prime.reconcile_scheduled_obj_of(key).object_ref() == key by {
-                    assert(s.reconcile_scheduled_for(key));
                 }
             }
         }
@@ -131,38 +137,40 @@ pub proof fn lemma_always_each_scheduled_key_is_consistent_with_its_object(
     init_invariant(spec, Self::init(), stronger_next, invariant);
 }
 
-pub open spec fn each_key_in_reconcile_is_consistent_with_its_object() -> StatePred<Self> {
+pub open spec fn each_object_in_reconcile_has_consistent_key_and_valid_metadata() -> StatePred<Self> {
     |s: Self| {
         forall |key: ObjectRef|
             #[trigger] s.reconcile_state_contains(key)
                 ==> s.triggering_cr_of(key).object_ref() == key
+                    && Self::metadata_is_well_formed(s.triggering_cr_of(key).metadata())
     }
 }
 
-pub proof fn lemma_always_each_key_in_reconcile_is_consistent_with_its_object(
+pub proof fn lemma_always_each_object_in_reconcile_has_consistent_key_and_valid_metadata(
     spec: TempPred<Self>
 )
     requires
         spec.entails(lift_state(Self::init())),
         spec.entails(always(lift_action(Self::next()))),
     ensures
-        spec.entails(always(lift_state(Self::each_key_in_reconcile_is_consistent_with_its_object()))),
+        spec.entails(always(lift_state(Self::each_object_in_reconcile_has_consistent_key_and_valid_metadata()))),
 {
-    let invariant = Self::each_key_in_reconcile_is_consistent_with_its_object();
+    let invariant = Self::each_object_in_reconcile_has_consistent_key_and_valid_metadata();
 
-    Self::lemma_always_each_scheduled_key_is_consistent_with_its_object(spec);
+    Self::lemma_always_each_scheduled_object_has_consistent_key_and_valid_metadata(spec);
 
     let stronger_next = |s, s_prime: Self| {
         &&& Self::next()(s, s_prime)
-        &&& Self::each_scheduled_key_is_consistent_with_its_object()(s)
+        &&& Self::each_scheduled_object_has_consistent_key_and_valid_metadata()(s)
     };
 
-    strengthen_next(spec, Self::next(), Self::each_scheduled_key_is_consistent_with_its_object(), stronger_next);
+    strengthen_next(spec, Self::next(), Self::each_scheduled_object_has_consistent_key_and_valid_metadata(), stronger_next);
 
     assert forall |s, s_prime: Self| invariant(s) && #[trigger] stronger_next(s, s_prime)
     implies invariant(s_prime) by {
         assert forall |key: ObjectRef| #[trigger] s_prime.reconcile_state_contains(key)
-        implies s_prime.triggering_cr_of(key).object_ref() == key by {
+        implies s_prime.triggering_cr_of(key).object_ref() == key
+        && Self::metadata_is_well_formed(s_prime.triggering_cr_of(key).metadata()) by {
             if s.reconcile_state_contains(key) {
             } else {
                 assert(s.reconcile_scheduled_for(key));

--- a/src/kubernetes_cluster/proof/controller_runtime_eventual_safety.rs
+++ b/src/kubernetes_cluster/proof/controller_runtime_eventual_safety.rs
@@ -44,19 +44,9 @@ pub proof fn lemma_true_leads_to_always_the_object_in_schedule_has_spec_and_uid_
         &&& Self::next()(s, s_prime)
         &&& Self::desired_state_is(cr)(s)
     };
-    entails_always_and_n!(
-        spec,
-        lift_action(Self::next()),
-        lift_state(Self::desired_state_is(cr))
-    );
-    temp_pred_equality(
-        lift_action(stronger_next),
-        lift_action(Self::next())
-        .and(lift_state(Self::desired_state_is(cr)))
-    );
+    combine_spec_entails_always_n!(spec, lift_action(stronger_next), lift_action(Self::next()), lift_state(Self::desired_state_is(cr)));
 
     K::object_ref_is_well_formed();
-
     Self::lemma_pre_leads_to_post_by_schedule_controller_reconcile_borrow_from_spec(
         spec, input, stronger_next, Self::desired_state_is(cr), pre, post
     );
@@ -94,11 +84,7 @@ pub proof fn lemma_true_leads_to_always_the_object_in_reconcile_has_spec_and_uid
                 &&& Self::next()(s, s_prime)
                 &&& Self::the_object_in_schedule_has_spec_and_uid_as(cr)(s)
             };
-            entails_always_and_n!(spec, lift_action(Self::next()), lift_state(Self::the_object_in_schedule_has_spec_and_uid_as(cr)));
-            temp_pred_equality(
-                lift_action(stronger_next),
-                lift_action(Self::next()).and(lift_state(Self::the_object_in_schedule_has_spec_and_uid_as(cr)))
-            );
+            combine_spec_entails_always_n!(spec, lift_action(stronger_next), lift_action(Self::next()), lift_state(Self::the_object_in_schedule_has_spec_and_uid_as(cr)));
 
             // Here we split the cases by whether s.reconcile_scheduled_for(cr.object_ref()) is true
             assert_by(

--- a/src/kubernetes_cluster/proof/controller_runtime_eventual_safety.rs
+++ b/src/kubernetes_cluster/proof/controller_runtime_eventual_safety.rs
@@ -89,35 +89,27 @@ pub proof fn lemma_true_leads_to_always_the_object_in_reconcile_has_spec_and_uid
     };
     // Here we split the cases by whether s.reconcile_scheduled_for(cr.object_ref()) is true
     assert_by(
-        spec.entails(
-            lift_state(scheduled_and_not_reconcile).leads_to(lift_state(Self::the_object_in_reconcile_has_spec_and_uid_as(cr)))
-        ),
+        spec.entails(lift_state(not_scheduled_or_reconcile).leads_to(lift_state(scheduled_and_not_reconcile))),
+        {
+            let input = cr.object_ref();
+            K::object_ref_is_well_formed();
+            Self::lemma_pre_leads_to_post_by_schedule_controller_reconcile_borrow_from_spec(
+                spec, input, stronger_next, Self::desired_state_is(cr), not_scheduled_or_reconcile, scheduled_and_not_reconcile
+            );
+        }
+    );
+    assert_by(
+        spec.entails(lift_state(scheduled_and_not_reconcile).leads_to(lift_state(Self::the_object_in_reconcile_has_spec_and_uid_as(cr)))),
         {
             let post = Self::the_object_in_reconcile_has_spec_and_uid_as(cr);
             let input = (None, None, Some(cr.object_ref()));
-
             K::object_ref_is_well_formed();
             Self::lemma_pre_leads_to_post_by_controller(
                 spec, input, stronger_next, Self::run_scheduled_reconcile(), scheduled_and_not_reconcile, post
             );
         }
     );
-
-    assert_by(
-        spec.entails(
-            lift_state(not_scheduled_or_reconcile).leads_to(lift_state(Self::the_object_in_reconcile_has_spec_and_uid_as(cr)))
-        ),
-        {
-            let input = cr.object_ref();
-
-            K::object_ref_is_well_formed();
-            Self::lemma_pre_leads_to_post_by_schedule_controller_reconcile_borrow_from_spec(
-                spec, input, stronger_next, Self::desired_state_is(cr), not_scheduled_or_reconcile, scheduled_and_not_reconcile
-            );
-            leads_to_trans_temp(spec, lift_state(not_scheduled_or_reconcile), lift_state(scheduled_and_not_reconcile), lift_state(Self::the_object_in_reconcile_has_spec_and_uid_as(cr)));
-        }
-    );
-
+    leads_to_trans_temp(spec, lift_state(not_scheduled_or_reconcile), lift_state(scheduled_and_not_reconcile), lift_state(Self::the_object_in_reconcile_has_spec_and_uid_as(cr)));
     let not_reconcile = |s: Self| !s.reconcile_state_contains(cr.object_ref());
 
     or_leads_to_combine_and_equality!(
@@ -126,8 +118,7 @@ pub proof fn lemma_true_leads_to_always_the_object_in_reconcile_has_spec_and_uid
     );
 
     leads_to_trans_temp(
-        spec, true_pred(),
-        lift_state(|s: Self| !s.reconcile_state_contains(cr.object_ref())),
+        spec, true_pred(), lift_state(|s: Self| !s.reconcile_state_contains(cr.object_ref())),
         lift_state(Self::the_object_in_reconcile_has_spec_and_uid_as(cr))
     );
     leads_to_stable_temp(spec, lift_action(stronger_next), true_pred(), lift_state(Self::the_object_in_reconcile_has_spec_and_uid_as(cr)));

--- a/src/kubernetes_cluster/proof/controller_runtime_liveness.rs
+++ b/src/kubernetes_cluster/proof/controller_runtime_liveness.rs
@@ -371,19 +371,12 @@ pub proof fn lemma_from_in_flight_resp_matches_pending_req_at_some_state_to_next
         &&& Self::each_resp_matches_at_most_one_pending_req(cr.object_ref())(s)
         &&& Self::each_resp_if_matches_pending_req_then_no_other_resp_matches(cr.object_ref())(s)
     };
-    entails_always_and_n!(
-        spec,
+    combine_spec_entails_always_n!(
+        spec, lift_action(stronger_next),
         lift_action(Self::next()),
         lift_state(Self::crash_disabled()),
         lift_state(Self::each_resp_matches_at_most_one_pending_req(cr.object_ref())),
         lift_state(Self::each_resp_if_matches_pending_req_then_no_other_resp_matches(cr.object_ref()))
-    );
-    temp_pred_equality(
-        lift_action(stronger_next),
-        lift_action(Self::next())
-        .and(lift_state(Self::crash_disabled()))
-        .and(lift_state(Self::each_resp_matches_at_most_one_pending_req(cr.object_ref())))
-        .and(lift_state(Self::each_resp_if_matches_pending_req_then_no_other_resp_matches(cr.object_ref())))
     );
     let known_resp_in_flight = |resp| lift_state(
         |s: Self| {
@@ -462,19 +455,12 @@ pub proof fn lemma_from_pending_req_in_flight_at_some_state_to_next_state(
             &&& Self::busy_disabled()(s)
             &&& Self::every_in_flight_msg_has_unique_id()(s)
         };
-        entails_always_and_n!(
-            spec,
+        combine_spec_entails_always_n!(
+            spec, lift_action(stronger_next),
             lift_action(Self::next()),
             lift_state(Self::crash_disabled()),
             lift_state(Self::busy_disabled()),
             lift_state(Self::every_in_flight_msg_has_unique_id())
-        );
-        temp_pred_equality(
-            lift_action(stronger_next),
-            lift_action(Self::next())
-            .and(lift_state(Self::crash_disabled()))
-            .and(lift_state(Self::busy_disabled()))
-            .and(lift_state(Self::every_in_flight_msg_has_unique_id()))
         );
         let input = Some(req_msg);
         assert forall |s, s_prime: Self| pre_1(s) && #[trigger] stronger_next(s, s_prime)
@@ -549,16 +535,7 @@ pub proof fn lemma_from_some_state_with_ext_resp_to_two_next_states_to_reconcile
         &&& Self::next()(s, s_prime)
         &&& Self::crash_disabled()(s)
     };
-    entails_always_and_n!(
-        spec,
-        lift_action(Self::next()),
-        lift_state(Self::crash_disabled())
-    );
-    temp_pred_equality(
-        lift_action(stronger_next),
-        lift_action(Self::next())
-        .and(lift_state(Self::crash_disabled()))
-    );
+    combine_spec_entails_always_n!(spec, lift_action(stronger_next), lift_action(Self::next()), lift_state(Self::crash_disabled()));
     let input = (None, None, Some(cr.object_ref()));
     Self::lemma_pre_leads_to_post_by_controller(spec, input, stronger_next, Self::continue_reconcile(), no_req_at_state, Self::at_expected_reconcile_states(cr.object_ref(), next_state));
     leads_to_trans_n!(

--- a/src/kubernetes_cluster/proof/controller_runtime_safety.rs
+++ b/src/kubernetes_cluster/proof/controller_runtime_safety.rs
@@ -41,13 +41,7 @@ pub proof fn lemma_always_scheduled_cr_has_lower_uid_than_uid_counter(spec: Temp
         && Self::every_object_in_etcd_has_lower_uid_than_uid_counter()(s)
     };
     Self::lemma_always_every_object_in_etcd_has_lower_uid_than_uid_counter(spec);
-    entails_always_and_n!(
-        spec, lift_action(Self::next()), lift_state(Self::every_object_in_etcd_has_lower_uid_than_uid_counter())
-    );
-    temp_pred_equality(
-        lift_action(stronger_next),
-        lift_action(Self::next()).and(lift_state(Self::every_object_in_etcd_has_lower_uid_than_uid_counter()))
-    );
+    combine_spec_entails_always_n!(spec, lift_action(stronger_next), lift_action(Self::next()), lift_state(Self::every_object_in_etcd_has_lower_uid_than_uid_counter()));
     assert forall |s, s_prime| invariant(s) && #[trigger] stronger_next(s, s_prime) implies invariant(s_prime) by {
         // if s_prime.controller_state.scheduled_reconciles.contains_key(key) {
             assert(s.kubernetes_api_state.uid_counter <= s_prime.kubernetes_api_state.uid_counter);
@@ -81,12 +75,8 @@ pub proof fn lemma_always_triggering_cr_has_lower_uid_than_uid_counter(spec: Tem
         && Self::scheduled_cr_has_lower_uid_than_uid_counter()(s)
     };
     Self::lemma_always_scheduled_cr_has_lower_uid_than_uid_counter(spec);
-    entails_always_and_n!(
-        spec, lift_action(Self::next()), lift_state(Self::scheduled_cr_has_lower_uid_than_uid_counter())
-    );
-    temp_pred_equality(
-        lift_action(stronger_next),
-        lift_action(Self::next()).and(lift_state(Self::scheduled_cr_has_lower_uid_than_uid_counter()))
+    combine_spec_entails_always_n!(
+        spec, lift_action(stronger_next), lift_action(Self::next()), lift_state(Self::scheduled_cr_has_lower_uid_than_uid_counter())
     );
     init_invariant(spec, Self::init(), stronger_next, invariant);
 }

--- a/src/kubernetes_cluster/proof/kubernetes_api_liveness.rs
+++ b/src/kubernetes_cluster/proof/kubernetes_api_liveness.rs
@@ -402,16 +402,11 @@ pub proof fn lemma_some_rest_id_leads_to_always_every_in_flight_req_msg_satisfie
                         && Self::rest_id_counter_is_no_smaller_than(rest_id)(s)
                         && Self::every_new_req_msg_if_in_flight_then_satisfies(requirements)(s, s_prime)
                     };
-                    entails_always_and_n!(
-                        spec_with_rest_id,
+                    combine_spec_entails_always_n!(
+                        spec_with_rest_id, lift_action(stronger_next),
                         lift_action(Self::next()),
                         lift_state(Self::rest_id_counter_is_no_smaller_than(rest_id)),
                         lift_action(Self::every_new_req_msg_if_in_flight_then_satisfies(requirements))
-                    );
-                    temp_pred_equality(
-                        lift_action(stronger_next),
-                        lift_action(Self::next()).and(lift_state(Self::rest_id_counter_is_no_smaller_than(rest_id)))
-                        .and(lift_action(Self::every_new_req_msg_if_in_flight_then_satisfies(requirements)))
                     );
                     init_invariant(spec_with_rest_id, init, stronger_next, invariant);
                 }
@@ -672,8 +667,8 @@ proof fn pending_requests_num_decreases(
         &&& s.has_rest_id_counter_no_smaller_than(rest_id)
         &&& !s.busy_enabled
     };
-    strengthen_next_n!(
-        stronger_next, spec,
+    combine_spec_entails_always_n!(
+        spec, lift_action(stronger_next), 
         lift_action(Self::next()),
         lift_state(Self::rest_id_counter_is_no_smaller_than(rest_id)),
         lift_state(Self::busy_disabled())

--- a/src/kubernetes_cluster/proof/message.rs
+++ b/src/kubernetes_cluster/proof/message.rs
@@ -138,8 +138,8 @@ pub proof fn lemma_always_every_in_flight_msg_has_unique_id()
     };
     Self::lemma_always_every_in_flight_msg_has_lower_id_than_allocator();
     Self::lemma_always_every_in_flight_req_is_unique();
-    strengthen_next_n!(
-        stronger_next, Self::sm_spec(),
+    combine_spec_entails_always_n!(
+        Self::sm_spec(), lift_action(stronger_next), 
         lift_action(Self::next()),
         lift_state(Self::every_in_flight_msg_has_lower_id_than_allocator()),
         lift_state(Self::every_in_flight_req_is_unique())

--- a/src/kubernetes_cluster/proof/mod.rs
+++ b/src/kubernetes_cluster/proof/mod.rs
@@ -1,5 +1,6 @@
 // Copyright 2022 VMware, Inc.
 // SPDX-License-Identifier: MIT
+pub mod builtin_controllers;
 pub mod cluster;
 pub mod cluster_safety;
 pub mod controller_runtime;

--- a/src/kubernetes_cluster/spec/builtin_controllers/garbage_collector.rs
+++ b/src/kubernetes_cluster/spec/builtin_controllers/garbage_collector.rs
@@ -25,50 +25,42 @@ impl <K: ResourceView, E: ExternalAPI, R: Reconciler<K, E>> Cluster<K, E, R> {
 
 pub open spec fn garbage_collector_deletion_enabled(key: ObjectRef) -> StatePred<Self> {
     |s: Self| {
-        let owner_references = s.resource_obj_of(key).metadata.owner_references.get_Some_0();
-
-        &&& s.resource_key_exists(key)
-        &&& s.resource_obj_of(key).metadata.owner_references.is_Some()
-        &&& s.resource_obj_of(key).metadata.owner_references.get_Some_0().len() > 0
-        &&& forall |i| #![trigger owner_references[i]] 0 <= i < owner_references.len() ==> {
-            ||| !s.resource_key_exists(owner_reference_to_object_reference(owner_references[i], key.namespace))
-            ||| s.resource_obj_of(owner_reference_to_object_reference(owner_references[i], key.namespace)).metadata.uid != Some(owner_references[i].uid)
-        }
+        let input = BuiltinControllersActionInput {
+            choice: BuiltinControllerChoice::GarbageCollector, key: key, 
+            resources: s.kubernetes_api_state.resources, rest_id_allocator: s.rest_id_allocator
+        };
+        (Self::run_garbage_collector().precondition)(input, s.builtin_controllers_state)
     }
 }
 
 pub open spec fn run_garbage_collector() -> BuiltinControllersAction {
     Action {
         precondition: |input: BuiltinControllersActionInput, s: BuiltinControllersState| {
+            let resources = input.resources;
+            let key = input.key;
+            let owner_references = resources[key].metadata.owner_references.get_Some_0();
             // The garbage collector is chosen by the top level state machine
             &&& input.choice.is_GarbageCollector()
             // The object exists in the cluster state
-            &&& input.resources.dom().contains(input.key)
+            &&& resources.dom().contains(input.key)
             // and it has at least one owner reference
-            &&& input.resources[input.key].metadata.owner_references.is_Some()
-            &&& input.resources[input.key].metadata.owner_references.get_Some_0().len() > 0
-        },
-        transition: |input: BuiltinControllersActionInput, s: BuiltinControllersState| {
-            let resources = input.resources;
-            let key = input.key;
-            let namespace = key.namespace;
-            let owner_references = resources[key].metadata.owner_references.get_Some_0();
+            &&& resources[key].metadata.owner_references.is_Some()
+            &&& resources[key].metadata.owner_references.get_Some_0().len() > 0
             // The garbage collector decides whether to delete an object by checking its owner references,
             // it deletes the object if for each owner reference...
-            if forall |i| #![trigger owner_references[i]] 0 <= i < owner_references.len() ==> {
+            &&& forall |i| #![trigger owner_references[i]] 0 <= i < owner_references.len() ==> {
                 // the referred owner object does not exist in the cluster state
-                ||| !resources.dom().contains(owner_reference_to_object_reference(owner_references[i], namespace))
+                ||| !resources.dom().contains(owner_reference_to_object_reference(owner_references[i], key.namespace))
                 // or it exists but has a different uid
                 // (which means the actual owner was deleted and another object with the same name gets created again)
-                ||| resources[owner_reference_to_object_reference(owner_references[i], namespace)].metadata.uid != Some(owner_references[i].uid)
-            } {
-                let delete_req_msg = built_in_controller_req_msg(delete_req_msg_content(
-                    key, input.rest_id_allocator.allocate().1
-                ));
-                (s, (Multiset::singleton(delete_req_msg), input.rest_id_allocator.allocate().0))
-            } else {
-                (s, (Multiset::empty(), input.rest_id_allocator))
+                ||| resources[owner_reference_to_object_reference(owner_references[i], key.namespace)].metadata.uid != Some(owner_references[i].uid)
             }
+        },
+        transition: |input: BuiltinControllersActionInput, s: BuiltinControllersState| {
+            let delete_req_msg = built_in_controller_req_msg(delete_req_msg_content(
+                input.key, input.rest_id_allocator.allocate().1
+            ));
+            (s, (Multiset::singleton(delete_req_msg), input.rest_id_allocator.allocate().0))
         },
     }
 }

--- a/src/temporal_logic/rules.rs
+++ b/src/temporal_logic/rules.rs
@@ -1138,11 +1138,11 @@ pub use combine_with_next_internal;
 ///     spec |= []p2
 ///        ...
 ///     spec |= []pn
-///     all == p1 /\ p2 /\ ... /\ pn
+///     partial_spec <==> p1 /\ p2 /\ ... /\ pn
 /// post:
 ///     spec |= []all
 ///
-/// Usage: combine_spec_entails_always_n!(spec, all, p1, p2, p3, p4)
+/// Usage: combine_spec_entails_always_n!(spec, partial_spec, p1, p2, p3, p4)
 #[macro_export]
 macro_rules! combine_spec_entails_always_n {
     [$($tail:tt)*] => {
@@ -1152,9 +1152,9 @@ macro_rules! combine_spec_entails_always_n {
 
 #[macro_export]
 macro_rules! combine_spec_entails_always_n_internal {
-    ($spec:expr, $all:expr, $($tail:tt)*) => {
+    ($spec:expr, $partial_spec:expr, $($tail:tt)*) => {
         entails_always_and_n!($spec, $($tail)*);
-        temp_pred_equality($all, combine_with_next!($($tail)*));
+        temp_pred_equality($partial_spec, combine_with_next!($($tail)*));
     };
 }
 
@@ -1163,13 +1163,12 @@ pub use combine_spec_entails_always_n_internal;
 
 /// Show that an spec entails the invariant by a group of action/state predicates which are also invariants entailed by spec.
 /// pre:
-///     spec |= []partial_spec
 ///     partial_spec |= inv
 ///     spec |= []p1
 ///     spec |= []p2
 ///         ...
 ///     spec |= []pn
-///     partial_spec == p1 /\ p2 /\ ... /\ pn
+///     partial_spec <==> p1 /\ p2 /\ ... /\ pn
 /// post:
 ///     spec |= []inv
 ///

--- a/src/temporal_logic/rules.rs
+++ b/src/temporal_logic/rules.rs
@@ -2400,27 +2400,6 @@ pub proof fn leads_to_trans_relaxed_auto<T>(spec: TempPred<T>)
     };
 }
 
-/// This rule can be used to prove leads_to when we have part (q) in this lemma of pre leads to post and
-/// the rest of pre directly implies post, which means pre ==> q \/ r.
-/// Sometimes pre ==> q \/ r is subject to some assumption. If that assumption is always satisfied, we can get
-/// spec |= always(assumption) |= always(pre ==> q \/ r) |= pre ~> q \/ r ~> r.
-///
-/// If there doesn't have to be an assumtpion, i.e., |= pre ==> q \/ r, just pass true as the assumption.
-pub proof fn partial_implies_and_partial_leads_to_to_leads_to<T>(spec: TempPred<T>, assumption: TempPred<T>, pre: TempPred<T>, q: TempPred<T>, r: TempPred<T>)
-    requires
-        spec.entails(always(assumption)),
-        assumption.entails(pre.implies(q.or(r))),
-        spec.entails(q.leads_to(r)),
-    ensures
-        spec.entails(pre.leads_to(r)),
-{
-    implies_preserved_by_always_temp(assumption, pre.implies(q.or(r)));
-    entails_trans(spec, always(assumption), always(pre.implies(q.or(r))));
-    leads_to_self_temp(r);
-    or_leads_to_combine_temp(spec, q, r, r);
-    leads_to_weaken_temp(spec, q.or(r), r, pre, r);
-}
-
 /// Weaken leads_to by implies.
 /// pre:
 ///     spec |= [](p2 => p1)

--- a/src/temporal_logic/rules.rs
+++ b/src/temporal_logic/rules.rs
@@ -1194,6 +1194,26 @@ macro_rules! invariant_action_n_internal {
 pub use invariant_action_n;
 pub use invariant_action_n_internal;
 
+#[macro_export]
+macro_rules! invariant_state_n {
+    [$($tail:tt)*] => {
+        ::builtin_macros::verus_proof_macro_exprs!($crate::temporal_logic::rules::invariant_state_n_internal!($($tail)*))
+    }
+}
+
+#[macro_export]
+macro_rules! invariant_state_n_internal {
+    ($spec:expr, $state:expr, $inv:expr, $($tail:tt)*) => {
+        entails_always_and_n!($spec, $($tail)*);
+        temp_pred_equality(lift_state($state), combine_with_next!($($tail)*));
+        implies_preserved_by_always_temp(lift_state($state), $inv);
+        entails_trans($spec, always(lift_state($state)), always($inv));
+    };
+}
+
+pub use invariant_state_n;
+pub use invariant_state_n_internal;
+
 /// Combining two specs together entails p and q if each of them entails p, q respectively.
 /// pre:
 ///     spec1 |= p

--- a/src/temporal_logic/rules.rs
+++ b/src/temporal_logic/rules.rs
@@ -2642,6 +2642,7 @@ macro_rules! leads_to_always_combine_n_internal {
     };
     ($spec:expr, $p:expr, $q1:expr, $q2:expr, $($tail:tt)*) => {
         leads_to_always_combine_temp($spec, $p, $q1, $q2);
+        always_and_equality($q1, $q2);
         leads_to_always_combine_n_internal!($spec, $p, $q1.and($q2), $($tail)*);
     };
 }
@@ -2661,6 +2662,7 @@ pub proof fn leads_to_always_combine_temp<T>(spec: TempPred<T>, p: TempPred<T>, 
         spec.entails(p.leads_to(always(r))),
     ensures
         spec.entails(p.leads_to(always(q.and(r)))),
+        spec.entails(p.leads_to(always(q).and(always(r)))),
 {
     assert forall |ex| #[trigger] spec.satisfied_by(ex) implies p.leads_to(always(q.and(r))).satisfied_by(ex) by {
         assert forall |i| #[trigger] p.satisfied_by(ex.suffix(i)) implies eventually(always(q.and(r))).satisfied_by(ex.suffix(i)) by {
@@ -2684,6 +2686,7 @@ pub proof fn leads_to_always_combine_temp<T>(spec: TempPred<T>, p: TempPred<T>, 
             }
         };
     };
+    always_and_equality(q, r);
 }
 
 /// StatePred version of leads_to_always_combine_temp.
@@ -2693,6 +2696,7 @@ pub proof fn leads_to_always_combine<T>(spec: TempPred<T>, p: StatePred<T>, q: S
         spec.entails(lift_state(p).leads_to(always(lift_state(r)))),
     ensures
         spec.entails(lift_state(p).leads_to(always(lift_state(q).and(lift_state(r))))),
+        spec.entails(lift_state(p).leads_to(always(lift_state(q)).and(always(lift_state(r))))),
 {
     leads_to_always_combine_temp::<T>(spec, lift_state(p), lift_state(q), lift_state(r));
 }

--- a/src/temporal_logic/rules.rs
+++ b/src/temporal_logic/rules.rs
@@ -581,6 +581,21 @@ pub proof fn temp_pred_equality<T>(p: TempPred<T>, q: TempPred<T>)
     fun_ext::<Execution<T>, bool>(p.pred, q.pred);
 }
 
+pub proof fn always_to_always_later<T>(spec: TempPred<T>, p: TempPred<T>)
+    requires
+        spec.entails(always(p)),
+    ensures
+        spec.entails(always(later(p))),
+{
+    assert forall |ex| #[trigger] always(p).satisfied_by(ex) implies always(later(p)).satisfied_by(ex) by {
+        always_propagate_forwards(ex, p, 1);
+        assert forall |i| #[trigger] later(p).satisfied_by(ex.suffix(i)) by {
+            execution_equality(ex.suffix(i).suffix(1), ex.suffix(1).suffix(i));
+        }
+    }
+    entails_trans(spec, always(p), always(later(p)));
+}
+
 pub proof fn always_double_equality<T>(p: TempPred<T>)
     ensures
         always(always(p)) == always(p),

--- a/src/temporal_logic/rules.rs
+++ b/src/temporal_logic/rules.rs
@@ -2421,19 +2421,6 @@ pub proof fn partial_implies_and_partial_leads_to_to_leads_to<T>(spec: TempPred<
     leads_to_weaken_temp(spec, q.or(r), r, pre, r);
 }
 
-pub proof fn implies_with_spec_to_leads_to<T>(spec: TempPred<T>, pre: TempPred<T>, p: TempPred<T>, q: TempPred<T>, r: TempPred<T>)
-    requires
-        spec.entails(always(pre)),
-        pre.entails(p.implies(q)),
-        spec.entails(q.leads_to(r)),
-    ensures
-        spec.entails(p.leads_to(r)),
-{
-    implies_preserved_by_always_temp(pre, p.implies(q));
-    entails_trans(spec, always(pre), always(p.implies(q)));
-    leads_to_weaken_temp(spec, q, r, p, r);
-}
-
 /// Weaken leads_to by implies.
 /// pre:
 ///     spec |= [](p2 => p1)


### PR DESCRIPTION
This PR first finishes the proof of all invariants used in the liveness proof of rabbitmq controller. Besides that, I also simplify the proof by removing some obviously redundant code and writing some common functions for different objects.

Also, I move the reasoning of gc action to the cluster module, so that all the controllers can use the lemma to prove that eventually only object with valid owner reference will exists.