### PR TITLE
Fix oscillation problem by renaming the client service of rabbitmq

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ e2e/target/
 /target
 /Cargo.lock
 src/liblib.rlib
+verifiable-controllers.code-workspace

--- a/e2e/src/rabbitmq_e2e.rs
+++ b/e2e/src/rabbitmq_e2e.rs
@@ -566,7 +566,7 @@ pub async fn rabbitmq_workload_test(client: Client, rabbitmq_name: String) -> Re
             "--image=pivotalrabbitmq/perf-test",
             "--",
             "--uri",
-            "\"amqp://new_user:new_pass@rabbitmq\"",
+            "\"amqp://new_user:new_pass@rabbitmq-client\"",
         ],
         "failed to run perf test pod",
     );

--- a/src/controller_examples/rabbitmq_controller/exec/resource/service.rs
+++ b/src/controller_examples/rabbitmq_controller/exec/resource/service.rs
@@ -93,7 +93,7 @@ pub fn make_main_service_name(rabbitmq: &RabbitmqCluster) -> (name: String)
     ensures
         name@ == spec_resource::make_main_service_name(rabbitmq@),
 {
-    rabbitmq.name().unwrap()
+    rabbitmq.name().unwrap().concat(new_strlit("-client"))
 }
 
 pub fn make_main_service(rabbitmq: &RabbitmqCluster) -> (service: Service)

--- a/src/controller_examples/rabbitmq_controller/spec/resource/service.rs
+++ b/src/controller_examples/rabbitmq_controller/spec/resource/service.rs
@@ -74,7 +74,7 @@ pub open spec fn make_main_service_name(rabbitmq: RabbitmqClusterView) -> String
     recommends
         rabbitmq.metadata.name.is_Some(),
 {
-    rabbitmq.metadata.name.get_Some_0()
+    rabbitmq.metadata.name.get_Some_0() + new_strlit("-client")@
 }
 
 pub open spec fn make_main_service_key(rabbitmq: RabbitmqClusterView) -> ObjectRef


### PR DESCRIPTION
This is to avoid a naming conflict bug when there are multiple rabbitmq cluster (cr) instances. Suppose one instance is called `foo` and the other is called `foo-nodes`. Before this change, the headless service of the first cr will be called `foo-nodes` and the client service of the second cr will be called `foo-nodes` as well. Thus, the reconciler instances for the two crs will start to compete on the `foo-nodes` service, causing oscillation problems and liveness violations.

This renaming fixes the problem. From now on, for every rabbitmq cluster instance, its headless and client services will never collide with the services of other rabbitmq cluster instances.