### PR TITLE
Add validations for ZooKeeper configuration parameters

### DIFF
--- a/deploy/zookeeper/crd.yaml
+++ b/deploy/zookeeper/crd.yaml
@@ -531,6 +531,9 @@ spec:
                     syncLimit:
                       format: int32
                       type: integer
+                      x-kubernetes-validations:
+                        - rule: "self >= 1"
+                          message: syncLimit must be greater than or equal to 1
                     tickTime:
                       format: int32
                       type: integer
@@ -551,6 +554,9 @@ spec:
                     - syncLimit
                     - tickTime
                   type: object
+                  x-kubernetes-validations:
+                    - rule: "self.minSessionTimeout <= self.maxSessionTimeout"
+                      message: minSessionTimeout must be less than or equal to maxSessionTimeout
                 image:
                   type: string
                 labels:


### PR DESCRIPTION
- Adding validation rule for the ZooKeeper configuration `syncLimit` to be greater or equal to 1. 
- Adding validation rule for the ZooKeeper configuration `minSessionTimeout` to be less or equal to `maxSessionTimeout`.

These two validation rules prevents ZooKeeper misconfigurations and fix the liveness bug.