### PR TITLE
Make `resource_version()` return string, instead of integer

### DIFF
--- a/src/controller_examples/rabbitmq_controller/proof/helper_invariants/invariants.rs
+++ b/src/controller_examples/rabbitmq_controller/proof/helper_invariants/invariants.rs
@@ -44,7 +44,7 @@ pub open spec fn server_config_map_update_request_msg(key: ObjectRef) -> FnSpec(
         && msg.content.get_update_request().key == make_server_config_map_key(key)
 }
 
-spec fn make_owner_references_with_name_and_uid(name: StringView, uid: nat) -> OwnerReferenceView {
+spec fn make_owner_references_with_name_and_uid(name: StringView, uid: Uid) -> OwnerReferenceView {
     OwnerReferenceView {
         block_owner_deletion: None,
         controller: Some(true),
@@ -60,7 +60,7 @@ spec fn server_config_map_create_request_msg_is_valid(key: ObjectRef) -> StatePr
             #[trigger] s.message_in_flight(msg)
             && server_config_map_create_request_msg(key)(msg)
             ==> msg.content.get_create_request().obj.metadata.finalizers.is_None()
-                && exists |uid: nat| #![auto]
+                && exists |uid: Uid| #![auto]
                     msg.content.get_create_request().obj.metadata.owner_references == Some(seq![
                         make_owner_references_with_name_and_uid(key.name, uid)
                     ])
@@ -201,7 +201,7 @@ proof fn lemma_always_server_config_map_create_request_msg_is_valid(spec: TempPr
     server_config_map_create_request_msg_is_valid(key)(s_prime) by {
         assert forall |msg| #[trigger] s_prime.message_in_flight(msg) && server_config_map_create_request_msg(key)(msg) implies
         msg.content.get_create_request().obj.metadata.finalizers.is_None()
-        && exists |uid: nat| #![auto] msg.content.get_create_request().obj.metadata.owner_references
+        && exists |uid: Uid| #![auto] msg.content.get_create_request().obj.metadata.owner_references
             == Some(seq![make_owner_references_with_name_and_uid(key.name, uid)]) by {
             if !s.message_in_flight(msg) {
                 let step = choose |step| RMQCluster::next_step(s, s_prime, step);
@@ -223,7 +223,7 @@ spec fn server_config_map_update_request_msg_is_valid(key: ObjectRef) -> StatePr
             #[trigger] s.message_in_flight(msg)
             && server_config_map_update_request_msg(key)(msg)
             ==> msg.content.get_update_request().obj.metadata.finalizers.is_None()
-                && exists |uid: nat| #![auto]
+                && exists |uid: Uid| #![auto]
                     msg.content.get_update_request().obj.metadata.owner_references == Some(seq![
                         make_owner_references_with_name_and_uid(key.name, uid)
                     ])
@@ -253,7 +253,7 @@ proof fn lemma_always_server_config_map_update_request_msg_is_valid(spec: TempPr
     server_config_map_update_request_msg_is_valid(key)(s_prime) by {
         assert forall |msg| #[trigger] s_prime.message_in_flight(msg) && server_config_map_update_request_msg(key)(msg) implies
         msg.content.get_update_request().obj.metadata.finalizers.is_None()
-        && exists |uid: nat| #![auto] msg.content.get_update_request().obj.metadata.owner_references
+        && exists |uid: Uid| #![auto] msg.content.get_update_request().obj.metadata.owner_references
             == Some(seq![make_owner_references_with_name_and_uid(key.name, uid)]) by {
             if !s.message_in_flight(msg) {
                 let step = choose |step| RMQCluster::next_step(s, s_prime, step);
@@ -274,7 +274,7 @@ spec fn sts_update_request_msg_is_valid(key: ObjectRef) -> StatePred<RMQCluster>
             #[trigger] s.message_in_flight(msg)
             && sts_update_request_msg(key)(msg)
             ==> msg.content.get_update_request().obj.metadata.finalizers.is_None()
-                && exists |uid: nat| #![auto]
+                && exists |uid: Uid| #![auto]
                     msg.content.get_update_request().obj.metadata.owner_references == Some(seq![
                         make_owner_references_with_name_and_uid(key.name, uid)
                     ])
@@ -304,7 +304,7 @@ proof fn lemma_always_sts_update_request_msg_is_valid(spec: TempPred<RMQCluster>
     sts_update_request_msg_is_valid(key)(s_prime) by {
         assert forall |msg| #[trigger] s_prime.message_in_flight(msg) && sts_update_request_msg(key)(msg) implies
         msg.content.get_update_request().obj.metadata.finalizers.is_None()
-        && exists |uid: nat| #![auto] msg.content.get_update_request().obj.metadata.owner_references
+        && exists |uid: Uid| #![auto] msg.content.get_update_request().obj.metadata.owner_references
             == Some(seq![make_owner_references_with_name_and_uid(key.name, uid)]) by {
             if !s.message_in_flight(msg) {
                 let step = choose |step| RMQCluster::next_step(s, s_prime, step);
@@ -325,7 +325,7 @@ spec fn sts_create_request_msg_is_valid(key: ObjectRef) -> StatePred<RMQCluster>
             #[trigger] s.message_in_flight(msg)
             && sts_create_request_msg(key)(msg)
             ==> msg.content.get_create_request().obj.metadata.finalizers.is_None()
-                && exists |uid: nat| #![auto]
+                && exists |uid: Uid| #![auto]
                     msg.content.get_create_request().obj.metadata.owner_references == Some(seq![
                         make_owner_references_with_name_and_uid(key.name, uid)
                     ])
@@ -355,7 +355,7 @@ proof fn lemma_always_sts_create_request_msg_is_valid(spec: TempPred<RMQCluster>
     sts_create_request_msg_is_valid(key)(s_prime) by {
         assert forall |msg| #[trigger] s_prime.message_in_flight(msg) && sts_create_request_msg(key)(msg) implies
         msg.content.get_create_request().obj.metadata.finalizers.is_None()
-        && exists |uid: nat| #![auto] msg.content.get_create_request().obj.metadata.owner_references
+        && exists |uid: Uid| #![auto] msg.content.get_create_request().obj.metadata.owner_references
             == Some(seq![make_owner_references_with_name_and_uid(key.name, uid)]) by {
             if !s.message_in_flight(msg) {
                 let step = choose |step| RMQCluster::next_step(s, s_prime, step);
@@ -561,7 +561,7 @@ pub open spec fn object_of_key_has_no_finalizers_or_timestamp_and_only_has_contr
         s.resource_key_exists(key)
         ==> s.resource_obj_of(key).metadata.deletion_timestamp.is_None()
             && s.resource_obj_of(key).metadata.finalizers.is_None()
-            && exists |uid: nat| #![auto]
+            && exists |uid: Uid| #![auto]
             s.resource_obj_of(key).metadata.owner_references == Some(seq![OwnerReferenceView {
                 block_owner_deletion: None,
                 controller: Some(true),

--- a/src/controller_examples/rabbitmq_controller/proof/safety/safety.rs
+++ b/src/controller_examples/rabbitmq_controller/proof/safety/safety.rs
@@ -491,6 +491,7 @@ proof fn replicas_of_stateful_set_create_request_msg_satisfies_order_induction(
                     }
                 }
             }
+            assert(replicas_satisfies_order(msg.content.get_create_request().obj, rabbitmq)(s_prime));
         },
         Step::ControllerStep(input) => {
             if !s.message_in_flight(msg) {
@@ -498,19 +499,23 @@ proof fn replicas_of_stateful_set_create_request_msg_satisfies_order_induction(
                 lemma_stateful_set_create_request_msg_implies_key_in_reconcile_equals(key, s, s_prime, msg, step);
                 assert(StatefulSetView::from_dynamic_object(msg.content.get_create_request().obj).get_Ok_0().spec.get_Some_0().replicas.get_Some_0() <= s.triggering_cr_of(key).spec.replicas);
             }
+            assert(replicas_satisfies_order(msg.content.get_create_request().obj, rabbitmq)(s_prime));
         },
         Step::ScheduleControllerReconcileStep(input) => {
             assert(s.message_in_flight(msg));
             assert(s.kubernetes_api_state == s_prime.kubernetes_api_state);
+            assert(replicas_satisfies_order(msg.content.get_create_request().obj, rabbitmq)(s_prime));
         },
         Step::RestartController() => {
             assert(s.message_in_flight(msg));
             assert(s.kubernetes_api_state == s_prime.kubernetes_api_state);
+            assert(replicas_satisfies_order(msg.content.get_create_request().obj, rabbitmq)(s_prime));
         },
         _ => {
             assert(s.message_in_flight(msg));
             assert(s.kubernetes_api_state == s_prime.kubernetes_api_state);
             assert(s.controller_state == s_prime.controller_state);
+            assert(replicas_satisfies_order(msg.content.get_create_request().obj, rabbitmq)(s_prime));
         }
     }
 }

--- a/src/kubernetes_api_objects/common.rs
+++ b/src/kubernetes_api_objects/common.rs
@@ -6,9 +6,9 @@ use vstd::string::*;
 
 verus! {
 
-pub type Uid = nat;
+pub type Uid = int;
 
-pub type ResourceVersion = nat;
+pub type ResourceVersion = int;
 
 #[is_variant]
 pub enum Kind {

--- a/src/kubernetes_api_objects/dynamic.rs
+++ b/src/kubernetes_api_objects/dynamic.rs
@@ -100,7 +100,7 @@ impl DynamicObjectView {
         }
     }
 
-    pub open spec fn set_resource_version(self, resource_version: nat) -> DynamicObjectView {
+    pub open spec fn set_resource_version(self, resource_version: ResourceVersion) -> DynamicObjectView {
         DynamicObjectView {
             metadata: ObjectMetaView {
                 resource_version: Some(resource_version),
@@ -110,7 +110,7 @@ impl DynamicObjectView {
         }
     }
 
-    pub open spec fn set_uid(self, uid: nat) -> DynamicObjectView {
+    pub open spec fn set_uid(self, uid: Uid) -> DynamicObjectView {
         DynamicObjectView {
             metadata: ObjectMetaView {
                 uid: Some(uid),

--- a/src/kubernetes_api_objects/owner_reference.rs
+++ b/src/kubernetes_api_objects/owner_reference.rs
@@ -49,7 +49,7 @@ pub struct OwnerReferenceView {
     pub controller: Option<bool>,
     pub kind: Kind,
     pub name: StringView,
-    pub uid: nat,
+    pub uid: Uid,
 }
 
 impl OwnerReferenceView {

--- a/src/kubernetes_cluster/proof/kubernetes_api_safety.rs
+++ b/src/kubernetes_cluster/proof/kubernetes_api_safety.rs
@@ -16,7 +16,7 @@ verus! {
 
 impl <K: ResourceView, E: ExternalAPI, R: Reconciler<K, E>> Cluster<K, E, R> {
 
-pub open spec fn has_lower_uid_than(obj: DynamicObjectView, uid: nat) -> bool {
+pub open spec fn has_lower_uid_than(obj: DynamicObjectView, uid: Uid) -> bool {
     obj.metadata.uid.is_Some() && obj.metadata.uid.get_Some_0() < uid
 }
 
@@ -45,7 +45,7 @@ pub proof fn lemma_always_every_object_in_etcd_has_lower_uid_than_uid_counter(sp
                 assert(Self::has_lower_uid_than(s_prime.resource_obj_of(key), s_prime.kubernetes_api_state.uid_counter));
             }
         }
-        
+
     }
     init_invariant(spec, Self::init(), Self::next(), invariant);
 }


### PR DESCRIPTION
This change will be useful later if the controller needs to get the resource version from some object and use it (as a label or annotation). To use `int_to_string_view()` in the postcondition of `resource_version()`, we also change the Uid/ResourceVersion type to int, instead of nat, which causes no difference to the proof.