### PR TITLE
Cosmetic changes to fluent controller

### DIFF
--- a/src/controller_examples/fluent_controller/fluentbit/exec/reconciler.rs
+++ b/src/controller_examples/fluent_controller/fluentbit/exec/reconciler.rs
@@ -21,13 +21,6 @@ use vstd::string::*;
 
 verus! {
 
-// TODO:
-// + Use Role after Anvil supports cluster-scoped resources
-//
-// + Add more features
-//
-// + Split the management logic into two reconciliation loops
-
 pub struct FluentBitReconcileState {
     pub reconcile_step: FluentBitReconcileStep,
 }
@@ -496,6 +489,23 @@ fn make_labels(fb: &FluentBit) -> (labels: StringMap)
     labels
 }
 
+pub fn make_owner_references(fb: &FluentBit) -> (owner_references: Vec<OwnerReference>)
+    requires
+        fb@.well_formed(),
+    ensures
+        owner_references@.map_values(|or: OwnerReference| or@) == fb_spec::make_owner_references(fb@),
+{
+    let mut owner_references = Vec::new();
+    owner_references.push(fb.controller_owner_ref());
+    proof {
+        assert_seqs_equal!(
+            owner_references@.map_values(|owner_ref: OwnerReference| owner_ref@),
+            fb_spec::make_owner_references(fb@)
+        );
+    }
+    owner_references
+}
+
 fn make_role_name(fb: &FluentBit) -> (name: String)
     requires
         fb@.well_formed(),
@@ -515,6 +525,8 @@ fn update_role(fb: &FluentBit, found_role: &Role) -> (role: Role)
     let made_role = make_role(fb);
     role.set_metadata({
         let mut metadata = found_role.metadata();
+        metadata.set_owner_references(make_owner_references(fb));
+        metadata.unset_finalizers();
         metadata.set_labels(made_role.metadata().labels().unwrap());
         metadata.set_annotations(made_role.metadata().annotations().unwrap());
         metadata
@@ -534,17 +546,7 @@ fn make_role(fb: &FluentBit) -> (role: Role)
         metadata.set_name(make_role_name(fb));
         metadata.set_labels(make_labels(fb));
         metadata.set_annotations(fb.spec().annotations());
-        metadata.set_owner_references({
-            let mut owner_references = Vec::new();
-            owner_references.push(fb.controller_owner_ref());
-            proof {
-                assert_seqs_equal!(
-                    owner_references@.map_values(|owner_ref: OwnerReference| owner_ref@),
-                    fb_spec::make_role(fb@).metadata.owner_references.get_Some_0()
-                );
-            }
-            owner_references
-        });
+        metadata.set_owner_references(make_owner_references(fb));
         metadata
     });
     role.set_policy_rules({
@@ -616,6 +618,8 @@ fn update_service_account(fb: &FluentBit, found_service_account: &ServiceAccount
     let made_service_account = make_service_account(fb);
     service_account.set_metadata({
         let mut metadata = found_service_account.metadata();
+        metadata.set_owner_references(make_owner_references(fb));
+        metadata.unset_finalizers();
         metadata.set_labels(made_service_account.metadata().labels().unwrap());
         metadata.set_annotations(made_service_account.metadata().annotations().unwrap());
         metadata
@@ -635,17 +639,7 @@ fn make_service_account(fb: &FluentBit) -> (service_account: ServiceAccount)
         metadata.set_name(make_service_account_name(fb));
         metadata.set_labels(make_labels(fb));
         metadata.set_annotations(fb.spec().annotations());
-        metadata.set_owner_references({
-            let mut owner_references = Vec::new();
-            owner_references.push(fb.controller_owner_ref());
-            proof {
-                assert_seqs_equal!(
-                    owner_references@.map_values(|owner_ref: OwnerReference| owner_ref@),
-                    fb_spec::make_service_account(fb@).metadata.owner_references.get_Some_0()
-                );
-            }
-            owner_references
-        });
+        metadata.set_owner_references(make_owner_references(fb));
         metadata
     });
     service_account
@@ -670,6 +664,8 @@ fn update_role_binding(fb: &FluentBit, found_role_binding: &RoleBinding) -> (rol
     let made_role_binding = make_role_binding(fb);
     role_binding.set_metadata({
         let mut metadata = found_role_binding.metadata();
+        metadata.set_owner_references(make_owner_references(fb));
+        metadata.unset_finalizers();
         metadata.set_labels(made_role_binding.metadata().labels().unwrap());
         metadata.set_annotations(made_role_binding.metadata().annotations().unwrap());
         metadata
@@ -689,17 +685,7 @@ fn make_role_binding(fb: &FluentBit) -> (role_binding: RoleBinding)
         metadata.set_name(make_role_binding_name(fb));
         metadata.set_labels(make_labels(fb));
         metadata.set_annotations(fb.spec().annotations());
-        metadata.set_owner_references({
-            let mut owner_references = Vec::new();
-            owner_references.push(fb.controller_owner_ref());
-            proof {
-                assert_seqs_equal!(
-                    owner_references@.map_values(|owner_ref: OwnerReference| owner_ref@),
-                    fb_spec::make_role_binding(fb@).metadata.owner_references.get_Some_0()
-                );
-            }
-            owner_references
-        });
+        metadata.set_owner_references(make_owner_references(fb));
         metadata
     });
     role_binding.set_role_ref({
@@ -750,6 +736,8 @@ fn update_daemon_set(fb: &FluentBit, found_daemon_set: &DaemonSet) -> (daemon_se
     let made_daemon_set = make_daemon_set(fb);
     daemon_set.set_metadata({
         let mut metadata = found_daemon_set.metadata();
+        metadata.set_owner_references(make_owner_references(fb));
+        metadata.unset_finalizers();
         metadata.set_labels(made_daemon_set.metadata().labels().unwrap());
         metadata.set_annotations(made_daemon_set.metadata().annotations().unwrap());
         metadata
@@ -774,17 +762,7 @@ fn make_daemon_set(fb: &FluentBit) -> (daemon_set: DaemonSet)
         metadata.set_name(make_daemon_set_name(fb));
         metadata.set_labels(make_labels(fb));
         metadata.set_annotations(fb.spec().annotations());
-        metadata.set_owner_references({
-            let mut owner_references = Vec::new();
-            owner_references.push(fb.controller_owner_ref());
-            proof {
-                assert_seqs_equal!(
-                    owner_references@.map_values(|owner_ref: OwnerReference| owner_ref@),
-                    fb_spec::make_daemon_set(fb@).metadata.owner_references.get_Some_0()
-                );
-            }
-            owner_references
-        });
+        metadata.set_owner_references(make_owner_references(fb));
         metadata
     });
     daemon_set.set_spec({

--- a/src/controller_examples/fluent_controller/fluentbit/spec/reconciler.rs
+++ b/src/controller_examples/fluent_controller/fluentbit/spec/reconciler.rs
@@ -6,8 +6,9 @@ use crate::fluent_controller::fluentbit::common::*;
 use crate::fluent_controller::fluentbit::spec::types::*;
 use crate::kubernetes_api_objects::{
     api_method::*, common::*, config_map::*, container::*, daemon_set::*, dynamic::*,
-    label_selector::*, object_meta::*, persistent_volume_claim::*, pod::*, pod_template_spec::*,
-    resource::*, role::*, role_binding::*, secret::*, service::*, service_account::*, volume::*,
+    label_selector::*, object_meta::*, owner_reference::*, persistent_volume_claim::*, pod::*,
+    pod_template_spec::*, resource::*, role::*, role_binding::*, secret::*, service::*,
+    service_account::*, volume::*,
 };
 use crate::kubernetes_cluster::spec::message::*;
 use crate::reconciler::spec::{io::*, reconciler::*};
@@ -509,6 +510,10 @@ pub open spec fn make_labels(fb: FluentBitView) -> Map<StringView, StringView> {
     fb.spec.labels.union_prefer_right(make_base_labels(fb))
 }
 
+pub open spec fn make_owner_references(fb: FluentBitView) -> Seq<OwnerReferenceView> {
+    seq![fb.controller_owner_ref()]
+}
+
 pub open spec fn make_role_name(fb_name: StringView) -> StringView {
     fb_name + new_strlit("-role")@
 }
@@ -530,6 +535,8 @@ pub open spec fn update_role(fb: FluentBitView, found_role: RoleView) -> RoleVie
 {
     RoleView {
         metadata: ObjectMetaView {
+            owner_references: Some(make_owner_references(fb)),
+            finalizers: None,
             labels: make_role(fb).metadata.labels,
             annotations: make_role(fb).metadata.annotations,
             ..found_role.metadata
@@ -547,7 +554,7 @@ pub open spec fn make_role(fb: FluentBitView) -> RoleView
             .set_name(make_role_name(fb.metadata.name.get_Some_0()))
             .set_labels(make_labels(fb))
             .set_annotations(fb.spec.annotations)
-            .set_owner_references(seq![fb.controller_owner_ref()])
+            .set_owner_references(make_owner_references(fb))
         ).set_policy_rules(
             seq![
                 PolicyRuleView::default()
@@ -579,6 +586,8 @@ pub open spec fn update_service_account(fb: FluentBitView, found_service_account
 {
     ServiceAccountView {
         metadata: ObjectMetaView {
+            owner_references: Some(make_owner_references(fb)),
+            finalizers: None,
             labels: make_service_account(fb).metadata.labels,
             annotations: make_service_account(fb).metadata.annotations,
             ..found_service_account.metadata
@@ -596,7 +605,7 @@ pub open spec fn make_service_account(fb: FluentBitView) -> ServiceAccountView
             .set_name(make_service_account_name(fb.metadata.name.get_Some_0()))
             .set_labels(make_labels(fb))
             .set_annotations(fb.spec.annotations)
-            .set_owner_references(seq![fb.controller_owner_ref()])
+            .set_owner_references(make_owner_references(fb))
         )
 }
 
@@ -621,6 +630,8 @@ pub open spec fn update_role_binding(fb: FluentBitView, found_role_binding: Role
 {
     RoleBindingView {
         metadata: ObjectMetaView {
+            owner_references: Some(make_owner_references(fb)),
+            finalizers: None,
             labels: make_role_binding(fb).metadata.labels,
             annotations: make_role_binding(fb).metadata.annotations,
             ..found_role_binding.metadata
@@ -638,7 +649,7 @@ pub open spec fn make_role_binding(fb: FluentBitView) -> RoleBindingView
             .set_name(make_role_binding_name(fb.metadata.name.get_Some_0()))
             .set_labels(make_labels(fb))
             .set_annotations(fb.spec.annotations)
-            .set_owner_references(seq![fb.controller_owner_ref()])
+            .set_owner_references(make_owner_references(fb))
         ).set_role_ref(RoleRefView::default()
             .set_api_group(new_strlit("rbac.authorization.k8s.io")@)
             .set_kind(new_strlit("Role")@)
@@ -671,6 +682,8 @@ pub open spec fn update_daemon_set(fb: FluentBitView, found_daemon_set: DaemonSe
 {
     DaemonSetView {
         metadata: ObjectMetaView {
+            owner_references: Some(make_owner_references(fb)),
+            finalizers: None,
             labels: make_daemon_set(fb).metadata.labels,
             annotations: make_daemon_set(fb).metadata.annotations,
             ..found_daemon_set.metadata
@@ -692,7 +705,7 @@ pub open spec fn make_daemon_set(fb: FluentBitView) -> DaemonSetView
             .set_name(make_daemon_set_name(fb.metadata.name.get_Some_0()))
             .set_labels(make_labels(fb))
             .set_annotations(fb.spec.annotations)
-            .set_owner_references(seq![fb.controller_owner_ref()])
+            .set_owner_references(make_owner_references(fb))
         ).set_spec(DaemonSetSpecView::default()
             .set_selector(LabelSelectorView::default().set_match_labels(make_base_labels(fb)))
             .set_template(PodTemplateSpecView::default()

--- a/src/controller_examples/fluent_controller/fluentbit_config/common/mod.rs
+++ b/src/controller_examples/fluent_controller/fluentbit_config/common/mod.rs
@@ -8,7 +8,9 @@ verus! {
 #[is_variant]
 pub enum FluentBitConfigReconcileStep {
     Init,
+    AfterGetSecret,
     AfterCreateSecret,
+    AfterUpdateSecret,
     Done,
     Error,
 }

--- a/src/controller_examples/fluent_controller/fluentbit_config/exec/reconciler.rs
+++ b/src/controller_examples/fluent_controller/fluentbit_config/exec/reconciler.rs
@@ -4,7 +4,7 @@
 use crate::external_api::exec::*;
 use crate::fluent_controller::fluentbit_config::common::*;
 use crate::fluent_controller::fluentbit_config::exec::types::*;
-use crate::fluent_controller::fluentbit_config::spec::reconciler as fluent_spec;
+use crate::fluent_controller::fluentbit_config::spec::reconciler as fbc_spec;
 use crate::kubernetes_api_objects::resource::ResourceWrapper;
 use crate::kubernetes_api_objects::{
     api_method::*, common::*, config_map::*, daemon_set::*, label_selector::*, object_meta::*,
@@ -20,20 +20,13 @@ use vstd::string::*;
 
 verus! {
 
-// TODO:
-// + Use Role after Anvil supports cluster-scoped resources
-//
-// + Add more features
-//
-// + Split the management logic into two reconciliation loops
-
 pub struct FluentBitConfigReconcileState {
     pub reconcile_step: FluentBitConfigReconcileStep,
 }
 
 impl FluentBitConfigReconcileState {
-    pub open spec fn to_view(&self) -> fluent_spec::FluentBitConfigReconcileState {
-        fluent_spec::FluentBitConfigReconcileState {
+    pub open spec fn to_view(&self) -> fbc_spec::FluentBitConfigReconcileState {
+        fbc_spec::FluentBitConfigReconcileState {
             reconcile_step: self.reconcile_step,
         }
     }
@@ -47,8 +40,8 @@ impl Reconciler<FluentBitConfig, FluentBitConfigReconcileState, EmptyType, Empty
         reconcile_init_state()
     }
 
-    fn reconcile_core(&self, fluentbit: &FluentBitConfig, resp_o: Option<Response<EmptyType>>, state: FluentBitConfigReconcileState) -> (FluentBitConfigReconcileState, Option<Request<EmptyType>>) {
-        reconcile_core(fluentbit, resp_o, state)
+    fn reconcile_core(&self, fbc: &FluentBitConfig, resp_o: Option<Response<EmptyType>>, state: FluentBitConfigReconcileState) -> (FluentBitConfigReconcileState, Option<Request<EmptyType>>) {
+        reconcile_core(fbc, resp_o, state)
     }
 
     fn reconcile_done(&self, state: &FluentBitConfigReconcileState) -> bool {
@@ -66,7 +59,7 @@ impl Default for FluentBitConfigReconciler {
 
 pub fn reconcile_init_state() -> (state: FluentBitConfigReconcileState)
     ensures
-        state.to_view() == fluent_spec::reconcile_init_state(),
+        state.to_view() == fbc_spec::reconcile_init_state(),
 {
     FluentBitConfigReconcileState {
         reconcile_step: FluentBitConfigReconcileStep::Init,
@@ -75,7 +68,7 @@ pub fn reconcile_init_state() -> (state: FluentBitConfigReconcileState)
 
 pub fn reconcile_done(state: &FluentBitConfigReconcileState) -> (res: bool)
     ensures
-        res == fluent_spec::reconcile_done(state.to_view()),
+        res == fbc_spec::reconcile_done(state.to_view()),
 {
     match state.reconcile_step {
         FluentBitConfigReconcileStep::Done => true,
@@ -85,7 +78,7 @@ pub fn reconcile_done(state: &FluentBitConfigReconcileState) -> (res: bool)
 
 pub fn reconcile_error(state: &FluentBitConfigReconcileState) -> (res: bool)
     ensures
-        res == fluent_spec::reconcile_error(state.to_view()),
+        res == fbc_spec::reconcile_error(state.to_view()),
 {
     match state.reconcile_step {
         FluentBitConfigReconcileStep::Error => true,
@@ -93,35 +86,98 @@ pub fn reconcile_error(state: &FluentBitConfigReconcileState) -> (res: bool)
     }
 }
 
-pub fn reconcile_core(fluentbit: &FluentBitConfig, resp_o: Option<Response<EmptyType>>, state: FluentBitConfigReconcileState) -> (res: (FluentBitConfigReconcileState, Option<Request<EmptyType>>))
+pub fn reconcile_core(fbc: &FluentBitConfig, resp_o: Option<Response<EmptyType>>, state: FluentBitConfigReconcileState) -> (res: (FluentBitConfigReconcileState, Option<Request<EmptyType>>))
     requires
-        fluentbit@.metadata.name.is_Some(),
-        fluentbit@.metadata.namespace.is_Some(),
+        fbc@.well_formed(),
     ensures
-        (res.0.to_view(), opt_request_to_view(&res.1)) == fluent_spec::reconcile_core(fluentbit@, opt_response_to_view(&resp_o), state.to_view()),
+        (res.0.to_view(), opt_request_to_view(&res.1)) == fbc_spec::reconcile_core(fbc@, opt_response_to_view(&resp_o), state.to_view()),
 {
     let step = state.reconcile_step;
     match step{
         FluentBitConfigReconcileStep::Init => {
-            let secret = make_secret(fluentbit);
-            let req_o = KubeAPIRequest::CreateRequest(KubeCreateRequest {
+            let req_o = KubeAPIRequest::GetRequest(KubeGetRequest {
                 api_resource: Secret::api_resource(),
-                namespace: fluentbit.metadata().namespace().unwrap(),
-                obj: secret.marshal(),
+                name: fbc.metadata().name().unwrap(),
+                namespace: fbc.metadata().namespace().unwrap(),
             });
             let state_prime = FluentBitConfigReconcileState {
-                reconcile_step: FluentBitConfigReconcileStep::AfterCreateSecret,
+                reconcile_step: FluentBitConfigReconcileStep::AfterGetSecret,
                 ..state
             };
             return (state_prime, Some(Request::KRequest(req_o)));
         },
-        FluentBitConfigReconcileStep::AfterCreateSecret => {
-            let req_o = None;
+        FluentBitConfigReconcileStep::AfterGetSecret => {
+            if resp_o.is_some() && resp_o.as_ref().unwrap().is_k_response()
+            && resp_o.as_ref().unwrap().as_k_response_ref().is_get_response() {
+                let get_secret_resp = resp_o.unwrap().into_k_response().into_get_response().res;
+                if get_secret_resp.is_ok() {
+                    let unmarshal_secret_result = Secret::unmarshal(get_secret_resp.unwrap());
+                    if unmarshal_secret_result.is_ok() {
+                        let found_secret = unmarshal_secret_result.unwrap();
+                        let new_secret = update_secret(fbc, &found_secret);
+                        let req_o = KubeAPIRequest::UpdateRequest(KubeUpdateRequest {
+                            api_resource: Secret::api_resource(),
+                            name: make_secret_name(fbc),
+                            namespace: fbc.metadata().namespace().unwrap(),
+                            obj: new_secret.marshal(),
+                        });
+                        let state_prime = FluentBitConfigReconcileState {
+                            reconcile_step: FluentBitConfigReconcileStep::AfterUpdateSecret,
+                            ..state
+                        };
+                        return (state_prime, Some(Request::KRequest(req_o)));
+                    }
+                } else if get_secret_resp.unwrap_err().is_object_not_found() {
+                    let secret = make_secret(fbc);
+                    let req_o = KubeAPIRequest::CreateRequest(KubeCreateRequest {
+                        api_resource: Secret::api_resource(),
+                        namespace: fbc.metadata().namespace().unwrap(),
+                        obj: secret.marshal(),
+                    });
+                    let state_prime = FluentBitConfigReconcileState {
+                        reconcile_step: FluentBitConfigReconcileStep::AfterCreateSecret,
+                        ..state
+                    };
+                    return (state_prime, Some(Request::KRequest(req_o)));
+                }
+            }
             let state_prime = FluentBitConfigReconcileState {
-                reconcile_step: FluentBitConfigReconcileStep::Done,
+                reconcile_step: FluentBitConfigReconcileStep::Error,
                 ..state
             };
-            (state_prime, req_o)
+            return (state_prime, None);
+        },
+        FluentBitConfigReconcileStep::AfterCreateSecret => {
+            if resp_o.is_some() && resp_o.as_ref().unwrap().is_k_response()
+            && resp_o.as_ref().unwrap().as_k_response_ref().is_create_response()
+            && resp_o.unwrap().into_k_response().into_create_response().res.is_ok() {
+                let state_prime = FluentBitConfigReconcileState {
+                    reconcile_step: FluentBitConfigReconcileStep::Done,
+                    ..state
+                };
+                return (state_prime, None);
+            }
+            let state_prime = FluentBitConfigReconcileState {
+                reconcile_step: FluentBitConfigReconcileStep::Error,
+                ..state
+            };
+            return (state_prime, None);
+        },
+        FluentBitConfigReconcileStep::AfterUpdateSecret => {
+            if resp_o.is_some() && resp_o.as_ref().unwrap().is_k_response()
+            && resp_o.as_ref().unwrap().as_k_response_ref().is_update_response()
+            && resp_o.unwrap().into_k_response().into_update_response().res.is_ok() {
+                let state_prime = FluentBitConfigReconcileState {
+                    reconcile_step: FluentBitConfigReconcileStep::Done,
+                    ..state
+                };
+                return (state_prime, None);
+            }
+            let state_prime = FluentBitConfigReconcileState {
+                reconcile_step: FluentBitConfigReconcileStep::Error,
+                ..state
+            };
+            return (state_prime, None);
         },
         _ => {
             let state_prime = FluentBitConfigReconcileState {
@@ -134,37 +190,69 @@ pub fn reconcile_core(fluentbit: &FluentBitConfig, resp_o: Option<Response<Empty
     }
 }
 
-
-pub fn make_secret(fluentbit: &FluentBitConfig) -> (secret: Secret)
+pub fn make_owner_references(fbc: &FluentBitConfig) -> (owner_references: Vec<OwnerReference>)
     requires
-        fluentbit@.metadata.name.is_Some(),
-        fluentbit@.metadata.namespace.is_Some(),
+        fbc@.well_formed(),
     ensures
-        secret@ == fluent_spec::make_secret(fluentbit@),
+        owner_references@.map_values(|or: OwnerReference| or@) == fbc_spec::make_owner_references(fbc@),
+{
+    let mut owner_references = Vec::new();
+    owner_references.push(fbc.controller_owner_ref());
+    proof {
+        assert_seqs_equal!(
+            owner_references@.map_values(|owner_ref: OwnerReference| owner_ref@),
+            fbc_spec::make_owner_references(fbc@)
+        );
+    }
+    owner_references
+}
+
+fn make_secret_name(fbc: &FluentBitConfig) -> (name: String)
+    requires
+        fbc@.well_formed(),
+    ensures
+        name@ == fbc_spec::make_secret_name(fbc@.metadata.name.get_Some_0()),
+{
+    fbc.metadata().name().unwrap()
+}
+
+pub fn make_secret(fbc: &FluentBitConfig) -> (secret: Secret)
+    requires
+        fbc@.well_formed(),
+    ensures
+        secret@ == fbc_spec::make_secret(fbc@),
 {
     let mut secret = Secret::default();
     secret.set_metadata({
         let mut metadata = ObjectMeta::default();
-        metadata.set_name(fluentbit.metadata().name().unwrap());
-        metadata.set_owner_references({
-            let mut owner_references = Vec::new();
-            owner_references.push(fluentbit.controller_owner_ref());
-            proof {
-                assert_seqs_equal!(
-                    owner_references@.map_values(|owner_ref: OwnerReference| owner_ref@),
-                    fluent_spec::make_secret(fluentbit@).metadata.owner_references.get_Some_0()
-                );
-            }
-            owner_references
-        });
+        metadata.set_name(make_secret_name(fbc));
+        metadata.set_owner_references(make_owner_references(fbc));
         metadata
     });
     secret.set_data({
         let mut data = StringMap::empty();
-        data.insert(new_strlit("fluent-bit.conf").to_string(), fluentbit.spec().fluentbit_config());
-        data.insert(new_strlit("parsers.conf").to_string(), fluentbit.spec().parsers_config());
+        data.insert(new_strlit("fluent-bit.conf").to_string(), fbc.spec().fluentbit_config());
+        data.insert(new_strlit("parsers.conf").to_string(), fbc.spec().parsers_config());
         data
     });
+    secret
+}
+
+fn update_secret(fbc: &FluentBitConfig, found_secret: &Secret) -> (secret: Secret)
+    requires
+        fbc@.well_formed(),
+    ensures
+        secret@ == fbc_spec::update_secret(fbc@, found_secret@),
+{
+    let mut secret = found_secret.clone();
+    let made_secret = make_secret(fbc);
+    secret.set_metadata({
+        let mut metadata = found_secret.metadata();
+        metadata.set_owner_references(make_owner_references(fbc));
+        metadata.unset_finalizers();
+        metadata
+    });
+    secret.set_data(made_secret.data().unwrap());
     secret
 }
 

--- a/src/controller_examples/fluent_controller/fluentbit_config/spec/reconciler.rs
+++ b/src/controller_examples/fluent_controller/fluentbit_config/spec/reconciler.rs
@@ -6,8 +6,8 @@ use crate::fluent_controller::fluentbit_config::common::*;
 use crate::fluent_controller::fluentbit_config::spec::types::*;
 use crate::kubernetes_api_objects::{
     api_method::*, common::*, config_map::*, daemon_set::*, dynamic::*, label_selector::*,
-    object_meta::*, persistent_volume_claim::*, pod::*, pod_template_spec::*, resource::*, role::*,
-    role_binding::*, secret::*, service::*, service_account::*,
+    object_meta::*, owner_reference::*, persistent_volume_claim::*, pod::*, pod_template_spec::*,
+    resource::*, role::*, role_binding::*, secret::*, service::*, service_account::*,
 };
 use crate::kubernetes_cluster::spec::message::*;
 use crate::reconciler::spec::{io::*, reconciler::*};
@@ -33,9 +33,9 @@ impl Reconciler<FluentBitConfigView, EmptyAPI> for FluentBitConfigReconciler {
     }
 
     open spec fn reconcile_core(
-        fluentbit_config: FluentBitConfigView, resp_o: Option<ResponseView<EmptyTypeView>>, state: FluentBitConfigReconcileState
+        fbc: FluentBitConfigView, resp_o: Option<ResponseView<EmptyTypeView>>, state: FluentBitConfigReconcileState
     ) -> (FluentBitConfigReconcileState, Option<RequestView<EmptyTypeView>>) {
-        reconcile_core(fluentbit_config, resp_o, state)
+        reconcile_core(fbc, resp_o, state)
     }
 
     open spec fn reconcile_done(state: FluentBitConfigReconcileState) -> bool {
@@ -72,32 +72,110 @@ pub open spec fn reconcile_error(state: FluentBitConfigReconcileState) -> bool {
 }
 
 pub open spec fn reconcile_core(
-    fluentbit_config: FluentBitConfigView, resp_o: Option<ResponseView<EmptyTypeView>>, state: FluentBitConfigReconcileState
+    fbc: FluentBitConfigView, resp_o: Option<ResponseView<EmptyTypeView>>, state: FluentBitConfigReconcileState
 ) -> (FluentBitConfigReconcileState, Option<RequestView<EmptyTypeView>>)
     recommends
-        fluentbit_config.metadata.name.is_Some(),
-        fluentbit_config.metadata.namespace.is_Some(),
+        fbc.well_formed(),
 {
     let step = state.reconcile_step;
+    let resp = resp_o.get_Some_0();
+    let fbc_name = fbc.metadata.name.get_Some_0();
+    let fbc_namespace = fbc.metadata.namespace.get_Some_0();
     match step{
         FluentBitConfigReconcileStep::Init => {
-            let secret = make_secret(fluentbit_config);
-            let req_o = APIRequest::CreateRequest(CreateRequest{
-                namespace: fluentbit_config.metadata.namespace.get_Some_0(),
-                obj: secret.marshal(),
+            let req_o = APIRequest::GetRequest(GetRequest {
+                key: make_secret_key(fbc.object_ref()),
             });
             let state_prime = FluentBitConfigReconcileState {
-                reconcile_step: FluentBitConfigReconcileStep::AfterCreateSecret,
+                reconcile_step: FluentBitConfigReconcileStep::AfterGetSecret,
                 ..state
             };
             (state_prime, Some(RequestView::KRequest(req_o)))
         },
+        FluentBitConfigReconcileStep::AfterGetSecret => {
+            if resp_o.is_Some() && resp.is_KResponse() && resp.get_KResponse_0().is_GetResponse() {
+                let get_secret_resp = resp.get_KResponse_0().get_GetResponse_0().res;
+                let unmarshal_secret_result = SecretView::unmarshal(get_secret_resp.get_Ok_0());
+                if get_secret_resp.is_Ok() {
+                    if unmarshal_secret_result.is_Ok() {
+                        // update
+                        let found_secret = unmarshal_secret_result.get_Ok_0();
+                        let req_o = APIRequest::UpdateRequest(UpdateRequest {
+                            namespace: fbc_namespace,
+                            name: make_secret_name(fbc_name),
+                            obj: update_secret(fbc, found_secret).marshal(),
+                        });
+                        let state_prime = FluentBitConfigReconcileState {
+                            reconcile_step: FluentBitConfigReconcileStep::AfterUpdateSecret,
+                            ..state
+                        };
+                        (state_prime, Some(RequestView::KRequest(req_o)))
+                    } else {
+                        let state_prime = FluentBitConfigReconcileState {
+                            reconcile_step: FluentBitConfigReconcileStep::Error,
+                            ..state
+                        };
+                        (state_prime, None)
+                    }
+                } else if get_secret_resp.get_Err_0().is_ObjectNotFound() {
+                    // create
+                    let req_o = APIRequest::CreateRequest(CreateRequest {
+                        namespace: fbc_namespace,
+                        obj: make_secret(fbc).marshal(),
+                    });
+                    let state_prime = FluentBitConfigReconcileState {
+                        reconcile_step: FluentBitConfigReconcileStep::AfterCreateSecret,
+                        ..state
+                    };
+                    (state_prime, Some(RequestView::KRequest(req_o)))
+                } else {
+                    let state_prime = FluentBitConfigReconcileState {
+                        reconcile_step: FluentBitConfigReconcileStep::Error,
+                        ..state
+                    };
+                    (state_prime, None)
+                }
+            } else {
+                let state_prime = FluentBitConfigReconcileState {
+                    reconcile_step: FluentBitConfigReconcileStep::Error,
+                    ..state
+                };
+                (state_prime, None)
+            }
+        },
         FluentBitConfigReconcileStep::AfterCreateSecret => {
-            let state_prime = FluentBitConfigReconcileState {
-                reconcile_step: FluentBitConfigReconcileStep::Done,
-                ..state
-            };
-            (state_prime, None)
+            let create_secret_resp = resp.get_KResponse_0().get_CreateResponse_0().res;
+            if resp_o.is_Some() && resp.is_KResponse() && resp.get_KResponse_0().is_CreateResponse()
+            && create_secret_resp.is_Ok() {
+                let state_prime = FluentBitConfigReconcileState {
+                    reconcile_step: FluentBitConfigReconcileStep::Done,
+                    ..state
+                };
+                (state_prime, None)
+            } else {
+                let state_prime = FluentBitConfigReconcileState {
+                    reconcile_step: FluentBitConfigReconcileStep::Error,
+                    ..state
+                };
+                (state_prime, None)
+            }
+        },
+        FluentBitConfigReconcileStep::AfterUpdateSecret => {
+            let update_secret_resp = resp.get_KResponse_0().get_UpdateResponse_0().res;
+            if resp_o.is_Some() && resp.is_KResponse() && resp.get_KResponse_0().is_UpdateResponse()
+            && update_secret_resp.is_Ok() {
+                let state_prime = FluentBitConfigReconcileState {
+                    reconcile_step: FluentBitConfigReconcileStep::Done,
+                    ..state
+                };
+                (state_prime, None)
+            } else {
+                let state_prime = FluentBitConfigReconcileState {
+                    reconcile_step: FluentBitConfigReconcileStep::Error,
+                    ..state
+                };
+                (state_prime, None)
+            }
         },
         _ => {
             let state_prime = FluentBitConfigReconcileState {
@@ -106,7 +184,6 @@ pub open spec fn reconcile_core(
             };
             (state_prime, None)
         }
-
     }
 }
 
@@ -119,24 +196,56 @@ pub open spec fn reconcile_error_result(state: FluentBitConfigReconcileState) ->
     (state_prime, req_o)
 }
 
-
-pub open spec fn make_secret_name(fluentbit_config_name: StringView) -> StringView {
-    fluentbit_config_name
+pub open spec fn make_owner_references(fbc: FluentBitConfigView) -> Seq<OwnerReferenceView> {
+    seq![fbc.controller_owner_ref()]
 }
 
-pub open spec fn make_secret(fluentbit_config: FluentBitConfigView) -> SecretView
+
+pub open spec fn make_secret_name(fbc_name: StringView) -> StringView {
+    fbc_name
+}
+
+pub open spec fn make_secret_key(key: ObjectRef) -> ObjectRef
     recommends
-        fluentbit_config.metadata.name.is_Some(),
-        fluentbit_config.metadata.namespace.is_Some(),
+        key.kind.is_CustomResourceKind(),
+{
+    ObjectRef {
+        kind: SecretView::kind(),
+        name: make_secret_name(key.name),
+        namespace: key.namespace,
+    }
+}
+
+pub open spec fn make_secret(fbc: FluentBitConfigView) -> SecretView
+    recommends
+        fbc.well_formed(),
 {
     SecretView::default()
         .set_metadata(ObjectMetaView::default()
-            .set_name(make_secret_name(fluentbit_config.metadata.name.get_Some_0()))
-            .set_owner_references(seq![fluentbit_config.controller_owner_ref()])
+            .set_name(make_secret_name(fbc.metadata.name.get_Some_0()))
+            .set_owner_references(make_owner_references(fbc))
         ).set_data(Map::empty()
-            .insert(new_strlit("fluent-bit.conf")@, fluentbit_config.spec.fluentbit_config)
-            .insert(new_strlit("parsers.conf")@, fluentbit_config.spec.parsers_config)
+            .insert(new_strlit("fluent-bit.conf")@, fbc.spec.fluentbit_config)
+            .insert(new_strlit("parsers.conf")@, fbc.spec.parsers_config)
         )
+}
+
+pub open spec fn update_secret(fbc: FluentBitConfigView, found_secret: SecretView) -> SecretView
+    recommends
+        fbc.well_formed(),
+{
+    SecretView {
+        metadata: ObjectMetaView {
+            owner_references: Some(make_owner_references(fbc)),
+            finalizers: None,
+            ..found_secret.metadata
+        },
+        data: Some(Map::empty()
+            .insert(new_strlit("fluent-bit.conf")@, fbc.spec.fluentbit_config)
+            .insert(new_strlit("parsers.conf")@, fbc.spec.parsers_config)
+        ),
+        ..found_secret
+    }
 }
 
 }

--- a/src/controller_examples/zookeeper_controller/exec/reconciler.rs
+++ b/src/controller_examples/zookeeper_controller/exec/reconciler.rs
@@ -856,7 +856,7 @@ pub fn make_owner_references(zk: &ZookeeperCluster) -> (owner_references: Vec<Ow
     requires
         zk@.well_formed(),
     ensures
-        owner_references@.map_values(|or: OwnerReference| or@) ==  zk_spec::make_owner_references(zk@),
+        owner_references@.map_values(|or: OwnerReference| or@) == zk_spec::make_owner_references(zk@),
 {
     let mut owner_references = Vec::new();
     owner_references.push(zk.controller_owner_ref());


### PR DESCRIPTION
It includes (1) overwriting finalizers and owner references when updating the fluent bit/fluent big config subresources, and (2) supporting update operations for the fluent bit config reconciler.