### PR TITLE
Treat resource version conflict as a transient error

### DIFF
--- a/src/kubernetes_api_objects/error.rs
+++ b/src/kubernetes_api_objects/error.rs
@@ -17,6 +17,7 @@ pub enum APIError {
     ObjectAlreadyExists,
     NotSupported,
     InternalError,
+    Timeout,
     ServerTimeout,
     Other
 }
@@ -33,6 +34,7 @@ impl std::fmt::Debug for APIError {
             APIError::ObjectAlreadyExists => write!(f, "ObjectAlreadyExists"),
             APIError::NotSupported => write!(f, "NotSupported"),
             APIError::InternalError => write!(f, "InternalError"),
+            APIError::Timeout => write!(f, "Timeout"),
             APIError::ServerTimeout => write!(f, "ServerTimeout"),
             APIError::Other => write!(f, "Other"),
         }

--- a/src/kubernetes_cluster/proof/cluster.rs
+++ b/src/kubernetes_cluster/proof/cluster.rs
@@ -61,7 +61,7 @@ pub proof fn sm_partial_spec_is_stable()
     Self::tla_forall_action_weak_fairness_is_stable::<Option<MsgType<E>>, ()>(Self::external_api_next());
     Self::tla_forall_action_weak_fairness_is_stable::<ObjectRef, ()>(Self::schedule_controller_reconcile());
     Self::action_weak_fairness_is_stable::<()>(Self::disable_crash());
-    Self::action_weak_fairness_is_stable::<()>(Self::disable_busy());
+    Self::action_weak_fairness_is_stable::<()>(Self::disable_transient_failure());
 
     stable_and_n!(
         always(lift_action(Self::next())),
@@ -71,7 +71,7 @@ pub proof fn sm_partial_spec_is_stable()
         tla_forall(|input| Self::external_api_next().weak_fairness(input)),
         tla_forall(|input| Self::schedule_controller_reconcile().weak_fairness(input)),
         Self::disable_crash().weak_fairness(()),
-        Self::disable_busy().weak_fairness(())
+        Self::disable_transient_failure().weak_fairness(())
     );
 }
 
@@ -94,12 +94,12 @@ pub proof fn lemma_true_leads_to_busy_always_disabled(
 )
     requires
         spec.entails(always(lift_action(Self::next()))),
-        spec.entails(Self::disable_busy().weak_fairness(())),
+        spec.entails(Self::disable_transient_failure().weak_fairness(())),
     ensures
         spec.entails(true_pred().leads_to(always(lift_state(Self::busy_disabled())))),
 {
     let true_state = |s: Self| true;
-    Self::disable_busy().wf1((), spec, Self::next(), true_state, Self::busy_disabled());
+    Self::disable_transient_failure().wf1((), spec, Self::next(), true_state, Self::busy_disabled());
     leads_to_stable_temp::<Self>(spec, lift_action(Self::next()), true_pred(), lift_state(Self::busy_disabled()));
 }
 

--- a/src/kubernetes_cluster/proof/controller_runtime_safety.rs
+++ b/src/kubernetes_cluster/proof/controller_runtime_safety.rs
@@ -358,9 +358,9 @@ pub proof fn lemma_always_pending_req_in_flight_or_resp_in_flight_at_reconcile_s
                         assert(s_prime.in_flight().contains(resp));
                     }
                 }
-                Step::KubernetesBusy(input) => {
-                    if input == Some(s.ongoing_reconciles()[key].pending_req_msg.get_Some_0()) {
-                        let resp_msg = Message::form_matched_err_resp_msg(s.ongoing_reconciles()[key].pending_req_msg.get_Some_0(), APIError::ServerTimeout);
+                Step::FailTransientlyStep(input) => {
+                    if input.0 == s.ongoing_reconciles()[key].pending_req_msg.get_Some_0() {
+                        let resp_msg = Message::form_matched_err_resp_msg(s.ongoing_reconciles()[key].pending_req_msg.get_Some_0(), input.1);
                         assert(s_prime.in_flight().contains(resp_msg));
                     } else {
                         if !s.in_flight().contains(s.ongoing_reconciles()[key].pending_req_msg.get_Some_0()) {

--- a/src/kubernetes_cluster/proof/kubernetes_api_liveness.rs
+++ b/src/kubernetes_cluster/proof/kubernetes_api_liveness.rs
@@ -118,9 +118,9 @@ pub proof fn lemma_get_req_leads_to_some_resp
                     assert(pre(s_prime));
                 }
             },
-            Step::KubernetesBusy(input) => {
-                if input.get_Some_0() == msg {
-                    let resp = Message::form_matched_err_resp_msg(msg, APIError::ServerTimeout);
+            Step::FailTransientlyStep(input) => {
+                if input.0 == msg {
+                    let resp = Message::form_matched_err_resp_msg(msg, input.1);
                     assert(s_prime.in_flight().contains(resp));
                     assert(Message::resp_msg_matches_req_msg(resp, msg));
                     assert(post(s_prime));
@@ -179,7 +179,7 @@ pub proof fn lemma_get_req_leads_to_ok_or_err_resp
     };
     let stronger_next = |s, s_prime: Self| {
         Self::next()(s, s_prime)
-        && !s.busy_enabled
+        && !s.transient_failure_enabled
     };
     strengthen_next::<Self>(spec, Self::next(), Self::busy_disabled(), stronger_next);
     Self::lemma_pre_leads_to_post_by_kubernetes_api(spec, Some(msg), stronger_next, Self::handle_request(), pre, post);
@@ -618,7 +618,7 @@ proof fn pending_requests_num_decreases(
     let stronger_next = |s, s_prime: Self| {
         &&& Self::next()(s, s_prime)
         &&& s.has_rest_id_counter_no_smaller_than(rest_id)
-        &&& !s.busy_enabled
+        &&& !s.transient_failure_enabled
     };
     combine_spec_entails_always_n!(
         spec, lift_action(stronger_next),

--- a/src/kubernetes_cluster/proof/message.rs
+++ b/src/kubernetes_cluster/proof/message.rs
@@ -68,8 +68,8 @@ proof fn next_preserves_every_in_flight_msg_has_lower_id_than_allocator(
                             assert(s.in_flight().contains(req_msg));
                             assert(id == req_msg.content.get_rest_id());
                         }
-                        Step::KubernetesBusy(input) => {
-                            let req_msg = input.get_Some_0();
+                        Step::FailTransientlyStep(input) => {
+                            let req_msg = input.0;
                             assert(s.in_flight().contains(req_msg));
                             assert(id == req_msg.content.get_rest_id());
                         }
@@ -303,8 +303,8 @@ proof fn newly_added_msg_have_different_id_from_existing_ones(
                 assert(s.network_state.in_flight.count(req_msg) <= 1);
                 assert(msg_1.content.get_rest_id() != msg_2.content.get_rest_id());
             }
-            Step::KubernetesBusy(input) => {
-                let req_msg = input.get_Some_0();
+            Step::FailTransientlyStep(input) => {
+                let req_msg = input.0;
                 assert(s.network_state.in_flight.count(req_msg) <= 1);
                 assert(msg_1.content.get_rest_id() != msg_2.content.get_rest_id());
             }
@@ -545,11 +545,11 @@ pub proof fn lemma_always_key_of_object_in_matched_ok_get_resp_message_is_same_a
                         assert(Self::is_ok_get_response_msg_and_matches_key(req_key)(msg));
                     }
                 },
-                Step::KubernetesBusy(input) => {
+                Step::FailTransientlyStep(input) => {
                     assert(s.ongoing_reconciles()[key] == s_prime.ongoing_reconciles()[key]);
                     if !s.in_flight().contains(msg) {
                         assert(Self::in_flight_or_pending_req_message(s, s.ongoing_reconciles()[key].pending_req_msg.get_Some_0()));
-                        assert(Self::in_flight_or_pending_req_message(s, input.get_Some_0()));
+                        assert(Self::in_flight_or_pending_req_message(s, input.0));
                         assert(msg.src.is_KubernetesAPI());
                         assert(msg.content.is_get_response());
                         assert(msg.content.get_get_response().res.is_Err());

--- a/src/kubernetes_cluster/proof/message.rs
+++ b/src/kubernetes_cluster/proof/message.rs
@@ -65,6 +65,14 @@ proof fn next_preserves_every_in_flight_msg_has_lower_id_than_allocator(
                     match next_step {
                         Step::KubernetesAPIStep(input) => {
                             let req_msg = input.get_Some_0();
+                            match req_msg.content.get_APIRequest_0() {
+                                APIRequest::GetRequest(_) => {}
+                                APIRequest::ListRequest(_) => {}
+                                APIRequest::CreateRequest(_) => {}
+                                APIRequest::DeleteRequest(_) => {}
+                                APIRequest::UpdateRequest(_) => {}
+                                APIRequest::UpdateStatusRequest(_) => {}
+                            }
                             assert(s.in_flight().contains(req_msg));
                             assert(id == req_msg.content.get_rest_id());
                         }

--- a/src/kubernetes_cluster/spec/cluster.rs
+++ b/src/kubernetes_cluster/spec/cluster.rs
@@ -35,7 +35,7 @@ pub struct Cluster<K: ResourceView, E: ExternalAPI, R: Reconciler<K, E>> {
     pub external_api_state: ExternalAPIState<E>,
     pub rest_id_allocator: RestIdAllocator,
     pub crash_enabled: bool,
-    pub busy_enabled: bool,
+    pub transient_failure_enabled: bool,
 }
 
 impl<K: ResourceView, E: ExternalAPI, R: Reconciler<K, E>> Cluster<K, E, R> {

--- a/src/kubernetes_cluster/spec/cluster_state_machine.rs
+++ b/src/kubernetes_cluster/spec/cluster_state_machine.rs
@@ -33,8 +33,8 @@ pub enum Step<Msg> {
     ScheduleControllerReconcileStep(ObjectRef),
     RestartController(),
     DisableCrash(),
-    KubernetesBusy(Option<Msg>),
-    DisableBusy(),
+    FailTransientlyStep((Msg, APIError)),
+    DisableTransientFailure(),
     StutterStep(),
 }
 
@@ -49,7 +49,7 @@ pub open spec fn init() -> StatePred<Self> {
         &&& (Self::network().init)(s.network_state)
         &&& (Self::external_api().init)(s.external_api_state)
         &&& s.crash_enabled
-        &&& s.busy_enabled
+        &&& s.transient_failure_enabled
     }
 }
 
@@ -270,45 +270,50 @@ pub open spec fn disable_crash() -> Action<Self, (), ()> {
     }
 }
 
-pub open spec fn busy_kubernetes_api_rejects_request() -> Action<Self, Option<MsgType<E>>, ()> {
-    let network_result = |input: Option<MsgType<E>>, s: Self| {
-        let req_msg = input.get_Some_0();
-        let resp = Message::form_matched_err_resp_msg(req_msg, APIError::ServerTimeout);
+/// This action fails a request sent to the Kubernetes API in a transient way:
+/// the request fails with timeout error or conflict error (caused by resource version conflicts).
+pub open spec fn fail_request_transiently() -> Action<Self, (MsgType<E>, APIError), ()> {
+    let result = |input: (MsgType<E>, APIError), s: Self| {
+        let req_msg = input.0;
+        let api_err = input.1;
+        let resp = Message::form_matched_err_resp_msg(req_msg, api_err);
         let msg_ops = MessageOps {
-            recv: input,
+            recv: Some(req_msg),
             send: Multiset::singleton(resp),
         };
         let result = Self::network().next_result(msg_ops, s.network_state);
         result
     };
     Action {
-        precondition: |input: Option<MsgType<E>>, s: Self| {
-            &&& s.busy_enabled
-            &&& input.is_Some()
-            &&& input.get_Some_0().dst.is_KubernetesAPI()
-            &&& input.get_Some_0().content.is_APIRequest()
-            &&& network_result(input, s).is_Enabled()
+        precondition: |input: (MsgType<E>, APIError), s: Self| {
+            let req_msg = input.0;
+            let api_err = input.1;
+            &&& s.transient_failure_enabled
+            &&& req_msg.dst.is_KubernetesAPI()
+            &&& req_msg.content.is_APIRequest()
+            &&& (api_err.is_Timeout() || api_err.is_ServerTimeout() || api_err.is_Conflict())
+            &&& result(input, s).is_Enabled()
         },
-        transition: |input: Option<MsgType<E>>, s: Self| {
+        transition: |input: (MsgType<E>, APIError), s: Self| {
             (Self {
-                network_state: network_result(input, s).get_Enabled_0(),
+                network_state: result(input, s).get_Enabled_0(),
                 ..s
             }, ())
         }
     }
 }
 
-/// This action disallows the Kubernetes API to be busy from this point.
+/// This action disallows the Kubernetes API to have transient failure from this point.
 /// This is used to constraint the transient error of Kubernetes APIs for liveness proof:
 /// the requests from the controller eventually stop being rejected by transient error.
-pub open spec fn disable_busy() -> Action<Self, (), ()> {
+pub open spec fn disable_transient_failure() -> Action<Self, (), ()> {
     Action {
         precondition: |input:(), s: Self| {
             true
         },
         transition: |input: (), s: Self| {
             (Self {
-                busy_enabled: false,
+                transient_failure_enabled: false,
                 ..s
             }, ())
         }
@@ -367,8 +372,8 @@ pub open spec fn next_step(s: Self, s_prime: Self, step: Step<MsgType<E>>) -> bo
         Step::ScheduleControllerReconcileStep(input) => Self::schedule_controller_reconcile().forward(input)(s, s_prime),
         Step::RestartController() => Self::restart_controller().forward(())(s, s_prime),
         Step::DisableCrash() => Self::disable_crash().forward(())(s, s_prime),
-        Step::KubernetesBusy(input) => Self::busy_kubernetes_api_rejects_request().forward(input)(s, s_prime),
-        Step::DisableBusy() => Self::disable_busy().forward(())(s, s_prime),
+        Step::FailTransientlyStep(input) => Self::fail_request_transiently().forward(input)(s, s_prime),
+        Step::DisableTransientFailure() => Self::disable_transient_failure().forward(())(s, s_prime),
         Step::StutterStep() => Self::stutter().forward(())(s, s_prime),
     }
 }
@@ -395,7 +400,7 @@ pub open spec fn sm_partial_spec() -> TempPred<Self> {
     .and(tla_forall(|input| Self::external_api_next().weak_fairness(input)))
     .and(tla_forall(|input| Self::schedule_controller_reconcile().weak_fairness(input)))
     .and(Self::disable_crash().weak_fairness(()))
-    .and(Self::disable_busy().weak_fairness(()))
+    .and(Self::disable_transient_failure().weak_fairness(()))
 }
 
 pub open spec fn kubernetes_api_action_pre(action: KubernetesAPIAction<E::Input, E::Output>, input: Option<MsgType<E>>) -> StatePred<Self> {
@@ -462,8 +467,9 @@ pub open spec fn crash_disabled() -> StatePred<Self> {
     |s: Self| !s.crash_enabled
 }
 
+// TODO: rename it!
 pub open spec fn busy_disabled() -> StatePred<Self> {
-    |s: Self| !s.busy_enabled
+    |s: Self| !s.transient_failure_enabled
 }
 
 pub open spec fn rest_id_counter_is(rest_id: nat) -> StatePred<Self> {

--- a/src/shim_layer/controller_runtime.rs
+++ b/src/shim_layer/controller_runtime.rs
@@ -347,6 +347,10 @@ pub fn kube_error_to_ghost(error: &deps_hack::kube::Error) -> APIError {
                 APIError::Invalid
             } else if &error_resp.reason == "InternalError" {
                 APIError::InternalError
+            } else if &error_resp.reason == "Timeout" {
+                APIError::Timeout
+            } else if &error_resp.reason == "ServerTimeout" {
+                APIError::ServerTimeout
             } else {
                 APIError::Other
             }


### PR DESCRIPTION
This PR considers resource version conflicts as a type of transient error and assumes that such conflicts eventually stop hindering our custom controller's progress.

Controllers run concurrently and share state. For example, one controller updates `o.spec` while the other one updates `o.status`. Without locking, conflicts could happen when two controllers are trying to update the same object "at the same time" -- if both of them try to update the same version, only one will succeed which increments the version number, so the other one will fail because its version number no longer matches.

It is tedious and takes tremendous effort to specify all kinds of conflicts between our custom controller and built-in controllers. Instead, we treat such conflicts as a transient error that eventually disappears. That is, our custom controller eventually will stop suffering from version conflicts and its requests will go through. This succinct specification abstracts away all the details on how other controllers might race with our custom controller and still captures the essence that our controller eventually wins all the races and makes progress.

Note that to treat version conflicts as a transient error, we are assuming that the controller, when updating an object, is always using the resource version obtained by reading the same object from etcd. This assumption is critical: if the controller makes up some bogus resource version number, the update will never go through as the version conflict will deterministically happen. Instead of trusting the developers, we impose a proof obligation in #315 to force the developer to prove that their resource version used in any update request comes from a previous get request for the same object.