### PR TITLE
Disallow downscale to 0 for zookeeper

### DIFF
--- a/deploy/zookeeper/crd.yaml
+++ b/deploy/zookeeper/crd.yaml
@@ -588,6 +588,9 @@ spec:
                 replicas:
                   format: int32
                   type: integer
+                  x-kubernetes-validations:
+                    - rule: "self > 0"
+                      message: replicas should be larger than 0
                 resources:
                   description: ResourceRequirements describes the compute resource requirements.
                   nullable: true

--- a/src/controller_examples/zookeeper_controller/spec/types.rs
+++ b/src/controller_examples/zookeeper_controller/spec/types.rs
@@ -97,7 +97,7 @@ impl ResourceView for ZookeeperClusterView {
     proof fn from_dynamic_object_result_determined_by_unmarshal() {}
 
     open spec fn rule(obj: ZookeeperClusterView) -> bool {
-        true
+        obj.spec.replicas > 0
     }
 
     open spec fn transition_rule(new_obj: ZookeeperClusterView, old_obj: ZookeeperClusterView) -> bool {


### PR DESCRIPTION
This fixes the bug that the controller fails to scale up the zookeeper cluster from 0 replicas. More details can be found in #269 .