### PR TITLE
Cosmetic changes to rabbitmq controller

### DIFF
--- a/deploy/rabbitmq/crd.yaml
+++ b/deploy/rabbitmq/crd.yaml
@@ -498,7 +498,7 @@ spec:
                   type: object
                 persistence:
                   default:
-                    storageClassName: ~
+                    storageClassName: standard
                     storage: 10Gi
                   properties:
                     storage:
@@ -509,7 +509,7 @@ spec:
                         - rule: "self == oldSelf"
                           message: storage should not be changed
                     storageClassName:
-                      nullable: true
+                      default: standard
                       type: string
                       x-kubernetes-validations:
                         - rule: "self == oldSelf"
@@ -605,6 +605,7 @@ spec:
                   nullable: true
                   type: array
               required:
+                - image
                 - replicas
               type: object
           required:

--- a/deploy/rabbitmq/crd.yaml
+++ b/deploy/rabbitmq/crd.yaml
@@ -527,8 +527,8 @@ spec:
                       type: string
                   type: object
                 podManagementPolicy:
+                  default: Parallel
                   description: "podManagementPolicy controls how pods are created during initial scale up, when replacing pods on nodes, or when scaling down. The default policy is `OrderedReady`, where pods are created in increasing order (pod-0, then pod-1, etc) and the controller will wait until each pod is ready before continuing. When scaling down, the pods are removed in the opposite order. The alternative policy is `Parallel` which will create pods in parallel to match the desired scale without waiting, and on scale down will delete all pods at once."
-                  nullable: true
                   type: string
                   x-kubernetes-validations:
                     - rule: "self == oldSelf"

--- a/deploy/rabbitmq/crd.yaml
+++ b/deploy/rabbitmq/crd.yaml
@@ -29,7 +29,7 @@ spec:
                       description: Describes node affinity scheduling rules for the pod.
                       properties:
                         preferredDuringSchedulingIgnoredDuringExecution:
-                          description: "The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding \"weight\" to the sum if the node matches the corresponding matchExpressions; the node(s) with the highest sum are the most preferred."
+                          description: 'The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding "weight" to the sum if the node matches the corresponding matchExpressions; the node(s) with the highest sum are the most preferred.'
                           items:
                             description: "An empty preferred scheduling term matches all objects with implicit weight 0 (i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op)."
                             properties:
@@ -148,7 +148,7 @@ spec:
                       description: "Describes pod affinity scheduling rules (e.g. co-locate this pod in the same node, zone, etc. as some other pod(s))."
                       properties:
                         preferredDuringSchedulingIgnoredDuringExecution:
-                          description: "The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding \"weight\" to the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred."
+                          description: 'The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.'
                           items:
                             description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)
                             properties:
@@ -182,11 +182,11 @@ spec:
                                       matchLabels:
                                         additionalProperties:
                                           type: string
-                                        description: "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed."
+                                        description: 'matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.'
                                         type: object
                                     type: object
                                   namespaceSelector:
-                                    description: "A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means \"this pod's namespace\". An empty selector ({}) matches all namespaces."
+                                    description: 'A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod''s namespace". An empty selector ({}) matches all namespaces.'
                                     properties:
                                       matchExpressions:
                                         description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
@@ -212,11 +212,11 @@ spec:
                                       matchLabels:
                                         additionalProperties:
                                           type: string
-                                        description: "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed."
+                                        description: 'matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.'
                                         type: object
                                     type: object
                                   namespaces:
-                                    description: "namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means \"this pod's namespace\"."
+                                    description: 'namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means "this pod''s namespace".'
                                     items:
                                       type: string
                                     type: array
@@ -267,11 +267,11 @@ spec:
                                   matchLabels:
                                     additionalProperties:
                                       type: string
-                                    description: "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed."
+                                    description: 'matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.'
                                     type: object
                                 type: object
                               namespaceSelector:
-                                description: "A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means \"this pod's namespace\". An empty selector ({}) matches all namespaces."
+                                description: 'A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod''s namespace". An empty selector ({}) matches all namespaces.'
                                 properties:
                                   matchExpressions:
                                     description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
@@ -297,11 +297,11 @@ spec:
                                   matchLabels:
                                     additionalProperties:
                                       type: string
-                                    description: "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed."
+                                    description: 'matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.'
                                     type: object
                                 type: object
                               namespaces:
-                                description: "namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means \"this pod's namespace\"."
+                                description: 'namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means "this pod''s namespace".'
                                 items:
                                   type: string
                                 type: array
@@ -317,7 +317,7 @@ spec:
                       description: "Describes pod anti-affinity scheduling rules (e.g. avoid putting this pod in the same node, zone, etc. as some other pod(s))."
                       properties:
                         preferredDuringSchedulingIgnoredDuringExecution:
-                          description: "The scheduler will prefer to schedule pods to nodes that satisfy the anti-affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling anti-affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding \"weight\" to the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred."
+                          description: 'The scheduler will prefer to schedule pods to nodes that satisfy the anti-affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling anti-affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.'
                           items:
                             description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)
                             properties:
@@ -351,11 +351,11 @@ spec:
                                       matchLabels:
                                         additionalProperties:
                                           type: string
-                                        description: "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed."
+                                        description: 'matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.'
                                         type: object
                                     type: object
                                   namespaceSelector:
-                                    description: "A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means \"this pod's namespace\". An empty selector ({}) matches all namespaces."
+                                    description: 'A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod''s namespace". An empty selector ({}) matches all namespaces.'
                                     properties:
                                       matchExpressions:
                                         description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
@@ -381,11 +381,11 @@ spec:
                                       matchLabels:
                                         additionalProperties:
                                           type: string
-                                        description: "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed."
+                                        description: 'matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.'
                                         type: object
                                     type: object
                                   namespaces:
-                                    description: "namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means \"this pod's namespace\"."
+                                    description: 'namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means "this pod''s namespace".'
                                     items:
                                       type: string
                                     type: array
@@ -436,11 +436,11 @@ spec:
                                   matchLabels:
                                     additionalProperties:
                                       type: string
-                                    description: "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed."
+                                    description: 'matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.'
                                     type: object
                                 type: object
                               namespaceSelector:
-                                description: "A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means \"this pod's namespace\". An empty selector ({}) matches all namespaces."
+                                description: 'A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod''s namespace". An empty selector ({}) matches all namespaces.'
                                 properties:
                                   matchExpressions:
                                     description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
@@ -466,11 +466,11 @@ spec:
                                   matchLabels:
                                     additionalProperties:
                                       type: string
-                                    description: "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed."
+                                    description: 'matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.'
                                     type: object
                                 type: object
                               namespaces:
-                                description: "namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means \"this pod's namespace\"."
+                                description: 'namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means "this pod''s namespace".'
                                 items:
                                   type: string
                                 type: array
@@ -506,14 +506,14 @@ spec:
                       description: "Quantity is a fixed-point representation of a number. It provides convenient marshaling/unmarshaling in JSON and YAML, in addition to String() and AsInt64() accessors.\n\nThe serialization format is:\n\n``` <quantity>        ::= <signedNumber><suffix>\n\n\t(Note that <suffix> may be empty, from the \"\" case in <decimalSI>.)\n\n<digit>           ::= 0 | 1 | ... | 9 <digits>          ::= <digit> | <digit><digits> <number>          ::= <digits> | <digits>.<digits> | <digits>. | .<digits> <sign>            ::= \"+\" | \"-\" <signedNumber>    ::= <number> | <sign><number> <suffix>          ::= <binarySI> | <decimalExponent> | <decimalSI> <binarySI>        ::= Ki | Mi | Gi | Ti | Pi | Ei\n\n\t(International System of units; See: http://physics.nist.gov/cuu/Units/binary.html)\n\n<decimalSI>       ::= m | \"\" | k | M | G | T | P | E\n\n\t(Note that 1024 = 1Ki but 1000 = 1k; I didn't choose the capitalization.)\n\n<decimalExponent> ::= \"e\" <signedNumber> | \"E\" <signedNumber> ```\n\nNo matter which of the three exponent forms is used, no quantity may represent a number greater than 2^63-1 in magnitude, nor may it have more than 3 decimal places. Numbers larger or more precise will be capped or rounded up. (E.g.: 0.1m will rounded up to 1m.) This may be extended in the future if we require larger or smaller quantities.\n\nWhen a Quantity is parsed from a string, it will remember the type of suffix it had, and will use the same type again when it is serialized.\n\nBefore serializing, Quantity will be put in \"canonical form\". This means that Exponent/suffix will be adjusted up or down (with a corresponding increase or decrease in Mantissa) such that:\n\n- No precision is lost - No fractional digits will be emitted - The exponent (or suffix) is as large as possible.\n\nThe sign will be omitted unless the number is negative.\n\nExamples:\n\n- 1.5 will be serialized as \"1500m\" - 1.5Gi will be serialized as \"1536Mi\"\n\nNote that the quantity will NEVER be internally represented by a floating point number. That is the whole point of this exercise.\n\nNon-canonical values will still parse as long as they are well formed, but will be re-emitted in their canonical form. (So always use canonical form, or don't diff.)\n\nThis format is intended to make it difficult to use these numbers without writing some sort of special handling code in the hopes that that will cause implementors to also use a fixed point implementation."
                       type: string
                       x-kubernetes-validations:
-                      - rule: "self == oldSelf"
-                        message: storage should not be changed
+                        - rule: "self == oldSelf"
+                          message: storage should not be changed
                     storageClassName:
                       nullable: true
                       type: string
                       x-kubernetes-validations:
-                      - rule: "self == oldSelf"
-                        message: storage class name should not be changed
+                        - rule: "self == oldSelf"
+                          message: storage class name should not be changed
                   type: object
                 persistentVolumeClaimRetentionPolicy:
                   description: StatefulSetPersistentVolumeClaimRetentionPolicy describes the policy used for PVCs created from the StatefulSet VolumeClaimTemplates.

--- a/src/controller_examples/rabbitmq_controller/exec/resource/role_binding.rs
+++ b/src/controller_examples/rabbitmq_controller/exec/resource/role_binding.rs
@@ -70,7 +70,6 @@ pub fn update_role_binding(rabbitmq: &RabbitmqCluster, found_role_binding: RoleB
 {
     let mut role_binding = found_role_binding.clone();
     let made_role_binding = make_role_binding(rabbitmq);
-    role_binding.set_role_ref(make_role_ref(rabbitmq));
     role_binding.set_subjects(make_subjects(rabbitmq));
     role_binding.set_metadata({
         let mut metadata = found_role_binding.metadata();

--- a/src/controller_examples/rabbitmq_controller/exec/resource/service.rs
+++ b/src/controller_examples/rabbitmq_controller/exec/resource/service.rs
@@ -45,10 +45,12 @@ impl ResourceBuilder<RabbitmqCluster, RabbitmqReconcileState, spec_resource::Ser
     fn update(rabbitmq: &RabbitmqCluster, state: &RabbitmqReconcileState, obj: DynamicObject) -> Result<DynamicObject, ()> {
         let service = Service::unmarshal(obj);
         if service.is_ok() {
-            Ok(update_main_service(rabbitmq, service.unwrap()).marshal())
-        } else {
-            Err(())
+            let found_service = service.unwrap();
+            if found_service.spec().is_some() {
+                return Ok(update_main_service(rabbitmq, found_service).marshal());
+            }
         }
+        Err(())
     }
 
     fn state_after_create_or_update(obj: DynamicObject, state: RabbitmqReconcileState) -> (res: Result<RabbitmqReconcileState, ()>) {
@@ -65,6 +67,7 @@ pub fn update_main_service(rabbitmq: &RabbitmqCluster, found_main_service: Servi
     requires
         rabbitmq@.metadata.name.is_Some(),
         rabbitmq@.metadata.namespace.is_Some(),
+        found_main_service@.spec.is_Some(),
     ensures
         service@ == spec_resource::update_main_service(rabbitmq@, found_main_service@),
 {
@@ -82,7 +85,14 @@ pub fn update_main_service(rabbitmq: &RabbitmqCluster, found_main_service: Servi
         metadata.set_annotations(made_service.metadata().annotations().unwrap());
         metadata
     });
-    main_service.set_spec(made_service.spec().unwrap());
+    main_service.set_spec({
+        let mut svc_spec = found_main_service.spec().unwrap();
+        let made_spec = made_service.spec().unwrap();
+        svc_spec.set_ports(made_spec.ports().unwrap());
+        svc_spec.set_selector(made_spec.selector().unwrap());
+        svc_spec.set_publish_not_ready_addresses(made_spec.publish_not_ready_addresses().unwrap());
+        svc_spec
+    });
     main_service
 }
 

--- a/src/controller_examples/rabbitmq_controller/exec/resource/stateful_set.rs
+++ b/src/controller_examples/rabbitmq_controller/exec/resource/stateful_set.rs
@@ -241,11 +241,7 @@ pub fn make_stateful_set(rabbitmq: &RabbitmqCluster, config_map_rv: &String) -> 
             pod_template_spec
         });
         // Set management policy
-        if rabbitmq.spec().pod_management_policy().is_some() {
-            stateful_set_spec.set_pod_management_policy(rabbitmq.spec().pod_management_policy().unwrap());
-        } else {
-            stateful_set_spec.set_pod_management_policy(new_strlit("Parallel").to_string());
-        }
+        stateful_set_spec.set_pod_management_policy(rabbitmq.spec().pod_management_policy());
 
         if rabbitmq.spec().persistent_volume_claim_retention_policy().is_some() {
             stateful_set_spec.set_pvc_retention_policy(rabbitmq.spec().persistent_volume_claim_retention_policy().unwrap());

--- a/src/controller_examples/rabbitmq_controller/exec/resource/stateful_set.rs
+++ b/src/controller_examples/rabbitmq_controller/exec/resource/stateful_set.rs
@@ -210,7 +210,7 @@ pub fn make_stateful_set(rabbitmq: &RabbitmqCluster, config_map_rv: &String) -> 
                             });
                             resources
                         });
-                        pvc_spec.overwrite_storage_class_name(rabbitmq.spec().persistence().storage_class_name());
+                        pvc_spec.set_storage_class_name(rabbitmq.spec().persistence().storage_class_name());
                         pvc_spec
                     });
                     pvc

--- a/src/controller_examples/rabbitmq_controller/exec/types.rs
+++ b/src/controller_examples/rabbitmq_controller/exec/types.rs
@@ -260,15 +260,11 @@ impl RabbitmqClusterSpec {
     }
 
     #[verifier(external_body)]
-    pub fn pod_management_policy(&self) -> (policy: Option<String>)
+    pub fn pod_management_policy(&self) -> (policy: String)
         ensures
-            policy.is_Some() == self@.pod_management_policy.is_Some(),
-            policy.is_Some() ==> policy.get_Some_0()@ == self@.pod_management_policy.get_Some_0(),
+            policy@ == self@.pod_management_policy,
     {
-        match &self.inner.pod_management_policy {
-            Some(s) => Some(String::from_rust_string(s.clone())),
-            None => None,
-        }
+        String::from_rust_string(self.inner.pod_management_policy.clone())
     }
 
     #[verifier(external_body)]

--- a/src/controller_examples/rabbitmq_controller/exec/types.rs
+++ b/src/controller_examples/rabbitmq_controller/exec/types.rs
@@ -346,15 +346,11 @@ impl RabbitmqClusterPersistenceSpec {
     }
 
     #[verifier(external_body)]
-    pub fn storage_class_name(&self) -> (storage_class_name: Option<String>)
+    pub fn storage_class_name(&self) -> (storage_class_name: String)
         ensures
-            storage_class_name.is_Some() == self@.storage_class_name.is_Some(),
-            storage_class_name.is_Some() ==> storage_class_name.get_Some_0()@ == self@.storage_class_name.get_Some_0(),
+            storage_class_name@ == self@.storage_class_name,
     {
-        match &self.inner.storage_class_name {
-            Some(n) => Some(String::from_rust_string(n.clone())),
-            None => None,
-        }
+        String::from_rust_string(self.inner.storage_class_name.clone())
     }
 }
 

--- a/src/controller_examples/rabbitmq_controller/proof/helper_invariants/proof.rs
+++ b/src/controller_examples/rabbitmq_controller/proof/helper_invariants/proof.rs
@@ -187,7 +187,6 @@ pub proof fn lemma_eventually_always_object_in_response_at_after_create_resource
         spec.entails(always(lift_state(RMQCluster::each_object_in_reconcile_has_consistent_key_and_valid_metadata()))),
         spec.entails(always(lift_state(RMQCluster::every_in_flight_msg_has_unique_id()))),
         spec.entails(always(lift_state(RMQCluster::every_in_flight_msg_has_lower_id_than_allocator()))),
-        spec.entails(always(lift_state(RMQCluster::each_object_in_etcd_is_well_formed()))),
         spec.entails(always(lift_state(RMQCluster::key_of_object_in_matched_ok_create_resp_message_is_same_as_key_of_pending_req(rabbitmq.object_ref())))),
         spec.entails(always(lift_state(RMQCluster::every_in_flight_or_pending_req_msg_has_unique_id()))),
         spec.entails(always(lift_state(no_delete_resource_request_msg_in_flight(SubResource::ServerConfigMap, rabbitmq)))),
@@ -205,7 +204,6 @@ pub proof fn lemma_eventually_always_object_in_response_at_after_create_resource
         &&& RMQCluster::each_object_in_reconcile_has_consistent_key_and_valid_metadata()(s)
         &&& RMQCluster::every_in_flight_msg_has_unique_id()(s)
         &&& RMQCluster::every_in_flight_msg_has_lower_id_than_allocator()(s)
-        &&& RMQCluster::each_object_in_etcd_is_well_formed()(s_prime)
         &&& RMQCluster::key_of_object_in_matched_ok_create_resp_message_is_same_as_key_of_pending_req(key)(s_prime)
         &&& RMQCluster::every_in_flight_or_pending_req_msg_has_unique_id()(s)
         &&& no_delete_resource_request_msg_in_flight(SubResource::ServerConfigMap, rabbitmq)(s)
@@ -213,14 +211,12 @@ pub proof fn lemma_eventually_always_object_in_response_at_after_create_resource
         &&& object_in_every_resource_update_request_only_has_owner_references_pointing_to_current_cr(SubResource::ServerConfigMap, rabbitmq)(s)
         &&& resource_object_has_no_finalizers_or_timestamp_and_only_has_controller_owner_ref(SubResource::ServerConfigMap, rabbitmq)(s)
     };
-    always_to_always_later(spec, lift_state(RMQCluster::each_object_in_etcd_is_well_formed()));
     always_to_always_later(spec, lift_state(RMQCluster::key_of_object_in_matched_ok_create_resp_message_is_same_as_key_of_pending_req(key)));
     combine_spec_entails_always_n!(
         spec, lift_action(next), lift_action(RMQCluster::next()),
         lift_state(RMQCluster::each_object_in_reconcile_has_consistent_key_and_valid_metadata()),
         lift_state(RMQCluster::every_in_flight_msg_has_unique_id()),
         lift_state(RMQCluster::every_in_flight_msg_has_lower_id_than_allocator()),
-        later(lift_state(RMQCluster::each_object_in_etcd_is_well_formed())),
         later(lift_state(RMQCluster::key_of_object_in_matched_ok_create_resp_message_is_same_as_key_of_pending_req(key))),
         lift_state(RMQCluster::every_in_flight_or_pending_req_msg_has_unique_id()),
         lift_state(no_delete_resource_request_msg_in_flight(SubResource::ServerConfigMap, rabbitmq)),

--- a/src/controller_examples/rabbitmq_controller/spec/resource/role_binding.rs
+++ b/src/controller_examples/rabbitmq_controller/spec/resource/role_binding.rs
@@ -100,7 +100,6 @@ pub open spec fn update_role_binding(rabbitmq: RabbitmqClusterView, found_role_b
             annotations: made_role_binding.metadata.annotations,
             ..found_role_binding.metadata
         },
-        role_ref: made_role_binding.role_ref,
         subjects: made_role_binding.subjects,
         ..found_role_binding
     }

--- a/src/controller_examples/rabbitmq_controller/spec/resource/stateful_set.rs
+++ b/src/controller_examples/rabbitmq_controller/spec/resource/stateful_set.rs
@@ -178,13 +178,7 @@ pub open spec fn make_stateful_set(rabbitmq: RabbitmqClusterView, config_map_rv:
                 ]
             }
         }),
-        pod_management_policy: Some({
-            if rabbitmq.spec.pod_management_policy.is_Some() {
-                rabbitmq.spec.pod_management_policy.get_Some_0()
-            } else {
-                new_strlit("Parallel")@
-            }
-        }),
+        pod_management_policy: Some(rabbitmq.spec.pod_management_policy),
         persistent_volume_claim_retention_policy: rabbitmq.spec.persistent_volume_claim_retention_policy,
         ..StatefulSetSpecView::default()
 

--- a/src/controller_examples/rabbitmq_controller/spec/resource/stateful_set.rs
+++ b/src/controller_examples/rabbitmq_controller/spec/resource/stateful_set.rs
@@ -173,7 +173,7 @@ pub open spec fn make_stateful_set(rabbitmq: RabbitmqClusterView, config_map_rv:
                                     .insert(new_strlit("storage")@, rabbitmq.spec.persistence.storage)
                                 )
                             )
-                            .overwrite_storage_class_name(rabbitmq.spec.persistence.storage_class_name)
+                            .set_storage_class_name(rabbitmq.spec.persistence.storage_class_name)
                         )
                 ]
             }

--- a/src/controller_examples/rabbitmq_controller/spec/types.rs
+++ b/src/controller_examples/rabbitmq_controller/spec/types.rs
@@ -132,7 +132,7 @@ impl ResourceView for RabbitmqClusterView {
 
     open spec fn state_validation(self) -> bool {
         &&& self.spec.replicas >= 0
-        // &&& self.spec.pod_management_policy.is_Some() ==> 
+        // &&& self.spec.pod_management_policy.is_Some() ==>
         //     (self.spec.pod_management_policy.get_Some_0() == new_strlit("OrderedReady")@
         //         || self.spec.pod_management_policy.get_Some_0() == new_strlit("Parallel")@)
         // &&& self.spec.persistent_volume_claim_retention_policy.is_Some() ==>
@@ -183,7 +183,7 @@ pub struct RabbitmqConfigView {
 }
 
 pub struct RabbitmqClusterPersistenceSpecView {
-    pub storage_class_name: Option<StringView>,
+    pub storage_class_name: StringView,
     pub storage: StringView,
 }
 

--- a/src/controller_examples/rabbitmq_controller/spec/types.rs
+++ b/src/controller_examples/rabbitmq_controller/spec/types.rs
@@ -158,7 +158,7 @@ pub struct RabbitmqClusterSpecView {
     pub labels: Map<StringView, StringView>,
     pub annotations: Map<StringView, StringView>,
     pub resources: Option<ResourceRequirementsView>,
-    pub pod_management_policy: Option<StringView>,
+    pub pod_management_policy: StringView,
     pub persistent_volume_claim_retention_policy: Option<StatefulSetPersistentVolumeClaimRetentionPolicyView>,
 }
 

--- a/src/deps_hack/src/lib.rs
+++ b/src/deps_hack/src/lib.rs
@@ -146,11 +146,18 @@ pub struct RabbitmqClusterSpec {
     /// The alternative policy is `Parallel` which will create pods in parallel
     /// to match the desired scale without waiting, and on scale down will delete
     /// all pods at once.
-    #[serde(rename = "podManagementPolicy")]
-    pub pod_management_policy: Option<String>,
+    #[serde(
+        rename = "podManagementPolicy",
+        default = "default_pod_management_policy"
+    )]
+    pub pod_management_policy: String,
     #[serde(rename = "persistentVolumeClaimRetentionPolicy")]
     pub persistent_volume_claim_retention_policy:
         Option<k8s_openapi::api::apps::v1::StatefulSetPersistentVolumeClaimRetentionPolicy>,
+}
+
+pub fn default_pod_management_policy() -> String {
+    "Parallel".to_string()
 }
 
 pub fn default_persistence() -> RabbitmqClusterPersistenceSpec {

--- a/src/deps_hack/src/lib.rs
+++ b/src/deps_hack/src/lib.rs
@@ -155,8 +155,8 @@ pub struct RabbitmqClusterSpec {
 
 pub fn default_persistence() -> RabbitmqClusterPersistenceSpec {
     RabbitmqClusterPersistenceSpec {
+        storage_class_name: default_storage_class_name(),
         storage: default_storage(),
-        storage_class_name: None,
     }
 }
 
@@ -170,14 +170,18 @@ pub struct RabbitmqConfig {
     pub env_config: Option<String>,
 }
 
+pub fn default_storage_class_name() -> String {
+    "standard".to_string()
+}
+
 pub fn default_storage() -> k8s_openapi::apimachinery::pkg::api::resource::Quantity {
     k8s_openapi::apimachinery::pkg::api::resource::Quantity("10Gi".to_string())
 }
 
 #[derive(Debug, Clone, serde::Deserialize, serde::Serialize, schemars::JsonSchema)]
 pub struct RabbitmqClusterPersistenceSpec {
-    #[serde(rename = "storageClassName", default)]
-    pub storage_class_name: Option<String>,
+    #[serde(rename = "storageClassName", default = "default_storage_class_name")]
+    pub storage_class_name: String,
     #[serde(default = "default_storage")]
     pub storage: k8s_openapi::apimachinery::pkg::api::resource::Quantity,
 }

--- a/src/kubernetes_api_objects/persistent_volume_claim.rs
+++ b/src/kubernetes_api_objects/persistent_volume_claim.rs
@@ -164,22 +164,6 @@ impl PersistentVolumeClaimSpec {
     {
         self.inner.storage_class_name = Some(storage_class_name.into_rust_string());
     }
-
-    #[verifier(external_body)]
-    pub fn overwrite_storage_class_name(&mut self, storage_class_name: Option<String>)
-        ensures
-            storage_class_name.is_None() ==> self@ == old(self)@.overwrite_storage_class_name(None),
-            storage_class_name.is_Some() ==> self@ == old(self)@.overwrite_storage_class_name(Some(storage_class_name.get_Some_0()@)),
-    {
-        match storage_class_name {
-            Some(n) => {
-                self.inner.storage_class_name = Some(n.into_rust_string());
-            },
-            None => {
-                self.inner.storage_class_name = None;
-            }
-        }
-    }
 }
 
 impl ResourceWrapper<deps_hack::k8s_openapi::api::core::v1::PersistentVolumeClaimSpec> for PersistentVolumeClaimSpec {
@@ -352,13 +336,6 @@ impl PersistentVolumeClaimSpecView {
     pub open spec fn set_storage_class_name(self, storage_class_name: StringView) -> PersistentVolumeClaimSpecView {
         PersistentVolumeClaimSpecView {
             storage_class_name: Some(storage_class_name),
-            ..self
-        }
-    }
-
-    pub open spec fn overwrite_storage_class_name(self, storage_class_name: Option<StringView>) -> PersistentVolumeClaimSpecView {
-        PersistentVolumeClaimSpecView {
-            storage_class_name: storage_class_name,
             ..self
         }
     }

--- a/src/kubernetes_api_objects/service.rs
+++ b/src/kubernetes_api_objects/service.rs
@@ -195,6 +195,15 @@ impl ServiceSpec {
     }
 
     #[verifier(external_body)]
+    pub fn publish_not_ready_addresses(&self) -> (publish_not_ready_addresses: Option<bool>)
+        ensures
+            self@.publish_not_ready_addresses.is_Some() == publish_not_ready_addresses.is_Some(),
+            publish_not_ready_addresses.is_Some() ==> publish_not_ready_addresses.get_Some_0() == self@.publish_not_ready_addresses.get_Some_0(),
+    {
+        self.inner.publish_not_ready_addresses.clone()
+    }
+
+    #[verifier(external_body)]
     pub fn set_publish_not_ready_addresses(&mut self, publish_not_ready_addresses: bool)
         ensures
             self@ == old(self)@.set_publish_not_ready_addresses(publish_not_ready_addresses),


### PR DESCRIPTION
This PR makes the following changes:
1. Change the update logic for RoleBiding object to avoid updating its role_ref
2. Change the update logic for main and headless service objects to avoid updating its cluster ip
3. Fix the immutability bugs of storage_class_name and pod_management_policy: these two fields should not be nullable since they should be immutable (the immutable validation rules don't work well for nullable fields) 