### PR TITLE
Add model reconciler and prove conformance for vrs controller

### DIFF
--- a/src/controller_examples/v_replica_set_controller/exec/reconciler.rs
+++ b/src/controller_examples/v_replica_set_controller/exec/reconciler.rs
@@ -292,10 +292,6 @@ fn make_pod(v_replica_set: &VReplicaSet) -> (pod: Pod)
         if labels.is_some() {
             metadata.set_labels(labels.unwrap());
         }
-        let labels = template.metadata().unwrap().labels();
-        if labels.is_some() {
-            metadata.set_labels(labels.unwrap());
-        }
         let annotations = template.metadata().unwrap().annotations();
         if annotations.is_some() {
             metadata.set_annotations(annotations.unwrap());

--- a/src/controller_examples/v_replica_set_controller/exec/reconciler.rs
+++ b/src/controller_examples/v_replica_set_controller/exec/reconciler.rs
@@ -6,9 +6,11 @@ use crate::kubernetes_api_objects::exec::{
     container::*, label_selector::*, pod_template_spec::*, prelude::*, resource_requirements::*,
     volume::*,
 };
+use crate::kubernetes_api_objects::spec::prelude::DynamicObjectView;
+use crate::kubernetes_api_objects::spec::prelude::PodView;
+use crate::kubernetes_api_objects::spec::resource::ResourceView;
 use crate::reconciler::exec::{io::*, reconciler::*, resource_builder::*};
-// use crate::v_replica_set_controller::model::reconciler as model_reconciler;
-// use crate::v_replica_set_controller::model::resource as model_resource;
+use crate::v_replica_set_controller::model::reconciler as model_reconciler;
 use crate::v_replica_set_controller::trusted::exec_types::*;
 use crate::v_replica_set_controller::trusted::spec_types;
 use crate::v_replica_set_controller::trusted::step::*;
@@ -50,7 +52,7 @@ impl Default for VReplicaSetReconciler {
 }
 
 pub fn reconcile_init_state() -> (state: VReplicaSetReconcileState)
-    // ensures state@ == model_reconciler::reconcile_init_state(),
+    ensures state@ == model_reconciler::reconcile_init_state(),
 {
     VReplicaSetReconcileState {
         reconcile_step: VReplicaSetReconcileStep::Init,
@@ -59,7 +61,7 @@ pub fn reconcile_init_state() -> (state: VReplicaSetReconcileState)
 }
 
 pub fn reconcile_done(state: &VReplicaSetReconcileState) -> (res: bool)
-    // ensures res == model_reconciler::reconcile_done(state@),
+    ensures res == model_reconciler::reconcile_done(state@),
 {
     match state.reconcile_step {
         VReplicaSetReconcileStep::Done => true,
@@ -68,7 +70,7 @@ pub fn reconcile_done(state: &VReplicaSetReconcileState) -> (res: bool)
 }
 
 pub fn reconcile_error(state: &VReplicaSetReconcileState) -> (res: bool)
-    // ensures res == model_reconciler::reconcile_error(state@),
+    ensures res == model_reconciler::reconcile_error(state@),
 {
     match state.reconcile_step {
         VReplicaSetReconcileStep::Error => true,
@@ -78,7 +80,7 @@ pub fn reconcile_error(state: &VReplicaSetReconcileState) -> (res: bool)
 
 pub fn reconcile_core(v_replica_set: &VReplicaSet, resp_o: Option<Response<EmptyType>>, state: VReplicaSetReconcileState) -> (res: (VReplicaSetReconcileState, Option<Request<EmptyType>>))
     requires v_replica_set@.well_formed(),
-    // ensures (res.0@, opt_request_to_view(&res.1)) == model_reconciler::reconcile_core(v_replica_set@, opt_response_to_view(&resp_o), state@),
+    ensures (res.0@, opt_request_to_view(&res.1)) == model_reconciler::reconcile_core(v_replica_set@, opt_response_to_view(&resp_o), state@),
 {
     let namespace = v_replica_set.metadata().namespace().unwrap();
     match &state.reconcile_step {
@@ -219,6 +221,7 @@ pub fn reconcile_core(v_replica_set: &VReplicaSet, resp_o: Option<Response<Empty
 }
 
 pub fn error_state(state: VReplicaSetReconcileState) -> (state_prime: VReplicaSetReconcileState)
+    ensures state_prime@ == model_reconciler::error_state(state@),
 {
     VReplicaSetReconcileState {
         reconcile_step: VReplicaSetReconcileStep::Error,
@@ -227,46 +230,153 @@ pub fn error_state(state: VReplicaSetReconcileState) -> (state_prime: VReplicaSe
 }
 
 pub fn make_owner_references(v_replica_set: &VReplicaSet) -> (owner_references: Vec<OwnerReference>)
-    // requires v_replica_set@.well_formed(),
-    // ensures owner_references@.map_values(|or: OwnerReference| or@) ==  model_resource::make_owner_references(v_replica_set@),
+    requires v_replica_set@.well_formed(),
+    ensures owner_references@.map_values(|or: OwnerReference| or@) ==  model_reconciler::make_owner_references(v_replica_set@),
 {
     let mut owner_references = Vec::new();
     owner_references.push(v_replica_set.controller_owner_ref());
-    // proof {
-    //     assert_seqs_equal!(
-    //         owner_references@.map_values(|owner_ref: OwnerReference| owner_ref@),
-    //         model_resource::make_owner_references(v_replica_set@)
-    //     );
-    // }
+    proof {
+        assert_seqs_equal!(
+            owner_references@.map_values(|owner_ref: OwnerReference| owner_ref@),
+            model_reconciler::make_owner_references(v_replica_set@)
+        );
+    }
     owner_references
 }
 
 // TODO: This function can be replaced by a map.
 // Revisit it if Verus supports Vec.map.
 fn objects_to_pods(objs: Vec<DynamicObject>) -> (pods_or_none: Option<Vec<Pod>>)
+    ensures opt_podvec_to_view(&pods_or_none) == model_reconciler::objects_to_pods(objs@.map_values(|o: DynamicObject| o@))
 {
     let mut pods = Vec::new();
     let mut idx = 0;
-    while idx < objs.len() {
+
+    proof {
+        let model_result = model_reconciler::objects_to_pods(objs@.map_values(|o: DynamicObject| o@));
+        if model_result.is_some() {
+            assert_seqs_equal!(
+                pods@.map_values(|p: Pod| p@), 
+                model_result.unwrap().take(0)
+            );
+        }
+    }
+
+    while idx < objs.len()
+        invariant
+            idx <= objs.len(),
+            ({
+                let model_result = model_reconciler::objects_to_pods(objs@.map_values(|o: DynamicObject| o@));
+                &&& (model_result.is_some() ==> 
+                        pods@.map_values(|p: Pod| p@) == model_result.unwrap().take(idx as int))
+                &&& forall|i: int| 0 <= i < idx ==> PodView::unmarshal(#[trigger] objs@[i]@).is_ok()
+            }),
+    {
         let pod_or_error = Pod::unmarshal(objs[idx].clone());
-        if pod_or_error.is_ok() {
+        if pod_or_error.is_ok() { 
             pods.push(pod_or_error.unwrap());
+            proof {
+                // Show that the pods Vec and the model_result are equal up to index idx + 1.
+                let model_result = model_reconciler::objects_to_pods(objs@.map_values(|o: DynamicObject| o@));
+                if (model_result.is_some()) {
+                    assert(model_result.unwrap().take((idx + 1) as int) 
+                        == model_result.unwrap().take(idx as int) + seq![model_result.unwrap()[idx as int]]);
+                    assert_seqs_equal!(
+                        pods@.map_values(|p: Pod| p@), 
+                        model_result.unwrap().take((idx + 1) as int) 
+                    );
+                }
+            }
         } else {
+            proof {
+                // Show that if a pod was unable to be serialized, the model would return None.
+                let model_input = objs@.map_values(|o: DynamicObject| o@);
+                let model_result = model_reconciler::objects_to_pods(model_input);
+                assert(
+                    model_input
+                        .filter(|o: DynamicObjectView| PodView::unmarshal(o).is_err())
+                        .contains(model_input[idx as int])
+                );
+                assert(model_result == None::<Seq<PodView>>);
+            }
             return None;
         }
         idx = idx + 1;
     }
+
+    proof {
+        let model_input = objs@.map_values(|o: DynamicObject| o@);
+        let model_result = model_reconciler::objects_to_pods(model_input);
+
+        // Prove, by contradiction, that the model_result can't be None.
+        let filter_result = model_input.filter(|o: DynamicObjectView| PodView::unmarshal(o).is_err());
+        assert(filter_result.len() == 0) by {
+            if filter_result.len() != 0 {
+                lemma_filter_contains_implies_contains(
+                    model_input, 
+                    |o: DynamicObjectView| PodView::unmarshal(o).is_err(),
+                    filter_result[0]
+                ); 
+            }
+        };
+        assert(model_result.is_some());
+
+        assert(model_result.unwrap().take(objs.len() as int) == model_result.unwrap());
+    }
+
     Some(pods)
+}
+
+proof fn lemma_filter_contains_implies_contains<A>(s: Seq<A>, pred: spec_fn(A) -> bool, e: A)
+    requires s.filter(pred).contains(e),
+    ensures s.contains(e),
+    decreases s.len(),
+{
+    reveal(Seq::filter);
+    if s.len() == 0 {
+        // Trivially true.
+    } else {
+        // Induction structure follows implementation of .filter().
+        if s.last() == e {
+            // The witness for .contains() is the last index.
+        } else {
+            // Inductive step.
+            lemma_filter_contains_implies_contains(s.drop_last(), pred, e);
+        }
+    }
+}
+
+pub open spec fn opt_podvec_to_view(vec_or_none: &Option<Vec<Pod>>) -> Option<Seq<PodView>> {
+    match vec_or_none {
+        Some(vec) => Some(vec@.map_values(|p: Pod| p@)),
+        None => None,
+    }
 }
 
 // TODO: This function can be replaced by a map.
 // Revisit it if Verus supports Vec.map.
 fn filter_pods(pods: Vec<Pod>, v_replica_set: &VReplicaSet) -> (filtered_pods: Vec<Pod>)
+    requires v_replica_set@.well_formed(),
+    ensures filtered_pods@.map_values(|p: Pod| p@) == model_reconciler::filter_pods(pods@.map_values(|p: Pod| p@), v_replica_set@),
 {
     let mut filtered_pods = Vec::new();
     let mut idx = 0;
-    while idx < pods.len() {
+
+    proof {
+        assert_seqs_equal!(
+            filtered_pods@.map_values(|p: Pod| p@), 
+            model_reconciler::filter_pods(pods@.map_values(|p: Pod| p@).take(0), v_replica_set@)
+        );
+    }
+
+    while idx < pods.len() 
+        invariant
+            idx <= pods.len(),
+            filtered_pods@.map_values(|p: Pod| p@) 
+                == model_reconciler::filter_pods(pods@.map_values(|p: Pod| p@).take(idx as int), v_replica_set@),
+    {
         let pod = &pods[idx];
+
         // TODO: check other conditions such as pod status
         // Check the following conditions:
         // (1) the pod's label should match the replica set's selector
@@ -276,13 +386,50 @@ fn filter_pods(pods: Vec<Pod>, v_replica_set: &VReplicaSet) -> (filtered_pods: V
         && !pod.metadata().has_deletion_timestamp() {
             filtered_pods.push(pod.clone());
         }
+        
+        proof {
+            let spec_filter = |pod: PodView|
+                pod.metadata.owner_references_contains(v_replica_set@.controller_owner_ref())
+                && v_replica_set@.spec.selector.matches(pod.metadata.labels.unwrap_or(Map::empty()))
+                && pod.metadata.deletion_timestamp.is_None();
+            let old_filtered = if spec_filter(pod@) {
+                filtered_pods@.map_values(|p: Pod| p@).drop_last()
+            } else {
+                filtered_pods@.map_values(|p: Pod| p@)
+            };
+            assert(old_filtered == pods@.map_values(|p: Pod| p@).take(idx as int).filter(spec_filter));
+            lemma_filter_maintained_after_add(
+                pods@.map_values(|p: Pod| p@).take(idx as int),
+                spec_filter,
+                old_filtered,
+                pod@
+            );
+            assert(pods@.map_values(|p: Pod| p@).take(idx as int).push(pod@)
+                    == pods@.map_values(|p: Pod| p@).take((idx + 1) as int));
+            assert(spec_filter(pod@) ==> filtered_pods@.map_values(|p: Pod| p@) == old_filtered.push(pod@));
+        }
+
         idx = idx + 1;
     }
+    assert(pods@.map_values(|p: Pod| p@) == pods@.map_values(|p: Pod| p@).take(pods.len() as int));
     filtered_pods
+}
+
+proof fn lemma_filter_maintained_after_add<A>(s: Seq<A>, pred: spec_fn(A) -> bool, filtered_s: Seq<A>, new_elt: A)
+    requires filtered_s == s.filter(pred),
+    ensures
+        (pred(new_elt) ==> filtered_s.push(new_elt) == s.push(new_elt).filter(pred)),
+        (!pred(new_elt) ==> filtered_s == s.push(new_elt).filter(pred)),
+{
+    // Lemma follows from body of Seq::filter.
+    reveal(Seq::filter);
+    // For some reason, this law needs to be explicitly asserted.
+    assert(s.push(new_elt).drop_last() == s);
 }
 
 fn make_pod(v_replica_set: &VReplicaSet) -> (pod: Pod)
     requires v_replica_set@.well_formed(),
+    ensures pod@ == model_reconciler::make_pod(v_replica_set@),
 {
     let template = v_replica_set.spec().template().unwrap();
     let mut pod = Pod::default();

--- a/src/controller_examples/v_replica_set_controller/model/reconciler.rs
+++ b/src/controller_examples/v_replica_set_controller/model/reconciler.rs
@@ -213,7 +213,7 @@ pub open spec fn objects_to_pods(objs: Seq<DynamicObjectView>) -> (pods_or_none:
     if objs.filter(|o: DynamicObjectView| PodView::unmarshal(o).is_err()).len() != 0 {
         None
     } else {
-        Some(objs.map(|i: int, o: DynamicObjectView| PodView::unmarshal(o).unwrap()))
+        Some(objs.map_values(|o: DynamicObjectView| PodView::unmarshal(o).unwrap()))
     }
 }
 

--- a/src/controller_examples/v_replica_set_controller/model/reconciler.rs
+++ b/src/controller_examples/v_replica_set_controller/model/reconciler.rs
@@ -31,7 +31,7 @@ impl Reconciler<VReplicaSetView, EmptyAPI> for VReplicaSetReconciler {
         reconcile_error(state)
     }
 
-    open spec fn expect_from_user(obj: DynamicObjectView) -> bool { false /* expect nothing: stub */ }
+    open spec fn expect_from_user(obj: DynamicObjectView) -> bool { false /* expect nothing */ }
 }
 
 pub open spec fn reconcile_init_state() -> VReplicaSetReconcileState { 
@@ -42,18 +42,216 @@ pub open spec fn reconcile_init_state() -> VReplicaSetReconcileState {
 }
 
 pub open spec fn reconcile_done(state: VReplicaSetReconcileState) -> bool {
-    false
+    match state.reconcile_step {
+        VReplicaSetReconcileStepView::Done => true,
+        _ => false,
+    }
 }
 
 pub open spec fn reconcile_error(state: VReplicaSetReconcileState) -> bool {
-    false
+    match state.reconcile_step {
+        VReplicaSetReconcileStepView::Error => true,
+        _ => false,
+    }
 }
 
 pub open spec fn reconcile_core(
-    fb: VReplicaSetView, resp_o: Option<ResponseView<EmptyTypeView>>, state: VReplicaSetReconcileState
+    v_replica_set: VReplicaSetView, resp_o: Option<ResponseView<EmptyTypeView>>, state: VReplicaSetReconcileState
 ) -> (VReplicaSetReconcileState, Option<RequestView<EmptyTypeView>>) {
-    (state, None)
+    let namespace = v_replica_set.metadata.namespace.unwrap();
+    match &state.reconcile_step {
+        VReplicaSetReconcileStepView::Init => {
+            let req = APIRequest::ListRequest(ListRequest {
+                kind: PodView::kind(),
+                namespace: namespace,
+            });
+            let state_prime = VReplicaSetReconcileState {
+                reconcile_step: VReplicaSetReconcileStepView::AfterListPods,
+                ..state
+            };
+            (state_prime, Some(RequestView::KRequest(req)))
+        },
+        VReplicaSetReconcileStepView::AfterListPods => {
+            if !(resp_o.is_Some() && resp_o.get_Some_0().is_KResponse()
+            && resp_o.get_Some_0().get_KResponse_0().is_ListResponse()
+            && resp_o.get_Some_0().get_KResponse_0().get_ListResponse_0().res.is_ok()) {
+                (error_state(state), None)
+            } else {
+                let objs = resp_o.unwrap().get_KResponse_0().get_ListResponse_0().res.unwrap();
+                let pods_or_none = objects_to_pods(objs);
+                if pods_or_none.is_none() {
+                    (error_state(state), None)
+                } else {
+                    let pods = pods_or_none.unwrap();
+                    let filtered_pods = filter_pods(pods, v_replica_set);
+                    let replicas = v_replica_set.spec.replicas.unwrap_or(0);
+                    if replicas < 0 {
+                        (error_state(state), None)
+                    } else {
+                        let desired_replicas: usize = replicas as usize;
+                        if filtered_pods.len() == desired_replicas {
+                            let state_prime = VReplicaSetReconcileState {
+                                reconcile_step: VReplicaSetReconcileStepView::Done,
+                                ..state
+                            };
+                            (state_prime, None)
+                        } else if filtered_pods.len() < desired_replicas {
+                            let diff =  desired_replicas - filtered_pods.len();
+                            let pod = make_pod(v_replica_set);
+                            let req = APIRequest::CreateRequest(CreateRequest {
+                                namespace: namespace,
+                                obj: pod.marshal(),
+                            });
+                            let state_prime = VReplicaSetReconcileState {
+                                reconcile_step: VReplicaSetReconcileStepView::AfterCreatePod((diff - 1) as nat),
+                                ..state
+                            };
+                            (state_prime, Some(RequestView::KRequest(req)))
+                        } else {
+                            let diff = filtered_pods.len() - desired_replicas;
+                            let pod_name_or_none = filtered_pods[diff - 1].metadata.name;
+                            if pod_name_or_none.is_none() {
+                                (error_state(state), None)
+                            } else {
+                                let req = APIRequest::DeleteRequest(DeleteRequest {
+                                    key: ObjectRef {
+                                        kind: PodView::kind(),
+                                        name: pod_name_or_none.unwrap(),
+                                        namespace: namespace,
+                                    }
+                                });
+                                let state_prime = VReplicaSetReconcileState {
+                                    reconcile_step: VReplicaSetReconcileStepView::AfterDeletePod((diff - 1) as nat),
+                                    filtered_pods: Some(filtered_pods),
+                                    ..state
+                                };
+                                (state_prime, Some(RequestView::KRequest(req)))
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        VReplicaSetReconcileStepView::AfterCreatePod(diff) => {
+            let diff = *diff;
+            if !(resp_o.is_Some() && resp_o.get_Some_0().is_KResponse()
+            && resp_o.get_Some_0().get_KResponse_0().is_CreateResponse()
+            && resp_o.get_Some_0().get_KResponse_0().get_CreateResponse_0().res.is_ok()) {
+                (error_state(state), None)
+            } else if diff == 0 {
+                let state_prime = VReplicaSetReconcileState {
+                    reconcile_step: VReplicaSetReconcileStepView::Done,
+                    ..state
+                };
+                (state_prime, None)
+            } else {
+                let pod = make_pod(v_replica_set);
+                let req = APIRequest::CreateRequest(CreateRequest {
+                    namespace: namespace,
+                    obj: pod.marshal(),
+                });
+                let state_prime = VReplicaSetReconcileState {
+                    reconcile_step: VReplicaSetReconcileStepView::AfterCreatePod((diff - 1) as nat),
+                    ..state
+                };
+                (state_prime, Some(RequestView::KRequest(req)))
+            }
+        },
+        VReplicaSetReconcileStepView::AfterDeletePod(diff) => {
+            let diff = *diff;
+            if !(resp_o.is_Some() && resp_o.get_Some_0().is_KResponse()
+            && resp_o.get_Some_0().get_KResponse_0().is_DeleteResponse()
+            && resp_o.get_Some_0().get_KResponse_0().get_DeleteResponse_0().res.is_ok()) {
+                (error_state(state), None)
+            } else if diff == 0 {
+                let state_prime = VReplicaSetReconcileState {
+                    reconcile_step: VReplicaSetReconcileStepView::Done,
+                    ..state
+                };
+                (state_prime, None)
+            } else {
+                if state.filtered_pods.is_none() {
+                    (error_state(state), None)
+                } else if diff > state.filtered_pods.unwrap().len() {
+                    (error_state(state), None)
+                } else {
+                    let pod_name_or_none = state.filtered_pods.unwrap()[diff - 1].metadata.name;
+                    if pod_name_or_none.is_none() {
+                        (error_state(state), None)
+                    } else {
+                        let req = APIRequest::DeleteRequest(DeleteRequest {
+                            key: ObjectRef {
+                                kind: PodView::kind(),
+                                name: pod_name_or_none.unwrap(),
+                                namespace: namespace,
+                            }
+                        });
+                        let state_prime = VReplicaSetReconcileState {
+                            reconcile_step: VReplicaSetReconcileStepView::AfterDeletePod((diff - 1) as nat),
+                            ..state
+                        };
+                        (state_prime, Some(RequestView::KRequest(req)))
+                    }
+                }
+            }
+        },
+        _ => {
+            (state, None)
+        }
+    }
 }
+
+pub open spec fn error_state(state: VReplicaSetReconcileState) -> (state_prime: VReplicaSetReconcileState)
+{
+    VReplicaSetReconcileState {
+        reconcile_step: VReplicaSetReconcileStepView::Error,
+        ..state
+    }
+}
+
+pub open spec fn objects_to_pods(objs: Seq<DynamicObjectView>) -> (pods_or_none: Option<Seq<PodView>>) {
+    if objs.filter(|o: DynamicObjectView| PodView::unmarshal(o).is_err()).len() != 0 {
+        None
+    } else {
+        Some(objs.map(|i: int, o: DynamicObjectView| PodView::unmarshal(o).unwrap()))
+    }
+}
+
+pub open spec fn filter_pods(pods: Seq<PodView>, v_replica_set: VReplicaSetView) -> (filtered_pods: Seq<PodView>) {
+    pods.filter(|pod: PodView|
+        pod.metadata.owner_references_contains(v_replica_set.controller_owner_ref())
+        && v_replica_set.spec.selector.matches(pod.metadata.labels.unwrap_or(Map::empty()))
+        && pod.metadata.deletion_timestamp.is_None())
+}
+
+pub open spec fn make_pod(v_replica_set: VReplicaSetView) -> (pod: PodView) {
+    let template = v_replica_set.spec.template.unwrap();
+    let pod = PodView::default();
+    let pod = PodView {
+        spec: template.spec,
+        metadata: {
+            let tm = template.metadata.unwrap();
+            let metadata = ObjectMetaView::default();
+            let metadata = ObjectMetaView {
+                labels: tm.labels,
+                annotations: tm.annotations,
+                finalizers: tm.finalizers,
+                ..metadata
+            };
+            let metadata = metadata.set_generate_name(
+                v_replica_set.metadata.name.unwrap() + "-"@
+            );
+            let metadata = metadata.set_owner_references(
+                make_owner_references(v_replica_set)
+            );
+            metadata
+        },
+        ..pod
+    };
+    pod
+}
+
+pub open spec fn make_owner_references(v_replica_set: VReplicaSetView) -> Seq<OwnerReferenceView> { seq![v_replica_set.controller_owner_ref()] }
 
 }
     


### PR DESCRIPTION
- Add a model reconciler for the `VReplicaSet` controller, modeled after the executable reconciler.
- Prove the implementation conforms to the model