### PR TITLE
Add the script for reproducing verification results

### DIFF
--- a/reproduce-verification-result.sh
+++ b/reproduce-verification-result.sh
@@ -12,44 +12,48 @@ GREEN='\033[1;32m'
 RED='\033[0;31m'
 NC='\033[0m'
 
-prefix="${GREEN}[Artifact Evaluation]"
+PREFIX="${GREEN}"
 
-echo -e "${prefix} Verifying Anvil framework...${NC}"
+CUR_DIR=$(pwd)
+
+echo -e "${PREFIX} Verifying Anvil framework...${NC}"
 ./build.sh anvil.rs --crate-type=lib --emit=dep-info --time --time-expanded --output-json --rlimit 50 > anvil.json
 
-echo -e "${prefix} Verifying Fluent controller...${NC}"
+echo -e "${PREFIX} Verifying Fluent controller...${NC}"
 ./verify-controller-only.sh fluent
 
-echo -e "${prefix} Verifying RabbitMQ controller...${NC}"
+echo -e "${PREFIX} Verifying RabbitMQ controller...${NC}"
 ./verify-controller-only.sh rabbitmq
 
-echo -e "${prefix} Verifying ZooKeeper controller...${NC}"
+echo -e "${PREFIX} Verifying ZooKeeper controller...${NC}"
 ./verify-controller-only.sh zookeeper
 
-echo -e "${prefix} Calling Verus line counting tool...${NC}"
+echo -e "${PREFIX} Calling Verus line counting tool...${NC}"
 pushd $VERUS_DIR/source/tools/line_count
-cargo run --release -- /Users/xudongsun/workspace/verifiable-controllers/src/anvil.d > anvil_loc_table
-cargo run --release -- /Users/xudongsun/workspace/verifiable-controllers/src/fluent_controller.d > fluent_loc_table
-cargo run --release -- /Users/xudongsun/workspace/verifiable-controllers/src/rabbitmq_controller.d > rabbitmq_loc_table
-cargo run --release -- /Users/xudongsun/workspace/verifiable-controllers/src/zookeeper_controller.d > zookeeper_loc_table
+cargo run --release -- $CUR_DIR/src/anvil.d > anvil_loc_table
+cargo run --release -- $CUR_DIR/src/fluent_controller.d > fluent_loc_table
+cargo run --release -- $CUR_DIR/src/rabbitmq_controller.d > rabbitmq_loc_table
+cargo run --release -- $CUR_DIR/src/zookeeper_controller.d > zookeeper_loc_table
 popd
 
-echo -e "${prefix} Generating verification time result...${NC}"
+echo -e "${PREFIX} Writing verification time results to tools/t1-time.txt${NC}"
 cp anvil.json tools/anvil.json
 cp fluent.json tools/fluent.json
 cp rabbitmq.json tools/rabbitmq.json
 cp zookeeper.json tools/zookeeper.json
 pushd tools
-python3 gen-t1-t2-time.py
+python3 gen-t1-time.py > t1-time.txt
 popd
 
-echo -e "${prefix} Generating code size result...${NC}"
+echo -e "${PREFIX} Generating code size results to tools/t1-loc.txt${NC}"
 pushd tools
-python3 gen-t1-t2-lines.py
+python3 gen-t1-loc.py > t1-loc.txt
 popd
 
-echo -e "${prefix} Presenting verification result...${NC}"
+echo -e "${PREFIX} Presenting verification results from Verus. You are expected to see 0 errors for Anvil and the three controllers, which means everything is verified.${NC}"
 cat anvil.json | grep "errors"
 cat fluent.json | grep "errors"
 cat rabbitmq.json | grep "errors"
 cat zookeeper.json | grep "errors"
+
+echo -e "${PREFIX} To check the verification time and code size results, just run cat tools/t1-time.txt and cat tools/t1-loc.txt.${NC}"

--- a/reproduce-verification-result.sh
+++ b/reproduce-verification-result.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+
+## Reproduce the verification result of the three controllers,
+## also generate the Table 1 in the paper including:
+## (1) the time spent on verifying each controller
+## (2) the code size breakdown of each controller
+
+set -xeu
+
+YELLOW='\033[1;33m'
+GREEN='\033[1;32m'
+RED='\033[0;31m'
+NC='\033[0m'
+
+prefix="${GREEN}[Artifact Evaluation]"
+
+echo -e "${prefix} Verifying Anvil framework...${NC}"
+./build.sh anvil.rs --crate-type=lib --emit=dep-info --time --time-expanded --output-json --rlimit 50 > anvil.json
+
+echo -e "${prefix} Verifying Fluent controller...${NC}"
+./verify-controller-only.sh fluent
+
+echo -e "${prefix} Verifying RabbitMQ controller...${NC}"
+./verify-controller-only.sh rabbitmq
+
+echo -e "${prefix} Verifying ZooKeeper controller...${NC}"
+./verify-controller-only.sh zookeeper
+
+echo -e "${prefix} Calling Verus line counting tool...${NC}"
+pushd $VERUS_DIR/source/tools/line_count
+cargo run --release -- /Users/xudongsun/workspace/verifiable-controllers/src/anvil.d > anvil_loc_table
+cargo run --release -- /Users/xudongsun/workspace/verifiable-controllers/src/fluent_controller.d > fluent_loc_table
+cargo run --release -- /Users/xudongsun/workspace/verifiable-controllers/src/rabbitmq_controller.d > rabbitmq_loc_table
+cargo run --release -- /Users/xudongsun/workspace/verifiable-controllers/src/zookeeper_controller.d > zookeeper_loc_table
+popd
+
+echo -e "${prefix} Generating verification time result...${NC}"
+cp anvil.json tools/anvil.json
+cp fluent.json tools/fluent.json
+cp rabbitmq.json tools/rabbitmq.json
+cp zookeeper.json tools/zookeeper.json
+pushd tools
+python3 gen-t1-t2-time.py
+popd
+
+echo -e "${prefix} Generating code size result...${NC}"
+pushd tools
+python3 gen-t1-t2-lines.py
+popd
+
+echo -e "${prefix} Presenting verification result...${NC}"
+cat anvil.json | grep "errors"
+cat fluent.json | grep "errors"
+cat rabbitmq.json | grep "errors"
+cat zookeeper.json | grep "errors"

--- a/tools/count-anvil-loc.py
+++ b/tools/count-anvil-loc.py
@@ -116,7 +116,7 @@ def parse_table_and_collect_lines(file_path):
         "object_wrapper_lines": object_wrapper_lines,
         "other_lines": other_lines,
     }
-    json.dump(all_lines, open("anvil-lines.json", "w"), indent=4)
+    json.dump(all_lines, open("anvil-loc.json", "w"), indent=4)
 
 
 def main():

--- a/tools/count-loc.py
+++ b/tools/count-loc.py
@@ -148,7 +148,7 @@ def parse_table_and_collect_lines(file_path, controller_name):
                 liveness_proof_lines["Proof"] += int(stripped_cols[PROOF_AND_EXEC_COL])
                 liveness_proof_lines["Proof"] += int(stripped_cols[SPEC_COL])
             else:
-                print(line)  # Print out the lines that are hard to classify
+                # print(line)  # Print out the lines that are hard to classify
                 other_lines["Exec"] += int(stripped_cols[EXEC_COL])
                 other_lines["Proof"] += int(stripped_cols[PROOF_COL])
                 other_lines["Proof"] += int(stripped_cols[PROOF_AND_EXEC_COL])
@@ -166,7 +166,7 @@ def parse_table_and_collect_lines(file_path, controller_name):
         "entry": entry_lines,
         "other": other_lines,
     }
-    json.dump(all_lines, open(controller_name + "-lines.json", "w"), indent=4)
+    json.dump(all_lines, open(controller_name + "-loc.json", "w"), indent=4)
 
 
 def main():

--- a/tools/gen-t1-loc.py
+++ b/tools/gen-t1-loc.py
@@ -12,11 +12,11 @@ def count_total_lines(data):
 
 def gen_for_controller(controller):
     os.system(
-        "python3 count-lines.py $VERUS_DIR/source/tools/line_count/{}_loc_table {}".format(
+        "python3 count-loc.py $VERUS_DIR/source/tools/line_count/{}_loc_table {}".format(
             controller, controller
         )
     )
-    data = json.load(open("{}-lines.json".format(controller)))
+    data = json.load(open("{}-loc.json".format(controller)))
 
     total_lines = count_total_lines(data)
     total_lines -= data["liveness_inv"]["Proof"]
@@ -85,18 +85,14 @@ def gen_for_controller(controller):
         )
     )
     total_lines -= data["entry"]["Trusted"]
-    print("{} lines are not included".format(total_lines))
+    # print("{} lines are not included".format(total_lines))
 
 
-def main():
-    gen_for_controller("zookeeper")
-    gen_for_controller("rabbitmq")
-    gen_for_controller("fluent")
-
+def gen_for_anvil():
     os.system(
-        "python3 count-anvil-lines.py $VERUS_DIR/source/tools/line_count/anvil_loc_table"
+        "python3 count-anvil-loc.py $VERUS_DIR/source/tools/line_count/anvil_loc_table"
     )
-    anvil_data = json.load(open("anvil-lines.json"))
+    anvil_data = json.load(open("anvil-loc.json"))
     total_lines = count_total_lines(anvil_data)
     total_lines -= anvil_data["test_lines"]["Exec"]
     print("Anvil:")
@@ -129,7 +125,14 @@ def main():
     total_lines -= anvil_data["object_wrapper_lines"]["Trusted"]
     print("Shim layer & {} & -- & --".format(anvil_data["other_lines"]["Exec"]))
     total_lines -= anvil_data["other_lines"]["Exec"]
-    print("{} lines are not included".format(total_lines))
+    # print("{} lines are not included".format(total_lines))
+
+
+def main():
+    gen_for_controller("zookeeper")
+    gen_for_controller("rabbitmq")
+    gen_for_controller("fluent")
+    # gen_for_anvil()
 
 
 if __name__ == "__main__":

--- a/tools/gen-t1-loc.py
+++ b/tools/gen-t1-loc.py
@@ -3,7 +3,7 @@ import json
 
 indent = "    "
 
-count_missed_lines = False
+debug = False
 
 cap_controllers = {
     "zookeeper": "ZooKeeper controller",
@@ -33,7 +33,7 @@ def gen_for_controller(controller):
         "Exec": 0,
         "Proof": 0,
     }
-    if count_missed_lines:
+    if debug:
         missed_lines = count_total_lines(data)
         missed_lines -= data["liveness_inv"]["Proof"]
 
@@ -49,7 +49,7 @@ def gen_for_controller(controller):
     )
     total["Trusted"] += data["liveness_theorem"]["Trusted"]
     total["Proof"] += data["liveness_proof"]["Proof"]
-    if count_missed_lines:
+    if debug:
         missed_lines -= data["liveness_theorem"]["Trusted"]
         missed_lines -= data["liveness_proof"]["Proof"]
 
@@ -64,7 +64,7 @@ def gen_for_controller(controller):
         )
         total["Trusted"] += data["safety_theorem"]["Trusted"]
         total["Proof"] += data["safety_proof"]["Proof"]
-        if count_missed_lines:
+        if debug:
             missed_lines -= data["safety_theorem"]["Trusted"]
             missed_lines -= data["safety_proof"]["Proof"]
 
@@ -89,7 +89,7 @@ def gen_for_controller(controller):
         )
         total["Trusted"] += 5
         total["Proof"] += data["reconcile_impl"]["Proof"] - 5
-    if count_missed_lines:
+    if debug:
         missed_lines -= data["reconcile_impl"]["Proof"]
 
     # Count LoC for controller model
@@ -100,7 +100,7 @@ def gen_for_controller(controller):
         )
     )
     total["Proof"] += data["reconcile_model"]["Proof"]
-    if count_missed_lines:
+    if debug:
         missed_lines -= data["reconcile_model"]["Proof"]
 
     # Count LoC for controller implementation
@@ -111,7 +111,7 @@ def gen_for_controller(controller):
         )
     )
     total["Exec"] += data["reconcile_model"]["Exec"] + data["reconcile_impl"]["Exec"]
-    if count_missed_lines:
+    if debug:
         missed_lines -= data["reconcile_model"]["Exec"] + data["reconcile_impl"]["Exec"]
 
     # Count LoC for trusted wrapper
@@ -122,7 +122,7 @@ def gen_for_controller(controller):
         )
     )
     total["Trusted"] += data["wrapper"]["Trusted"]
-    if count_missed_lines:
+    if debug:
         missed_lines -= data["wrapper"]["Trusted"]
 
     if controller == "zookeeper":
@@ -134,7 +134,7 @@ def gen_for_controller(controller):
             )
         )
         total["Trusted"] += data["external_model"]["Trusted"]
-        if count_missed_lines:
+        if debug:
             missed_lines -= data["external_model"]["Trusted"]
 
     # Count LoC for trusted entry point
@@ -145,7 +145,7 @@ def gen_for_controller(controller):
         )
     )
     total["Trusted"] += data["entry"]["Trusted"]
-    if count_missed_lines:
+    if debug:
         missed_lines -= data["entry"]["Trusted"]
 
     # Count total LoC
@@ -157,7 +157,7 @@ def gen_for_controller(controller):
             total["Proof"],
         )
     )
-    if count_missed_lines:
+    if debug:
         print("{} lines are not included".format(missed_lines))
     return total
 
@@ -167,7 +167,7 @@ def gen_for_anvil():
         "python3 count-anvil-loc.py $VERUS_DIR/source/tools/line_count/anvil_loc_table"
     )
     anvil_data = json.load(open("anvil-loc.json"))
-    if count_missed_lines:
+    if debug:
         missed_lines = count_total_lines(anvil_data)
         missed_lines -= anvil_data["test_lines"]["Exec"]
     print("Anvil:")
@@ -178,7 +178,7 @@ def gen_for_anvil():
             + anvil_data["tla_lemma_lines"]["Proof"]
         )
     )
-    if count_missed_lines:
+    if debug:
         missed_lines -= (
             anvil_data["k8s_lemma_lines"]["Proof"]
             + anvil_data["tla_lemma_lines"]["Proof"]
@@ -189,10 +189,10 @@ def gen_for_anvil():
             anvil_data["tla_embedding_lines"]["Trusted"]
         )
     )
-    if count_missed_lines:
+    if debug:
         missed_lines -= anvil_data["tla_embedding_lines"]["Trusted"]
     print(indent + "Model & {} & -- & --".format(anvil_data["other_lines"]["Trusted"]))
-    if count_missed_lines:
+    if debug:
         missed_lines -= anvil_data["other_lines"]["Trusted"]
     print(
         indent
@@ -200,7 +200,7 @@ def gen_for_anvil():
             anvil_data["object_model_lines"]["Trusted"]
         )
     )
-    if count_missed_lines:
+    if debug:
         missed_lines -= anvil_data["object_model_lines"]["Trusted"]
     print(
         indent
@@ -208,14 +208,14 @@ def gen_for_anvil():
             anvil_data["object_wrapper_lines"]["Trusted"]
         )
     )
-    if count_missed_lines:
+    if debug:
         missed_lines -= anvil_data["object_wrapper_lines"]["Trusted"]
     print(
         indent + "Shim layer & {} & -- & --".format(anvil_data["other_lines"]["Exec"])
     )
-    if count_missed_lines:
+    if debug:
         missed_lines -= anvil_data["other_lines"]["Exec"]
-    if count_missed_lines:
+    if debug:
         print("{} lines are not included".format(missed_lines))
 
 

--- a/tools/gen-t1-t2-lines.py
+++ b/tools/gen-t1-t2-lines.py
@@ -12,7 +12,7 @@ def count_total_lines(data):
 
 def gen_for_controller(controller):
     os.system(
-        "python3 count-lines.py $VERUS_DIR/source/tools/line_count/{}_table {}".format(
+        "python3 count-lines.py $VERUS_DIR/source/tools/line_count/{}_loc_table {}".format(
             controller, controller
         )
     )
@@ -94,7 +94,7 @@ def main():
     gen_for_controller("fluent")
 
     os.system(
-        "python3 count-anvil-lines.py $VERUS_DIR/source/tools/line_count/lib_table"
+        "python3 count-anvil-lines.py $VERUS_DIR/source/tools/line_count/anvil_loc_table"
     )
     anvil_data = json.load(open("anvil-lines.json"))
     total_lines = count_total_lines(anvil_data)

--- a/tools/gen-t1-t2-time.py
+++ b/tools/gen-t1-t2-time.py
@@ -12,7 +12,7 @@ def main():
     zk_raw_data = json.load(open("zookeeper.json"))
     rmq_raw_data = json.load(open("rabbitmq.json"))
     fb_raw_data = json.load(open("fluent.json"))
-    anvil_raw_data = json.load(open("lib.json"))
+    anvil_raw_data = json.load(open("anvil.json"))
     print("ZooKeeper:")
     print("Liveness & {}".format(zk_data["Liveness"] / 1000))
     print("Safety & {}".format(zk_data["Safety"] / 1000))

--- a/tools/gen-t1-time.py
+++ b/tools/gen-t1-time.py
@@ -1,6 +1,8 @@
 import os
 import json
 
+indent = "    "
+
 
 def main():
     os.system("python3 count-time.py zookeeper.json zookeeper")
@@ -13,31 +15,45 @@ def main():
     rmq_raw_data = json.load(open("rabbitmq.json"))
     fb_raw_data = json.load(open("fluent.json"))
     anvil_raw_data = json.load(open("anvil.json"))
-    print("ZooKeeper:")
-    print("Liveness & {}".format(zk_data["Liveness"] / 1000))
-    print("Safety & {}".format(zk_data["Safety"] / 1000))
-    print("Conformance & {}".format(zk_data["Impl"] / 1000))
+    print("ZooKeeper controller:")
+    print(indent + "Liveness & {}".format(zk_data["Liveness"] / 1000))
+    print(indent + "Safety & {}".format(zk_data["Safety"] / 1000))
+    print(indent + "Conformance & {}".format(zk_data["Impl"] / 1000))
     print(
-        "Total & {} ({})".format(
+        indent
+        + "Total & {} ({})".format(
             zk_data["Total"] / 1000, zk_raw_data["times-ms"]["total"] / 1000
         )
     )
-    print("RabbitMQ:")
-    print("Liveness & {}".format(rmq_data["Liveness"] / 1000))
-    print("Safety & {}".format(rmq_data["Safety"] / 1000))
-    print("Conformance & {}".format(rmq_data["Impl"] / 1000))
+    print("RabbitMQ controller:")
+    print(indent + "Liveness & {}".format(rmq_data["Liveness"] / 1000))
+    print(indent + "Safety & {}".format(rmq_data["Safety"] / 1000))
+    print(indent + "Conformance & {}".format(rmq_data["Impl"] / 1000))
     print(
-        "Total & {} ({})".format(
+        indent
+        + "Total & {} ({})".format(
             rmq_data["Total"] / 1000, rmq_raw_data["times-ms"]["total"] / 1000
         )
     )
-    print("Fluent:")
-    print("Liveness & {}".format(fb_data["Liveness"] / 1000))
-    print("Safety & {}".format(fb_data["Safety"] / 1000))
-    print("Conformance & {}".format(fb_data["Impl"] / 1000))
+    print("Fluent controller:")
+    print(indent + "Liveness & {}".format(fb_data["Liveness"] / 1000))
+    print(indent + "Safety & {}".format(fb_data["Safety"] / 1000))
+    print(indent + "Conformance & {}".format(fb_data["Impl"] / 1000))
     print(
-        "Total & {} ({})".format(
+        indent
+        + "Total & {} ({})".format(
             fb_data["Total"] / 1000, fb_raw_data["times-ms"]["total"] / 1000
+        )
+    )
+    print(
+        "Total(all) & {} ({})".format(
+            (zk_data["Total"] + rmq_data["Total"] + fb_data["Total"]) / 1000,
+            (
+                zk_raw_data["times-ms"]["total"]
+                + rmq_raw_data["times-ms"]["total"]
+                + fb_raw_data["times-ms"]["total"]
+            )
+            / 1000,
         )
     )
     # print("Anvil:")

--- a/tools/gen-t1-time.py
+++ b/tools/gen-t1-time.py
@@ -40,13 +40,13 @@ def main():
             fb_data["Total"] / 1000, fb_raw_data["times-ms"]["total"] / 1000
         )
     )
-    print("Anvil:")
-    print(
-        "Reusable lemmas & {} ({})".format(
-            anvil_raw_data["times-ms"]["total-verify"] / 1000,
-            anvil_raw_data["times-ms"]["total"] / 1000,
-        )
-    )
+    # print("Anvil:")
+    # print(
+    #     "Reusable lemmas & {} ({})".format(
+    #         anvil_raw_data["times-ms"]["total-verify"] / 1000,
+    #         anvil_raw_data["times-ms"]["total"] / 1000,
+    #     )
+    # )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
The newly added script `reproduce-verification-result.sh` will verify the Anvil framework and the three controllers, generate the code size and time to verify as tables, and output the verification result (0 errors expected).