### PR TITLE
Validate that there is only one controller owner reference

### DIFF
--- a/src/kubernetes_api_objects/owner_reference.rs
+++ b/src/kubernetes_api_objects/owner_reference.rs
@@ -52,6 +52,13 @@ pub struct OwnerReferenceView {
     pub uid: nat,
 }
 
+impl OwnerReferenceView {
+    pub open spec fn is_controller_ref(self) -> bool {
+        self.controller.is_Some()
+        && self.controller.get_Some_0()
+    }
+}
+
 pub open spec fn owner_reference_to_object_reference(owner_reference: OwnerReferenceView, namespace: StringView) -> ObjectRef {
     ObjectRef {
         kind: owner_reference.kind,

--- a/src/kubernetes_cluster/proof/kubernetes_api_liveness.rs
+++ b/src/kubernetes_cluster/proof/kubernetes_api_liveness.rs
@@ -204,6 +204,8 @@ pub proof fn lemma_create_req_leads_to_res_exists(spec: TempPred<Self>, msg: Mes
                 &&& msg.content.get_create_request().obj.metadata.name.is_Some()
                 &&& msg.content.get_create_request().obj.metadata.namespace.is_None()
                 &&& Self::object_has_well_formed_spec(msg.content.get_create_request().obj)
+                &&& msg.content.get_create_request().obj.metadata.owner_references.is_Some()
+                &&& msg.content.get_create_request().obj.metadata.owner_references.get_Some_0().len() == 1
                 &&& msg.content.get_create_request().obj.kind == K::kind() ==> K::rule(K::from_dynamic_object(msg.content.get_create_request().obj).get_Ok_0())
             })
                 .leads_to(lift_state(|s: Self|
@@ -223,6 +225,8 @@ pub proof fn lemma_create_req_leads_to_res_exists(spec: TempPred<Self>, msg: Mes
         &&& obj.metadata.name.is_Some()
         &&& obj.metadata.namespace.is_None()
         &&& Self::object_has_well_formed_spec(obj)
+        &&& msg.content.get_create_request().obj.metadata.owner_references.is_Some()
+        &&& msg.content.get_create_request().obj.metadata.owner_references.get_Some_0().len() == 1
         &&& obj.kind == K::kind() ==> K::rule(K::from_dynamic_object(obj).get_Ok_0())
     };
     let post = |s: Self|
@@ -668,7 +672,7 @@ proof fn pending_requests_num_decreases(
         &&& !s.busy_enabled
     };
     combine_spec_entails_always_n!(
-        spec, lift_action(stronger_next), 
+        spec, lift_action(stronger_next),
         lift_action(Self::next()),
         lift_state(Self::rest_id_counter_is_no_smaller_than(rest_id)),
         lift_state(Self::busy_disabled())

--- a/src/kubernetes_cluster/spec/kubernetes_api/state_machine.rs
+++ b/src/kubernetes_cluster/spec/kubernetes_api/state_machine.rs
@@ -95,6 +95,17 @@ pub open spec fn validate_create_request(req: CreateRequest, s: KubernetesAPISta
     } else if s.resources.dom().contains(req.obj.set_namespace(req.namespace).object_ref()) {
         // Creation fails because the object already exists
         Some(APIError::ObjectAlreadyExists)
+    } else if req.obj.metadata.owner_references.is_Some()
+        && req.obj.metadata.owner_references.get_Some_0().len() > 1
+        && exists |i, j| #![auto] (
+            i != j
+            && 0 <= i < req.obj.metadata.owner_references.get_Some_0().len()
+            && 0 <= j < req.obj.metadata.owner_references.get_Some_0().len()
+            && req.obj.metadata.owner_references.get_Some_0()[i].is_controller_ref()
+            && req.obj.metadata.owner_references.get_Some_0()[j].is_controller_ref()
+        ) {
+        // Creation fails because the object has multiple controller owner references
+        Some(APIError::Invalid)
     } else if req.obj.kind == K::kind() && !K::rule(K::from_dynamic_object(req.obj).get_Ok_0()) {
         Some(APIError::Invalid)
     } else {

--- a/src/kubernetes_cluster/spec/kubernetes_api/state_machine.rs
+++ b/src/kubernetes_cluster/spec/kubernetes_api/state_machine.rs
@@ -223,6 +223,17 @@ pub open spec fn validate_update_request(req: UpdateRequest, s: KubernetesAPISta
         // Update fails because the object has a wrong uid
         // TODO: double check the Error type
         Some(APIError::InternalError)
+    } else if req.obj.metadata.owner_references.is_Some()
+        && req.obj.metadata.owner_references.get_Some_0().len() > 1
+        && exists |i, j| #![auto] (
+            i != j
+            && 0 <= i < req.obj.metadata.owner_references.get_Some_0().len()
+            && 0 <= j < req.obj.metadata.owner_references.get_Some_0().len()
+            && req.obj.metadata.owner_references.get_Some_0()[i].is_controller_ref()
+            && req.obj.metadata.owner_references.get_Some_0()[j].is_controller_ref()
+        ) {
+        // Update fails because the object has multiple controller owner references
+        Some(APIError::Invalid)
     } else if req.obj.kind == K::kind() && !(
         K::rule(K::from_dynamic_object(req.obj).get_Ok_0())
         && K::transition_rule(K::from_dynamic_object(req.obj).get_Ok_0(), K::from_dynamic_object(s.resources[req.key]).get_Ok_0())


### PR DESCRIPTION
Add the specification for checking whether the controller has multiple controller owner references, and if so, reject the creation/update requests. The corresponding validation implementation in Kubernetes can be found at https://github.com/kubernetes/kubernetes/blob/v1.26.3/staging/src/k8s.io/apimachinery/pkg/api/validation/objectmeta.go#L92-L108.