### PR TITLE
Add scaling tests and perf tests for zookeeper and rabbitmq controllers

### DIFF
--- a/e2e/src/common.rs
+++ b/e2e/src/common.rs
@@ -12,7 +12,9 @@ use kube::{
     discovery::{ApiCapabilities, ApiResource, Discovery, Scope},
     Client, CustomResource,
 };
+use std::process::Command;
 use thiserror::Error;
+
 #[derive(Debug, Error)]
 pub enum Error {
     #[error("Failed to get kube client: {0}")]
@@ -119,4 +121,10 @@ pub async fn get_output_and_err(mut attached: AttachedProcess) -> (String, Strin
         .join("");
     attached.join().await.unwrap();
     (out, err)
+}
+
+pub fn run_command(program: &str, args: Vec<&str>, err_msg: &str) {
+    let cmd = Command::new(program).args(args).output().expect(err_msg);
+    println!("cmd output: {}", String::from_utf8_lossy(&cmd.stdout));
+    println!("cmd error: {}", String::from_utf8_lossy(&cmd.stderr));
 }

--- a/e2e/src/rabbitmq_e2e.rs
+++ b/e2e/src/rabbitmq_e2e.rs
@@ -192,6 +192,7 @@ pub async fn rabbitmq_workload_test(client: Client, rabbitmq_name: String) -> Re
         };
     }
     // Shall we delete the perf test pod here?
+    println!("Rabbitmq workload test passed.");
     Ok(())
 }
 

--- a/e2e/src/rabbitmq_e2e.rs
+++ b/e2e/src/rabbitmq_e2e.rs
@@ -17,7 +17,6 @@ use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use serde_json::json;
 use std::path::PathBuf;
-use std::process::Command;
 use std::thread;
 use std::time::{Duration, Instant};
 use tokio::time::sleep;
@@ -140,17 +139,18 @@ pub async fn authenticate_user_test(client: Client, rabbitmq_name: String) -> Re
 }
 
 pub async fn rabbitmq_workload_test(client: Client, rabbitmq_name: String) -> Result<(), Error> {
-    Command::new("kubectl")
-        .args([
+    run_command(
+        "kubectl",
+        vec![
             "run",
             "perf-test",
             "--image=pivotalrabbitmq/perf-test",
             "--",
             "--uri",
             "\"amqp://new_user:new_pass@rabbitmq\"",
-        ])
-        .output()
-        .expect("failed to run perf test pod");
+        ],
+        "failed to run perf test pod",
+    );
     let pod_name = "perf-test";
     let pod_api: Api<Pod> = Api::default_namespaced(client.clone());
     let timeout = Duration::from_secs(600);

--- a/e2e/src/zookeeper_e2e.rs
+++ b/e2e/src/zookeeper_e2e.rs
@@ -159,7 +159,7 @@ pub async fn scaling_test(client: Client, zk_name: String) -> Result<(), Error> 
     let timeout = Duration::from_secs(360);
     let start = Instant::now();
     let sts_api: Api<StatefulSet> = Api::default_namespaced(client.clone());
-    Command::new("kubectl")
+    let scale_output = Command::new("kubectl")
         .args([
             "patch",
             "zk",
@@ -169,7 +169,15 @@ pub async fn scaling_test(client: Client, zk_name: String) -> Result<(), Error> 
             "'[{\"op\": \"replace\", \"path\": \"/spec/replicas\", \"value\": 2}]'",
         ])
         .output()
-        .expect("failed to run perf test pod");
+        .expect("failed to scale zk");
+    println!(
+        "scale output: {}",
+        String::from_utf8_lossy(&scale_output.stdout)
+    );
+    println!(
+        "scale error: {}",
+        String::from_utf8_lossy(&scale_output.stderr)
+    );
 
     loop {
         sleep(Duration::from_secs(5)).await;
@@ -230,7 +238,7 @@ pub async fn scaling_test(client: Client, zk_name: String) -> Result<(), Error> 
             "'[{\"op\": \"replace\", \"path\": \"/spec/replicas\", \"value\": 3}]'",
         ])
         .output()
-        .expect("failed to run perf test pod");
+        .expect("failed to scale zk");
 
     loop {
         sleep(Duration::from_secs(5)).await;

--- a/e2e/src/zookeeper_e2e.rs
+++ b/e2e/src/zookeeper_e2e.rs
@@ -164,8 +164,9 @@ pub async fn scaling_test(client: Client, zk_name: String) -> Result<(), Error> 
             "patch",
             "zk",
             "zookeeper",
-            "--patch",
-            "'{\"spec\": {\"replicas\": 2}}'",
+            "--type=json",
+            "-p",
+            "'[{\"op\": \"replace\", \"path\": \"/spec/replicas\", \"value\": 2}]'",
         ])
         .output()
         .expect("failed to run perf test pod");
@@ -185,8 +186,10 @@ pub async fn scaling_test(client: Client, zk_name: String) -> Result<(), Error> 
             }
             Ok(sts) => {
                 if sts.spec.unwrap().replicas != Some(2) {
-                    println!("Stateful set spec is not consistent with zookeeper cluster spec. E2e test failed.");
-                    return Err(Error::ZookeeperStsFailed);
+                    println!(
+                        "Stateful set spec is not consistent with zookeeper cluster spec yet."
+                    );
+                    continue;
                 }
                 println!("Stateful set is found as expected.");
                 if sts.status.as_ref().unwrap().ready_replicas.is_none() {
@@ -222,8 +225,9 @@ pub async fn scaling_test(client: Client, zk_name: String) -> Result<(), Error> 
             "patch",
             "zk",
             "zookeeper",
-            "--patch",
-            "'{\"spec\": {\"replicas\": 3}}'",
+            "--type=json",
+            "-p",
+            "'[{\"op\": \"replace\", \"path\": \"/spec/replicas\", \"value\": 3}]'",
         ])
         .output()
         .expect("failed to run perf test pod");
@@ -242,8 +246,10 @@ pub async fn scaling_test(client: Client, zk_name: String) -> Result<(), Error> 
             }
             Ok(sts) => {
                 if sts.spec.unwrap().replicas != Some(3) {
-                    println!("Stateful set spec is not consistent with zookeeper cluster spec. E2e test failed.");
-                    return Err(Error::ZookeeperStsFailed);
+                    println!(
+                        "Stateful set spec is not consistent with zookeeper cluster spec yet."
+                    );
+                    continue;
                 }
                 println!("Stateful set is found as expected.");
                 if sts.status.as_ref().unwrap().ready_replicas.is_none() {

--- a/e2e/src/zookeeper_e2e.rs
+++ b/e2e/src/zookeeper_e2e.rs
@@ -1,7 +1,7 @@
 #![allow(unused_imports)]
 #![allow(unused_variables)]
-use k8s_openapi::api::core::v1::{ConfigMap, Pod};
-use k8s_openapi::api::{apps::v1::StatefulSet, core::v1::Service};
+use k8s_openapi::api::apps::v1::StatefulSet;
+use k8s_openapi::api::core::v1::{ConfigMap, Pod, Service};
 use k8s_openapi::apiextensions_apiserver::pkg::apis::apiextensions::v1::CustomResourceDefinition;
 use kube::{
     api::{
@@ -16,7 +16,6 @@ use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use serde_json::json;
 use std::path::PathBuf;
-use std::process::Command;
 use std::thread;
 use std::time::{Duration, Instant};
 use tokio::time::sleep;
@@ -159,24 +158,17 @@ pub async fn scaling_test(client: Client, zk_name: String) -> Result<(), Error> 
     let timeout = Duration::from_secs(360);
     let start = Instant::now();
     let sts_api: Api<StatefulSet> = Api::default_namespaced(client.clone());
-    let scale_output = Command::new("kubectl")
-        .args([
+    run_command(
+        "kubectl",
+        vec![
             "patch",
             "zk",
             "zookeeper",
             "--type=json",
             "-p",
             "[{\"op\": \"replace\", \"path\": \"/spec/replicas\", \"value\": 2}]",
-        ])
-        .output()
-        .expect("failed to scale zk");
-    println!(
-        "cmd output: {}",
-        String::from_utf8_lossy(&scale_output.stdout)
-    );
-    println!(
-        "cmd error: {}",
-        String::from_utf8_lossy(&scale_output.stderr)
+        ],
+        "failed to scale zk",
     );
 
     loop {
@@ -228,24 +220,17 @@ pub async fn scaling_test(client: Client, zk_name: String) -> Result<(), Error> 
         };
     }
 
-    Command::new("kubectl")
-        .args([
+    run_command(
+        "kubectl",
+        vec![
             "patch",
             "zk",
             "zookeeper",
             "--type=json",
             "-p",
             "[{\"op\": \"replace\", \"path\": \"/spec/replicas\", \"value\": 3}]",
-        ])
-        .output()
-        .expect("failed to scale zk");
-    println!(
-        "cmd output: {}",
-        String::from_utf8_lossy(&scale_output.stdout)
-    );
-    println!(
-        "cmd error: {}",
-        String::from_utf8_lossy(&scale_output.stderr)
+        ],
+        "failed to scale zk",
     );
 
     loop {

--- a/e2e/src/zookeeper_e2e.rs
+++ b/e2e/src/zookeeper_e2e.rs
@@ -166,16 +166,16 @@ pub async fn scaling_test(client: Client, zk_name: String) -> Result<(), Error> 
             "zookeeper",
             "--type=json",
             "-p",
-            "'[{\"op\": \"replace\", \"path\": \"/spec/replicas\", \"value\": 2}]'",
+            "[{\"op\": \"replace\", \"path\": \"/spec/replicas\", \"value\": 2}]",
         ])
         .output()
         .expect("failed to scale zk");
     println!(
-        "scale output: {}",
+        "cmd output: {}",
         String::from_utf8_lossy(&scale_output.stdout)
     );
     println!(
-        "scale error: {}",
+        "cmd error: {}",
         String::from_utf8_lossy(&scale_output.stderr)
     );
 
@@ -235,10 +235,18 @@ pub async fn scaling_test(client: Client, zk_name: String) -> Result<(), Error> 
             "zookeeper",
             "--type=json",
             "-p",
-            "'[{\"op\": \"replace\", \"path\": \"/spec/replicas\", \"value\": 3}]'",
+            "[{\"op\": \"replace\", \"path\": \"/spec/replicas\", \"value\": 3}]",
         ])
         .output()
         .expect("failed to scale zk");
+    println!(
+        "cmd output: {}",
+        String::from_utf8_lossy(&scale_output.stdout)
+    );
+    println!(
+        "cmd error: {}",
+        String::from_utf8_lossy(&scale_output.stderr)
+    );
 
     loop {
         sleep(Duration::from_secs(5)).await;

--- a/src/controller_examples/zookeeper_controller/exec/reconciler.rs
+++ b/src/controller_examples/zookeeper_controller/exec/reconciler.rs
@@ -1110,8 +1110,7 @@ fn make_env_config(zk: &ZookeeperCluster) -> (s: String)
         CLIENT_PORT=")).concat(client_port.as_str()).concat(new_strlit("\n\
         ADMIN_SERVER_HOST=")).concat(name.as_str()).concat(new_strlit("-admin-server\n\
         ADMIN_SERVER_PORT=")).concat(admin_server_port.as_str()).concat(new_strlit("\n\
-        CLUSTER_NAME=")).concat(name.as_str()).concat(new_strlit("\n\
-        CLUSTER_SIZE=")).concat(i32_to_string(zk.spec().replicas()).as_str()).concat(new_strlit("\n"))
+        CLUSTER_NAME=")).concat(name.as_str()).concat(new_strlit("\n"))
 }
 
 fn make_stateful_set_name(zk: &ZookeeperCluster) -> (name: String)

--- a/src/controller_examples/zookeeper_controller/exec/reconciler.rs
+++ b/src/controller_examples/zookeeper_controller/exec/reconciler.rs
@@ -274,13 +274,13 @@ pub fn reconcile_core(
                 if create_client_service_resp.is_ok() {
                     let unmarshal_client_service_result = Service::from_dynamic_object(create_client_service_resp.unwrap());
                     if unmarshal_client_service_result.is_ok() {
-                        let req_o = KubeAPIRequest::CreateRequest(KubeCreateRequest {
+                        let req_o = KubeAPIRequest::GetRequest(KubeGetRequest {
                             api_resource: Service::api_resource(),
+                            name: make_admin_server_service_name(zk),
                             namespace: zk.metadata().namespace().unwrap(),
-                            obj: make_admin_server_service(zk).to_dynamic_object(),
                         });
                         let state_prime = ZookeeperReconcileState {
-                            reconcile_step: ZookeeperReconcileStep::AfterCreateAdminServerService,
+                            reconcile_step: ZookeeperReconcileStep::AfterGetAdminServerService,
                             ..state
                         };
                         return (state_prime, Some(Request::KRequest(req_o)));
@@ -300,13 +300,13 @@ pub fn reconcile_core(
                 if update_client_service_resp.is_ok() {
                     let unmarshal_client_service_result = Service::from_dynamic_object(update_client_service_resp.unwrap());
                     if unmarshal_client_service_result.is_ok() {
-                        let req_o = KubeAPIRequest::CreateRequest(KubeCreateRequest {
+                        let req_o = KubeAPIRequest::GetRequest(KubeGetRequest {
                             api_resource: Service::api_resource(),
+                            name: make_admin_server_service_name(zk),
                             namespace: zk.metadata().namespace().unwrap(),
-                            obj: make_admin_server_service(zk).to_dynamic_object(),
                         });
                         let state_prime = ZookeeperReconcileState {
-                            reconcile_step: ZookeeperReconcileStep::AfterCreateAdminServerService,
+                            reconcile_step: ZookeeperReconcileStep::AfterGetAdminServerService,
                             ..state
                         };
                         return (state_prime, Some(Request::KRequest(req_o)));

--- a/src/controller_examples/zookeeper_controller/spec/reconciler.rs
+++ b/src/controller_examples/zookeeper_controller/spec/reconciler.rs
@@ -982,8 +982,7 @@ pub open spec fn make_env_config(zk: ZookeeperClusterView) -> StringView
         CLIENT_PORT=")@ + client_port + new_strlit("\n\
         ADMIN_SERVER_HOST=")@ + name + new_strlit("-admin-server\n\
         ADMIN_SERVER_PORT=")@ + admin_server_port + new_strlit("\n\
-        CLUSTER_NAME=")@ + name + new_strlit("\n\
-        CLUSTER_SIZE=")@ + int_to_string_view(zk.spec.replicas) + new_strlit("\n")@
+        CLUSTER_NAME=")@ + name + new_strlit("\n")@
 }
 
 pub open spec fn make_stateful_set_key(key: ObjectRef) -> ObjectRef

--- a/src/controller_examples/zookeeper_controller/spec/reconciler.rs
+++ b/src/controller_examples/zookeeper_controller/spec/reconciler.rs
@@ -251,12 +251,15 @@ pub open spec fn reconcile_core(
             let unmarshal_client_service_result = ServiceView::from_dynamic_object(create_client_service_resp.get_Ok_0());
             if resp_o.is_Some() && resp.is_KResponse() && resp.get_KResponse_0().is_CreateResponse()
             && create_client_service_resp.is_Ok() && unmarshal_client_service_result.is_Ok() {
-                let req_o = APIRequest::CreateRequest(CreateRequest{
-                    namespace: zk_namespace,
-                    obj: make_admin_server_service(zk).to_dynamic_object(),
+                let req_o = APIRequest::GetRequest(GetRequest{
+                    key: ObjectRef {
+                        kind: ServiceView::kind(),
+                        name: make_admin_server_service_name(zk_name),
+                        namespace: zk_namespace,
+                    }
                 });
                 let state_prime = ZookeeperReconcileState {
-                    reconcile_step: ZookeeperReconcileStep::AfterCreateAdminServerService,
+                    reconcile_step: ZookeeperReconcileStep::AfterGetAdminServerService,
                     ..state
                 };
                 (state_prime, Some(RequestView::KRequest(req_o)))
@@ -273,12 +276,15 @@ pub open spec fn reconcile_core(
             let unmarshal_client_service_result = ServiceView::from_dynamic_object(update_client_service_resp.get_Ok_0());
             if resp_o.is_Some() && resp.is_KResponse() && resp.get_KResponse_0().is_UpdateResponse()
             && update_client_service_resp.is_Ok() && unmarshal_client_service_result.is_Ok() {
-                let req_o = APIRequest::CreateRequest(CreateRequest{
-                    namespace: zk_namespace,
-                    obj: make_admin_server_service(zk).to_dynamic_object(),
+                let req_o = APIRequest::GetRequest(GetRequest{
+                    key: ObjectRef {
+                        kind: ServiceView::kind(),
+                        name: make_admin_server_service_name(zk_name),
+                        namespace: zk_namespace,
+                    }
                 });
                 let state_prime = ZookeeperReconcileState {
-                    reconcile_step: ZookeeperReconcileStep::AfterCreateAdminServerService,
+                    reconcile_step: ZookeeperReconcileStep::AfterGetAdminServerService,
                     ..state
                 };
                 (state_prime, Some(RequestView::KRequest(req_o)))


### PR DESCRIPTION
Add scaling tests for both zookeeper and rabbitmq, and add perf test for rabbitmq. Also fix a liveness bug in the zookeeper controller implementation, and remove unused entry `CLUSTER_SIZE` from the env.sh in the config map object.