### PR TITLE
Accelerate some lemmas in rabbitmq proof

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ e2e/target/
 /Cargo.lock
 src/liblib.rlib
 verifiable-controllers.code-workspace
+src/.verus-solver-log/

--- a/src/controller_examples/rabbitmq_controller/proof/helper_invariants/owner_ref.rs
+++ b/src/controller_examples/rabbitmq_controller/proof/helper_invariants/owner_ref.rs
@@ -94,6 +94,7 @@ pub proof fn lemma_always_object_in_every_resource_create_or_update_request_msg_
     init_invariant(spec, RMQCluster::init(), next, inv);
 }
 
+#[verifier(spinoff_prover)]
 proof fn object_in_every_resource_create_or_update_request_msg_only_has_valid_owner_references_helper(
     s: RMQCluster, s_prime: RMQCluster, sub_resource: SubResource, rabbitmq: RabbitmqClusterView, msg: RMQMessage
 )

--- a/src/controller_examples/rabbitmq_controller/proof/helper_invariants/owner_ref.rs
+++ b/src/controller_examples/rabbitmq_controller/proof/helper_invariants/owner_ref.rs
@@ -88,16 +88,17 @@ pub proof fn lemma_always_object_in_every_resource_create_or_update_request_msg_
             assert(s.kubernetes_api_state.uid_counter <= s_prime.kubernetes_api_state.uid_counter);
             if !s.in_flight().contains(msg) {
                 let step = choose |step| RMQCluster::next_step(s, s_prime, step);
-                lemma_resource_create_or_update_request_msg_implies_key_in_reconcile_equals(sub_resource, rabbitmq, s, s_prime, msg, step);
                 let input = step.get_ControllerStep_0();
                 let cr = s.ongoing_reconciles()[input.1.get_Some_0()].triggering_cr;
                 if resource_create_request_msg(resource_key)(msg) {
+                    lemma_resource_create_request_msg_implies_key_in_reconcile_equals(sub_resource, rabbitmq, s, s_prime, msg, step);
                     let owner_refs = msg.content.get_create_request().obj.metadata.owner_references;
                     assert(owner_refs == Some(seq![cr.controller_owner_ref()]));
                     assert(owner_refs.is_Some());
                     assert(owner_refs.get_Some_0().len() == 1);
                     assert(owner_refs.get_Some_0()[0].uid < s.kubernetes_api_state.uid_counter);
                 } else if resource_update_request_msg(resource_key)(msg) {
+                    lemma_resource_update_request_msg_implies_key_in_reconcile_equals(sub_resource, rabbitmq, s, s_prime, msg, step);
                     let owner_refs = msg.content.get_update_request().obj.metadata.owner_references;
                     assert(owner_refs == Some(seq![cr.controller_owner_ref()]));
                     assert(owner_refs.is_Some());

--- a/src/controller_examples/rabbitmq_controller/proof/helper_invariants/owner_ref.rs
+++ b/src/controller_examples/rabbitmq_controller/proof/helper_invariants/owner_ref.rs
@@ -87,28 +87,45 @@ pub proof fn lemma_always_object_in_every_resource_create_or_update_request_msg_
         assert forall |msg| #[trigger] s_prime.in_flight().contains(msg) implies create_valid(msg, s_prime) && update_valid(msg, s_prime) by {
             assert(s.kubernetes_api_state.uid_counter <= s_prime.kubernetes_api_state.uid_counter);
             if !s.in_flight().contains(msg) {
-                let step = choose |step| RMQCluster::next_step(s, s_prime, step);
-                let input = step.get_ControllerStep_0();
-                let cr = s.ongoing_reconciles()[input.1.get_Some_0()].triggering_cr;
-                if resource_create_request_msg(resource_key)(msg) {
-                    lemma_resource_create_request_msg_implies_key_in_reconcile_equals(sub_resource, rabbitmq, s, s_prime, msg, step);
-                    let owner_refs = msg.content.get_create_request().obj.metadata.owner_references;
-                    assert(owner_refs == Some(seq![cr.controller_owner_ref()]));
-                    assert(owner_refs.is_Some());
-                    assert(owner_refs.get_Some_0().len() == 1);
-                    assert(owner_refs.get_Some_0()[0].uid < s.kubernetes_api_state.uid_counter);
-                } else if resource_update_request_msg(resource_key)(msg) {
-                    lemma_resource_update_request_msg_implies_key_in_reconcile_equals(sub_resource, rabbitmq, s, s_prime, msg, step);
-                    let owner_refs = msg.content.get_update_request().obj.metadata.owner_references;
-                    assert(owner_refs == Some(seq![cr.controller_owner_ref()]));
-                    assert(owner_refs.is_Some());
-                    assert(owner_refs.get_Some_0().len() == 1);
-                    assert(owner_refs.get_Some_0()[0].uid < s.kubernetes_api_state.uid_counter);
-                }
+                object_in_every_resource_create_or_update_request_msg_only_has_valid_owner_references_helper(s, s_prime, sub_resource, rabbitmq, msg);
             }
         }
     }
     init_invariant(spec, RMQCluster::init(), next, inv);
+}
+
+proof fn object_in_every_resource_create_or_update_request_msg_only_has_valid_owner_references_helper(
+    s: RMQCluster, s_prime: RMQCluster, sub_resource: SubResource, rabbitmq: RabbitmqClusterView, msg: RMQMessage
+)
+    requires
+        !s.in_flight().contains(msg), s_prime.in_flight().contains(msg),
+        RMQCluster::next()(s, s_prime),
+        RMQCluster::triggering_cr_has_lower_uid_than_uid_counter()(s),
+        RMQCluster::each_object_in_reconcile_has_consistent_key_and_valid_metadata()(s),
+    ensures
+        resource_create_request_msg(get_request(sub_resource, rabbitmq).key)(msg) ==> owner_references_is_valid(msg.content.get_create_request().obj, s_prime),
+        resource_update_request_msg(get_request(sub_resource, rabbitmq).key)(msg) ==> owner_references_is_valid(msg.content.get_update_request().obj, s_prime),
+{
+    let resource_key = get_request(sub_resource, rabbitmq).key;
+    assert(s.kubernetes_api_state.uid_counter <= s_prime.kubernetes_api_state.uid_counter);
+    let step = choose |step| RMQCluster::next_step(s, s_prime, step);
+    let input = step.get_ControllerStep_0();
+    let cr = s.ongoing_reconciles()[input.1.get_Some_0()].triggering_cr;
+    if resource_create_request_msg(resource_key)(msg) {
+        lemma_resource_create_request_msg_implies_key_in_reconcile_equals(sub_resource, rabbitmq, s, s_prime, msg, step);
+        let owner_refs = msg.content.get_create_request().obj.metadata.owner_references;
+        assert(owner_refs == Some(seq![cr.controller_owner_ref()]));
+        assert(owner_refs.is_Some());
+        assert(owner_refs.get_Some_0().len() == 1);
+        assert(owner_refs.get_Some_0()[0].uid < s.kubernetes_api_state.uid_counter);
+    } else if resource_update_request_msg(resource_key)(msg) {
+        lemma_resource_update_request_msg_implies_key_in_reconcile_equals(sub_resource, rabbitmq, s, s_prime, msg, step);
+        let owner_refs = msg.content.get_update_request().obj.metadata.owner_references;
+        assert(owner_refs == Some(seq![cr.controller_owner_ref()]));
+        assert(owner_refs.is_Some());
+        assert(owner_refs.get_Some_0().len() == 1);
+        assert(owner_refs.get_Some_0()[0].uid < s.kubernetes_api_state.uid_counter);
+    }
 }
 
 pub open spec fn every_owner_ref_of_every_object_in_etcd_has_different_uid_from_uid_counter(

--- a/src/controller_examples/rabbitmq_controller/proof/helper_invariants/predicate.rs
+++ b/src/controller_examples/rabbitmq_controller/proof/helper_invariants/predicate.rs
@@ -125,14 +125,24 @@ pub open spec fn response_at_after_get_resource_step_is_resource_get_response(
     let resource_key = get_request(sub_resource, rabbitmq).key;
     |s: RMQCluster| {
         at_rabbitmq_step(key, RabbitmqReconcileStep::AfterKRequestStep(ActionKind::Get, sub_resource))(s)
-        ==> s.ongoing_reconciles()[key].pending_req_msg.is_Some()
-            && resource_get_request_msg(resource_key)(s.ongoing_reconciles()[key].pending_req_msg.get_Some_0())
-            && (
+        ==> (
                 forall |msg: RMQMessage|
                     #[trigger] s.in_flight().contains(msg)
                     && Message::resp_msg_matches_req_msg(msg, s.ongoing_reconciles()[key].pending_req_msg.get_Some_0())
                     ==> resource_get_response_msg(resource_key)(msg)
             )
+    }
+}
+
+pub open spec fn request_at_after_get_request_step_is_resource_get_request(
+    sub_resource: SubResource, rabbitmq: RabbitmqClusterView
+) -> StatePred<RMQCluster> {
+    let key = rabbitmq.object_ref();
+    let resource_key = get_request(sub_resource, rabbitmq).key;
+    |s: RMQCluster| {
+        at_rabbitmq_step(key, RabbitmqReconcileStep::AfterKRequestStep(ActionKind::Get, sub_resource))(s)
+        ==> s.ongoing_reconciles()[key].pending_req_msg.is_Some()
+            && resource_get_request_msg(resource_key)(s.ongoing_reconciles()[key].pending_req_msg.get_Some_0())
     }
 }
 

--- a/src/controller_examples/rabbitmq_controller/proof/helper_invariants/predicate.rs
+++ b/src/controller_examples/rabbitmq_controller/proof/helper_invariants/predicate.rs
@@ -125,7 +125,9 @@ pub open spec fn response_at_after_get_resource_step_is_resource_get_response(
     let resource_key = get_request(sub_resource, rabbitmq).key;
     |s: RMQCluster| {
         at_rabbitmq_step(key, RabbitmqReconcileStep::AfterKRequestStep(ActionKind::Get, sub_resource))(s)
-        ==> (
+        ==> s.ongoing_reconciles()[key].pending_req_msg.is_Some()
+            && resource_get_request_msg(resource_key)(s.ongoing_reconciles()[key].pending_req_msg.get_Some_0())
+            && (
                 forall |msg: RMQMessage|
                     #[trigger] s.in_flight().contains(msg)
                     && Message::resp_msg_matches_req_msg(msg, s.ongoing_reconciles()[key].pending_req_msg.get_Some_0())

--- a/src/controller_examples/rabbitmq_controller/proof/helper_invariants/proof.rs
+++ b/src/controller_examples/rabbitmq_controller/proof/helper_invariants/proof.rs
@@ -1255,13 +1255,12 @@ pub proof fn lemma_resource_update_request_msg_implies_key_in_reconcile_equals(
     let key = rabbitmq.object_ref();
     let cr = s.ongoing_reconciles()[key].triggering_cr;
     let resource_key = get_request(sub_resource, rabbitmq).key;
-    // if resource_update_request_msg(get_request(sub_resource, rabbitmq).key)(msg) {
     assert(step.is_ControllerStep());
     assert(s.ongoing_reconciles().contains_key(cr_key));
     let local_step = s.ongoing_reconciles()[cr_key].local_state.reconcile_step;
     let local_step_prime = s_prime.ongoing_reconciles()[cr_key].local_state.reconcile_step;
-    assert(local_step_prime.is_AfterKRequestStep());
     assert(local_step.is_AfterKRequestStep() && local_step.get_AfterKRequestStep_0() == ActionKind::Get);
+    assert(local_step_prime.is_AfterKRequestStep());
     // It's easy for the verifier to know that cr_key has the same kind and namespace as key.
     match sub_resource {
         SubResource::ServerConfigMap => {
@@ -1272,13 +1271,9 @@ pub proof fn lemma_resource_update_request_msg_implies_key_in_reconcile_equals(
                 cr_key.name + new_strlit("-plugins-conf")@ != key.name + new_strlit("-server-conf")@,
                 {
                     let str1 = cr_key.name + new_strlit("-plugins-conf")@;
-                    let str2 = key.name + new_strlit("-server-conf")@;
                     reveal_strlit("-server-conf");
                     reveal_strlit("-plugins-conf");
-                    if str1.len() == str2.len() {
-                        assert(str1[str1.len() - 6] == 's');
-                        assert(str2[str1.len() - 6] == 'r');
-                    }
+                    assert(str1[str1.len() - 6] == 's');
                 }
             );
             // Then we show that only if cr_key.name equals key.name, can this message be created in this step.
@@ -1289,13 +1284,9 @@ pub proof fn lemma_resource_update_request_msg_implies_key_in_reconcile_equals(
                 key.name + new_strlit("-plugins-conf")@ != cr_key.name + new_strlit("-server-conf")@,
                 {
                     let str1 = key.name + new_strlit("-plugins-conf")@;
-                    let str2 = cr_key.name + new_strlit("-server-conf")@;
                     reveal_strlit("-server-conf");
                     reveal_strlit("-plugins-conf");
-                    if str1.len() == str2.len() {
-                        assert(str1[str1.len() - 6] == 's');
-                        assert(str2[str1.len() - 6] == 'r');
-                    }
+                    assert(str1[str1.len() - 6] == 's');
                 }
             );
             seq_lib::seq_equal_preserved_by_add(key.name, cr_key.name, new_strlit("-plugins-conf")@);
@@ -1305,13 +1296,9 @@ pub proof fn lemma_resource_update_request_msg_implies_key_in_reconcile_equals(
                 cr_key.name + new_strlit("-default-user")@ != key.name + new_strlit("-erlang-cookie")@,
                 {
                     let str1 = cr_key.name + new_strlit("-default-user")@;
-                    let str2 = key.name + new_strlit("-erlang-cookie")@;
                     reveal_strlit("-erlang-cookie");
                     reveal_strlit("-default-user");
-                    if str1.len() == str2.len() {
-                        assert(str1[str1.len() - 1] == 'r');
-                        assert(str2[str1.len() - 1] == 'e');
-                    }
+                    assert(str1[str1.len() - 1] == 'r');
                 }
             );
             // Then we show that only if cr_key.name equals key.name, can this message be created in this step.
@@ -1322,13 +1309,9 @@ pub proof fn lemma_resource_update_request_msg_implies_key_in_reconcile_equals(
                 key.name + new_strlit("-default-user")@ != cr_key.name + new_strlit("-erlang-cookie")@,
                 {
                     let str1 = key.name + new_strlit("-default-user")@;
-                    let str2 = cr_key.name + new_strlit("-erlang-cookie")@;
                     reveal_strlit("-erlang-cookie");
                     reveal_strlit("-default-user");
-                    if str1.len() == str2.len() {
-                        assert(str1[str1.len() - 1] == 'r');
-                        assert(str2[str1.len() - 1] == 'e');
-                    }
+                    assert(str1[str1.len() - 1] == 'r');
                 }
             );
             seq_lib::seq_equal_preserved_by_add(key.name, cr_key.name, new_strlit("-default-user")@);
@@ -1338,13 +1321,9 @@ pub proof fn lemma_resource_update_request_msg_implies_key_in_reconcile_equals(
                 key.name + new_strlit("-nodes")@ != cr_key.name + new_strlit("-client")@,
                 {
                     let str1 = key.name + new_strlit("-nodes")@;
-                    let str2 = cr_key.name + new_strlit("-client")@;
                     reveal_strlit("-client");
                     reveal_strlit("-nodes");
-                    if str1.len() == str2.len() {
-                        assert(str1[str1.len() - 1] == 's');
-                        assert(str2[str1.len() - 1] == 't');
-                    }
+                    assert(str1[str1.len() - 1] == 's');
                 }
             );
             seq_lib::seq_equal_preserved_by_add(key.name, cr_key.name, new_strlit("-nodes")@);
@@ -1354,13 +1333,9 @@ pub proof fn lemma_resource_update_request_msg_implies_key_in_reconcile_equals(
                 cr_key.name + new_strlit("-nodes")@ != key.name + new_strlit("-client")@,
                 {
                     let str1 = cr_key.name + new_strlit("-nodes")@;
-                    let str2 = key.name + new_strlit("-client")@;
                     reveal_strlit("-client");
                     reveal_strlit("-nodes");
-                    if str1.len() == str2.len() {
-                        assert(str1[str1.len() - 1] == 's');
-                        assert(str2[str1.len() - 1] == 't');
-                    }
+                    assert(str1[str1.len() - 1] == 's');
                 }
             );
             seq_lib::seq_equal_preserved_by_add(key.name, cr_key.name, new_strlit("-client")@);
@@ -1397,13 +1372,12 @@ pub proof fn lemma_resource_create_request_msg_implies_key_in_reconcile_equals(
     let key = rabbitmq.object_ref();
     let cr = s.ongoing_reconciles()[key].triggering_cr;
     let resource_key = get_request(sub_resource, rabbitmq).key;
-    // if resource_update_request_msg(get_request(sub_resource, rabbitmq).key)(msg) {
     assert(step.is_ControllerStep());
     assert(s.ongoing_reconciles().contains_key(cr_key));
     let local_step = s.ongoing_reconciles()[cr_key].local_state.reconcile_step;
     let local_step_prime = s_prime.ongoing_reconciles()[cr_key].local_state.reconcile_step;
-    assert(local_step_prime.is_AfterKRequestStep());
     assert(local_step.is_AfterKRequestStep() && local_step.get_AfterKRequestStep_0() == ActionKind::Get);
+    assert(local_step_prime.is_AfterKRequestStep());
     // It's easy for the verifier to know that cr_key has the same kind and namespace as key.
     match sub_resource {
         SubResource::ServerConfigMap => {
@@ -1414,13 +1388,9 @@ pub proof fn lemma_resource_create_request_msg_implies_key_in_reconcile_equals(
                 cr_key.name + new_strlit("-plugins-conf")@ != key.name + new_strlit("-server-conf")@,
                 {
                     let str1 = cr_key.name + new_strlit("-plugins-conf")@;
-                    let str2 = key.name + new_strlit("-server-conf")@;
                     reveal_strlit("-server-conf");
                     reveal_strlit("-plugins-conf");
-                    if str1.len() == str2.len() {
-                        assert(str1[str1.len() - 6] == 's');
-                        assert(str2[str1.len() - 6] == 'r');
-                    }
+                    assert(str1[str1.len() - 6] == 's');
                 }
             );
             // Then we show that only if cr_key.name equals key.name, can this message be created in this step.
@@ -1431,13 +1401,9 @@ pub proof fn lemma_resource_create_request_msg_implies_key_in_reconcile_equals(
                 key.name + new_strlit("-plugins-conf")@ != cr_key.name + new_strlit("-server-conf")@,
                 {
                     let str1 = key.name + new_strlit("-plugins-conf")@;
-                    let str2 = cr_key.name + new_strlit("-server-conf")@;
                     reveal_strlit("-server-conf");
                     reveal_strlit("-plugins-conf");
-                    if str1.len() == str2.len() {
-                        assert(str1[str1.len() - 6] == 's');
-                        assert(str2[str1.len() - 6] == 'r');
-                    }
+                    assert(str1[str1.len() - 6] == 's');
                 }
             );
             seq_lib::seq_equal_preserved_by_add(key.name, cr_key.name, new_strlit("-plugins-conf")@);
@@ -1447,13 +1413,9 @@ pub proof fn lemma_resource_create_request_msg_implies_key_in_reconcile_equals(
                 cr_key.name + new_strlit("-default-user")@ != key.name + new_strlit("-erlang-cookie")@,
                 {
                     let str1 = cr_key.name + new_strlit("-default-user")@;
-                    let str2 = key.name + new_strlit("-erlang-cookie")@;
                     reveal_strlit("-erlang-cookie");
                     reveal_strlit("-default-user");
-                    if str1.len() == str2.len() {
-                        assert(str1[str1.len() - 1] == 'r');
-                        assert(str2[str1.len() - 1] == 'e');
-                    }
+                    assert(str1[str1.len() - 1] == 'r');
                 }
             );
             // Then we show that only if cr_key.name equals key.name, can this message be created in this step.
@@ -1464,13 +1426,9 @@ pub proof fn lemma_resource_create_request_msg_implies_key_in_reconcile_equals(
                 key.name + new_strlit("-default-user")@ != cr_key.name + new_strlit("-erlang-cookie")@,
                 {
                     let str1 = key.name + new_strlit("-default-user")@;
-                    let str2 = cr_key.name + new_strlit("-erlang-cookie")@;
                     reveal_strlit("-erlang-cookie");
                     reveal_strlit("-default-user");
-                    if str1.len() == str2.len() {
-                        assert(str1[str1.len() - 1] == 'r');
-                        assert(str2[str1.len() - 1] == 'e');
-                    }
+                    assert(str1[str1.len() - 1] == 'r');
                 }
             );
             seq_lib::seq_equal_preserved_by_add(key.name, cr_key.name, new_strlit("-default-user")@);
@@ -1480,13 +1438,9 @@ pub proof fn lemma_resource_create_request_msg_implies_key_in_reconcile_equals(
                 key.name + new_strlit("-nodes")@ != cr_key.name + new_strlit("-client")@,
                 {
                     let str1 = key.name + new_strlit("-nodes")@;
-                    let str2 = cr_key.name + new_strlit("-client")@;
                     reveal_strlit("-client");
                     reveal_strlit("-nodes");
-                    if str1.len() == str2.len() {
-                        assert(str1[str1.len() - 1] == 's');
-                        assert(str2[str1.len() - 1] == 't');
-                    }
+                    assert(str1[str1.len() - 1] == 's');
                 }
             );
             seq_lib::seq_equal_preserved_by_add(key.name, cr_key.name, new_strlit("-nodes")@);
@@ -1496,13 +1450,9 @@ pub proof fn lemma_resource_create_request_msg_implies_key_in_reconcile_equals(
                 cr_key.name + new_strlit("-nodes")@ != key.name + new_strlit("-client")@,
                 {
                     let str1 = cr_key.name + new_strlit("-nodes")@;
-                    let str2 = key.name + new_strlit("-client")@;
                     reveal_strlit("-client");
                     reveal_strlit("-nodes");
-                    if str1.len() == str2.len() {
-                        assert(str1[str1.len() - 1] == 's');
-                        assert(str2[str1.len() - 1] == 't');
-                    }
+                    assert(str1[str1.len() - 1] == 's');
                 }
             );
             seq_lib::seq_equal_preserved_by_add(key.name, cr_key.name, new_strlit("-client")@);

--- a/src/controller_examples/rabbitmq_controller/proof/helper_invariants/proof.rs
+++ b/src/controller_examples/rabbitmq_controller/proof/helper_invariants/proof.rs
@@ -1592,7 +1592,6 @@ proof fn lemma_eventually_always_no_delete_resource_request_msg_in_flight(
         &&& RMQCluster::desired_state_is(rabbitmq)(s)
         &&& resource_object_only_has_owner_reference_pointing_to_current_cr(sub_resource, rabbitmq)(s)
         &&& resource_well_formed(s)
-        // &&& RMQCluster::each_object_in_etcd_is_well_formed()(s)
     };
     always_weaken(spec, RMQCluster::each_object_in_etcd_is_well_formed(), resource_well_formed);
     assert forall |s: RMQCluster, s_prime: RMQCluster| #[trigger] stronger_next(s, s_prime) implies RMQCluster::every_new_req_msg_if_in_flight_then_satisfies(requirements)(s, s_prime) by {

--- a/src/controller_examples/rabbitmq_controller/proof/helper_invariants/proof.rs
+++ b/src/controller_examples/rabbitmq_controller/proof/helper_invariants/proof.rs
@@ -437,8 +437,6 @@ pub proof fn lemma_eventually_always_object_in_response_at_after_update_resource
             );
 
             assert forall |msg: RMQMessage| #[trigger] s_prime.in_flight().contains(msg) && Message::resp_msg_matches_req_msg(msg, pending_req) implies resource_update_response_msg(resource_key, s_prime)(msg) by {
-                assert(msg.src.is_KubernetesAPI());
-                assert(msg.content.is_update_response());
                 if msg.content.get_update_response().res.is_Ok() {
                     let step = choose |step| RMQCluster::next_step(s, s_prime, step);
                     match step {
@@ -455,19 +453,18 @@ pub proof fn lemma_eventually_always_object_in_response_at_after_update_resource
                                         assert(s.ongoing_reconciles()[key] == s_prime.ongoing_reconciles()[key]);
                                         assert(!s.in_flight().contains(pending_req));
                                     }
-                                }
+                                },
                                 _ => {
                                     assert(s.in_flight().contains(msg));
                                     assert(s.ongoing_reconciles()[key] == s_prime.ongoing_reconciles()[key]);
                                     assert(!s.in_flight().contains(pending_req));
-                                }
+                                },
                             }
                         },
                         _ => {
                             assert(s.in_flight().contains(msg));
                             assert(s.ongoing_reconciles()[key] == s_prime.ongoing_reconciles()[key]);
-                            assert(!s.in_flight().contains(pending_req));
-                        }
+                        },
                     }
                 }
             }
@@ -634,7 +631,7 @@ pub proof fn lemma_eventually_always_every_resource_update_request_implies_at_af
             if resource_update_request_msg(resource_key)(msg) {
                 let step = choose |step| RMQCluster::next_step(s, s_prime, step);
                 if !s.in_flight().contains(msg) {
-                    lemma_resource_create_or_update_request_msg_implies_key_in_reconcile_equals(sub_resource, rabbitmq, s, s_prime, msg, step);
+                    lemma_resource_update_request_msg_implies_key_in_reconcile_equals(sub_resource, rabbitmq, s, s_prime, msg, step);
                     let resp = step.get_ControllerStep_0().0.get_Some_0();
                     assert(RMQCluster::is_ok_get_response_msg()(resp));
                     assert(s.in_flight().contains(resp));
@@ -747,7 +744,7 @@ pub proof fn lemma_eventually_always_object_in_every_resource_update_request_onl
             if resource_update_request_msg(resource_key)(msg) {
                 let step = choose |step| RMQCluster::next_step(s, s_prime, step);
                 if !s.in_flight().contains(msg) {
-                    lemma_resource_create_or_update_request_msg_implies_key_in_reconcile_equals(sub_resource, rabbitmq, s, s_prime, msg, step);
+                    lemma_resource_update_request_msg_implies_key_in_reconcile_equals(sub_resource, rabbitmq, s, s_prime, msg, step);
                 } else {
                     assert(requirements(msg, s));
                     assert(s.ongoing_reconciles()[key] == s_prime.ongoing_reconciles()[key]);
@@ -840,7 +837,7 @@ pub proof fn lemma_eventually_always_every_resource_create_request_implies_at_af
             if resource_create_request_msg(resource_key)(msg) {
                 let step = choose |step| RMQCluster::next_step(s, s_prime, step);
                 if !s.in_flight().contains(msg) {
-                    lemma_resource_create_or_update_request_msg_implies_key_in_reconcile_equals(sub_resource, rabbitmq, s, s_prime, msg, step);
+                    lemma_resource_create_request_msg_implies_key_in_reconcile_equals(sub_resource, rabbitmq, s, s_prime, msg, step);
                 } else {
                     assert(requirements(msg, s));
                     assert(s.ongoing_reconciles()[key] == s_prime.ongoing_reconciles()[key]);
@@ -1142,9 +1139,9 @@ proof fn lemma_always_resource_object_create_or_update_request_msg_has_one_contr
         assert forall |msg| #[trigger] s_prime.in_flight().contains(msg) implies update_msg_pred(msg) && create_msg_pred(msg) by {
             if !s.in_flight().contains(msg) {
                 let step = choose |step| RMQCluster::next_step(s, s_prime, step);
-                lemma_resource_create_or_update_request_msg_implies_key_in_reconcile_equals(sub_resource, rabbitmq, s, s_prime, msg, step);
                 let cr = s.ongoing_reconciles()[key].triggering_cr;
                 if resource_create_request_msg(resource_key)(msg) {
+                    lemma_resource_create_request_msg_implies_key_in_reconcile_equals(sub_resource, rabbitmq, s, s_prime, msg, step);
                     assert(msg.content.get_create_request().obj == make(sub_resource, cr, s.ongoing_reconciles()[key].local_state).get_Ok_0());
                     assert(msg.content.get_create_request().obj.metadata.finalizers.is_None());
                     assert(msg.content.get_create_request().obj.metadata.owner_references == Some(seq![
@@ -1152,6 +1149,7 @@ proof fn lemma_always_resource_object_create_or_update_request_msg_has_one_contr
                     ]));
                 }
                 if resource_update_request_msg(resource_key)(msg) {
+                    lemma_resource_update_request_msg_implies_key_in_reconcile_equals(sub_resource, rabbitmq, s, s_prime, msg, step);
                     assert(step.get_ControllerStep_0().0.get_Some_0().content.is_get_response());
                     assert(step.get_ControllerStep_0().0.get_Some_0().content.get_get_response().res.is_Ok());
                     assert(update(
@@ -1178,24 +1176,20 @@ proof fn lemma_always_resource_object_create_or_update_request_msg_has_one_contr
 ///
 /// Tips: Talking about both s and s_prime give more information to those using this lemma and also makes the verification faster.
 #[verifier(spinoff_prover)]
-pub proof fn lemma_resource_create_or_update_request_msg_implies_key_in_reconcile_equals(
+pub proof fn lemma_resource_update_request_msg_implies_key_in_reconcile_equals(
     sub_resource: SubResource, rabbitmq: RabbitmqClusterView, s: RMQCluster, s_prime: RMQCluster, msg: RMQMessage, step: RMQStep
 )
     requires
         !s.in_flight().contains(msg), s_prime.in_flight().contains(msg),
         RMQCluster::next_step(s, s_prime, step),
         RMQCluster::each_object_in_reconcile_has_consistent_key_and_valid_metadata()(s),
+        resource_update_request_msg(get_request(sub_resource, rabbitmq).key)(msg),
     ensures
-        resource_create_request_msg(get_request(sub_resource, rabbitmq).key)(msg)
-        ==> step.is_ControllerStep() && step.get_ControllerStep_0().1.get_Some_0() == rabbitmq.object_ref()
-            && at_rabbitmq_step(rabbitmq.object_ref(), RabbitmqReconcileStep::AfterKRequestStep(ActionKind::Get, sub_resource))(s)
-            && at_rabbitmq_step(rabbitmq.object_ref(), RabbitmqReconcileStep::AfterKRequestStep(ActionKind::Create, sub_resource))(s_prime)
-            && RMQCluster::pending_k8s_api_req_msg_is(s_prime, rabbitmq.object_ref(), msg),
-        resource_update_request_msg(get_request(sub_resource, rabbitmq).key)(msg)
-        ==> step.is_ControllerStep() && step.get_ControllerStep_0().1.get_Some_0() == rabbitmq.object_ref()
-            && at_rabbitmq_step(rabbitmq.object_ref(), RabbitmqReconcileStep::AfterKRequestStep(ActionKind::Get, sub_resource))(s)
-            && at_rabbitmq_step(rabbitmq.object_ref(), RabbitmqReconcileStep::AfterKRequestStep(ActionKind::Update, sub_resource))(s_prime)
-            && RMQCluster::pending_k8s_api_req_msg_is(s_prime, rabbitmq.object_ref(), msg),
+        step.is_ControllerStep(),
+        step.get_ControllerStep_0().1.get_Some_0() == rabbitmq.object_ref(),
+        at_rabbitmq_step(rabbitmq.object_ref(), RabbitmqReconcileStep::AfterKRequestStep(ActionKind::Get, sub_resource))(s),
+        at_rabbitmq_step(rabbitmq.object_ref(), RabbitmqReconcileStep::AfterKRequestStep(ActionKind::Update, sub_resource))(s_prime),
+        RMQCluster::pending_k8s_api_req_msg_is(s_prime, rabbitmq.object_ref(), msg),
 {
     // Since we know that this step creates a create server config map message, it is easy to see that it's a controller action.
     // This action creates a config map, and there are two kinds of config maps, we have to show that only server config map
@@ -1204,134 +1198,264 @@ pub proof fn lemma_resource_create_or_update_request_msg_implies_key_in_reconcil
     let key = rabbitmq.object_ref();
     let cr = s.ongoing_reconciles()[key].triggering_cr;
     let resource_key = get_request(sub_resource, rabbitmq).key;
-    if resource_create_request_msg(get_request(sub_resource, rabbitmq).key)(msg) || resource_update_request_msg(get_request(sub_resource, rabbitmq).key)(msg) {
-        assert(step.is_ControllerStep());
-        assert(s.ongoing_reconciles().contains_key(cr_key));
-        let local_step = s.ongoing_reconciles()[cr_key].local_state.reconcile_step;
-        let local_step_prime = s_prime.ongoing_reconciles()[cr_key].local_state.reconcile_step;
-        assert(local_step_prime.is_AfterKRequestStep());
-        assert(local_step.is_AfterKRequestStep() && local_step.get_AfterKRequestStep_0() == ActionKind::Get);
-        if resource_create_request_msg(get_request(sub_resource, rabbitmq).key)(msg) {
-            assert(local_step_prime.get_AfterKRequestStep_0() == ActionKind::Create);
-        }
-        if resource_update_request_msg(get_request(sub_resource, rabbitmq).key)(msg) {
-            assert(local_step_prime.get_AfterKRequestStep_0() == ActionKind::Update);
-        }
-        assert_by(
-            cr_key == rabbitmq.object_ref() && local_step.get_AfterKRequestStep_1() == sub_resource && RMQCluster::pending_k8s_api_req_msg_is(s_prime, cr_key, msg),
-            {
-                // It's easy for the verifier to know that cr_key has the same kind and namespace as key.
-                match sub_resource {
-                    SubResource::ServerConfigMap => {
-                        // resource_create_request_msg(key)(msg) requires the msg has a key with name key.name "-server-conf". So we
-                        // first show that in this action, cr_key is only possible to add "-server-conf" rather than "-plugins-conf" to reach
-                        // such a post state.
-                        assert_by(
-                            cr_key.name + new_strlit("-plugins-conf")@ != key.name + new_strlit("-server-conf")@,
-                            {
-                                let str1 = cr_key.name + new_strlit("-plugins-conf")@;
-                                let str2 = key.name + new_strlit("-server-conf")@;
-                                reveal_strlit("-server-conf");
-                                reveal_strlit("-plugins-conf");
-                                if str1.len() == str2.len() {
-                                    assert(str1[str1.len() - 6] == 's');
-                                    assert(str2[str1.len() - 6] == 'r');
-                                }
-                            }
-                        );
-                        // Then we show that only if cr_key.name equals key.name, can this message be created in this step.
-                        seq_lib::seq_equal_preserved_by_add(key.name, cr_key.name, new_strlit("-server-conf")@);
-                    },
-                    SubResource::PluginsConfigMap => {
-                        assert_by(
-                            key.name + new_strlit("-plugins-conf")@ != cr_key.name + new_strlit("-server-conf")@,
-                            {
-                                let str1 = key.name + new_strlit("-plugins-conf")@;
-                                let str2 = cr_key.name + new_strlit("-server-conf")@;
-                                reveal_strlit("-server-conf");
-                                reveal_strlit("-plugins-conf");
-                                if str1.len() == str2.len() {
-                                    assert(str1[str1.len() - 6] == 's');
-                                    assert(str2[str1.len() - 6] == 'r');
-                                }
-                            }
-                        );
-                        seq_lib::seq_equal_preserved_by_add(key.name, cr_key.name, new_strlit("-plugins-conf")@);
-                    },
-                    SubResource::ErlangCookieSecret => {
-                        assert_by(
-                            cr_key.name + new_strlit("-default-user")@ != key.name + new_strlit("-erlang-cookie")@,
-                            {
-                                let str1 = cr_key.name + new_strlit("-default-user")@;
-                                let str2 = key.name + new_strlit("-erlang-cookie")@;
-                                reveal_strlit("-erlang-cookie");
-                                reveal_strlit("-default-user");
-                                if str1.len() == str2.len() {
-                                    assert(str1[str1.len() - 1] == 'r');
-                                    assert(str2[str1.len() - 1] == 'e');
-                                }
-                            }
-                        );
-                        // Then we show that only if cr_key.name equals key.name, can this message be created in this step.
-                        seq_lib::seq_equal_preserved_by_add(key.name, cr_key.name, new_strlit("-erlang-cookie")@);
-                    },
-                    SubResource::DefaultUserSecret => {
-                        assert_by(
-                            key.name + new_strlit("-default-user")@ != cr_key.name + new_strlit("-erlang-cookie")@,
-                            {
-                                let str1 = key.name + new_strlit("-default-user")@;
-                                let str2 = cr_key.name + new_strlit("-erlang-cookie")@;
-                                reveal_strlit("-erlang-cookie");
-                                reveal_strlit("-default-user");
-                                if str1.len() == str2.len() {
-                                    assert(str1[str1.len() - 1] == 'r');
-                                    assert(str2[str1.len() - 1] == 'e');
-                                }
-                            }
-                        );
-                        seq_lib::seq_equal_preserved_by_add(key.name, cr_key.name, new_strlit("-default-user")@);
-                    },
-                    SubResource::HeadlessService => {
-                        assert_by(
-                            key.name + new_strlit("-nodes")@ != cr_key.name + new_strlit("-client")@,
-                            {
-                                let str1 = key.name + new_strlit("-nodes")@;
-                                let str2 = cr_key.name + new_strlit("-client")@;
-                                reveal_strlit("-client");
-                                reveal_strlit("-nodes");
-                                if str1.len() == str2.len() {
-                                    assert(str1[str1.len() - 1] == 's');
-                                    assert(str2[str1.len() - 1] == 't');
-                                }
-                            }
-                        );
-                        seq_lib::seq_equal_preserved_by_add(key.name, cr_key.name, new_strlit("-nodes")@);
-                    },
-                    SubResource::Service => {
-                        assert_by(
-                            cr_key.name + new_strlit("-nodes")@ != key.name + new_strlit("-client")@,
-                            {
-                                let str1 = cr_key.name + new_strlit("-nodes")@;
-                                let str2 = key.name + new_strlit("-client")@;
-                                reveal_strlit("-client");
-                                reveal_strlit("-nodes");
-                                if str1.len() == str2.len() {
-                                    assert(str1[str1.len() - 1] == 's');
-                                    assert(str2[str1.len() - 1] == 't');
-                                }
-                            }
-                        );
-                        seq_lib::seq_equal_preserved_by_add(key.name, cr_key.name, new_strlit("-client")@);
-                    },
-                    SubResource::RoleBinding | SubResource::ServiceAccount | SubResource::StatefulSet => {
-                        seq_lib::seq_equal_preserved_by_add(key.name, cr_key.name, new_strlit("-server")@);
-                    },
-                    SubResource::Role => {
-                        seq_lib::seq_equal_preserved_by_add(key.name, cr_key.name, new_strlit("-peer-discovery")@);
-                    },
+    // if resource_update_request_msg(get_request(sub_resource, rabbitmq).key)(msg) {
+    assert(step.is_ControllerStep());
+    assert(s.ongoing_reconciles().contains_key(cr_key));
+    let local_step = s.ongoing_reconciles()[cr_key].local_state.reconcile_step;
+    let local_step_prime = s_prime.ongoing_reconciles()[cr_key].local_state.reconcile_step;
+    assert(local_step_prime.is_AfterKRequestStep());
+    assert(local_step.is_AfterKRequestStep() && local_step.get_AfterKRequestStep_0() == ActionKind::Get);
+    // It's easy for the verifier to know that cr_key has the same kind and namespace as key.
+    match sub_resource {
+        SubResource::ServerConfigMap => {
+            // resource_create_request_msg(key)(msg) requires the msg has a key with name key.name "-server-conf". So we
+            // first show that in this action, cr_key is only possible to add "-server-conf" rather than "-plugins-conf" to reach
+            // such a post state.
+            assert_by(
+                cr_key.name + new_strlit("-plugins-conf")@ != key.name + new_strlit("-server-conf")@,
+                {
+                    let str1 = cr_key.name + new_strlit("-plugins-conf")@;
+                    let str2 = key.name + new_strlit("-server-conf")@;
+                    reveal_strlit("-server-conf");
+                    reveal_strlit("-plugins-conf");
+                    if str1.len() == str2.len() {
+                        assert(str1[str1.len() - 6] == 's');
+                        assert(str2[str1.len() - 6] == 'r');
+                    }
                 }
-            }
-        )
+            );
+            // Then we show that only if cr_key.name equals key.name, can this message be created in this step.
+            seq_lib::seq_equal_preserved_by_add(key.name, cr_key.name, new_strlit("-server-conf")@);
+        },
+        SubResource::PluginsConfigMap => {
+            assert_by(
+                key.name + new_strlit("-plugins-conf")@ != cr_key.name + new_strlit("-server-conf")@,
+                {
+                    let str1 = key.name + new_strlit("-plugins-conf")@;
+                    let str2 = cr_key.name + new_strlit("-server-conf")@;
+                    reveal_strlit("-server-conf");
+                    reveal_strlit("-plugins-conf");
+                    if str1.len() == str2.len() {
+                        assert(str1[str1.len() - 6] == 's');
+                        assert(str2[str1.len() - 6] == 'r');
+                    }
+                }
+            );
+            seq_lib::seq_equal_preserved_by_add(key.name, cr_key.name, new_strlit("-plugins-conf")@);
+        },
+        SubResource::ErlangCookieSecret => {
+            assert_by(
+                cr_key.name + new_strlit("-default-user")@ != key.name + new_strlit("-erlang-cookie")@,
+                {
+                    let str1 = cr_key.name + new_strlit("-default-user")@;
+                    let str2 = key.name + new_strlit("-erlang-cookie")@;
+                    reveal_strlit("-erlang-cookie");
+                    reveal_strlit("-default-user");
+                    if str1.len() == str2.len() {
+                        assert(str1[str1.len() - 1] == 'r');
+                        assert(str2[str1.len() - 1] == 'e');
+                    }
+                }
+            );
+            // Then we show that only if cr_key.name equals key.name, can this message be created in this step.
+            seq_lib::seq_equal_preserved_by_add(key.name, cr_key.name, new_strlit("-erlang-cookie")@);
+        },
+        SubResource::DefaultUserSecret => {
+            assert_by(
+                key.name + new_strlit("-default-user")@ != cr_key.name + new_strlit("-erlang-cookie")@,
+                {
+                    let str1 = key.name + new_strlit("-default-user")@;
+                    let str2 = cr_key.name + new_strlit("-erlang-cookie")@;
+                    reveal_strlit("-erlang-cookie");
+                    reveal_strlit("-default-user");
+                    if str1.len() == str2.len() {
+                        assert(str1[str1.len() - 1] == 'r');
+                        assert(str2[str1.len() - 1] == 'e');
+                    }
+                }
+            );
+            seq_lib::seq_equal_preserved_by_add(key.name, cr_key.name, new_strlit("-default-user")@);
+        },
+        SubResource::HeadlessService => {
+            assert_by(
+                key.name + new_strlit("-nodes")@ != cr_key.name + new_strlit("-client")@,
+                {
+                    let str1 = key.name + new_strlit("-nodes")@;
+                    let str2 = cr_key.name + new_strlit("-client")@;
+                    reveal_strlit("-client");
+                    reveal_strlit("-nodes");
+                    if str1.len() == str2.len() {
+                        assert(str1[str1.len() - 1] == 's');
+                        assert(str2[str1.len() - 1] == 't');
+                    }
+                }
+            );
+            seq_lib::seq_equal_preserved_by_add(key.name, cr_key.name, new_strlit("-nodes")@);
+        },
+        SubResource::Service => {
+            assert_by(
+                cr_key.name + new_strlit("-nodes")@ != key.name + new_strlit("-client")@,
+                {
+                    let str1 = cr_key.name + new_strlit("-nodes")@;
+                    let str2 = key.name + new_strlit("-client")@;
+                    reveal_strlit("-client");
+                    reveal_strlit("-nodes");
+                    if str1.len() == str2.len() {
+                        assert(str1[str1.len() - 1] == 's');
+                        assert(str2[str1.len() - 1] == 't');
+                    }
+                }
+            );
+            seq_lib::seq_equal_preserved_by_add(key.name, cr_key.name, new_strlit("-client")@);
+        },
+        SubResource::RoleBinding | SubResource::ServiceAccount | SubResource::StatefulSet => {
+            seq_lib::seq_equal_preserved_by_add(key.name, cr_key.name, new_strlit("-server")@);
+        },
+        SubResource::Role => {
+            seq_lib::seq_equal_preserved_by_add(key.name, cr_key.name, new_strlit("-peer-discovery")@);
+        },
+    }
+}
+
+#[verifier(spinoff_prover)]
+pub proof fn lemma_resource_create_request_msg_implies_key_in_reconcile_equals(
+    sub_resource: SubResource, rabbitmq: RabbitmqClusterView, s: RMQCluster, s_prime: RMQCluster, msg: RMQMessage, step: RMQStep
+)
+    requires
+        !s.in_flight().contains(msg), s_prime.in_flight().contains(msg),
+        RMQCluster::next_step(s, s_prime, step),
+        RMQCluster::each_object_in_reconcile_has_consistent_key_and_valid_metadata()(s),
+        resource_create_request_msg(get_request(sub_resource, rabbitmq).key)(msg),
+    ensures
+        step.is_ControllerStep(),
+        step.get_ControllerStep_0().1.get_Some_0() == rabbitmq.object_ref(),
+        at_rabbitmq_step(rabbitmq.object_ref(), RabbitmqReconcileStep::AfterKRequestStep(ActionKind::Get, sub_resource))(s),
+        at_rabbitmq_step(rabbitmq.object_ref(), RabbitmqReconcileStep::AfterKRequestStep(ActionKind::Create, sub_resource))(s_prime),
+        RMQCluster::pending_k8s_api_req_msg_is(s_prime, rabbitmq.object_ref(), msg),
+{
+    // Since we know that this step creates a create server config map message, it is easy to see that it's a controller action.
+    // This action creates a config map, and there are two kinds of config maps, we have to show that only server config map
+    // is possible by extra reasoning about the strings.
+    let cr_key = step.get_ControllerStep_0().1.get_Some_0();
+    let key = rabbitmq.object_ref();
+    let cr = s.ongoing_reconciles()[key].triggering_cr;
+    let resource_key = get_request(sub_resource, rabbitmq).key;
+    // if resource_update_request_msg(get_request(sub_resource, rabbitmq).key)(msg) {
+    assert(step.is_ControllerStep());
+    assert(s.ongoing_reconciles().contains_key(cr_key));
+    let local_step = s.ongoing_reconciles()[cr_key].local_state.reconcile_step;
+    let local_step_prime = s_prime.ongoing_reconciles()[cr_key].local_state.reconcile_step;
+    assert(local_step_prime.is_AfterKRequestStep());
+    assert(local_step.is_AfterKRequestStep() && local_step.get_AfterKRequestStep_0() == ActionKind::Get);
+    // It's easy for the verifier to know that cr_key has the same kind and namespace as key.
+    match sub_resource {
+        SubResource::ServerConfigMap => {
+            // resource_create_request_msg(key)(msg) requires the msg has a key with name key.name "-server-conf". So we
+            // first show that in this action, cr_key is only possible to add "-server-conf" rather than "-plugins-conf" to reach
+            // such a post state.
+            assert_by(
+                cr_key.name + new_strlit("-plugins-conf")@ != key.name + new_strlit("-server-conf")@,
+                {
+                    let str1 = cr_key.name + new_strlit("-plugins-conf")@;
+                    let str2 = key.name + new_strlit("-server-conf")@;
+                    reveal_strlit("-server-conf");
+                    reveal_strlit("-plugins-conf");
+                    if str1.len() == str2.len() {
+                        assert(str1[str1.len() - 6] == 's');
+                        assert(str2[str1.len() - 6] == 'r');
+                    }
+                }
+            );
+            // Then we show that only if cr_key.name equals key.name, can this message be created in this step.
+            seq_lib::seq_equal_preserved_by_add(key.name, cr_key.name, new_strlit("-server-conf")@);
+        },
+        SubResource::PluginsConfigMap => {
+            assert_by(
+                key.name + new_strlit("-plugins-conf")@ != cr_key.name + new_strlit("-server-conf")@,
+                {
+                    let str1 = key.name + new_strlit("-plugins-conf")@;
+                    let str2 = cr_key.name + new_strlit("-server-conf")@;
+                    reveal_strlit("-server-conf");
+                    reveal_strlit("-plugins-conf");
+                    if str1.len() == str2.len() {
+                        assert(str1[str1.len() - 6] == 's');
+                        assert(str2[str1.len() - 6] == 'r');
+                    }
+                }
+            );
+            seq_lib::seq_equal_preserved_by_add(key.name, cr_key.name, new_strlit("-plugins-conf")@);
+        },
+        SubResource::ErlangCookieSecret => {
+            assert_by(
+                cr_key.name + new_strlit("-default-user")@ != key.name + new_strlit("-erlang-cookie")@,
+                {
+                    let str1 = cr_key.name + new_strlit("-default-user")@;
+                    let str2 = key.name + new_strlit("-erlang-cookie")@;
+                    reveal_strlit("-erlang-cookie");
+                    reveal_strlit("-default-user");
+                    if str1.len() == str2.len() {
+                        assert(str1[str1.len() - 1] == 'r');
+                        assert(str2[str1.len() - 1] == 'e');
+                    }
+                }
+            );
+            // Then we show that only if cr_key.name equals key.name, can this message be created in this step.
+            seq_lib::seq_equal_preserved_by_add(key.name, cr_key.name, new_strlit("-erlang-cookie")@);
+        },
+        SubResource::DefaultUserSecret => {
+            assert_by(
+                key.name + new_strlit("-default-user")@ != cr_key.name + new_strlit("-erlang-cookie")@,
+                {
+                    let str1 = key.name + new_strlit("-default-user")@;
+                    let str2 = cr_key.name + new_strlit("-erlang-cookie")@;
+                    reveal_strlit("-erlang-cookie");
+                    reveal_strlit("-default-user");
+                    if str1.len() == str2.len() {
+                        assert(str1[str1.len() - 1] == 'r');
+                        assert(str2[str1.len() - 1] == 'e');
+                    }
+                }
+            );
+            seq_lib::seq_equal_preserved_by_add(key.name, cr_key.name, new_strlit("-default-user")@);
+        },
+        SubResource::HeadlessService => {
+            assert_by(
+                key.name + new_strlit("-nodes")@ != cr_key.name + new_strlit("-client")@,
+                {
+                    let str1 = key.name + new_strlit("-nodes")@;
+                    let str2 = cr_key.name + new_strlit("-client")@;
+                    reveal_strlit("-client");
+                    reveal_strlit("-nodes");
+                    if str1.len() == str2.len() {
+                        assert(str1[str1.len() - 1] == 's');
+                        assert(str2[str1.len() - 1] == 't');
+                    }
+                }
+            );
+            seq_lib::seq_equal_preserved_by_add(key.name, cr_key.name, new_strlit("-nodes")@);
+        },
+        SubResource::Service => {
+            assert_by(
+                cr_key.name + new_strlit("-nodes")@ != key.name + new_strlit("-client")@,
+                {
+                    let str1 = cr_key.name + new_strlit("-nodes")@;
+                    let str2 = key.name + new_strlit("-client")@;
+                    reveal_strlit("-client");
+                    reveal_strlit("-nodes");
+                    if str1.len() == str2.len() {
+                        assert(str1[str1.len() - 1] == 's');
+                        assert(str2[str1.len() - 1] == 't');
+                    }
+                }
+            );
+            seq_lib::seq_equal_preserved_by_add(key.name, cr_key.name, new_strlit("-client")@);
+        },
+        SubResource::RoleBinding | SubResource::ServiceAccount | SubResource::StatefulSet => {
+            seq_lib::seq_equal_preserved_by_add(key.name, cr_key.name, new_strlit("-server")@);
+        },
+        SubResource::Role => {
+            seq_lib::seq_equal_preserved_by_add(key.name, cr_key.name, new_strlit("-peer-discovery")@);
+        },
     }
 }
 

--- a/src/controller_examples/rabbitmq_controller/proof/helper_invariants/proof.rs
+++ b/src/controller_examples/rabbitmq_controller/proof/helper_invariants/proof.rs
@@ -44,7 +44,7 @@ pub proof fn lemma_always_rabbitmq_is_well_formed(spec: TempPred<RMQCluster>, ra
     );
 }
 
-pub proof fn lemma_always_cr_objects_in_etcd_satisfy_state_validation(spec: TempPred<RMQCluster>)
+proof fn lemma_always_cr_objects_in_etcd_satisfy_state_validation(spec: TempPred<RMQCluster>)
     requires
         spec.entails(lift_state(RMQCluster::init())),
         spec.entails(always(lift_action(RMQCluster::next()))),
@@ -56,7 +56,7 @@ pub proof fn lemma_always_cr_objects_in_etcd_satisfy_state_validation(spec: Temp
     init_invariant(spec, RMQCluster::init(), RMQCluster::next(), inv);
 }
 
-pub proof fn lemma_always_the_object_in_schedule_satisfies_state_validation(spec: TempPred<RMQCluster>)
+proof fn lemma_always_the_object_in_schedule_satisfies_state_validation(spec: TempPred<RMQCluster>)
     requires
         spec.entails(lift_state(RMQCluster::init())),
         spec.entails(always(lift_action(RMQCluster::next()))),
@@ -120,7 +120,7 @@ pub proof fn lemma_eventually_always_cm_rv_is_the_same_as_etcd_server_cm_if_cm_u
 }
 
 #[verifier(spinoff_prover)]
-pub proof fn lemma_eventually_always_cm_rv_is_the_same_as_etcd_server_cm_if_cm_updated(spec: TempPred<RMQCluster>, rabbitmq: RabbitmqClusterView)
+proof fn lemma_eventually_always_cm_rv_is_the_same_as_etcd_server_cm_if_cm_updated(spec: TempPred<RMQCluster>, rabbitmq: RabbitmqClusterView)
     requires
         spec.entails(always(lift_action(RMQCluster::next()))),
         spec.entails(always(lift_state(RMQCluster::each_object_in_reconcile_has_consistent_key_and_valid_metadata()))),
@@ -194,7 +194,7 @@ pub proof fn lemma_eventually_always_object_in_response_at_after_create_resource
 }
 
 #[verifier(spinoff_prover)]
-pub proof fn lemma_eventually_always_object_in_response_at_after_create_resource_step_is_same_as_etcd(
+proof fn lemma_eventually_always_object_in_response_at_after_create_resource_step_is_same_as_etcd(
     spec: TempPred<RMQCluster>, rabbitmq: RabbitmqClusterView
 )
     requires
@@ -376,7 +376,7 @@ pub proof fn lemma_eventually_always_object_in_response_at_after_update_resource
 }
 
 #[verifier(spinoff_prover)]
-pub proof fn lemma_eventually_always_object_in_response_at_after_update_resource_step_is_same_as_etcd(
+proof fn lemma_eventually_always_object_in_response_at_after_update_resource_step_is_same_as_etcd(
     spec: TempPred<RMQCluster>, rabbitmq: RabbitmqClusterView
 )
     requires
@@ -620,7 +620,7 @@ pub proof fn lemma_eventually_always_every_resource_update_request_implies_at_af
 }
 
 #[verifier(spinoff_prover)]
-pub proof fn lemma_eventually_always_every_resource_update_request_implies_at_after_update_resource_step(
+proof fn lemma_eventually_always_every_resource_update_request_implies_at_after_update_resource_step(
     spec: TempPred<RMQCluster>, sub_resource: SubResource, rabbitmq: RabbitmqClusterView
 )
     requires
@@ -760,7 +760,7 @@ pub proof fn lemma_eventually_always_object_in_every_resource_update_request_onl
 }
 
 #[verifier(spinoff_prover)]
-pub proof fn lemma_eventually_always_object_in_every_resource_update_request_only_has_owner_references_pointing_to_current_cr(
+proof fn lemma_eventually_always_object_in_every_resource_update_request_only_has_owner_references_pointing_to_current_cr(
     spec: TempPred<RMQCluster>, sub_resource: SubResource, rabbitmq: RabbitmqClusterView
 )
     requires
@@ -850,7 +850,7 @@ pub proof fn lemma_eventually_always_every_resource_create_request_implies_at_af
 }
 
 #[verifier(spinoff_prover)]
-pub proof fn lemma_eventually_always_every_resource_create_request_implies_at_after_create_resource_step(
+proof fn lemma_eventually_always_every_resource_create_request_implies_at_after_create_resource_step(
     spec: TempPred<RMQCluster>, sub_resource: SubResource, rabbitmq: RabbitmqClusterView
 )
     requires
@@ -1673,7 +1673,7 @@ pub proof fn lemma_eventually_always_resource_object_only_has_owner_reference_po
 }
 
 #[verifier(spinoff_prover)]
-pub proof fn lemma_eventually_always_resource_object_only_has_owner_reference_pointing_to_current_cr(
+proof fn lemma_eventually_always_resource_object_only_has_owner_reference_pointing_to_current_cr(
     spec: TempPred<RMQCluster>, sub_resource: SubResource, rabbitmq: RabbitmqClusterView
 )
     requires

--- a/src/controller_examples/rabbitmq_controller/proof/helper_invariants/unchangeable.rs
+++ b/src/controller_examples/rabbitmq_controller/proof/helper_invariants/unchangeable.rs
@@ -86,7 +86,7 @@ proof fn lemma_always_object_in_every_create_request_msg_satisfies_unchangeable(
         implies unchangeable(sub_resource, msg.content.get_create_request().obj, rabbitmq) by {
             if !s.in_flight().contains(msg) {
                 let step = choose |step| RMQCluster::next_step(s, s_prime, step);
-                lemma_resource_create_or_update_request_msg_implies_key_in_reconcile_equals(sub_resource, rabbitmq, s, s_prime, msg, step);
+                lemma_resource_create_request_msg_implies_key_in_reconcile_equals(sub_resource, rabbitmq, s, s_prime, msg, step);
                 match sub_resource {
                     SubResource::ErlangCookieSecret => {
                         SecretView::marshal_preserves_integrity();
@@ -247,7 +247,7 @@ pub proof fn object_in_every_update_request_msg_satisfies_unchangeable_induction
             assert(unchangeable(sub_resource, msg.content.get_update_request().obj, rabbitmq));
         } else {
             let step = choose |step| RMQCluster::next_step(s, s_prime, step);
-            lemma_resource_create_or_update_request_msg_implies_key_in_reconcile_equals(sub_resource, rabbitmq, s, s_prime, msg, step);
+            lemma_resource_update_request_msg_implies_key_in_reconcile_equals(sub_resource, rabbitmq, s, s_prime, msg, step);
             match sub_resource {
                 SubResource::ErlangCookieSecret => {
                     SecretView::marshal_preserves_integrity();

--- a/src/controller_examples/rabbitmq_controller/proof/helper_invariants/validation.rs
+++ b/src/controller_examples/rabbitmq_controller/proof/helper_invariants/validation.rs
@@ -182,7 +182,7 @@ pub proof fn lemma_always_stateful_set_update_request_msg_does_not_change_owner_
                     assert(msg.content.get_update_request().obj.metadata.resource_version.get_Some_0() < s_prime.resources()[sts_key].metadata.resource_version.get_Some_0());
                 }
             } else if resource_update_request_msg(sts_key)(msg) {
-                lemma_resource_create_or_update_request_msg_implies_key_in_reconcile_equals(SubResource::StatefulSet, rabbitmq, s, s_prime, msg, step);
+                lemma_resource_update_request_msg_implies_key_in_reconcile_equals(SubResource::StatefulSet, rabbitmq, s, s_prime, msg, step);
             }
         }
     }
@@ -244,7 +244,7 @@ pub proof fn lemma_always_object_in_resource_update_request_msg_has_smaller_rv_t
             if s.in_flight().contains(msg) {
                 assert(s.kubernetes_api_state.resource_version_counter <= s_prime.kubernetes_api_state.resource_version_counter);
             } else if resource_update_request_msg(sts_key)(msg) {
-                lemma_resource_create_or_update_request_msg_implies_key_in_reconcile_equals(sub_resource, rabbitmq, s, s_prime, msg, step);
+                lemma_resource_update_request_msg_implies_key_in_reconcile_equals(sub_resource, rabbitmq, s, s_prime, msg, step);
             }
         }
     }
@@ -321,7 +321,7 @@ proof fn lemma_always_stateful_set_in_create_request_msg_satisfies_unchangeable(
                     if !s.in_flight().contains(msg) {
                         StatefulSetView::marshal_preserves_integrity();
                         StatefulSetView::marshal_spec_preserves_integrity();
-                        lemma_resource_create_or_update_request_msg_implies_key_in_reconcile_equals(sts_res, rabbitmq, s, s_prime, msg, step);
+                        lemma_resource_create_request_msg_implies_key_in_reconcile_equals(sts_res, rabbitmq, s, s_prime, msg, step);
                         let triggering_cr = s.ongoing_reconciles()[key].triggering_cr;
                         let etcd_cr = RabbitmqClusterView::unmarshal(s_prime.resources()[key]).get_Ok_0();
                         assert(msg.content.get_create_request().obj.metadata.owner_references_only_contains(triggering_cr.controller_owner_ref()));

--- a/src/controller_examples/rabbitmq_controller/proof/safety/safety.rs
+++ b/src/controller_examples/rabbitmq_controller/proof/safety/safety.rs
@@ -165,7 +165,7 @@ proof fn lemma_always_replicas_of_stateful_set_update_request_msg_is_no_smaller_
             } else {
                 StatefulSetView::marshal_preserves_integrity();
                 StatefulSetView::marshal_spec_preserves_integrity();
-                lemma_resource_create_or_update_request_msg_implies_key_in_reconcile_equals(SubResource::StatefulSet, rabbitmq, s, s_prime, msg, step);
+                lemma_resource_update_request_msg_implies_key_in_reconcile_equals(SubResource::StatefulSet, rabbitmq, s, s_prime, msg, step);
             }
         }
     }
@@ -367,7 +367,7 @@ proof fn replicas_of_stateful_set_create_request_msg_satisfies_order_induction(
             if !s.in_flight().contains(msg) {
                 StatefulSetView::marshal_preserves_integrity();
                 StatefulSetView::marshal_spec_preserves_integrity();
-                lemma_resource_create_or_update_request_msg_implies_key_in_reconcile_equals(SubResource::StatefulSet, rabbitmq, s, s_prime, msg, step);
+                lemma_resource_create_request_msg_implies_key_in_reconcile_equals(SubResource::StatefulSet, rabbitmq, s, s_prime, msg, step);
             }
         },
         _ => {
@@ -419,7 +419,7 @@ proof fn replicas_of_stateful_set_update_request_msg_satisfies_order_induction(
             if !s.in_flight().contains(msg) {
                 StatefulSetView::marshal_preserves_integrity();
                 StatefulSetView::marshal_spec_preserves_integrity();
-                lemma_resource_create_or_update_request_msg_implies_key_in_reconcile_equals(SubResource::StatefulSet, rabbitmq, s, s_prime, msg, step);
+                lemma_resource_update_request_msg_implies_key_in_reconcile_equals(SubResource::StatefulSet, rabbitmq, s, s_prime, msg, step);
             }
         },
         _ => {

--- a/src/kubernetes_cluster/proof/message.rs
+++ b/src/kubernetes_cluster/proof/message.rs
@@ -421,16 +421,13 @@ pub proof fn lemma_always_object_in_ok_get_response_has_smaller_rv_than_etcd(spe
         &&& Self::next()(s, s_prime)
         &&& Self::each_object_in_etcd_is_well_formed()(s)
         &&& Self::each_object_in_etcd_is_well_formed()(s_prime)
-        &&& Self::each_object_in_reconcile_has_consistent_key_and_valid_metadata()(s)
     };
     Self::lemma_always_each_object_in_etcd_is_well_formed(spec);
     always_to_always_later(spec, lift_state(Self::each_object_in_etcd_is_well_formed()));
-    Self::lemma_always_each_object_in_reconcile_has_consistent_key_and_valid_metadata(spec);
     combine_spec_entails_always_n!(
         spec, lift_action(next), lift_action(Self::next()),
         lift_state(Self::each_object_in_etcd_is_well_formed()),
-        later(lift_state(Self::each_object_in_etcd_is_well_formed())),
-        lift_state(Self::each_object_in_reconcile_has_consistent_key_and_valid_metadata())
+        later(lift_state(Self::each_object_in_etcd_is_well_formed()))
     );
     assert forall |s, s_prime| inv(s) && #[trigger] next(s, s_prime) implies inv(s_prime) by {
         assert forall |msg| #[trigger] s_prime.in_flight().contains(msg) && Self::is_ok_get_response_msg()(msg) implies
@@ -559,19 +556,16 @@ pub proof fn lemma_always_key_of_object_in_matched_ok_get_resp_message_is_same_a
         &&& Self::each_object_in_etcd_is_well_formed()(s)
         &&& Self::every_in_flight_msg_has_lower_id_than_allocator()(s)
         &&& Self::every_in_flight_or_pending_req_msg_has_unique_id()(s)
-        &&& Self::each_object_in_reconcile_has_consistent_key_and_valid_metadata()(s)
         &&& Self::each_resp_if_matches_pending_req_then_no_other_resp_matches(key)(s)
     };
     Self::lemma_always_each_object_in_etcd_is_well_formed(spec);
     Self::lemma_always_every_in_flight_msg_has_lower_id_than_allocator(spec);
     Self::lemma_always_every_in_flight_or_pending_req_msg_has_unique_id(spec);
-    Self::lemma_always_each_object_in_reconcile_has_consistent_key_and_valid_metadata(spec);
     Self::lemma_always_each_resp_if_matches_pending_req_then_no_other_resp_matches(spec, key);
     combine_spec_entails_always_n!(
         spec, lift_action(next), lift_action(Self::next()), lift_state(Self::each_object_in_etcd_is_well_formed()),
         lift_state(Self::every_in_flight_msg_has_lower_id_than_allocator()),
         lift_state(Self::every_in_flight_or_pending_req_msg_has_unique_id()),
-        lift_state(Self::each_object_in_reconcile_has_consistent_key_and_valid_metadata()),
         lift_state(Self::each_resp_if_matches_pending_req_then_no_other_resp_matches(key))
     );
     assert forall |s, s_prime| inv(s) && #[trigger] next(s, s_prime) implies inv(s_prime) by {
@@ -662,19 +656,16 @@ pub proof fn lemma_always_key_of_object_in_matched_ok_update_resp_message_is_sam
         &&& Self::each_object_in_etcd_is_well_formed()(s)
         &&& Self::every_in_flight_msg_has_lower_id_than_allocator()(s)
         &&& Self::every_in_flight_or_pending_req_msg_has_unique_id()(s)
-        &&& Self::each_object_in_reconcile_has_consistent_key_and_valid_metadata()(s)
         &&& Self::each_resp_if_matches_pending_req_then_no_other_resp_matches(key)(s)
     };
     Self::lemma_always_each_object_in_etcd_is_well_formed(spec);
     Self::lemma_always_every_in_flight_msg_has_lower_id_than_allocator(spec);
     Self::lemma_always_every_in_flight_or_pending_req_msg_has_unique_id(spec);
-    Self::lemma_always_each_object_in_reconcile_has_consistent_key_and_valid_metadata(spec);
     Self::lemma_always_each_resp_if_matches_pending_req_then_no_other_resp_matches(spec, key);
     combine_spec_entails_always_n!(
         spec, lift_action(next), lift_action(Self::next()), lift_state(Self::each_object_in_etcd_is_well_formed()),
         lift_state(Self::every_in_flight_msg_has_lower_id_than_allocator()),
         lift_state(Self::every_in_flight_or_pending_req_msg_has_unique_id()),
-        lift_state(Self::each_object_in_reconcile_has_consistent_key_and_valid_metadata()),
         lift_state(Self::each_resp_if_matches_pending_req_then_no_other_resp_matches(key))
     );
     assert forall |s, s_prime| inv(s) && #[trigger] next(s, s_prime) implies inv(s_prime) by {
@@ -768,19 +759,16 @@ pub proof fn lemma_always_key_of_object_in_matched_ok_create_resp_message_is_sam
         &&& Self::each_object_in_etcd_is_well_formed()(s)
         &&& Self::every_in_flight_msg_has_lower_id_than_allocator()(s)
         &&& Self::every_in_flight_or_pending_req_msg_has_unique_id()(s)
-        &&& Self::each_object_in_reconcile_has_consistent_key_and_valid_metadata()(s)
         &&& Self::each_resp_if_matches_pending_req_then_no_other_resp_matches(key)(s)
     };
     Self::lemma_always_each_object_in_etcd_is_well_formed(spec);
     Self::lemma_always_every_in_flight_msg_has_lower_id_than_allocator(spec);
     Self::lemma_always_every_in_flight_or_pending_req_msg_has_unique_id(spec);
-    Self::lemma_always_each_object_in_reconcile_has_consistent_key_and_valid_metadata(spec);
     Self::lemma_always_each_resp_if_matches_pending_req_then_no_other_resp_matches(spec, key);
     combine_spec_entails_always_n!(
         spec, lift_action(next), lift_action(Self::next()), lift_state(Self::each_object_in_etcd_is_well_formed()),
         lift_state(Self::every_in_flight_msg_has_lower_id_than_allocator()),
         lift_state(Self::every_in_flight_or_pending_req_msg_has_unique_id()),
-        lift_state(Self::each_object_in_reconcile_has_consistent_key_and_valid_metadata()),
         lift_state(Self::each_resp_if_matches_pending_req_then_no_other_resp_matches(key))
     );
     assert forall |s, s_prime| inv(s) && #[trigger] next(s, s_prime) implies inv(s_prime) by {


### PR DESCRIPTION
This PR tries to accelerate some time-consuming lemmas in the proof of rabbitmq controller. The approaches and observations are as follows:

- Break down the proof into multiple methods. Suppose we have a `lemma_a` which runs for $n$ seconds. We can move part of it into a new lemma `lemma_b` and call `lemma_b` inside `lemma_a`. Then `lemma_a` and `lemma_b` run for $n'$ and $m$ seconds separately. The interesting thing is that usually $n'+m < n$.
- Make the lemma simpler. We tend to carry multiple things using one lemma (one spec in most cases) if they can be easily proved together. However, sometimes this makes things worse. We can first prove the part that is independent of the rest and get a simpler lemma first. [This lemma](https://github.com/vmware-research/verifiable-controllers/blob/821a0c7db7f170239750a4472e98b80b2061c5c9/src/controller_examples/rabbitmq_controller/proof/helper_invariants/proof.rs#L579) can be an illustration.
- Try to reduce the possible instantiations of each universal quantifiers. When proving a lemma, we use other lemmas to assist. If the lemmas to help contain universal quantifiers, we have weaken their domains to those we actually use (sometimes remove the quantifiers). [Here](https://github.com/vmware-research/verifiable-controllers/blob/821a0c7db7f170239750a4472e98b80b2061c5c9/src/controller_examples/rabbitmq_controller/proof/helper_invariants/proof.rs#L1554) is an example.
- Take care of the assertions and their ordering. We used to think adding more assertions would help to remind the verifier of some predicates and then make verification faster. But it poses more burden sometimes. And the order of assertions also makes a difference. About the assertions [here](https://github.com/vmware-research/verifiable-controllers/blob/821a0c7db7f170239750a4472e98b80b2061c5c9/src/controller_examples/rabbitmq_controller/proof/helper_invariants/proof.rs#L1281), I swap the two assertions or change them into
```rust
assert(local_step.is_AfterKRequestStep() && local_step.get_AfterKRequestStep_0() == ActionKind::Get);
assert(local_step_prime.is_AfterKRequestStep() && local_step_prime.get_AfterKRequestStep_0() == ActionKind::Update);
```
or
```rust
assert(local_step.is_AfterKRequestStep());
assert(local_step_prime.is_AfterKRequestStep());
```
, then the time is (greatly) increased. (I don't really know why).