### PR TITLE
Prove termination for rabbitmq controller

### DIFF
--- a/src/controller_examples/rabbitmq_controller/exec/resource/common.rs
+++ b/src/controller_examples/rabbitmq_controller/exec/resource/common.rs
@@ -40,6 +40,9 @@ pub trait ResourceBuilder<SpecBuilder: spec_resource::ResourceBuilder> {
         ensures
             resource_res_to_view(res) == SpecBuilder::update(rabbitmq@, state@, obj@);
 
+    /// state_after_create_or_update describes how a successfully created/updated object influences the reconcile state except
+    /// the part concerning control flow, i.e., what the next step is. The next step will be decided by the reconciler. Such design
+    /// leads to lower coupling and fewer mistakes (e.g. next step and get request mismatch).
     fn state_after_create_or_update(obj: DynamicObject, state: RabbitmqReconcileState) -> (res: Result<RabbitmqReconcileState, RabbitmqError>)
         ensures
             resource_res_to_view(res) == SpecBuilder::state_after_create_or_update(obj@, state@);

--- a/src/controller_examples/rabbitmq_controller/exec/resource/config_map.rs
+++ b/src/controller_examples/rabbitmq_controller/exec/resource/config_map.rs
@@ -49,7 +49,6 @@ impl ResourceBuilder<spec_resource::ServerConfigMapBuilder> for ServerConfigMapB
         let cm = ConfigMap::unmarshal(obj);
         if cm.is_ok() && cm.as_ref().unwrap().metadata().resource_version().is_some() {
             Ok(RabbitmqReconcileState {
-                reconcile_step: RabbitmqReconcileStep::AfterKRequestStep(ActionKind::Get, SubResource::ServiceAccount),
                 latest_config_map_rv_opt: Some(cm.unwrap().metadata().resource_version().unwrap()),
                 ..state
             })

--- a/src/controller_examples/rabbitmq_controller/exec/resource/default_user_secret.rs
+++ b/src/controller_examples/rabbitmq_controller/exec/resource/default_user_secret.rs
@@ -48,10 +48,7 @@ impl ResourceBuilder<spec_resource::DefaultUserSecretBuilder> for DefaultUserSec
     fn state_after_create_or_update(obj: DynamicObject, state: RabbitmqReconcileState) -> (res: Result<RabbitmqReconcileState, RabbitmqError>) {
         let secret = Secret::unmarshal(obj);
         if secret.is_ok() {
-            Ok(RabbitmqReconcileState {
-                reconcile_step: RabbitmqReconcileStep::AfterKRequestStep(ActionKind::Get, SubResource::PluginsConfigMap),
-                ..state
-            })
+            Ok(state)
         } else {
             Err(RabbitmqError::Error)
         }

--- a/src/controller_examples/rabbitmq_controller/exec/resource/erlang_cookie.rs
+++ b/src/controller_examples/rabbitmq_controller/exec/resource/erlang_cookie.rs
@@ -48,10 +48,7 @@ impl ResourceBuilder<spec_resource::ErlangCookieBuilder> for ErlangCookieBuilder
     fn state_after_create_or_update(obj: DynamicObject, state: RabbitmqReconcileState) -> (res: Result<RabbitmqReconcileState, RabbitmqError>) {
         let secret = Secret::unmarshal(obj);
         if secret.is_ok() {
-            Ok(RabbitmqReconcileState {
-                reconcile_step: RabbitmqReconcileStep::AfterKRequestStep(ActionKind::Get, SubResource::DefaultUserSecret),
-                ..state
-            })
+            Ok(state)
         } else {
             Err(RabbitmqError::Error)
         }

--- a/src/controller_examples/rabbitmq_controller/exec/resource/headless_service.rs
+++ b/src/controller_examples/rabbitmq_controller/exec/resource/headless_service.rs
@@ -48,10 +48,7 @@ impl ResourceBuilder<spec_resource::HeadlessServiceBuilder> for HeadlessServiceB
     fn state_after_create_or_update(obj: DynamicObject, state: RabbitmqReconcileState) -> (res: Result<RabbitmqReconcileState, RabbitmqError>) {
         let service = Service::unmarshal(obj);
         if service.is_ok() {
-            Ok(RabbitmqReconcileState {
-                reconcile_step: RabbitmqReconcileStep::AfterKRequestStep(ActionKind::Get, SubResource::Service),
-                ..state
-            })
+            Ok(state)
         } else {
             Err(RabbitmqError::Error)
         }

--- a/src/controller_examples/rabbitmq_controller/exec/resource/rabbitmq_plugins.rs
+++ b/src/controller_examples/rabbitmq_controller/exec/resource/rabbitmq_plugins.rs
@@ -48,10 +48,7 @@ impl ResourceBuilder<spec_resource::PluginsConfigMapBuilder> for PluginsConfigMa
     fn state_after_create_or_update(obj: DynamicObject, state: RabbitmqReconcileState) -> (res: Result<RabbitmqReconcileState, RabbitmqError>) {
         let cm = ConfigMap::unmarshal(obj);
         if cm.is_ok() {
-            Ok(RabbitmqReconcileState {
-                reconcile_step: RabbitmqReconcileStep::AfterKRequestStep(ActionKind::Get, SubResource::ServerConfigMap),
-                ..state
-            })
+            Ok(state)
         } else {
             Err(RabbitmqError::Error)
         }

--- a/src/controller_examples/rabbitmq_controller/exec/resource/role.rs
+++ b/src/controller_examples/rabbitmq_controller/exec/resource/role.rs
@@ -48,10 +48,7 @@ impl ResourceBuilder<spec_resource::RoleBuilder> for RoleBuilder {
     fn state_after_create_or_update(obj: DynamicObject, state: RabbitmqReconcileState) -> (res: Result<RabbitmqReconcileState, RabbitmqError>) {
         let role = Role::unmarshal(obj);
         if role.is_ok() {
-            Ok(RabbitmqReconcileState {
-                reconcile_step: RabbitmqReconcileStep::AfterKRequestStep(ActionKind::Get, SubResource::RoleBinding),
-                ..state
-            })
+            Ok(state)
         } else {
             Err(RabbitmqError::Error)
         }

--- a/src/controller_examples/rabbitmq_controller/exec/resource/role_binding.rs
+++ b/src/controller_examples/rabbitmq_controller/exec/resource/role_binding.rs
@@ -48,10 +48,7 @@ impl ResourceBuilder<spec_resource::RoleBindingBuilder> for RoleBindingBuilder {
     fn state_after_create_or_update(obj: DynamicObject, state: RabbitmqReconcileState) -> (res: Result<RabbitmqReconcileState, RabbitmqError>) {
         let rb = RoleBinding::unmarshal(obj);
         if rb.is_ok() {
-            Ok(RabbitmqReconcileState {
-                reconcile_step: RabbitmqReconcileStep::AfterKRequestStep(ActionKind::Get, SubResource::StatefulSet),
-                ..state
-            })
+            Ok(state)
         } else {
             Err(RabbitmqError::Error)
         }

--- a/src/controller_examples/rabbitmq_controller/exec/resource/service.rs
+++ b/src/controller_examples/rabbitmq_controller/exec/resource/service.rs
@@ -48,10 +48,7 @@ impl ResourceBuilder<spec_resource::ServiceBuilder> for ServiceBuilder {
     fn state_after_create_or_update(obj: DynamicObject, state: RabbitmqReconcileState) -> (res: Result<RabbitmqReconcileState, RabbitmqError>) {
         let service = Service::unmarshal(obj);
         if service.is_ok() {
-            Ok(RabbitmqReconcileState {
-                reconcile_step: RabbitmqReconcileStep::AfterKRequestStep(ActionKind::Get, SubResource::ErlangCookieSecret),
-                ..state
-            })
+            Ok(state)
         } else {
             Err(RabbitmqError::Error)
         }

--- a/src/controller_examples/rabbitmq_controller/exec/resource/service_account.rs
+++ b/src/controller_examples/rabbitmq_controller/exec/resource/service_account.rs
@@ -48,10 +48,7 @@ impl ResourceBuilder<spec_resource::ServiceAccountBuilder> for ServiceAccountBui
     fn state_after_create_or_update(obj: DynamicObject, state: RabbitmqReconcileState) -> (res: Result<RabbitmqReconcileState, RabbitmqError>) {
         let sa = ServiceAccount::unmarshal(obj);
         if sa.is_ok() {
-            Ok(RabbitmqReconcileState {
-                reconcile_step: RabbitmqReconcileStep::AfterKRequestStep(ActionKind::Get, SubResource::Role),
-                ..state
-            })
+            Ok(state)
         } else {
             Err(RabbitmqError::Error)
         }

--- a/src/controller_examples/rabbitmq_controller/exec/resource/stateful_set.rs
+++ b/src/controller_examples/rabbitmq_controller/exec/resource/stateful_set.rs
@@ -61,10 +61,7 @@ impl ResourceBuilder<spec_resource::StatefulSetBuilder> for StatefulSetBuilder {
     fn state_after_create_or_update(obj: DynamicObject, state: RabbitmqReconcileState) -> (res: Result<RabbitmqReconcileState, RabbitmqError>) {
         let sts = StatefulSet::unmarshal(obj);
         if sts.is_ok() {
-            Ok(RabbitmqReconcileState {
-                reconcile_step: RabbitmqReconcileStep::Done,
-                ..state
-            })
+            Ok(state)
         } else {
             Err(RabbitmqError::Error)
         }

--- a/src/controller_examples/rabbitmq_controller/proof/common.rs
+++ b/src/controller_examples/rabbitmq_controller/proof/common.rs
@@ -19,30 +19,6 @@ use vstd::prelude::*;
 
 verus! {
 
-pub type RMQStep = Step<RMQMessage>;
-
-pub type RMQCluster = Cluster<RabbitmqClusterView, EmptyAPI, RabbitmqReconciler>;
-
-pub type RMQMessage = Message<EmptyTypeView, EmptyTypeView>;
-
-pub open spec fn cluster_spec() -> TempPred<RMQCluster> {
-    RMQCluster::sm_spec()
-}
-
-pub open spec fn at_rabbitmq_step(key: ObjectRef, step: RabbitmqReconcileStep) -> StatePred<RMQCluster>
-    recommends
-        key.kind.is_CustomResourceKind()
-{
-    |s: RMQCluster| {
-        &&& s.ongoing_reconciles().contains_key(key)
-        &&& s.ongoing_reconciles()[key].local_state.reconcile_step == step
-    }
-}
-
-pub open spec fn at_step_closure(step: RabbitmqReconcileStep) -> FnSpec(RabbitmqReconcileState) -> bool {
-    |s: RabbitmqReconcileState| s.reconcile_step == step
-}
-
 pub open spec fn at_rabbitmq_step_with_rabbitmq(rabbitmq: RabbitmqClusterView, step: RabbitmqReconcileStep) -> StatePred<RMQCluster> {
     |s: RMQCluster| {
         &&& s.ongoing_reconciles().contains_key(rabbitmq.object_ref())

--- a/src/controller_examples/rabbitmq_controller/proof/liveness/mod.rs
+++ b/src/controller_examples/rabbitmq_controller/proof/liveness/mod.rs
@@ -1,5 +1,5 @@
 // Copyright 2022 VMware, Inc.
 // SPDX-License-Identifier: MIT
 // pub mod liveness_proof;
-// pub mod terminate;
+pub mod terminate;
 pub mod property;

--- a/src/controller_examples/rabbitmq_controller/proof/liveness/property.rs
+++ b/src/controller_examples/rabbitmq_controller/proof/liveness/property.rs
@@ -15,15 +15,13 @@ use crate::kubernetes_cluster::spec::{
 };
 use crate::rabbitmq_controller::{
     common::*,
-    proof::resource::*,
+    proof::{predicate::*, resource::*},
     spec::{reconciler::*, types::*},
 };
 use crate::temporal_logic::{defs::*, rules::*};
 use vstd::prelude::*;
 
 verus! {
-
-pub type RMQCluster = Cluster<RabbitmqClusterView, EmptyAPI, RabbitmqReconciler>;
 
 spec fn liveness(rabbitmq: RabbitmqClusterView) -> TempPred<RMQCluster>
     recommends
@@ -34,7 +32,7 @@ spec fn liveness(rabbitmq: RabbitmqClusterView) -> TempPred<RMQCluster>
 
 pub open spec fn current_state_matches(rabbitmq: RabbitmqClusterView) -> StatePred<RMQCluster> {
     |s: RMQCluster| {
-        forall |sub_resource: SubResource| 
+        forall |sub_resource: SubResource|
             #[trigger] resource_state_matches(sub_resource, rabbitmq, s.resources())
     }
 }

--- a/src/controller_examples/rabbitmq_controller/proof/liveness/terminate.rs
+++ b/src/controller_examples/rabbitmq_controller/proof/liveness/terminate.rs
@@ -11,7 +11,7 @@ use crate::kubernetes_cluster::spec::{
     message::*,
 };
 use crate::rabbitmq_controller::{
-    common::RabbitmqReconcileStep,
+    common::*,
     proof::predicate::*,
     spec::{reconciler::*, types::*},
 };
@@ -21,7 +21,6 @@ use vstd::prelude::*;
 
 verus! {
 
-#[verifier(external_body)]
 pub proof fn reconcile_eventually_terminates(spec: TempPred<RMQCluster>, rabbitmq: RabbitmqClusterView)
     requires
         spec.entails(always(lift_action(RMQCluster::next()))),
@@ -46,102 +45,126 @@ pub proof fn reconcile_eventually_terminates(spec: TempPred<RMQCluster>, rabbitm
 {
     let reconcile_idle = |s: RMQCluster| { !s.ongoing_reconciles().contains_key(rabbitmq.object_ref()) };
 
-    // First, prove that reconcile_done \/ reconcile_error ~> reconcile_idle.
+    // First, prove that reconcile_done \/ reconcile_error \/ reconcile_ide ~> reconcile_idle.
     // Here we simply apply a cluster lemma which uses the wf1 of end_reconcile action.
     RMQCluster::lemma_reconcile_error_leads_to_reconcile_idle(spec, rabbitmq.object_ref());
     RMQCluster::lemma_reconcile_done_leads_to_reconcile_idle(spec, rabbitmq.object_ref());
     temp_pred_equality(lift_state(at_step_state_pred(rabbitmq, RabbitmqReconcileStep::Done)), lift_state(RMQCluster::reconciler_reconcile_done(rabbitmq.object_ref())));
     temp_pred_equality(lift_state(at_step_state_pred(rabbitmq, RabbitmqReconcileStep::Error)), lift_state(RMQCluster::reconciler_reconcile_error(rabbitmq.object_ref())));
-    // RMQCluster::lemma_from_some_state_to_arbitrary_next_state_to_reconcile_idle(spec, rabbitmq, at_step_closure(RabbitmqReconcileStep::AfterUpdateStatefulSet), at_step_closure(RabbitmqReconcileStep::Done));
-    // RMQCluster::lemma_from_some_state_to_arbitrary_next_state_to_reconcile_idle(spec, rabbitmq, at_step_closure(RabbitmqReconcileStep::AfterCreateStatefulSet), at_step_closure(RabbitmqReconcileStep::Done));
-    // let next_state = |s: RabbitmqReconcileState| {
-    //     s.reconcile_step == RabbitmqReconcileStep::AfterUpdateStatefulSet
-    //     || s.reconcile_step == RabbitmqReconcileStep::AfterCreateStatefulSet
-    //     || s.reconcile_step == RabbitmqReconcileStep::Error
-    // };
-    // or_leads_to_combine_and_equality!(
-    //     spec, lift_state(RMQCluster::at_expected_reconcile_states(rabbitmq.object_ref(), next_state)),
-    //     lift_state(at_step_state_pred(rabbitmq, RabbitmqReconcileStep::AfterUpdateStatefulSet)),
-    //     lift_state(at_step_state_pred(rabbitmq, RabbitmqReconcileStep::AfterCreateStatefulSet)),
-    //     lift_state(at_step_state_pred(rabbitmq, RabbitmqReconcileStep::Error));
-    //     lift_state(|s: RMQCluster| { !s.ongoing_reconciles().contains_key(rabbitmq.object_ref()) })
-    // );
-    // RMQCluster::lemma_from_some_state_to_arbitrary_next_state_to_reconcile_idle(
-    //     spec, rabbitmq, at_step_closure(RabbitmqReconcileStep::AfterGetStatefulSet), next_state
-    // );
-    // RMQCluster::lemma_from_some_state_to_arbitrary_next_state_to_reconcile_idle(spec, rabbitmq, at_step_closure(RabbitmqReconcileStep::AfterCreateRoleBinding), at_step_closure(RabbitmqReconcileStep::AfterGetStatefulSet));
-    // RMQCluster::lemma_from_some_state_to_arbitrary_next_state_to_reconcile_idle(spec, rabbitmq, at_step_closure(RabbitmqReconcileStep::AfterCreateRole), at_step_closure(RabbitmqReconcileStep::AfterCreateRoleBinding));
-    // RMQCluster::lemma_from_some_state_to_arbitrary_next_state_to_reconcile_idle(spec, rabbitmq, at_step_closure(RabbitmqReconcileStep::AfterCreateServiceAccount), at_step_closure(RabbitmqReconcileStep::AfterCreateRole));
-    // RMQCluster::lemma_from_some_state_to_arbitrary_next_state_to_reconcile_idle(spec, rabbitmq, at_step_closure(RabbitmqReconcileStep::AfterCreateServerConfigMap), at_step_closure(RabbitmqReconcileStep::AfterCreateServiceAccount));
-    // RMQCluster::lemma_from_some_state_to_arbitrary_next_state_to_reconcile_idle(spec, rabbitmq, at_step_closure(RabbitmqReconcileStep::AfterUpdateServerConfigMap), at_step_closure(RabbitmqReconcileStep::AfterCreateServiceAccount));
+    valid_implies_implies_leads_to(spec, lift_state(reconcile_idle), lift_state(reconcile_idle));
 
-    // let next_state_1 = |s: RabbitmqReconcileState| {
-    //     s.reconcile_step == RabbitmqReconcileStep::AfterUpdateServerConfigMap
-    //     || s.reconcile_step == RabbitmqReconcileStep::AfterCreateServerConfigMap
-    //     || s.reconcile_step == RabbitmqReconcileStep::Error
-    // };
-    // or_leads_to_combine_and_equality!(
-    //     spec, lift_state(RMQCluster::at_expected_reconcile_states(rabbitmq.object_ref(), next_state_1)),
-    //     lift_state(at_step_state_pred(rabbitmq, RabbitmqReconcileStep::AfterUpdateServerConfigMap)),
-    //     lift_state(at_step_state_pred(rabbitmq, RabbitmqReconcileStep::AfterCreateServerConfigMap)),
-    //     lift_state(at_step_state_pred(rabbitmq, RabbitmqReconcileStep::Error));
-    //     lift_state(|s: RMQCluster| { !s.ongoing_reconciles().contains_key(rabbitmq.object_ref()) })
-    // );
-    // RMQCluster::lemma_from_some_state_to_arbitrary_next_state_to_reconcile_idle(
-    //     spec, rabbitmq, at_step_closure(RabbitmqReconcileStep::AfterGetServerConfigMap), next_state_1
-    // );
-    // RMQCluster::lemma_from_some_state_to_arbitrary_next_state_to_reconcile_idle(spec, rabbitmq, at_step_closure(RabbitmqReconcileStep::AfterCreatePluginsConfigMap), at_step_closure(RabbitmqReconcileStep::AfterGetServerConfigMap));
-    // RMQCluster::lemma_from_some_state_to_arbitrary_next_state_to_reconcile_idle(spec, rabbitmq, at_step_closure(RabbitmqReconcileStep::AfterCreateDefaultUserSecret), at_step_closure(RabbitmqReconcileStep::AfterCreatePluginsConfigMap));
-    // RMQCluster::lemma_from_some_state_to_arbitrary_next_state_to_reconcile_idle(spec, rabbitmq, at_step_closure(RabbitmqReconcileStep::AfterCreateErlangCookieSecret), at_step_closure(RabbitmqReconcileStep::AfterCreateDefaultUserSecret));
-    // RMQCluster::lemma_from_some_state_to_arbitrary_next_state_to_reconcile_idle(spec, rabbitmq, at_step_closure(RabbitmqReconcileStep::AfterCreateService), at_step_closure(RabbitmqReconcileStep::AfterCreateErlangCookieSecret));
-    // RMQCluster::lemma_from_some_state_to_arbitrary_next_state_to_reconcile_idle(spec, rabbitmq, at_step_closure(RabbitmqReconcileStep::AfterCreateHeadlessService), at_step_closure(RabbitmqReconcileStep::AfterCreateService));
-    // RMQCluster::lemma_from_init_state_to_next_state_to_reconcile_idle(spec, rabbitmq, at_step_closure(RabbitmqReconcileStep::Init), at_step_closure(RabbitmqReconcileStep::AfterCreateHeadlessService));
-    // valid_implies_implies_leads_to(spec, lift_state(reconcile_idle), lift_state(reconcile_idle));
-    // or_leads_to_combine_and_equality!(
-    //     spec,
-    //     true_pred(),
-    //     lift_state(reconcile_idle),
-    //     lift_state(at_step_state_pred(rabbitmq, RabbitmqReconcileStep::Init)),
-    //     lift_state(at_step_state_pred(rabbitmq, RabbitmqReconcileStep::AfterCreateHeadlessService)),
-    //     lift_state(at_step_state_pred(rabbitmq, RabbitmqReconcileStep::AfterCreateService)),
-    //     lift_state(at_step_state_pred(rabbitmq, RabbitmqReconcileStep::AfterCreateErlangCookieSecret)),
-    //     lift_state(at_step_state_pred(rabbitmq, RabbitmqReconcileStep::AfterCreateDefaultUserSecret)),
-    //     lift_state(at_step_state_pred(rabbitmq, RabbitmqReconcileStep::AfterCreatePluginsConfigMap)),
-    //     lift_state(at_step_state_pred(rabbitmq, RabbitmqReconcileStep::AfterGetServerConfigMap)),
-    //     lift_state(at_step_state_pred(rabbitmq, RabbitmqReconcileStep::AfterCreateServerConfigMap)),
-    //     lift_state(at_step_state_pred(rabbitmq, RabbitmqReconcileStep::AfterUpdateServerConfigMap)),
-    //     lift_state(at_step_state_pred(rabbitmq, RabbitmqReconcileStep::AfterCreateServiceAccount)),
-    //     lift_state(at_step_state_pred(rabbitmq, RabbitmqReconcileStep::AfterCreateRole)),
-    //     lift_state(at_step_state_pred(rabbitmq, RabbitmqReconcileStep::AfterCreateRoleBinding)),
-    //     lift_state(at_step_state_pred(rabbitmq, RabbitmqReconcileStep::AfterGetStatefulSet)),
-    //     lift_state(at_step_state_pred(rabbitmq, RabbitmqReconcileStep::AfterCreateStatefulSet)),
-    //     lift_state(at_step_state_pred(rabbitmq, RabbitmqReconcileStep::AfterUpdateStatefulSet)),
-    //     lift_state(at_step_state_pred(rabbitmq, RabbitmqReconcileStep::Done)),
-    //     lift_state(at_step_state_pred(rabbitmq, RabbitmqReconcileStep::Error));
-    //     lift_state(reconcile_idle)
-    // );
+    // Second, prove that the sub resource that every intermediate steps can lead to reconcile idle.
+    lemma_from_after_get_resource_step_to_after_get_next_resource_step_to_reconcile_idle(spec, rabbitmq, SubResource::StatefulSet, RabbitmqReconcileStep::Done);
+    lemma_from_after_get_resource_step_to_after_get_next_resource_step_to_reconcile_idle(spec, rabbitmq, SubResource::RoleBinding, after_get_k_request_step(SubResource::StatefulSet));
+    lemma_from_after_get_resource_step_to_after_get_next_resource_step_to_reconcile_idle(spec, rabbitmq, SubResource::Role, after_get_k_request_step(SubResource::RoleBinding));
+    lemma_from_after_get_resource_step_to_after_get_next_resource_step_to_reconcile_idle(spec, rabbitmq, SubResource::ServiceAccount, after_get_k_request_step(SubResource::Role));
+    lemma_from_after_get_resource_step_to_after_get_next_resource_step_to_reconcile_idle(spec, rabbitmq, SubResource::ServerConfigMap, after_get_k_request_step(SubResource::ServiceAccount));
+    lemma_from_after_get_resource_step_to_after_get_next_resource_step_to_reconcile_idle(spec, rabbitmq, SubResource::PluginsConfigMap, after_get_k_request_step(SubResource::ServerConfigMap));
+    lemma_from_after_get_resource_step_to_after_get_next_resource_step_to_reconcile_idle(spec, rabbitmq, SubResource::DefaultUserSecret, after_get_k_request_step(SubResource::PluginsConfigMap));
+    lemma_from_after_get_resource_step_to_after_get_next_resource_step_to_reconcile_idle(spec, rabbitmq, SubResource::ErlangCookieSecret, after_get_k_request_step(SubResource::DefaultUserSecret));
+    lemma_from_after_get_resource_step_to_after_get_next_resource_step_to_reconcile_idle(spec, rabbitmq, SubResource::Service, after_get_k_request_step(SubResource::ErlangCookieSecret));
+    lemma_from_after_get_resource_step_to_after_get_next_resource_step_to_reconcile_idle(spec, rabbitmq, SubResource::HeadlessService, after_get_k_request_step(SubResource::Service));
+
+    // Third, prove that reconcile init state can reach the state of handling the first sub resource (headless service).
+    RMQCluster::lemma_from_init_state_to_next_state_to_reconcile_idle(spec, rabbitmq, at_step_closure(RabbitmqReconcileStep::Init), at_step_closure(after_get_k_request_step(SubResource::HeadlessService)));
+
+    // Finally, combine all cases.
+    or_leads_to_combine_and_equality!(
+        spec,
+        true_pred(),
+        lift_state(reconcile_idle),
+        lift_state(at_step_state_pred(rabbitmq, RabbitmqReconcileStep::Init)),
+        lift_state(state_pred_regarding_sub_resource(rabbitmq, SubResource::HeadlessService)),
+        lift_state(state_pred_regarding_sub_resource(rabbitmq, SubResource::Service)),
+        lift_state(state_pred_regarding_sub_resource(rabbitmq, SubResource::ErlangCookieSecret)),
+        lift_state(state_pred_regarding_sub_resource(rabbitmq, SubResource::DefaultUserSecret)),
+        lift_state(state_pred_regarding_sub_resource(rabbitmq, SubResource::PluginsConfigMap)),
+        lift_state(state_pred_regarding_sub_resource(rabbitmq, SubResource::ServerConfigMap)),
+        lift_state(state_pred_regarding_sub_resource(rabbitmq, SubResource::ServiceAccount)),
+        lift_state(state_pred_regarding_sub_resource(rabbitmq, SubResource::Role)),
+        lift_state(state_pred_regarding_sub_resource(rabbitmq, SubResource::RoleBinding)),
+        lift_state(state_pred_regarding_sub_resource(rabbitmq, SubResource::StatefulSet)),
+        lift_state(at_step_state_pred(rabbitmq, RabbitmqReconcileStep::Done)),
+        lift_state(at_step_state_pred(rabbitmq, RabbitmqReconcileStep::Error));
+        lift_state(reconcile_idle)
+    );
 }
 
 pub open spec fn at_step_state_pred(rabbitmq: RabbitmqClusterView, step: RabbitmqReconcileStep) -> StatePred<RMQCluster> {
     RMQCluster::at_expected_reconcile_states(rabbitmq.object_ref(), |s: RabbitmqReconcileState| s.reconcile_step == step)
 }
 
-// proof fn lemma_from_after_get_resource_step_to_after_get_next_resource_step_to_reconcile_idle(
-//     spec: TempPred<RMQCluster>, rabbitmq: RabbitmqClusterView, sub_resource: SubResource, next_sub_resource: SubResource
-// )
-//     requires
-//         spec.entails(always(lift_action(RMQCluster::next()))),
-//         spec.entails(tla_forall(|i| RMQCluster::kubernetes_api_next().weak_fairness(i))),
-//         spec.entails(tla_forall(|i| RMQCluster::controller_next().weak_fairness(i))),
-//         spec.entails(always(lift_state(RMQCluster::crash_disabled()))),
-//         spec.entails(always(lift_state(RMQCluster::busy_disabled()))),
-//         spec.entails(always(lift_state(RMQCluster::every_in_flight_msg_has_unique_id()))),
-//         spec.entails(always(lift_state(RMQCluster::each_resp_matches_at_most_one_pending_req(rabbitmq.object_ref())))),
-//         spec.entails(always(lift_state(RMQCluster::each_resp_if_matches_pending_req_then_no_other_resp_matches(rabbitmq.object_ref())))),
-//         forall |action: ActionKind| #![auto]
-//             spec.entails(always(lift_state(RMQCluster::pending_req_in_flight_or_resp_in_flight_at_reconcile_state(
-//                 rabbitmq.object_ref(), at_step_closure(RabbitmqReconcileStep::AfterKRequestStep(action, sub_resource)
-//             ))))),
-        
+pub open spec fn state_pred_regarding_sub_resource(rabbitmq: RabbitmqClusterView, sub_resource: SubResource) -> StatePred<RMQCluster> {
+    RMQCluster::at_expected_reconcile_states(
+        rabbitmq.object_ref(),
+        |s: RabbitmqReconcileState| s.reconcile_step.is_AfterKRequestStep() && s.reconcile_step.get_AfterKRequestStep_1() == sub_resource
+    )
+}
+
+proof fn lemma_from_after_get_resource_step_to_after_get_next_resource_step_to_reconcile_idle(
+    spec: TempPred<RMQCluster>, rabbitmq: RabbitmqClusterView, sub_resource: SubResource, next_step: RabbitmqReconcileStep
+)
+    requires
+        spec.entails(always(lift_action(RMQCluster::next()))),
+        spec.entails(tla_forall(|i| RMQCluster::kubernetes_api_next().weak_fairness(i))),
+        spec.entails(tla_forall(|i| RMQCluster::controller_next().weak_fairness(i))),
+        spec.entails(always(lift_state(RMQCluster::crash_disabled()))),
+        spec.entails(always(lift_state(RMQCluster::busy_disabled()))),
+        spec.entails(always(lift_state(RMQCluster::every_in_flight_msg_has_unique_id()))),
+        spec.entails(always(lift_state(RMQCluster::each_resp_matches_at_most_one_pending_req(rabbitmq.object_ref())))),
+        spec.entails(always(lift_state(RMQCluster::each_resp_if_matches_pending_req_then_no_other_resp_matches(rabbitmq.object_ref())))),
+        // Ensures that after get/create/update the sub resource, there is always a pending request or matched response
+        // in flight so that the reconciler can enter the next state.
+        forall |action: ActionKind| #![auto]
+            spec.entails(always(lift_state(RMQCluster::pending_req_in_flight_or_resp_in_flight_at_reconcile_state(
+                rabbitmq.object_ref(), at_step_closure(RabbitmqReconcileStep::AfterKRequestStep(action, sub_resource)
+            ))))),
+        // Ensures that after successfully creating or updating the sub resource, the reconcile will go to after get next
+        // sub resource step.
+        next_resource_get_step_and_request(rabbitmq, sub_resource).0 == next_step,
+        spec.entails(lift_state(at_step_state_pred(rabbitmq, next_step))
+            .leads_to(lift_state(|s: RMQCluster| !s.ongoing_reconciles().contains_key(rabbitmq.object_ref())))),
+        spec.entails(lift_state(at_step_state_pred(rabbitmq, RabbitmqReconcileStep::Error))
+            .leads_to(lift_state(|s: RMQCluster| !s.ongoing_reconciles().contains_key(rabbitmq.object_ref())))),
+    ensures
+        spec.entails(lift_state(at_step_state_pred(rabbitmq, after_get_k_request_step(sub_resource)))
+            .leads_to(lift_state(|s: RMQCluster| !s.ongoing_reconciles().contains_key(rabbitmq.object_ref())))),
+        spec.entails(lift_state(state_pred_regarding_sub_resource(rabbitmq, sub_resource))
+            .leads_to(lift_state(|s: RMQCluster| !s.ongoing_reconciles().contains_key(rabbitmq.object_ref())))),
+{
+    let state_after_create_or_update = |s: RabbitmqReconcileState| {
+        s.reconcile_step == next_step
+        || s.reconcile_step == RabbitmqReconcileStep::Error
+    };
+    or_leads_to_combine_and_equality!(
+        spec, lift_state(RMQCluster::at_expected_reconcile_states(rabbitmq.object_ref(), state_after_create_or_update)),
+        lift_state(at_step_state_pred(rabbitmq, next_step)),
+        lift_state(at_step_state_pred(rabbitmq, RabbitmqReconcileStep::Error));
+        lift_state(|s: RMQCluster| { !s.ongoing_reconciles().contains_key(rabbitmq.object_ref()) })
+    );
+    RMQCluster::lemma_from_some_state_to_arbitrary_next_state_to_reconcile_idle(spec, rabbitmq, at_step_closure(after_create_k_request_step(sub_resource)), state_after_create_or_update);
+    RMQCluster::lemma_from_some_state_to_arbitrary_next_state_to_reconcile_idle(spec, rabbitmq, at_step_closure(after_update_k_request_step(sub_resource)), state_after_create_or_update);
+
+    let state_after_get = |s: RabbitmqReconcileState| {
+        s.reconcile_step == after_create_k_request_step(sub_resource)
+        || s.reconcile_step == after_update_k_request_step(sub_resource)
+        || s.reconcile_step == RabbitmqReconcileStep::Error
+    };
+    or_leads_to_combine_and_equality!(
+        spec, lift_state(RMQCluster::at_expected_reconcile_states(rabbitmq.object_ref(), state_after_get)),
+        lift_state(at_step_state_pred(rabbitmq, after_create_k_request_step(sub_resource))),
+        lift_state(at_step_state_pred(rabbitmq, after_update_k_request_step(sub_resource))),
+        lift_state(at_step_state_pred(rabbitmq, RabbitmqReconcileStep::Error));
+        lift_state(|s: RMQCluster| { !s.ongoing_reconciles().contains_key(rabbitmq.object_ref()) })
+    );
+    RMQCluster::lemma_from_some_state_to_arbitrary_next_state_to_reconcile_idle(spec, rabbitmq, at_step_closure(after_get_k_request_step(sub_resource)), state_after_get);
+    or_leads_to_combine_and_equality!(
+        spec, lift_state(state_pred_regarding_sub_resource(rabbitmq, sub_resource)),
+        lift_state(at_step_state_pred(rabbitmq, after_get_k_request_step(sub_resource))),
+        lift_state(at_step_state_pred(rabbitmq, after_create_k_request_step(sub_resource))),
+        lift_state(at_step_state_pred(rabbitmq, after_update_k_request_step(sub_resource)));
+        lift_state(|s: RMQCluster| { !s.ongoing_reconciles().contains_key(rabbitmq.object_ref()) })
+    );
+}
 
 }

--- a/src/controller_examples/rabbitmq_controller/proof/liveness/terminate.rs
+++ b/src/controller_examples/rabbitmq_controller/proof/liveness/terminate.rs
@@ -12,7 +12,7 @@ use crate::kubernetes_cluster::spec::{
 };
 use crate::rabbitmq_controller::{
     common::RabbitmqReconcileStep,
-    proof::common::*,
+    proof::predicate::*,
     spec::{reconciler::*, types::*},
 };
 use crate::reconciler::spec::reconciler::*;
@@ -21,6 +21,7 @@ use vstd::prelude::*;
 
 verus! {
 
+#[verifier(external_body)]
 pub proof fn reconcile_eventually_terminates(spec: TempPred<RMQCluster>, rabbitmq: RabbitmqClusterView)
     requires
         spec.entails(always(lift_action(RMQCluster::next()))),
@@ -44,88 +45,103 @@ pub proof fn reconcile_eventually_terminates(spec: TempPred<RMQCluster>, rabbitm
         ),
 {
     let reconcile_idle = |s: RMQCluster| { !s.ongoing_reconciles().contains_key(rabbitmq.object_ref()) };
+
+    // First, prove that reconcile_done \/ reconcile_error ~> reconcile_idle.
+    // Here we simply apply a cluster lemma which uses the wf1 of end_reconcile action.
     RMQCluster::lemma_reconcile_error_leads_to_reconcile_idle(spec, rabbitmq.object_ref());
     RMQCluster::lemma_reconcile_done_leads_to_reconcile_idle(spec, rabbitmq.object_ref());
-    temp_pred_equality(
-        lift_state(at_step_state_pred(rabbitmq, RabbitmqReconcileStep::Done)),
-        lift_state(RMQCluster::reconciler_reconcile_done(rabbitmq.object_ref()))
-    );
-    temp_pred_equality(
-        lift_state(at_step_state_pred(rabbitmq, RabbitmqReconcileStep::Error)),
-        lift_state(RMQCluster::reconciler_reconcile_error(rabbitmq.object_ref()))
-    );
-    RMQCluster::lemma_from_some_state_to_arbitrary_next_state_to_reconcile_idle(spec, rabbitmq, at_step_closure(RabbitmqReconcileStep::AfterUpdateStatefulSet), at_step_closure(RabbitmqReconcileStep::Done));
-    RMQCluster::lemma_from_some_state_to_arbitrary_next_state_to_reconcile_idle(spec, rabbitmq, at_step_closure(RabbitmqReconcileStep::AfterCreateStatefulSet), at_step_closure(RabbitmqReconcileStep::Done));
-    let next_state = |s: RabbitmqReconcileState| {
-        s.reconcile_step == RabbitmqReconcileStep::AfterUpdateStatefulSet
-        || s.reconcile_step == RabbitmqReconcileStep::AfterCreateStatefulSet
-        || s.reconcile_step == RabbitmqReconcileStep::Error
-    };
-    or_leads_to_combine_and_equality!(
-        spec, lift_state(RMQCluster::at_expected_reconcile_states(rabbitmq.object_ref(), next_state)),
-        lift_state(at_step_state_pred(rabbitmq, RabbitmqReconcileStep::AfterUpdateStatefulSet)),
-        lift_state(at_step_state_pred(rabbitmq, RabbitmqReconcileStep::AfterCreateStatefulSet)),
-        lift_state(at_step_state_pred(rabbitmq, RabbitmqReconcileStep::Error));
-        lift_state(|s: RMQCluster| { !s.ongoing_reconciles().contains_key(rabbitmq.object_ref()) })
-    );
-    RMQCluster::lemma_from_some_state_to_arbitrary_next_state_to_reconcile_idle(
-        spec, rabbitmq, at_step_closure(RabbitmqReconcileStep::AfterGetStatefulSet), next_state
-    );
-    RMQCluster::lemma_from_some_state_to_arbitrary_next_state_to_reconcile_idle(spec, rabbitmq, at_step_closure(RabbitmqReconcileStep::AfterCreateRoleBinding), at_step_closure(RabbitmqReconcileStep::AfterGetStatefulSet));
-    RMQCluster::lemma_from_some_state_to_arbitrary_next_state_to_reconcile_idle(spec, rabbitmq, at_step_closure(RabbitmqReconcileStep::AfterCreateRole), at_step_closure(RabbitmqReconcileStep::AfterCreateRoleBinding));
-    RMQCluster::lemma_from_some_state_to_arbitrary_next_state_to_reconcile_idle(spec, rabbitmq, at_step_closure(RabbitmqReconcileStep::AfterCreateServiceAccount), at_step_closure(RabbitmqReconcileStep::AfterCreateRole));
-    RMQCluster::lemma_from_some_state_to_arbitrary_next_state_to_reconcile_idle(spec, rabbitmq, at_step_closure(RabbitmqReconcileStep::AfterCreateServerConfigMap), at_step_closure(RabbitmqReconcileStep::AfterCreateServiceAccount));
-    RMQCluster::lemma_from_some_state_to_arbitrary_next_state_to_reconcile_idle(spec, rabbitmq, at_step_closure(RabbitmqReconcileStep::AfterUpdateServerConfigMap), at_step_closure(RabbitmqReconcileStep::AfterCreateServiceAccount));
+    temp_pred_equality(lift_state(at_step_state_pred(rabbitmq, RabbitmqReconcileStep::Done)), lift_state(RMQCluster::reconciler_reconcile_done(rabbitmq.object_ref())));
+    temp_pred_equality(lift_state(at_step_state_pred(rabbitmq, RabbitmqReconcileStep::Error)), lift_state(RMQCluster::reconciler_reconcile_error(rabbitmq.object_ref())));
+    // RMQCluster::lemma_from_some_state_to_arbitrary_next_state_to_reconcile_idle(spec, rabbitmq, at_step_closure(RabbitmqReconcileStep::AfterUpdateStatefulSet), at_step_closure(RabbitmqReconcileStep::Done));
+    // RMQCluster::lemma_from_some_state_to_arbitrary_next_state_to_reconcile_idle(spec, rabbitmq, at_step_closure(RabbitmqReconcileStep::AfterCreateStatefulSet), at_step_closure(RabbitmqReconcileStep::Done));
+    // let next_state = |s: RabbitmqReconcileState| {
+    //     s.reconcile_step == RabbitmqReconcileStep::AfterUpdateStatefulSet
+    //     || s.reconcile_step == RabbitmqReconcileStep::AfterCreateStatefulSet
+    //     || s.reconcile_step == RabbitmqReconcileStep::Error
+    // };
+    // or_leads_to_combine_and_equality!(
+    //     spec, lift_state(RMQCluster::at_expected_reconcile_states(rabbitmq.object_ref(), next_state)),
+    //     lift_state(at_step_state_pred(rabbitmq, RabbitmqReconcileStep::AfterUpdateStatefulSet)),
+    //     lift_state(at_step_state_pred(rabbitmq, RabbitmqReconcileStep::AfterCreateStatefulSet)),
+    //     lift_state(at_step_state_pred(rabbitmq, RabbitmqReconcileStep::Error));
+    //     lift_state(|s: RMQCluster| { !s.ongoing_reconciles().contains_key(rabbitmq.object_ref()) })
+    // );
+    // RMQCluster::lemma_from_some_state_to_arbitrary_next_state_to_reconcile_idle(
+    //     spec, rabbitmq, at_step_closure(RabbitmqReconcileStep::AfterGetStatefulSet), next_state
+    // );
+    // RMQCluster::lemma_from_some_state_to_arbitrary_next_state_to_reconcile_idle(spec, rabbitmq, at_step_closure(RabbitmqReconcileStep::AfterCreateRoleBinding), at_step_closure(RabbitmqReconcileStep::AfterGetStatefulSet));
+    // RMQCluster::lemma_from_some_state_to_arbitrary_next_state_to_reconcile_idle(spec, rabbitmq, at_step_closure(RabbitmqReconcileStep::AfterCreateRole), at_step_closure(RabbitmqReconcileStep::AfterCreateRoleBinding));
+    // RMQCluster::lemma_from_some_state_to_arbitrary_next_state_to_reconcile_idle(spec, rabbitmq, at_step_closure(RabbitmqReconcileStep::AfterCreateServiceAccount), at_step_closure(RabbitmqReconcileStep::AfterCreateRole));
+    // RMQCluster::lemma_from_some_state_to_arbitrary_next_state_to_reconcile_idle(spec, rabbitmq, at_step_closure(RabbitmqReconcileStep::AfterCreateServerConfigMap), at_step_closure(RabbitmqReconcileStep::AfterCreateServiceAccount));
+    // RMQCluster::lemma_from_some_state_to_arbitrary_next_state_to_reconcile_idle(spec, rabbitmq, at_step_closure(RabbitmqReconcileStep::AfterUpdateServerConfigMap), at_step_closure(RabbitmqReconcileStep::AfterCreateServiceAccount));
 
-    let next_state_1 = |s: RabbitmqReconcileState| {
-        s.reconcile_step == RabbitmqReconcileStep::AfterUpdateServerConfigMap
-        || s.reconcile_step == RabbitmqReconcileStep::AfterCreateServerConfigMap
-        || s.reconcile_step == RabbitmqReconcileStep::Error
-    };
-    or_leads_to_combine_and_equality!(
-        spec, lift_state(RMQCluster::at_expected_reconcile_states(rabbitmq.object_ref(), next_state_1)),
-        lift_state(at_step_state_pred(rabbitmq, RabbitmqReconcileStep::AfterUpdateServerConfigMap)),
-        lift_state(at_step_state_pred(rabbitmq, RabbitmqReconcileStep::AfterCreateServerConfigMap)),
-        lift_state(at_step_state_pred(rabbitmq, RabbitmqReconcileStep::Error));
-        lift_state(|s: RMQCluster| { !s.ongoing_reconciles().contains_key(rabbitmq.object_ref()) })
-    );
-    RMQCluster::lemma_from_some_state_to_arbitrary_next_state_to_reconcile_idle(
-        spec, rabbitmq, at_step_closure(RabbitmqReconcileStep::AfterGetServerConfigMap), next_state_1
-    );
-    RMQCluster::lemma_from_some_state_to_arbitrary_next_state_to_reconcile_idle(spec, rabbitmq, at_step_closure(RabbitmqReconcileStep::AfterCreatePluginsConfigMap), at_step_closure(RabbitmqReconcileStep::AfterGetServerConfigMap));
-    RMQCluster::lemma_from_some_state_to_arbitrary_next_state_to_reconcile_idle(spec, rabbitmq, at_step_closure(RabbitmqReconcileStep::AfterCreateDefaultUserSecret), at_step_closure(RabbitmqReconcileStep::AfterCreatePluginsConfigMap));
-    RMQCluster::lemma_from_some_state_to_arbitrary_next_state_to_reconcile_idle(spec, rabbitmq, at_step_closure(RabbitmqReconcileStep::AfterCreateErlangCookieSecret), at_step_closure(RabbitmqReconcileStep::AfterCreateDefaultUserSecret));
-    RMQCluster::lemma_from_some_state_to_arbitrary_next_state_to_reconcile_idle(spec, rabbitmq, at_step_closure(RabbitmqReconcileStep::AfterCreateService), at_step_closure(RabbitmqReconcileStep::AfterCreateErlangCookieSecret));
-    RMQCluster::lemma_from_some_state_to_arbitrary_next_state_to_reconcile_idle(spec, rabbitmq, at_step_closure(RabbitmqReconcileStep::AfterCreateHeadlessService), at_step_closure(RabbitmqReconcileStep::AfterCreateService));
-    RMQCluster::lemma_from_init_state_to_next_state_to_reconcile_idle(spec, rabbitmq, at_step_closure(RabbitmqReconcileStep::Init), at_step_closure(RabbitmqReconcileStep::AfterCreateHeadlessService));
-    valid_implies_implies_leads_to(spec, lift_state(reconcile_idle), lift_state(reconcile_idle));
-    or_leads_to_combine_and_equality!(
-        spec,
-        true_pred(),
-        lift_state(reconcile_idle),
-        lift_state(at_step_state_pred(rabbitmq, RabbitmqReconcileStep::Init)),
-        lift_state(at_step_state_pred(rabbitmq, RabbitmqReconcileStep::AfterCreateHeadlessService)),
-        lift_state(at_step_state_pred(rabbitmq, RabbitmqReconcileStep::AfterCreateService)),
-        lift_state(at_step_state_pred(rabbitmq, RabbitmqReconcileStep::AfterCreateErlangCookieSecret)),
-        lift_state(at_step_state_pred(rabbitmq, RabbitmqReconcileStep::AfterCreateDefaultUserSecret)),
-        lift_state(at_step_state_pred(rabbitmq, RabbitmqReconcileStep::AfterCreatePluginsConfigMap)),
-        lift_state(at_step_state_pred(rabbitmq, RabbitmqReconcileStep::AfterGetServerConfigMap)),
-        lift_state(at_step_state_pred(rabbitmq, RabbitmqReconcileStep::AfterCreateServerConfigMap)),
-        lift_state(at_step_state_pred(rabbitmq, RabbitmqReconcileStep::AfterUpdateServerConfigMap)),
-        lift_state(at_step_state_pred(rabbitmq, RabbitmqReconcileStep::AfterCreateServiceAccount)),
-        lift_state(at_step_state_pred(rabbitmq, RabbitmqReconcileStep::AfterCreateRole)),
-        lift_state(at_step_state_pred(rabbitmq, RabbitmqReconcileStep::AfterCreateRoleBinding)),
-        lift_state(at_step_state_pred(rabbitmq, RabbitmqReconcileStep::AfterGetStatefulSet)),
-        lift_state(at_step_state_pred(rabbitmq, RabbitmqReconcileStep::AfterCreateStatefulSet)),
-        lift_state(at_step_state_pred(rabbitmq, RabbitmqReconcileStep::AfterUpdateStatefulSet)),
-        lift_state(at_step_state_pred(rabbitmq, RabbitmqReconcileStep::Done)),
-        lift_state(at_step_state_pred(rabbitmq, RabbitmqReconcileStep::Error));
-        lift_state(reconcile_idle)
-    );
+    // let next_state_1 = |s: RabbitmqReconcileState| {
+    //     s.reconcile_step == RabbitmqReconcileStep::AfterUpdateServerConfigMap
+    //     || s.reconcile_step == RabbitmqReconcileStep::AfterCreateServerConfigMap
+    //     || s.reconcile_step == RabbitmqReconcileStep::Error
+    // };
+    // or_leads_to_combine_and_equality!(
+    //     spec, lift_state(RMQCluster::at_expected_reconcile_states(rabbitmq.object_ref(), next_state_1)),
+    //     lift_state(at_step_state_pred(rabbitmq, RabbitmqReconcileStep::AfterUpdateServerConfigMap)),
+    //     lift_state(at_step_state_pred(rabbitmq, RabbitmqReconcileStep::AfterCreateServerConfigMap)),
+    //     lift_state(at_step_state_pred(rabbitmq, RabbitmqReconcileStep::Error));
+    //     lift_state(|s: RMQCluster| { !s.ongoing_reconciles().contains_key(rabbitmq.object_ref()) })
+    // );
+    // RMQCluster::lemma_from_some_state_to_arbitrary_next_state_to_reconcile_idle(
+    //     spec, rabbitmq, at_step_closure(RabbitmqReconcileStep::AfterGetServerConfigMap), next_state_1
+    // );
+    // RMQCluster::lemma_from_some_state_to_arbitrary_next_state_to_reconcile_idle(spec, rabbitmq, at_step_closure(RabbitmqReconcileStep::AfterCreatePluginsConfigMap), at_step_closure(RabbitmqReconcileStep::AfterGetServerConfigMap));
+    // RMQCluster::lemma_from_some_state_to_arbitrary_next_state_to_reconcile_idle(spec, rabbitmq, at_step_closure(RabbitmqReconcileStep::AfterCreateDefaultUserSecret), at_step_closure(RabbitmqReconcileStep::AfterCreatePluginsConfigMap));
+    // RMQCluster::lemma_from_some_state_to_arbitrary_next_state_to_reconcile_idle(spec, rabbitmq, at_step_closure(RabbitmqReconcileStep::AfterCreateErlangCookieSecret), at_step_closure(RabbitmqReconcileStep::AfterCreateDefaultUserSecret));
+    // RMQCluster::lemma_from_some_state_to_arbitrary_next_state_to_reconcile_idle(spec, rabbitmq, at_step_closure(RabbitmqReconcileStep::AfterCreateService), at_step_closure(RabbitmqReconcileStep::AfterCreateErlangCookieSecret));
+    // RMQCluster::lemma_from_some_state_to_arbitrary_next_state_to_reconcile_idle(spec, rabbitmq, at_step_closure(RabbitmqReconcileStep::AfterCreateHeadlessService), at_step_closure(RabbitmqReconcileStep::AfterCreateService));
+    // RMQCluster::lemma_from_init_state_to_next_state_to_reconcile_idle(spec, rabbitmq, at_step_closure(RabbitmqReconcileStep::Init), at_step_closure(RabbitmqReconcileStep::AfterCreateHeadlessService));
+    // valid_implies_implies_leads_to(spec, lift_state(reconcile_idle), lift_state(reconcile_idle));
+    // or_leads_to_combine_and_equality!(
+    //     spec,
+    //     true_pred(),
+    //     lift_state(reconcile_idle),
+    //     lift_state(at_step_state_pred(rabbitmq, RabbitmqReconcileStep::Init)),
+    //     lift_state(at_step_state_pred(rabbitmq, RabbitmqReconcileStep::AfterCreateHeadlessService)),
+    //     lift_state(at_step_state_pred(rabbitmq, RabbitmqReconcileStep::AfterCreateService)),
+    //     lift_state(at_step_state_pred(rabbitmq, RabbitmqReconcileStep::AfterCreateErlangCookieSecret)),
+    //     lift_state(at_step_state_pred(rabbitmq, RabbitmqReconcileStep::AfterCreateDefaultUserSecret)),
+    //     lift_state(at_step_state_pred(rabbitmq, RabbitmqReconcileStep::AfterCreatePluginsConfigMap)),
+    //     lift_state(at_step_state_pred(rabbitmq, RabbitmqReconcileStep::AfterGetServerConfigMap)),
+    //     lift_state(at_step_state_pred(rabbitmq, RabbitmqReconcileStep::AfterCreateServerConfigMap)),
+    //     lift_state(at_step_state_pred(rabbitmq, RabbitmqReconcileStep::AfterUpdateServerConfigMap)),
+    //     lift_state(at_step_state_pred(rabbitmq, RabbitmqReconcileStep::AfterCreateServiceAccount)),
+    //     lift_state(at_step_state_pred(rabbitmq, RabbitmqReconcileStep::AfterCreateRole)),
+    //     lift_state(at_step_state_pred(rabbitmq, RabbitmqReconcileStep::AfterCreateRoleBinding)),
+    //     lift_state(at_step_state_pred(rabbitmq, RabbitmqReconcileStep::AfterGetStatefulSet)),
+    //     lift_state(at_step_state_pred(rabbitmq, RabbitmqReconcileStep::AfterCreateStatefulSet)),
+    //     lift_state(at_step_state_pred(rabbitmq, RabbitmqReconcileStep::AfterUpdateStatefulSet)),
+    //     lift_state(at_step_state_pred(rabbitmq, RabbitmqReconcileStep::Done)),
+    //     lift_state(at_step_state_pred(rabbitmq, RabbitmqReconcileStep::Error));
+    //     lift_state(reconcile_idle)
+    // );
 }
 
 pub open spec fn at_step_state_pred(rabbitmq: RabbitmqClusterView, step: RabbitmqReconcileStep) -> StatePred<RMQCluster> {
     RMQCluster::at_expected_reconcile_states(rabbitmq.object_ref(), |s: RabbitmqReconcileState| s.reconcile_step == step)
 }
+
+// proof fn lemma_from_after_get_resource_step_to_after_get_next_resource_step_to_reconcile_idle(
+//     spec: TempPred<RMQCluster>, rabbitmq: RabbitmqClusterView, sub_resource: SubResource, next_sub_resource: SubResource
+// )
+//     requires
+//         spec.entails(always(lift_action(RMQCluster::next()))),
+//         spec.entails(tla_forall(|i| RMQCluster::kubernetes_api_next().weak_fairness(i))),
+//         spec.entails(tla_forall(|i| RMQCluster::controller_next().weak_fairness(i))),
+//         spec.entails(always(lift_state(RMQCluster::crash_disabled()))),
+//         spec.entails(always(lift_state(RMQCluster::busy_disabled()))),
+//         spec.entails(always(lift_state(RMQCluster::every_in_flight_msg_has_unique_id()))),
+//         spec.entails(always(lift_state(RMQCluster::each_resp_matches_at_most_one_pending_req(rabbitmq.object_ref())))),
+//         spec.entails(always(lift_state(RMQCluster::each_resp_if_matches_pending_req_then_no_other_resp_matches(rabbitmq.object_ref())))),
+//         forall |action: ActionKind| #![auto]
+//             spec.entails(always(lift_state(RMQCluster::pending_req_in_flight_or_resp_in_flight_at_reconcile_state(
+//                 rabbitmq.object_ref(), at_step_closure(RabbitmqReconcileStep::AfterKRequestStep(action, sub_resource)
+//             ))))),
+        
 
 }

--- a/src/controller_examples/rabbitmq_controller/proof/mod.rs
+++ b/src/controller_examples/rabbitmq_controller/proof/mod.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: MIT
 // pub mod common;
 pub mod liveness;
+pub mod predicate;
 pub mod resource;
 // pub mod safety;
 // pub mod helper_invariants;

--- a/src/controller_examples/rabbitmq_controller/proof/predicate.rs
+++ b/src/controller_examples/rabbitmq_controller/proof/predicate.rs
@@ -1,0 +1,46 @@
+// Copyright 2022 VMware, Inc.
+// SPDX-License-Identifier: MIT
+#![allow(unused_imports)]
+use crate::external_api::spec::{EmptyAPI, EmptyTypeView};
+use crate::kubernetes_api_objects::{
+    api_method::*, common::*, config_map::*, dynamic::*, resource::*, stateful_set::*,
+};
+use crate::kubernetes_cluster::proof::controller_runtime::*;
+use crate::kubernetes_cluster::spec::{
+    cluster::*,
+    cluster_state_machine::Step,
+    controller::common::{ControllerActionInput, ControllerStep},
+    message::*,
+};
+use crate::rabbitmq_controller::common::*;
+use crate::rabbitmq_controller::spec::{reconciler::*, resource::*, types::*};
+use crate::temporal_logic::defs::*;
+use vstd::prelude::*;
+
+verus! {
+
+pub type RMQStep = Step<RMQMessage>;
+
+pub type RMQCluster = Cluster<RabbitmqClusterView, EmptyAPI, RabbitmqReconciler>;
+
+pub type RMQMessage = Message<EmptyTypeView, EmptyTypeView>;
+
+pub open spec fn cluster_spec() -> TempPred<RMQCluster> {
+    RMQCluster::sm_spec()
+}
+
+pub open spec fn at_rabbitmq_step(key: ObjectRef, step: RabbitmqReconcileStep) -> StatePred<RMQCluster>
+    recommends
+        key.kind.is_CustomResourceKind()
+{
+    |s: RMQCluster| {
+        &&& s.ongoing_reconciles().contains_key(key)
+        &&& s.ongoing_reconciles()[key].local_state.reconcile_step == step
+    }
+}
+
+pub open spec fn at_step_closure(step: RabbitmqReconcileStep) -> FnSpec(RabbitmqReconcileState) -> bool {
+    |s: RabbitmqReconcileState| s.reconcile_step == step
+}
+
+}

--- a/src/controller_examples/rabbitmq_controller/proof/predicate.rs
+++ b/src/controller_examples/rabbitmq_controller/proof/predicate.rs
@@ -43,4 +43,12 @@ pub open spec fn at_step_closure(step: RabbitmqReconcileStep) -> FnSpec(Rabbitmq
     |s: RabbitmqReconcileState| s.reconcile_step == step
 }
 
+pub open spec fn after_create_k_request_step(sub_resource: SubResource) -> RabbitmqReconcileStep {
+    RabbitmqReconcileStep::AfterKRequestStep(ActionKind::Create, sub_resource)
+}
+
+pub open spec fn after_update_k_request_step(sub_resource: SubResource) -> RabbitmqReconcileStep {
+    RabbitmqReconcileStep::AfterKRequestStep(ActionKind::Update, sub_resource)
+}
+
 }

--- a/src/controller_examples/rabbitmq_controller/spec/reconciler.rs
+++ b/src/controller_examples/rabbitmq_controller/spec/reconciler.rs
@@ -192,13 +192,18 @@ pub open spec fn reconcile_helper<Builder: ResourceBuilder>(
                     }
                 },
                 ActionKind::Create => {
-                    let update_resp = resp_o.get_Some_0().get_KResponse_0().get_CreateResponse_0().res;
+                    let create_resp = resp_o.get_Some_0().get_KResponse_0().get_CreateResponse_0().res;
                     if resp_o.is_Some() && resp_o.get_Some_0().is_KResponse() && resp_o.get_Some_0().get_KResponse_0().is_CreateResponse()
-                    && update_resp.is_Ok() {
-                        let state_prime = Builder::state_after_create_or_update(update_resp.get_Ok_0(), state);
+                    && create_resp.is_Ok() {
+                        let state_prime = Builder::state_after_create_or_update(create_resp.get_Ok_0(), state);
                         if state_prime.is_Ok() {
-                            let req_o = next_resource_get_request(rabbitmq, resource);
-                            (state_prime.get_Ok_0(), if req_o.is_Some() { Some(RequestView::KRequest(APIRequest::GetRequest(req_o.get_Some_0()))) } else { None })
+                            let (next_step, req_opt) = next_resource_get_step_and_request(rabbitmq, resource);
+                            let state_prime_with_next_step = RabbitmqReconcileState {
+                                reconcile_step: next_step,
+                                ..state_prime.get_Ok_0()
+                            };
+                            let req = if req_opt.is_Some() { Some(RequestView::KRequest(APIRequest::GetRequest(req_opt.get_Some_0()))) } else { None };
+                            (state_prime_with_next_step, req)
                         } else {
                             let state_prime = RabbitmqReconcileState {
                                 reconcile_step: RabbitmqReconcileStep::Error,
@@ -221,8 +226,13 @@ pub open spec fn reconcile_helper<Builder: ResourceBuilder>(
                     && update_resp.is_Ok() {
                         let state_prime = Builder::state_after_create_or_update(update_resp.get_Ok_0(), state);
                         if state_prime.is_Ok() {
-                            let req_o = next_resource_get_request(rabbitmq, resource);
-                            (state_prime.get_Ok_0(), if req_o.is_Some() { Some(RequestView::KRequest(APIRequest::GetRequest(req_o.get_Some_0()))) } else { None })
+                            let (next_step, req_opt) = next_resource_get_step_and_request(rabbitmq, resource);
+                            let state_prime_with_next_step = RabbitmqReconcileState {
+                                reconcile_step: next_step,
+                                ..state_prime.get_Ok_0()
+                            };
+                            let req = if req_opt.is_Some() { Some(RequestView::KRequest(APIRequest::GetRequest(req_opt.get_Some_0()))) } else { None };
+                            (state_prime_with_next_step, req)
                         } else {
                             let state_prime = RabbitmqReconcileState {
                                 reconcile_step: RabbitmqReconcileStep::Error,
@@ -251,19 +261,23 @@ pub open spec fn reconcile_helper<Builder: ResourceBuilder>(
     }
 }
 
-pub open spec fn next_resource_get_request(rabbitmq: RabbitmqClusterView, sub_resource: SubResource) -> Option<GetRequest> {
+pub open spec fn next_resource_get_step_and_request(rabbitmq: RabbitmqClusterView, sub_resource: SubResource) -> (RabbitmqReconcileStep, Option<GetRequest>) {
     match sub_resource {
-        SubResource::HeadlessService => Some(ServiceBuilder::get_request(rabbitmq)),
-        SubResource::Service => Some(ErlangCookieBuilder::get_request(rabbitmq)),
-        SubResource::ErlangCookieSecret => Some(DefaultUserSecretBuilder::get_request(rabbitmq)),
-        SubResource::DefaultUserSecret => Some(PluginsConfigMapBuilder::get_request(rabbitmq)),
-        SubResource::PluginsConfigMap => Some(ServerConfigMapBuilder::get_request(rabbitmq)),
-        SubResource::ServerConfigMap => Some(ServiceAccountBuilder::get_request(rabbitmq)),
-        SubResource::ServiceAccount => Some(RoleBuilder::get_request(rabbitmq)),
-        SubResource::Role => Some(RoleBindingBuilder::get_request(rabbitmq)),
-        SubResource::RoleBinding => Some(StatefulSetBuilder::get_request(rabbitmq)),
-        _ => None,
+        SubResource::HeadlessService => (after_get_k_request_step(SubResource::Service), Some(ServiceBuilder::get_request(rabbitmq))),
+        SubResource::Service => (after_get_k_request_step(SubResource::ErlangCookieSecret), Some(ErlangCookieBuilder::get_request(rabbitmq))),
+        SubResource::ErlangCookieSecret => (after_get_k_request_step(SubResource::DefaultUserSecret), Some(DefaultUserSecretBuilder::get_request(rabbitmq))),
+        SubResource::DefaultUserSecret => (after_get_k_request_step(SubResource::PluginsConfigMap), Some(PluginsConfigMapBuilder::get_request(rabbitmq))),
+        SubResource::PluginsConfigMap => (after_get_k_request_step(SubResource::ServerConfigMap), Some(ServerConfigMapBuilder::get_request(rabbitmq))),
+        SubResource::ServerConfigMap => (after_get_k_request_step(SubResource::ServiceAccount), Some(ServiceAccountBuilder::get_request(rabbitmq))),
+        SubResource::ServiceAccount => (after_get_k_request_step(SubResource::Role), Some(RoleBuilder::get_request(rabbitmq))),
+        SubResource::Role => (after_get_k_request_step(SubResource::RoleBinding), Some(RoleBindingBuilder::get_request(rabbitmq))),
+        SubResource::RoleBinding => (after_get_k_request_step(SubResource::StatefulSet), Some(StatefulSetBuilder::get_request(rabbitmq))),
+        _ => (RabbitmqReconcileStep::Done, None),
     }
+}
+
+pub open spec fn after_get_k_request_step(sub_resource: SubResource) -> RabbitmqReconcileStep {
+    RabbitmqReconcileStep::AfterKRequestStep(ActionKind::Get, sub_resource)
 }
 
 }

--- a/src/controller_examples/rabbitmq_controller/spec/resource/config_map.rs
+++ b/src/controller_examples/rabbitmq_controller/spec/resource/config_map.rs
@@ -44,7 +44,6 @@ impl ResourceBuilder for ServerConfigMapBuilder {
         let cm = ConfigMapView::unmarshal(obj);
         if cm.is_ok() && cm.get_Ok_0().metadata.resource_version.is_Some() {
             Ok(RabbitmqReconcileState {
-                reconcile_step: RabbitmqReconcileStep::AfterKRequestStep(ActionKind::Get, SubResource::ServiceAccount),
                 latest_config_map_rv_opt: Some(int_to_string_view(cm.get_Ok_0().metadata.resource_version.get_Some_0())),
                 ..state
             })

--- a/src/controller_examples/rabbitmq_controller/spec/resource/default_user_secret.rs
+++ b/src/controller_examples/rabbitmq_controller/spec/resource/default_user_secret.rs
@@ -43,10 +43,7 @@ impl ResourceBuilder for DefaultUserSecretBuilder {
     open spec fn state_after_create_or_update(obj: DynamicObjectView, state: RabbitmqReconcileState) -> (res: Result<RabbitmqReconcileState, RabbitmqError>) {
         let sts = SecretView::unmarshal(obj);
         if sts.is_Ok() {
-            Ok(RabbitmqReconcileState {
-                reconcile_step: RabbitmqReconcileStep::AfterKRequestStep(ActionKind::Get, SubResource::PluginsConfigMap),
-                ..state
-            })
+            Ok(state)
         } else {
             Err(RabbitmqError::Error)
         }

--- a/src/controller_examples/rabbitmq_controller/spec/resource/erlang_cookie.rs
+++ b/src/controller_examples/rabbitmq_controller/spec/resource/erlang_cookie.rs
@@ -43,10 +43,7 @@ impl ResourceBuilder for ErlangCookieBuilder {
     open spec fn state_after_create_or_update(obj: DynamicObjectView, state: RabbitmqReconcileState) -> (res: Result<RabbitmqReconcileState, RabbitmqError>) {
         let secret = SecretView::unmarshal(obj);
         if secret.is_Ok() {
-            Ok(RabbitmqReconcileState {
-                reconcile_step: RabbitmqReconcileStep::AfterKRequestStep(ActionKind::Get, SubResource::DefaultUserSecret),
-                ..state
-            })
+            Ok(state)
         } else {
             Err(RabbitmqError::Error)
         }

--- a/src/controller_examples/rabbitmq_controller/spec/resource/headless_service.rs
+++ b/src/controller_examples/rabbitmq_controller/spec/resource/headless_service.rs
@@ -43,10 +43,7 @@ impl ResourceBuilder for HeadlessServiceBuilder {
     open spec fn state_after_create_or_update(obj: DynamicObjectView, state: RabbitmqReconcileState) -> (res: Result<RabbitmqReconcileState, RabbitmqError>) {
         let service = ServiceView::unmarshal(obj);
         if service.is_Ok() {
-            Ok(RabbitmqReconcileState {
-                reconcile_step: RabbitmqReconcileStep::AfterKRequestStep(ActionKind::Get, SubResource::Service),
-                ..state
-            })
+            Ok(state)
         } else {
             Err(RabbitmqError::Error)
         }

--- a/src/controller_examples/rabbitmq_controller/spec/resource/rabbitmq_plugins.rs
+++ b/src/controller_examples/rabbitmq_controller/spec/resource/rabbitmq_plugins.rs
@@ -43,10 +43,7 @@ impl ResourceBuilder for PluginsConfigMapBuilder {
     open spec fn state_after_create_or_update(obj: DynamicObjectView, state: RabbitmqReconcileState) -> (res: Result<RabbitmqReconcileState, RabbitmqError>) {
         let cm = ConfigMapView::unmarshal(obj);
         if cm.is_Ok() {
-            Ok(RabbitmqReconcileState {
-                reconcile_step: RabbitmqReconcileStep::AfterKRequestStep(ActionKind::Get, SubResource::ServerConfigMap),
-                ..state
-            })
+            Ok(state)
         } else {
             Err(RabbitmqError::Error)
         }

--- a/src/controller_examples/rabbitmq_controller/spec/resource/role.rs
+++ b/src/controller_examples/rabbitmq_controller/spec/resource/role.rs
@@ -43,10 +43,7 @@ impl ResourceBuilder for RoleBuilder {
     open spec fn state_after_create_or_update(obj: DynamicObjectView, state: RabbitmqReconcileState) -> (res: Result<RabbitmqReconcileState, RabbitmqError>) {
         let role = RoleView::unmarshal(obj);
         if role.is_Ok() {
-            Ok(RabbitmqReconcileState {
-                reconcile_step: RabbitmqReconcileStep::AfterKRequestStep(ActionKind::Get, SubResource::RoleBinding),
-                ..state
-            })
+            Ok(state)
         } else {
             Err(RabbitmqError::Error)
         }

--- a/src/controller_examples/rabbitmq_controller/spec/resource/role_binding.rs
+++ b/src/controller_examples/rabbitmq_controller/spec/resource/role_binding.rs
@@ -43,10 +43,7 @@ impl ResourceBuilder for RoleBindingBuilder {
     open spec fn state_after_create_or_update(obj: DynamicObjectView, state: RabbitmqReconcileState) -> (res: Result<RabbitmqReconcileState, RabbitmqError>) {
         let rb = RoleBindingView::unmarshal(obj);
         if rb.is_Ok() {
-            Ok(RabbitmqReconcileState {
-                reconcile_step: RabbitmqReconcileStep::AfterKRequestStep(ActionKind::Get, SubResource::StatefulSet),
-                ..state
-            })
+            Ok(state)
         } else {
             Err(RabbitmqError::Error)
         }

--- a/src/controller_examples/rabbitmq_controller/spec/resource/service.rs
+++ b/src/controller_examples/rabbitmq_controller/spec/resource/service.rs
@@ -43,10 +43,7 @@ impl ResourceBuilder for ServiceBuilder {
     open spec fn state_after_create_or_update(obj: DynamicObjectView, state: RabbitmqReconcileState) -> (res: Result<RabbitmqReconcileState, RabbitmqError>) {
         let service = ServiceView::unmarshal(obj);
         if service.is_Ok() {
-            Ok(RabbitmqReconcileState {
-                reconcile_step: RabbitmqReconcileStep::AfterKRequestStep(ActionKind::Get, SubResource::ErlangCookieSecret),
-                ..state
-            })
+            Ok(state)
         } else {
             Err(RabbitmqError::Error)
         }

--- a/src/controller_examples/rabbitmq_controller/spec/resource/service_account.rs
+++ b/src/controller_examples/rabbitmq_controller/spec/resource/service_account.rs
@@ -43,10 +43,7 @@ impl ResourceBuilder for ServiceAccountBuilder {
     open spec fn state_after_create_or_update(obj: DynamicObjectView, state: RabbitmqReconcileState) -> (res: Result<RabbitmqReconcileState, RabbitmqError>) {
         let sa = ServiceAccountView::unmarshal(obj);
         if sa.is_Ok() {
-            Ok(RabbitmqReconcileState {
-                reconcile_step: RabbitmqReconcileStep::AfterKRequestStep(ActionKind::Get, SubResource::Role),
-                ..state
-            })
+            Ok(state)
         } else {
             Err(RabbitmqError::Error)
         }

--- a/src/controller_examples/rabbitmq_controller/spec/resource/stateful_set.rs
+++ b/src/controller_examples/rabbitmq_controller/spec/resource/stateful_set.rs
@@ -49,10 +49,7 @@ impl ResourceBuilder for StatefulSetBuilder {
     open spec fn state_after_create_or_update(obj: DynamicObjectView, state: RabbitmqReconcileState) -> (res: Result<RabbitmqReconcileState, RabbitmqError>) {
         let sts = StatefulSetView::unmarshal(obj);
         if sts.is_Ok() {
-            Ok(RabbitmqReconcileState {
-                reconcile_step: RabbitmqReconcileStep::Done,
-                ..state
-            })
+            Ok(state)
         } else {
             Err(RabbitmqError::Error)
         }


### PR DESCRIPTION
This PR proves the termination of rabbitmq controller. To facilitate this, one notable change is that I move the reconcile step change from method `state_after_create_or_update` to the reconciler.