### PR TITLE
Add fields to k8s api objects

### DIFF
--- a/src/controller_examples/fluent_controller/fluentbit_config/proof/liveness/resource_match.rs
+++ b/src/controller_examples/fluent_controller/fluentbit_config/proof/liveness/resource_match.rs
@@ -323,6 +323,7 @@ proof fn lemma_from_key_not_exists_to_receives_not_found_resp_at_after_get_resou
     );
 }
 
+#[verifier(spinoff_prover)]
 proof fn lemma_from_after_get_resource_step_to_after_create_resource_step(spec: TempPred<FBCCluster>, sub_resource: SubResource, fbc: FluentBitConfigView, resp_msg: FBCMessage)
     requires
         spec.entails(always(lift_action(FBCCluster::next()))),

--- a/src/controller_examples/rabbitmq_controller/proof/helper_invariants/proof.rs
+++ b/src/controller_examples/rabbitmq_controller/proof/helper_invariants/proof.rs
@@ -549,6 +549,7 @@ proof fn lemma_always_request_at_after_get_request_step_is_resource_get_request(
         spec.entails(always(lift_action(RMQCluster::next()))),
     ensures spec.entails(always(lift_state(request_at_after_get_request_step_is_resource_get_request(sub_resource, rabbitmq)))),
 {
+    hide(make_stateful_set);
     let key = rabbitmq.object_ref();
     let resource_key = get_request(sub_resource, rabbitmq).key;
     let inv = request_at_after_get_request_step_is_resource_get_request(sub_resource, rabbitmq);

--- a/src/kubernetes_api_objects/exec/container.rs
+++ b/src/kubernetes_api_objects/exec/container.rs
@@ -125,6 +125,20 @@ impl Container {
         self.inner.env = Some(env.into_iter().map(|e: EnvVar| e.into_kube()).collect())
     }
 
+    #[verifier(external_body)]
+    pub fn set_args(&mut self, args: Vec<String>)
+        ensures self@ == old(self)@.set_args(args@.map_values(|s: String| s@)),
+    {
+        self.inner.args = Some(args.into_iter().map(|c: String| c.into_rust_string()).collect())
+    }
+
+    #[verifier(external_body)]
+    pub fn set_security_context(&mut self, security_context: SecurityContext)
+        ensures self@ == old(self)@.set_security_context(security_context@),
+    {
+        self.inner.security_context = Some(security_context.into_kube())
+    }
+
     #[verifier(external)]
     pub fn from_kube(inner: deps_hack::k8s_openapi::api::core::v1::Container) -> Container { Container { inner: inner } }
 
@@ -597,6 +611,21 @@ impl EnvVarSource {
 
     #[verifier(external)]
     pub fn into_kube(self) -> deps_hack::k8s_openapi::api::core::v1::EnvVarSource { self.inner }
+}
+
+#[verifier(external_body)]
+pub struct SecurityContext {
+    inner: deps_hack::k8s_openapi::api::core::v1::SecurityContext,
+}
+
+impl SecurityContext {
+    pub spec fn view(&self) -> SecurityContextView;
+
+    #[verifier(external)]
+    pub fn from_kube(inner: deps_hack::k8s_openapi::api::core::v1::SecurityContext) -> SecurityContext { SecurityContext { inner: inner } }
+
+    #[verifier(external)]
+    pub fn into_kube(self) -> deps_hack::k8s_openapi::api::core::v1::SecurityContext { self.inner }
 }
 
 }

--- a/src/kubernetes_api_objects/exec/pod.rs
+++ b/src/kubernetes_api_objects/exec/pod.rs
@@ -267,10 +267,16 @@ impl PodSpec {
 
     #[verifier(external_body)]
     pub fn set_termination_grace_period_seconds(&mut self, termination_grace_period_seconds: i64)
-        ensures
-            self@ == old(self)@.set_termination_grace_period_seconds(termination_grace_period_seconds as int),
+        ensures self@ == old(self)@.set_termination_grace_period_seconds(termination_grace_period_seconds as int),
     {
         self.inner.termination_grace_period_seconds = Some(termination_grace_period_seconds);
+    }
+
+    #[verifier(external_body)]
+    pub fn set_image_pull_secrets(&mut self, image_pull_secrets: Vec<LocalObjectReference>)
+        ensures self@ == old(self)@.set_image_pull_secrets(image_pull_secrets@.map_values(|r: LocalObjectReference| r@)),
+    {
+        self.inner.image_pull_secrets = Some(image_pull_secrets.into_iter().map(|r: LocalObjectReference| r.into_kube()).collect())
     }
 
     #[verifier(external)]
@@ -297,6 +303,25 @@ impl ResourceWrapper<deps_hack::k8s_openapi::api::core::v1::PodSecurityContext> 
 
     #[verifier(external)]
     fn into_kube(self) -> deps_hack::k8s_openapi::api::core::v1::PodSecurityContext { self.inner }
+}
+
+#[verifier(external_body)]
+pub struct LocalObjectReference {
+    inner: deps_hack::k8s_openapi::api::core::v1::LocalObjectReference,
+}
+
+impl View for LocalObjectReference {
+    type V = LocalObjectReferenceView;
+
+    spec fn view(&self) -> LocalObjectReferenceView;
+}
+
+impl ResourceWrapper<deps_hack::k8s_openapi::api::core::v1::LocalObjectReference> for LocalObjectReference {
+    #[verifier(external)]
+    fn from_kube(inner: deps_hack::k8s_openapi::api::core::v1::LocalObjectReference) -> LocalObjectReference { LocalObjectReference { inner: inner } }
+
+    #[verifier(external)]
+    fn into_kube(self) -> deps_hack::k8s_openapi::api::core::v1::LocalObjectReference { self.inner }
 }
 
 }

--- a/src/kubernetes_api_objects/spec/container.rs
+++ b/src/kubernetes_api_objects/spec/container.rs
@@ -20,6 +20,8 @@ pub struct ContainerView {
     pub liveness_probe: Option<ProbeView>,
     pub command: Option<Seq<StringView>>,
     pub image_pull_policy: Option<StringView>,
+    pub args: Option<Seq<StringView>>,
+    pub security_context: Option<SecurityContextView>,
 }
 
 impl ContainerView {
@@ -36,6 +38,8 @@ impl ContainerView {
             liveness_probe: None,
             command: None,
             image_pull_policy: None,
+            args: None,
+            security_context: None,
         }
     }
 
@@ -119,6 +123,20 @@ impl ContainerView {
     pub open spec fn set_image_pull_policy(self, image_pull_policy: StringView) -> ContainerView {
         ContainerView {
             image_pull_policy: Some(image_pull_policy),
+            ..self
+        }
+    }
+
+    pub open spec fn set_args(self, args: Seq<StringView>) -> ContainerView {
+        ContainerView {
+            args: Some(args),
+            ..self
+        }
+    }
+
+    pub open spec fn set_security_context(self, security_context: SecurityContextView) -> ContainerView {
+        ContainerView {
+            security_context: Some(security_context),
             ..self
         }
     }
@@ -420,5 +438,7 @@ impl EnvVarSourceView {
         }
     }
 }
+
+pub struct SecurityContextView {}
 
 }

--- a/src/kubernetes_api_objects/spec/pod.rs
+++ b/src/kubernetes_api_objects/spec/pod.rs
@@ -151,6 +151,7 @@ pub struct PodSpecView {
     pub security_context: Option<PodSecurityContextView>,
     pub host_network: Option<bool>,
     pub termination_grace_period_seconds: Option<int>,
+    pub image_pull_secrets: Option<Seq<LocalObjectReferenceView>>,
 }
 
 impl PodSpecView {
@@ -170,6 +171,7 @@ impl PodSpecView {
             security_context: None,
             host_network: None,
             termination_grace_period_seconds: None,
+            image_pull_secrets: None,
         }
     }
 
@@ -284,8 +286,17 @@ impl PodSpecView {
             ..self
         }
     }
+
+    pub open spec fn set_image_pull_secrets(self, image_pull_secrets: Seq<LocalObjectReferenceView>) -> PodSpecView {
+        PodSpecView {
+            image_pull_secrets: Some(image_pull_secrets),
+            ..self
+        }
+    }
 }
 
 pub struct PodSecurityContextView {}
+
+pub struct LocalObjectReferenceView {}
 
 }


### PR DESCRIPTION
Add `security_context` and `args` to `Container`.
Add `image_pull_secrets` to `PodSpec`.