### PR TITLE
Support `generate_name` in the API server model

### DIFF
--- a/src/controller_examples/fluent_controller/fluentbit/proof/helper_invariants/predicate.rs
+++ b/src/controller_examples/fluent_controller/fluentbit/proof/helper_invariants/predicate.rs
@@ -193,6 +193,11 @@ pub open spec fn resource_object_only_has_owner_reference_pointing_to_current_cr
     }
 }
 
+pub open spec fn no_create_resource_request_msg_with_empty_name_in_flight(sub_resource: SubResource, fb: FluentBitView) -> StatePred<FBCluster> {
+    let resource_key = get_request(sub_resource, fb).key;
+    FBCluster::no_create_msg_that_uses_generate_name(resource_key.kind, resource_key.namespace)
+}
+
 pub open spec fn no_delete_resource_request_msg_in_flight(sub_resource: SubResource, fb: FluentBitView) -> StatePred<FBCluster> {
     |s: FBCluster| {
         forall |msg: FBMessage| !{

--- a/src/controller_examples/fluent_controller/fluentbit/proof/helper_invariants/proof.rs
+++ b/src/controller_examples/fluent_controller/fluentbit/proof/helper_invariants/proof.rs
@@ -620,15 +620,29 @@ pub proof fn lemma_always_resource_object_has_no_finalizers_or_timestamp_and_onl
 {
     let inv = resource_object_has_no_finalizers_or_timestamp_and_only_has_controller_owner_ref(sub_resource, fb);
     lemma_always_resource_object_create_or_update_request_msg_has_one_controller_ref_and_no_finalizers(spec, sub_resource, fb);
+    lemma_always_no_create_resource_request_msg_with_empty_name_in_flight(spec, sub_resource, fb);
     let stronger_next = |s, s_prime| {
         &&& FBCluster::next()(s, s_prime)
         &&& resource_object_create_or_update_request_msg_has_one_controller_ref_and_no_finalizers(sub_resource, fb)(s)
+        &&& no_create_resource_request_msg_with_empty_name_in_flight(sub_resource, fb)(s)
     };
     combine_spec_entails_always_n!(
         spec, lift_action(stronger_next),
         lift_action(FBCluster::next()),
-        lift_state(resource_object_create_or_update_request_msg_has_one_controller_ref_and_no_finalizers(sub_resource, fb))
+        lift_state(resource_object_create_or_update_request_msg_has_one_controller_ref_and_no_finalizers(sub_resource, fb)),
+        lift_state(no_create_resource_request_msg_with_empty_name_in_flight(sub_resource, fb))
     );
+    let resource_key = get_request(sub_resource, fb).key;
+    assert forall |s, s_prime| inv(s) && #[trigger] stronger_next(s, s_prime) implies inv(s_prime) by {
+        let step = choose |step| FBCluster::next_step(s, s_prime, step);
+        match step {
+            Step::ApiServerStep(input) => {
+                let req_msg = input.get_Some_0();
+                assert(!resource_create_request_msg_with_empty_name(resource_key.kind, resource_key.namespace)(req_msg));
+            }
+            _ => {}
+        }
+    }
     init_invariant(spec, FBCluster::init(), stronger_next, inv);
 }
 
@@ -912,12 +926,14 @@ pub proof fn lemma_eventually_always_resource_object_only_has_owner_reference_po
         spec.entails(always(tla_forall(|sub_resource: SubResource| lift_state(resource_object_has_no_finalizers_or_timestamp_and_only_has_controller_owner_ref(sub_resource, fb))))),
         spec.entails(always(tla_forall(|sub_resource: SubResource|lift_state(every_resource_create_request_implies_at_after_create_resource_step(sub_resource, fb))))),
         spec.entails(always(tla_forall(|sub_resource: SubResource|lift_state(object_in_every_resource_update_request_only_has_owner_references_pointing_to_current_cr(sub_resource, fb))))),
+        spec.entails(always(tla_forall(|sub_resource: SubResource|lift_state(no_create_resource_request_msg_with_empty_name_in_flight(sub_resource, fb))))),
     ensures spec.entails(true_pred().leads_to(always(tla_forall(|sub_resource: SubResource| (lift_state(resource_object_only_has_owner_reference_pointing_to_current_cr(sub_resource, fb))))))),
 {
     assert forall |sub_resource: SubResource| spec.entails(true_pred().leads_to(always(lift_state(#[trigger] resource_object_only_has_owner_reference_pointing_to_current_cr(sub_resource, fb))))) by {
         always_tla_forall_apply(spec, |res: SubResource| lift_state(resource_object_has_no_finalizers_or_timestamp_and_only_has_controller_owner_ref(res, fb)), sub_resource);
         always_tla_forall_apply(spec, |res: SubResource|lift_state(every_resource_create_request_implies_at_after_create_resource_step(res, fb)), sub_resource);
         always_tla_forall_apply(spec, |res: SubResource|lift_state(object_in_every_resource_update_request_only_has_owner_references_pointing_to_current_cr(res, fb)), sub_resource);
+        always_tla_forall_apply(spec, |res: SubResource|lift_state(no_create_resource_request_msg_with_empty_name_in_flight(res, fb)), sub_resource);
         lemma_eventually_always_resource_object_only_has_owner_reference_pointing_to_current_cr(spec, sub_resource, fb);
     }
     leads_to_always_tla_forall_subresource(spec, true_pred(), |sub_resource: SubResource| lift_state(resource_object_only_has_owner_reference_pointing_to_current_cr(sub_resource, fb)));
@@ -934,6 +950,7 @@ pub proof fn lemma_eventually_always_resource_object_only_has_owner_reference_po
         spec.entails(always(lift_state(resource_object_has_no_finalizers_or_timestamp_and_only_has_controller_owner_ref(sub_resource, fb)))),
         spec.entails(always(lift_state(every_resource_create_request_implies_at_after_create_resource_step(sub_resource, fb)))),
         spec.entails(always(lift_state(object_in_every_resource_update_request_only_has_owner_references_pointing_to_current_cr(sub_resource, fb)))),
+        spec.entails(always(lift_state(no_create_resource_request_msg_with_empty_name_in_flight(sub_resource, fb)))),
     ensures spec.entails(true_pred().leads_to(always(lift_state(resource_object_only_has_owner_reference_pointing_to_current_cr(sub_resource, fb))))),
 {
     let key = get_request(sub_resource, fb).key;
@@ -979,6 +996,7 @@ pub proof fn lemma_eventually_always_daemon_set_not_exists_or_matches_or_no_more
         spec.entails(always(lift_state(every_resource_update_request_implies_at_after_update_resource_step(SubResource::DaemonSet, fb)))),
         spec.entails(always(lift_state(daemon_set_in_etcd_satisfies_unchangeable(fb)))),
         spec.entails(always(lift_state(resource_object_only_has_owner_reference_pointing_to_current_cr(SubResource::DaemonSet, fb)))),
+        spec.entails(always(lift_state(no_create_resource_request_msg_with_empty_name_in_flight(SubResource::DaemonSet, fb)))),
         spec.entails(always(lift_state(no_update_status_request_msg_not_from_bc_in_flight_of_daemon_set(fb)))),
     ensures spec.entails(true_pred().leads_to(always(lift_state(daemon_set_not_exists_or_matches_or_no_more_status_update(fb))))),
 {
@@ -1043,5 +1061,46 @@ pub proof fn lemma_eventually_always_daemon_set_not_exists_or_matches_or_no_more
         lift_state(daemon_set_not_exists_or_matches_or_no_more_status_update(fb))
     );
 }
+
+// We can probably hide a lof of spec functions to make this lemma faster
+pub proof fn lemma_always_no_create_resource_request_msg_with_empty_name_in_flight(spec: TempPred<FBCluster>, sub_resource: SubResource, fb: FluentBitView)
+    requires
+        spec.entails(lift_state(FBCluster::init())),
+        spec.entails(always(lift_action(FBCluster::next()))),
+    ensures spec.entails(always(lift_state(no_create_resource_request_msg_with_empty_name_in_flight(sub_resource, fb)))),
+{
+    let key = fb.object_ref();
+    let resource_key = get_request(sub_resource, fb).key;
+    let inv = no_create_resource_request_msg_with_empty_name_in_flight(sub_resource, fb);
+
+    assert forall |s: FBCluster| #[trigger] FBCluster::init()(s) implies inv(s) by {}
+
+    assert forall |s: FBCluster, s_prime: FBCluster| #[trigger] FBCluster::next()(s, s_prime) && inv(s) implies inv(s_prime) by {
+        assert forall |msg: FBMessage|
+            !(s_prime.in_flight().contains(msg) && #[trigger] resource_create_request_msg_with_empty_name(resource_key.kind, resource_key.namespace)(msg))
+        by {
+            let step = choose |step| FBCluster::next_step(s, s_prime, step);
+            match step {
+                Step::ApiServerStep(_) => {
+                    if !s.in_flight().contains(msg) && s_prime.in_flight().contains(msg) {
+                        assert(!resource_create_request_msg_with_empty_name(resource_key.kind, resource_key.namespace)(msg));
+                    }
+                },
+                Step::ControllerStep(_) => {
+                    if !s.in_flight().contains(msg) && s_prime.in_flight().contains(msg) {
+                        assert(!resource_create_request_msg_with_empty_name(resource_key.kind, resource_key.namespace)(msg));
+                    }
+                },
+                _ => {
+                    if !s.in_flight().contains(msg) && s_prime.in_flight().contains(msg) {
+                        assert(!resource_create_request_msg_with_empty_name(resource_key.kind, resource_key.namespace)(msg));
+                    }
+                },
+            }
+        }
+    }
+    init_invariant(spec, FBCluster::init(), FBCluster::next(), inv);
+}
+
 
 }

--- a/src/controller_examples/fluent_controller/fluentbit/proof/helper_invariants/unchangeable.rs
+++ b/src/controller_examples/fluent_controller/fluentbit/proof/helper_invariants/unchangeable.rs
@@ -125,6 +125,7 @@ pub proof fn lemma_always_object_in_etcd_satisfies_unchangeable(spec: TempPred<F
         &&& object_in_resource_update_request_msg_has_smaller_rv_than_etcd(sub_resource, fb)(s)
         &&& object_in_every_create_request_msg_satisfies_unchangeable(sub_resource, fb)(s)
         &&& response_at_after_get_resource_step_is_resource_get_response(sub_resource, fb)(s)
+        &&& no_create_resource_request_msg_with_empty_name_in_flight(sub_resource, fb)(s)
     };
     FBCluster::lemma_always_each_object_in_reconcile_has_consistent_key_and_valid_metadata(spec);
     FBCluster::lemma_always_each_object_in_etcd_is_well_formed(spec);
@@ -133,6 +134,7 @@ pub proof fn lemma_always_object_in_etcd_satisfies_unchangeable(spec: TempPred<F
     lemma_always_object_in_resource_update_request_msg_has_smaller_rv_than_etcd(spec, sub_resource, fb);
     lemma_always_object_in_every_create_request_msg_satisfies_unchangeable(spec, sub_resource, fb);
     lemma_always_response_at_after_get_resource_step_is_resource_get_response(spec, sub_resource, fb);
+    lemma_always_no_create_resource_request_msg_with_empty_name_in_flight(spec, sub_resource, fb);
     combine_spec_entails_always_n!(
         spec, lift_action(next), lift_action(FBCluster::next()),
         lift_state(FBCluster::each_object_in_reconcile_has_consistent_key_and_valid_metadata()),
@@ -141,7 +143,8 @@ pub proof fn lemma_always_object_in_etcd_satisfies_unchangeable(spec: TempPred<F
         lift_state(FBCluster::object_in_ok_get_resp_is_same_as_etcd_with_same_rv(resource_key)),
         lift_state(object_in_resource_update_request_msg_has_smaller_rv_than_etcd(sub_resource, fb)),
         lift_state(object_in_every_create_request_msg_satisfies_unchangeable(sub_resource, fb)),
-        lift_state(response_at_after_get_resource_step_is_resource_get_response(sub_resource, fb))
+        lift_state(response_at_after_get_resource_step_is_resource_get_response(sub_resource, fb)),
+        lift_state(no_create_resource_request_msg_with_empty_name_in_flight(sub_resource, fb))
     );
     assert forall |s: FBCluster, s_prime: FBCluster| inv(s) && #[trigger] next(s, s_prime) implies inv(s_prime) by {
         object_in_etcd_satisfies_unchangeable_induction(sub_resource, fb, s, s_prime);
@@ -161,6 +164,7 @@ pub proof fn object_in_etcd_satisfies_unchangeable_induction(sub_resource: SubRe
         FBCluster::each_object_in_etcd_is_well_formed()(s_prime),
         object_in_resource_update_request_msg_has_smaller_rv_than_etcd(sub_resource, fb)(s),
         object_in_etcd_satisfies_unchangeable(sub_resource, fb)(s),
+        no_create_resource_request_msg_with_empty_name_in_flight(sub_resource, fb)(s),
     ensures object_in_etcd_satisfies_unchangeable(sub_resource, fb)(s_prime),
 {
     let resource_key = get_request(sub_resource, fb).key;
@@ -189,6 +193,7 @@ pub proof fn object_in_etcd_satisfies_unchangeable_induction(sub_resource: SubRe
             Step::ApiServerStep(input) => {
                 let req = input.get_Some_0();
                 if resource_update_request_msg(resource_key)(req) {} else {}
+                if resource_create_request_msg_with_empty_name(resource_key.kind, resource_key.namespace)(req) {} else {}
             },
             _ => {}
         }

--- a/src/controller_examples/fluent_controller/fluentbit/proof/liveness/daemon_set_match.rs
+++ b/src/controller_examples/fluent_controller/fluentbit/proof/liveness/daemon_set_match.rs
@@ -42,6 +42,7 @@ pub proof fn lemma_from_after_get_daemon_set_step_to_daemon_set_matches(spec: Te
         spec.entails(always(lift_state(helper_invariants::resource_object_only_has_owner_reference_pointing_to_current_cr(SubResource::DaemonSet, fb)))),
         spec.entails(always(lift_state(helper_invariants::resource_object_has_no_finalizers_or_timestamp_and_only_has_controller_owner_ref(SubResource::DaemonSet, fb)))),
         spec.entails(always(lift_state(helper_invariants::every_resource_create_request_implies_at_after_create_resource_step(SubResource::DaemonSet, fb)))),
+        spec.entails(always(lift_state(helper_invariants::no_create_resource_request_msg_with_empty_name_in_flight(SubResource::DaemonSet, fb)))),
         spec.entails(always(lift_state(helper_invariants::daemon_set_in_etcd_satisfies_unchangeable(fb)))),
     ensures
         spec.entails(lift_state(pending_req_in_flight_at_after_get_resource_step(SubResource::DaemonSet, fb)).leads_to(lift_state(sub_resource_state_matches(SubResource::DaemonSet, fb)))),

--- a/src/controller_examples/fluent_controller/fluentbit/proof/liveness/proof.rs
+++ b/src/controller_examples/fluent_controller/fluentbit/proof/liveness/proof.rs
@@ -471,6 +471,7 @@ proof fn always_tla_forall_apply_for_sub_resource(spec: TempPred<FBCluster>, sub
         spec.entails(always(tla_forall(|res: SubResource| lift_state(helper_invariants::resource_object_has_no_finalizers_or_timestamp_and_only_has_controller_owner_ref(res, fb))))),
         spec.entails(always(tla_forall(|res: SubResource| lift_state(helper_invariants::object_in_etcd_satisfies_unchangeable(res, fb))))),
         spec.entails(always(tla_forall(|res: SubResource| lift_state(helper_invariants::resource_object_only_has_owner_reference_pointing_to_current_cr(res, fb))))),
+        spec.entails(always(tla_forall(|res: SubResource| lift_state(helper_invariants::no_create_resource_request_msg_with_empty_name_in_flight(res, fb))))),
     ensures
         spec.entails(always(lift_state(helper_invariants::every_resource_update_request_implies_at_after_update_resource_step(sub_resource, fb)))),
         spec.entails(always(lift_state(helper_invariants::every_resource_create_request_implies_at_after_create_resource_step(sub_resource, fb)))),
@@ -479,6 +480,7 @@ proof fn always_tla_forall_apply_for_sub_resource(spec: TempPred<FBCluster>, sub
         spec.entails(always(lift_state(helper_invariants::resource_object_has_no_finalizers_or_timestamp_and_only_has_controller_owner_ref(sub_resource, fb)))),
         spec.entails(always(lift_state(helper_invariants::object_in_etcd_satisfies_unchangeable(sub_resource, fb)))),
         spec.entails(always(lift_state(helper_invariants::resource_object_only_has_owner_reference_pointing_to_current_cr(sub_resource, fb)))),
+        spec.entails(always(lift_state(helper_invariants::no_create_resource_request_msg_with_empty_name_in_flight(sub_resource, fb)))),
 {
     always_tla_forall_apply(spec, |res: SubResource| lift_state(helper_invariants::every_resource_update_request_implies_at_after_update_resource_step(res, fb)), sub_resource);
     always_tla_forall_apply(spec, |res: SubResource| lift_state(helper_invariants::every_resource_create_request_implies_at_after_create_resource_step(res, fb)), sub_resource);
@@ -487,6 +489,7 @@ proof fn always_tla_forall_apply_for_sub_resource(spec: TempPred<FBCluster>, sub
     always_tla_forall_apply(spec, |res: SubResource| lift_state(helper_invariants::resource_object_has_no_finalizers_or_timestamp_and_only_has_controller_owner_ref(res, fb)), sub_resource);
     always_tla_forall_apply(spec, |res: SubResource| lift_state(helper_invariants::object_in_etcd_satisfies_unchangeable(res, fb)), sub_resource);
     always_tla_forall_apply(spec, |res: SubResource| lift_state(helper_invariants::resource_object_only_has_owner_reference_pointing_to_current_cr(res, fb)), sub_resource);
+    always_tla_forall_apply(spec, |res: SubResource| lift_state(helper_invariants::no_create_resource_request_msg_with_empty_name_in_flight(res, fb)), sub_resource);
 }
 
 }

--- a/src/controller_examples/fluent_controller/fluentbit/proof/liveness/spec.rs
+++ b/src/controller_examples/fluent_controller/fluentbit/proof/liveness/spec.rs
@@ -112,6 +112,7 @@ pub proof fn spec_of_previous_phases_entails_eventually_new_invariants(i: nat, f
             always_tla_forall_apply(spec, |sub_resource: SubResource| lift_state(helper_invariants::every_resource_create_request_implies_at_after_create_resource_step(sub_resource, fb)), SubResource::DaemonSet);
             always_tla_forall_apply(spec, |sub_resource: SubResource| lift_state(helper_invariants::every_resource_update_request_implies_at_after_update_resource_step(sub_resource, fb)), SubResource::DaemonSet);
             always_tla_forall_apply(spec, |sub_resource: SubResource| lift_state(helper_invariants::object_in_etcd_satisfies_unchangeable(sub_resource, fb)), SubResource::DaemonSet);
+            always_tla_forall_apply(spec, |sub_resource: SubResource| lift_state(helper_invariants::no_create_resource_request_msg_with_empty_name_in_flight(sub_resource, fb)), SubResource::DaemonSet);
             helper_invariants::lemma_eventually_always_daemon_set_not_exists_or_matches_or_no_more_status_update(spec, fb);
         }
     }
@@ -220,6 +221,7 @@ pub open spec fn derived_invariants_since_beginning(fb: FluentBitView) -> TempPr
     .and(always(tla_forall(|res: SubResource| lift_state(FBCluster::object_in_ok_get_resp_is_same_as_etcd_with_same_rv(get_request(res, fb).key)))))
     .and(always(lift_state(helper_invariants::daemon_set_in_etcd_satisfies_unchangeable(fb))))
     .and(always(tla_forall(|sub_resource: SubResource| lift_state(helper_invariants::object_in_etcd_satisfies_unchangeable(sub_resource, fb)))))
+    .and(always(tla_forall(|sub_resource: SubResource| lift_state(helper_invariants::no_create_resource_request_msg_with_empty_name_in_flight(sub_resource, fb)))))
 }
 
 pub proof fn derived_invariants_since_beginning_is_stable(fb: FluentBitView)
@@ -231,6 +233,7 @@ pub proof fn derived_invariants_since_beginning_is_stable(fb: FluentBitView)
     let a_to_p_4 = |res: SubResource| lift_state(helper_invariants::response_at_after_get_resource_step_is_resource_get_response(res, fb));
     let a_to_p_5 = |res: SubResource| lift_state(FBCluster::object_in_ok_get_resp_is_same_as_etcd_with_same_rv(get_request(res, fb).key));
     let a_to_p_6 = |sub_resource: SubResource| lift_state(helper_invariants::object_in_etcd_satisfies_unchangeable(sub_resource, fb));
+    let a_to_p_7 = |sub_resource: SubResource| lift_state(helper_invariants::no_create_resource_request_msg_with_empty_name_in_flight(sub_resource, fb));
     stable_and_always_n!(
         lift_state(FBCluster::every_in_flight_msg_has_unique_id()),
         lift_state(FBCluster::every_in_flight_req_msg_has_different_id_from_pending_req_msg_of(fb.object_ref())),
@@ -253,7 +256,8 @@ pub proof fn derived_invariants_since_beginning_is_stable(fb: FluentBitView)
         tla_forall(a_to_p_4),
         tla_forall(a_to_p_5),
         lift_state(helper_invariants::daemon_set_in_etcd_satisfies_unchangeable(fb)),
-        tla_forall(a_to_p_6)
+        tla_forall(a_to_p_6),
+        tla_forall(a_to_p_7)
     );
 }
 
@@ -438,6 +442,13 @@ pub proof fn sm_spec_entails_all_invariants(fb: FluentBitView)
         }
         spec_entails_always_tla_forall(spec, a_to_p_6);
     });
+    let a_to_p_7 = |sub_resource: SubResource| lift_state(helper_invariants::no_create_resource_request_msg_with_empty_name_in_flight(sub_resource, fb));
+    assert_by(spec.entails(always(tla_forall(a_to_p_7))), {
+        assert forall |sub_resource: SubResource| spec.entails(always(#[trigger] a_to_p_7(sub_resource))) by {
+            helper_invariants::lemma_always_no_create_resource_request_msg_with_empty_name_in_flight(spec, sub_resource, fb);
+        }
+        spec_entails_always_tla_forall(spec, a_to_p_7);
+    });
 
     entails_always_and_n!(
         spec,
@@ -462,7 +473,8 @@ pub proof fn sm_spec_entails_all_invariants(fb: FluentBitView)
         tla_forall(a_to_p_4),
         tla_forall(a_to_p_5),
         lift_state(helper_invariants::daemon_set_in_etcd_satisfies_unchangeable(fb)),
-        tla_forall(a_to_p_6)
+        tla_forall(a_to_p_6),
+        tla_forall(a_to_p_7)
     );
 }
 

--- a/src/controller_examples/fluent_controller/fluentbit_config/proof/helper_invariants/owner_ref.rs
+++ b/src/controller_examples/fluent_controller/fluentbit_config/proof/helper_invariants/owner_ref.rs
@@ -127,14 +127,27 @@ pub proof fn lemma_always_every_owner_ref_of_every_object_in_etcd_has_different_
     let next = |s, s_prime| {
         &&& FBCCluster::next()(s, s_prime)
         &&& object_in_every_resource_create_or_update_request_msg_only_has_valid_owner_references(sub_resource, fb)(s)
+        &&& no_create_resource_request_msg_with_empty_name_in_flight(sub_resource, fb)(s)
     };
     lemma_always_object_in_every_resource_create_or_update_request_msg_only_has_valid_owner_references(spec, sub_resource, fb);
-    combine_spec_entails_always_n!(spec, lift_action(next), lift_action(FBCCluster::next()), lift_state(object_in_every_resource_create_or_update_request_msg_only_has_valid_owner_references(sub_resource, fb)));
+    lemma_always_no_create_resource_request_msg_with_empty_name_in_flight(spec, sub_resource, fb);
+    combine_spec_entails_always_n!(spec, lift_action(next), lift_action(FBCCluster::next()),
+        lift_state(object_in_every_resource_create_or_update_request_msg_only_has_valid_owner_references(sub_resource, fb)),
+        lift_state(no_create_resource_request_msg_with_empty_name_in_flight(sub_resource, fb))
+    );
     let resource_key = get_request(sub_resource, fb).key;
     assert forall |s, s_prime| inv(s) && #[trigger] next(s, s_prime) implies inv(s_prime) by {
         if s_prime.resources().contains_key(resource_key) {
             assert(s.kubernetes_api_state.uid_counter <= s_prime.kubernetes_api_state.uid_counter);
-            if !s.resources().contains_key(resource_key) || s.resources()[resource_key].metadata.owner_references != s_prime.resources()[resource_key].metadata.owner_references {} else {}
+            // if !s.resources().contains_key(resource_key) || s.resources()[resource_key].metadata.owner_references != s_prime.resources()[resource_key].metadata.owner_references {} else {}
+            let step = choose |step| FBCCluster::next_step(s, s_prime, step);
+            match step {
+                Step::ApiServerStep(input) => {
+                    assert(!resource_create_request_msg_with_empty_name(resource_key.kind, resource_key.namespace)(input.get_Some_0()));
+                    if !s.resources().contains_key(resource_key) || s.resources()[resource_key].metadata.owner_references != s_prime.resources()[resource_key].metadata.owner_references {} else {}
+                },
+                _ => {}
+            }
         }
     }
     init_invariant(spec, FBCCluster::init(), next, inv);

--- a/src/controller_examples/fluent_controller/fluentbit_config/proof/helper_invariants/predicate.rs
+++ b/src/controller_examples/fluent_controller/fluentbit_config/proof/helper_invariants/predicate.rs
@@ -189,6 +189,11 @@ pub open spec fn resource_object_only_has_owner_reference_pointing_to_current_cr
     }
 }
 
+pub open spec fn no_create_resource_request_msg_with_empty_name_in_flight(sub_resource: SubResource, fbc: FluentBitConfigView) -> StatePred<FBCCluster> {
+    let resource_key = get_request(sub_resource, fbc).key;
+    FBCCluster::no_create_msg_that_uses_generate_name(resource_key.kind, resource_key.namespace)
+}
+
 pub open spec fn no_delete_resource_request_msg_in_flight(sub_resource: SubResource, fbc: FluentBitConfigView) -> StatePred<FBCCluster> {
     |s: FBCCluster| {
         forall |msg: FBCMessage| !{

--- a/src/controller_examples/fluent_controller/fluentbit_config/proof/helper_invariants/proof.rs
+++ b/src/controller_examples/fluent_controller/fluentbit_config/proof/helper_invariants/proof.rs
@@ -530,15 +530,29 @@ pub proof fn lemma_always_resource_object_has_no_finalizers_or_timestamp_and_onl
 {
     let inv = resource_object_has_no_finalizers_or_timestamp_and_only_has_controller_owner_ref(sub_resource, fbc);
     lemma_always_resource_object_create_or_update_request_msg_has_one_controller_ref_and_no_finalizers(spec, sub_resource, fbc);
+    lemma_always_no_create_resource_request_msg_with_empty_name_in_flight(spec, sub_resource, fbc);
     let stronger_next = |s, s_prime| {
         &&& FBCCluster::next()(s, s_prime)
         &&& resource_object_create_or_update_request_msg_has_one_controller_ref_and_no_finalizers(sub_resource, fbc)(s)
+        &&& no_create_resource_request_msg_with_empty_name_in_flight(sub_resource, fbc)(s)
     };
     combine_spec_entails_always_n!(
         spec, lift_action(stronger_next),
         lift_action(FBCCluster::next()),
-        lift_state(resource_object_create_or_update_request_msg_has_one_controller_ref_and_no_finalizers(sub_resource, fbc))
+        lift_state(resource_object_create_or_update_request_msg_has_one_controller_ref_and_no_finalizers(sub_resource, fbc)),
+        lift_state(no_create_resource_request_msg_with_empty_name_in_flight(sub_resource, fbc))
     );
+    let resource_key = get_request(sub_resource, fbc).key;
+    assert forall |s, s_prime| inv(s) && #[trigger] stronger_next(s, s_prime) implies inv(s_prime) by {
+        let step = choose |step| FBCCluster::next_step(s, s_prime, step);
+        match step {
+            Step::ApiServerStep(input) => {
+                let req_msg = input.get_Some_0();
+                assert(!resource_create_request_msg_with_empty_name(resource_key.kind, resource_key.namespace)(req_msg));
+            }
+            _ => {}
+        }
+    }
     init_invariant(spec, FBCCluster::init(), stronger_next, inv);
 }
 
@@ -797,12 +811,14 @@ pub proof fn lemma_eventually_always_resource_object_only_has_owner_reference_po
         spec.entails(always(tla_forall(|sub_resource: SubResource| lift_state(resource_object_has_no_finalizers_or_timestamp_and_only_has_controller_owner_ref(sub_resource, fbc))))),
         spec.entails(always(tla_forall(|sub_resource: SubResource|lift_state(every_resource_create_request_implies_at_after_create_resource_step(sub_resource, fbc))))),
         spec.entails(always(tla_forall(|sub_resource: SubResource|lift_state(object_in_every_resource_update_request_only_has_owner_references_pointing_to_current_cr(sub_resource, fbc))))),
+        spec.entails(always(tla_forall(|sub_resource: SubResource|lift_state(no_create_resource_request_msg_with_empty_name_in_flight(sub_resource, fbc))))),
     ensures spec.entails(true_pred().leads_to(always(tla_forall(|sub_resource: SubResource| (lift_state(resource_object_only_has_owner_reference_pointing_to_current_cr(sub_resource, fbc))))))),
 {
     assert forall |sub_resource: SubResource| spec.entails(true_pred().leads_to(always(lift_state(#[trigger] resource_object_only_has_owner_reference_pointing_to_current_cr(sub_resource, fbc))))) by {
         always_tla_forall_apply(spec, |res: SubResource| lift_state(resource_object_has_no_finalizers_or_timestamp_and_only_has_controller_owner_ref(res, fbc)), sub_resource);
         always_tla_forall_apply(spec, |res: SubResource|lift_state(every_resource_create_request_implies_at_after_create_resource_step(res, fbc)), sub_resource);
         always_tla_forall_apply(spec, |res: SubResource|lift_state(object_in_every_resource_update_request_only_has_owner_references_pointing_to_current_cr(res, fbc)), sub_resource);
+        always_tla_forall_apply(spec, |res: SubResource|lift_state(no_create_resource_request_msg_with_empty_name_in_flight(res, fbc)), sub_resource);
         lemma_eventually_always_resource_object_only_has_owner_reference_pointing_to_current_cr(spec, sub_resource, fbc);
     }
     leads_to_always_tla_forall_subresource(spec, true_pred(), |sub_resource: SubResource| lift_state(resource_object_only_has_owner_reference_pointing_to_current_cr(sub_resource, fbc)));
@@ -819,6 +835,7 @@ pub proof fn lemma_eventually_always_resource_object_only_has_owner_reference_po
         spec.entails(always(lift_state(resource_object_has_no_finalizers_or_timestamp_and_only_has_controller_owner_ref(sub_resource, fbc)))),
         spec.entails(always(lift_state(every_resource_create_request_implies_at_after_create_resource_step(sub_resource, fbc)))),
         spec.entails(always(lift_state(object_in_every_resource_update_request_only_has_owner_references_pointing_to_current_cr(sub_resource, fbc)))),
+        spec.entails(always(lift_state(no_create_resource_request_msg_with_empty_name_in_flight(sub_resource, fbc)))),
     ensures spec.entails(true_pred().leads_to(always(lift_state(resource_object_only_has_owner_reference_pointing_to_current_cr(sub_resource, fbc))))),
 {
     let key = get_request(sub_resource, fbc).key;
@@ -852,5 +869,46 @@ pub proof fn leads_to_always_tla_forall_subresource(spec: TempPred<FBCCluster>, 
         set![SubResource::Secret]
     );
 }
+
+// We can probably hide a lof of spec functions to make this lemma faster
+pub proof fn lemma_always_no_create_resource_request_msg_with_empty_name_in_flight(spec: TempPred<FBCCluster>, sub_resource: SubResource, fbc: FluentBitConfigView)
+    requires
+        spec.entails(lift_state(FBCCluster::init())),
+        spec.entails(always(lift_action(FBCCluster::next()))),
+    ensures spec.entails(always(lift_state(no_create_resource_request_msg_with_empty_name_in_flight(sub_resource, fbc)))),
+{
+    let key = fbc.object_ref();
+    let resource_key = get_request(sub_resource, fbc).key;
+    let inv = no_create_resource_request_msg_with_empty_name_in_flight(sub_resource, fbc);
+
+    assert forall |s: FBCCluster| #[trigger] FBCCluster::init()(s) implies inv(s) by {}
+
+    assert forall |s: FBCCluster, s_prime: FBCCluster| #[trigger] FBCCluster::next()(s, s_prime) && inv(s) implies inv(s_prime) by {
+        assert forall |msg: FBCMessage|
+            !(s_prime.in_flight().contains(msg) && #[trigger] resource_create_request_msg_with_empty_name(resource_key.kind, resource_key.namespace)(msg))
+        by {
+            let step = choose |step| FBCCluster::next_step(s, s_prime, step);
+            match step {
+                Step::ApiServerStep(_) => {
+                    if !s.in_flight().contains(msg) && s_prime.in_flight().contains(msg) {
+                        assert(!resource_create_request_msg_with_empty_name(resource_key.kind, resource_key.namespace)(msg));
+                    }
+                },
+                Step::ControllerStep(_) => {
+                    if !s.in_flight().contains(msg) && s_prime.in_flight().contains(msg) {
+                        assert(!resource_create_request_msg_with_empty_name(resource_key.kind, resource_key.namespace)(msg));
+                    }
+                },
+                _ => {
+                    if !s.in_flight().contains(msg) && s_prime.in_flight().contains(msg) {
+                        assert(!resource_create_request_msg_with_empty_name(resource_key.kind, resource_key.namespace)(msg));
+                    }
+                },
+            }
+        }
+    }
+    init_invariant(spec, FBCCluster::init(), FBCCluster::next(), inv);
+}
+
 
 }

--- a/src/controller_examples/fluent_controller/fluentbit_config/proof/liveness/proof.rs
+++ b/src/controller_examples/fluent_controller/fluentbit_config/proof/liveness/proof.rs
@@ -231,6 +231,7 @@ proof fn always_tla_forall_apply_for_sub_resource(spec: TempPred<FBCCluster>, su
         spec.entails(always(tla_forall(|res: SubResource| lift_state(helper_invariants::no_delete_resource_request_msg_in_flight(res, fbc))))),
         spec.entails(always(tla_forall(|res: SubResource| lift_state(helper_invariants::resource_object_has_no_finalizers_or_timestamp_and_only_has_controller_owner_ref(res, fbc))))),
         spec.entails(always(tla_forall(|res: SubResource| lift_state(helper_invariants::resource_object_only_has_owner_reference_pointing_to_current_cr(res, fbc))))),
+        spec.entails(always(tla_forall(|res: SubResource| lift_state(helper_invariants::no_create_resource_request_msg_with_empty_name_in_flight(res, fbc))))),
     ensures
         spec.entails(always(lift_state(helper_invariants::every_resource_update_request_implies_at_after_update_resource_step(sub_resource, fbc)))),
         spec.entails(always(lift_state(helper_invariants::every_resource_create_request_implies_at_after_create_resource_step(sub_resource, fbc)))),
@@ -238,6 +239,7 @@ proof fn always_tla_forall_apply_for_sub_resource(spec: TempPred<FBCCluster>, su
         spec.entails(always(lift_state(helper_invariants::no_delete_resource_request_msg_in_flight(sub_resource, fbc)))),
         spec.entails(always(lift_state(helper_invariants::resource_object_has_no_finalizers_or_timestamp_and_only_has_controller_owner_ref(sub_resource, fbc)))),
         spec.entails(always(lift_state(helper_invariants::resource_object_only_has_owner_reference_pointing_to_current_cr(sub_resource, fbc)))),
+        spec.entails(always(lift_state(helper_invariants::no_create_resource_request_msg_with_empty_name_in_flight(sub_resource, fbc)))),
 {
     always_tla_forall_apply(spec, |res: SubResource| lift_state(helper_invariants::every_resource_update_request_implies_at_after_update_resource_step(res, fbc)), sub_resource);
     always_tla_forall_apply(spec, |res: SubResource| lift_state(helper_invariants::every_resource_create_request_implies_at_after_create_resource_step(res, fbc)), sub_resource);
@@ -245,6 +247,7 @@ proof fn always_tla_forall_apply_for_sub_resource(spec: TempPred<FBCCluster>, su
     always_tla_forall_apply(spec, |res: SubResource| lift_state(helper_invariants::no_delete_resource_request_msg_in_flight(res, fbc)), sub_resource);
     always_tla_forall_apply(spec, |res: SubResource| lift_state(helper_invariants::resource_object_has_no_finalizers_or_timestamp_and_only_has_controller_owner_ref(res, fbc)), sub_resource);
     always_tla_forall_apply(spec, |res: SubResource| lift_state(helper_invariants::resource_object_only_has_owner_reference_pointing_to_current_cr(res, fbc)), sub_resource);
+    always_tla_forall_apply(spec, |res: SubResource| lift_state(helper_invariants::no_create_resource_request_msg_with_empty_name_in_flight(res, fbc)), sub_resource);
 }
 
 }

--- a/src/controller_examples/rabbitmq_controller/proof/helper_invariants/owner_ref.rs
+++ b/src/controller_examples/rabbitmq_controller/proof/helper_invariants/owner_ref.rs
@@ -150,14 +150,26 @@ pub proof fn lemma_always_every_owner_ref_of_every_object_in_etcd_has_different_
     let next = |s, s_prime| {
         &&& RMQCluster::next()(s, s_prime)
         &&& object_in_every_resource_create_or_update_request_msg_only_has_valid_owner_references(sub_resource, rabbitmq)(s)
+        &&& no_create_resource_request_msg_with_empty_name_in_flight(sub_resource, rabbitmq)(s)
     };
     lemma_always_object_in_every_resource_create_or_update_request_msg_only_has_valid_owner_references(spec, sub_resource, rabbitmq);
-    combine_spec_entails_always_n!(spec, lift_action(next), lift_action(RMQCluster::next()), lift_state(object_in_every_resource_create_or_update_request_msg_only_has_valid_owner_references(sub_resource, rabbitmq)));
+    lemma_always_no_create_resource_request_msg_with_empty_name_in_flight(spec, sub_resource, rabbitmq);
+    combine_spec_entails_always_n!(spec, lift_action(next), lift_action(RMQCluster::next()),
+        lift_state(object_in_every_resource_create_or_update_request_msg_only_has_valid_owner_references(sub_resource, rabbitmq)),
+        lift_state(no_create_resource_request_msg_with_empty_name_in_flight(sub_resource, rabbitmq))
+    );
     let resource_key = get_request(sub_resource, rabbitmq).key;
     assert forall |s, s_prime| inv(s) && #[trigger] next(s, s_prime) implies inv(s_prime) by {
         if s_prime.resources().contains_key(resource_key) {
             assert(s.kubernetes_api_state.uid_counter <= s_prime.kubernetes_api_state.uid_counter);
-            if !s.resources().contains_key(resource_key) || s.resources()[resource_key].metadata.owner_references != s_prime.resources()[resource_key].metadata.owner_references {} else {}
+            let step = choose |step| RMQCluster::next_step(s, s_prime, step);
+            match step {
+                Step::ApiServerStep(input) => {
+                    assert(!resource_create_request_msg_with_empty_name(resource_key.kind, resource_key.namespace)(input.get_Some_0()));
+                    if !s.resources().contains_key(resource_key) || s.resources()[resource_key].metadata.owner_references != s_prime.resources()[resource_key].metadata.owner_references {} else {}
+                },
+                _ => {}
+            }
         }
     }
     init_invariant(spec, RMQCluster::init(), next, inv);

--- a/src/controller_examples/rabbitmq_controller/proof/helper_invariants/predicate.rs
+++ b/src/controller_examples/rabbitmq_controller/proof/helper_invariants/predicate.rs
@@ -246,6 +246,11 @@ pub open spec fn resource_object_only_has_owner_reference_pointing_to_current_cr
     }
 }
 
+pub open spec fn no_create_resource_request_msg_with_empty_name_in_flight(sub_resource: SubResource, rabbitmq: RabbitmqClusterView) -> StatePred<RMQCluster> {
+    let resource_key = get_request(sub_resource, rabbitmq).key;
+    RMQCluster::no_create_msg_that_uses_generate_name(resource_key.kind, resource_key.namespace)
+}
+
 pub open spec fn no_delete_resource_request_msg_in_flight(sub_resource: SubResource, rabbitmq: RabbitmqClusterView) -> StatePred<RMQCluster> {
     |s: RMQCluster| {
         forall |msg: RMQMessage| !{

--- a/src/controller_examples/rabbitmq_controller/proof/helper_invariants/proof.rs
+++ b/src/controller_examples/rabbitmq_controller/proof/helper_invariants/proof.rs
@@ -6,7 +6,6 @@ use crate::kubernetes_api_objects::spec::{
     api_method::*, common::*, owner_reference::*, prelude::*, resource::*,
 };
 use crate::kubernetes_cluster::spec::{
-    api_server::state_machine::generated_name_is_unique,
     cluster::*,
     cluster_state_machine::Step,
     controller::types::{ControllerActionInput, ControllerStep},
@@ -170,7 +169,6 @@ proof fn lemma_eventually_always_cm_rv_is_the_same_as_etcd_server_cm_if_cm_updat
                                     let req = input.get_Some_0();
                                     assert(!resource_delete_request_msg(get_request(SubResource::ServerConfigMap, rabbitmq).key)(req));
                                     assert(!resource_update_status_request_msg(get_request(SubResource::ServerConfigMap, rabbitmq).key)(req));
-                                    generated_name_is_unique(s.kubernetes_api_state);
                                     if resource_update_request_msg(get_request(SubResource::ServerConfigMap, rabbitmq).key)(req) {} else {}
                                 },
                                 _ => {},
@@ -338,7 +336,6 @@ proof fn object_in_response_at_after_create_resource_step_is_same_as_etcd_helper
                     assert(!resource_delete_request_msg(resource_key)(req_msg));
                     assert(!resource_update_request_msg(resource_key)(req_msg));
                     assert(!resource_update_status_request_msg(resource_key)(req_msg));
-                    generated_name_is_unique(s.kubernetes_api_state);
                     match req_msg.content.get_APIRequest_0() {
                         APIRequest::CreateRequest(_) => {
                             if !s.in_flight().contains(msg) {
@@ -515,7 +512,6 @@ proof fn object_in_response_at_after_update_resource_step_is_same_as_etcd_helper
                     let req_msg = input.get_Some_0();
                     assert(!resource_delete_request_msg(resource_key)(req_msg));
                     assert(!resource_update_status_request_msg(resource_key)(req_msg));
-                    generated_name_is_unique(s.kubernetes_api_state);
                     match req_msg.content.get_APIRequest_0() {
                         APIRequest::UpdateRequest(_) => {
                             if !s.in_flight().contains(msg) {
@@ -1801,7 +1797,6 @@ pub proof fn lemma_always_cm_rv_stays_unchanged(spec: TempPred<RMQCluster>, rabb
                 let req = input.get_Some_0();
                 assert(!resource_delete_request_msg(cm_key)(req));
                 assert(!resource_update_status_request_msg(cm_key)(req));
-                generated_name_is_unique(s.kubernetes_api_state);
                 if resource_update_request_msg(cm_key)(req) {} else {}
             },
             _ => {},

--- a/src/controller_examples/rabbitmq_controller/proof/helper_invariants/proof.rs
+++ b/src/controller_examples/rabbitmq_controller/proof/helper_invariants/proof.rs
@@ -1828,6 +1828,11 @@ pub proof fn lemma_always_no_create_resource_request_msg_with_empty_name_in_flig
         spec.entails(always(lift_action(RMQCluster::next()))),
     ensures spec.entails(always(lift_state(no_create_resource_request_msg_with_empty_name_in_flight(sub_resource, rabbitmq)))),
 {
+    // hide(crate::kubernetes_cluster::spec::api_server::state_machine::create_request_admission_check);
+    // hide(crate::kubernetes_cluster::spec::api_server::state_machine::created_object_validity_check);
+    // hide(crate::kubernetes_cluster::spec::api_server::state_machine::update_request_admission_check);
+    // hide(crate::kubernetes_cluster::spec::api_server::state_machine::update_status_request_admission_check);
+    // hide(crate::kubernetes_cluster::spec::api_server::state_machine::updated_object_validity_check);
     let key = rabbitmq.object_ref();
     let resource_key = get_request(sub_resource, rabbitmq).key;
     let inv = no_create_resource_request_msg_with_empty_name_in_flight(sub_resource, rabbitmq);
@@ -1850,17 +1855,21 @@ pub proof fn lemma_always_no_create_resource_request_msg_with_empty_name_in_flig
                         assert(!resource_create_request_msg_with_empty_name(resource_key.kind, resource_key.namespace)(msg));
                     }
                 },
-                Step::ClientStep() => {
+                // Step::ClientStep() => {
+                //     if !s.in_flight().contains(msg) && s_prime.in_flight().contains(msg) {
+                //         assert(!resource_create_request_msg_with_empty_name(resource_key.kind, resource_key.namespace)(msg));
+                //     }
+                // },
+                // Step::BuiltinControllersStep(_) => {
+                //     if !s.in_flight().contains(msg) && s_prime.in_flight().contains(msg) {
+                //         assert(!resource_create_request_msg_with_empty_name(resource_key.kind, resource_key.namespace)(msg));
+                //     }
+                // },
+                _ => {
                     if !s.in_flight().contains(msg) && s_prime.in_flight().contains(msg) {
                         assert(!resource_create_request_msg_with_empty_name(resource_key.kind, resource_key.namespace)(msg));
                     }
                 },
-                Step::BuiltinControllersStep(_) => {
-                    if !s.in_flight().contains(msg) && s_prime.in_flight().contains(msg) {
-                        assert(!resource_create_request_msg_with_empty_name(resource_key.kind, resource_key.namespace)(msg));
-                    }
-                },
-                _ => {},
             }
         }
     }

--- a/src/controller_examples/rabbitmq_controller/proof/helper_invariants/unchangeable.rs
+++ b/src/controller_examples/rabbitmq_controller/proof/helper_invariants/unchangeable.rs
@@ -125,6 +125,7 @@ pub proof fn lemma_always_object_in_etcd_satisfies_unchangeable(spec: TempPred<R
         &&& object_in_resource_update_request_msg_has_smaller_rv_than_etcd(sub_resource, rabbitmq)(s)
         &&& object_in_every_create_request_msg_satisfies_unchangeable(sub_resource, rabbitmq)(s)
         &&& response_at_after_get_resource_step_is_resource_get_response(sub_resource, rabbitmq)(s)
+        &&& no_create_resource_request_msg_with_empty_name_in_flight(sub_resource, rabbitmq)(s)
     };
     RMQCluster::lemma_always_each_object_in_reconcile_has_consistent_key_and_valid_metadata(spec);
     RMQCluster::lemma_always_each_object_in_etcd_is_well_formed(spec);
@@ -133,6 +134,7 @@ pub proof fn lemma_always_object_in_etcd_satisfies_unchangeable(spec: TempPred<R
     lemma_always_object_in_resource_update_request_msg_has_smaller_rv_than_etcd(spec, sub_resource, rabbitmq);
     lemma_always_object_in_every_create_request_msg_satisfies_unchangeable(spec, sub_resource, rabbitmq);
     lemma_always_response_at_after_get_resource_step_is_resource_get_response(spec, sub_resource, rabbitmq);
+    lemma_always_no_create_resource_request_msg_with_empty_name_in_flight(spec, sub_resource, rabbitmq);
     combine_spec_entails_always_n!(
         spec, lift_action(next), lift_action(RMQCluster::next()),
         lift_state(RMQCluster::each_object_in_reconcile_has_consistent_key_and_valid_metadata()),
@@ -141,7 +143,8 @@ pub proof fn lemma_always_object_in_etcd_satisfies_unchangeable(spec: TempPred<R
         lift_state(RMQCluster::object_in_ok_get_resp_is_same_as_etcd_with_same_rv(resource_key)),
         lift_state(object_in_resource_update_request_msg_has_smaller_rv_than_etcd(sub_resource, rabbitmq)),
         lift_state(object_in_every_create_request_msg_satisfies_unchangeable(sub_resource, rabbitmq)),
-        lift_state(response_at_after_get_resource_step_is_resource_get_response(sub_resource, rabbitmq))
+        lift_state(response_at_after_get_resource_step_is_resource_get_response(sub_resource, rabbitmq)),
+        lift_state(no_create_resource_request_msg_with_empty_name_in_flight(sub_resource, rabbitmq))
     );
     assert forall |s: RMQCluster, s_prime: RMQCluster| inv(s) && #[trigger] next(s, s_prime) implies inv(s_prime) by {
         object_in_etcd_satisfies_unchangeable_induction(sub_resource, rabbitmq, s, s_prime);
@@ -161,6 +164,7 @@ pub proof fn object_in_etcd_satisfies_unchangeable_induction(sub_resource: SubRe
         RMQCluster::each_object_in_etcd_is_well_formed()(s_prime),
         object_in_resource_update_request_msg_has_smaller_rv_than_etcd(sub_resource, rabbitmq)(s),
         object_in_etcd_satisfies_unchangeable(sub_resource, rabbitmq)(s),
+        no_create_resource_request_msg_with_empty_name_in_flight(sub_resource, rabbitmq)(s),
     ensures object_in_etcd_satisfies_unchangeable(sub_resource, rabbitmq)(s_prime),
 {
     let resource_key = get_request(sub_resource, rabbitmq).key;
@@ -189,6 +193,7 @@ pub proof fn object_in_etcd_satisfies_unchangeable_induction(sub_resource: SubRe
             Step::ApiServerStep(input) => {
                 let req = input.get_Some_0();
                 if resource_update_request_msg(resource_key)(req) {} else {}
+                if resource_create_request_msg_with_empty_name(resource_key.kind, resource_key.namespace)(req) {} else {}
             },
             _ => {}
         }

--- a/src/controller_examples/rabbitmq_controller/proof/helper_invariants/validation.rs
+++ b/src/controller_examples/rabbitmq_controller/proof/helper_invariants/validation.rs
@@ -7,7 +7,6 @@ use crate::kubernetes_api_objects::spec::{
     stateful_set::*,
 };
 use crate::kubernetes_cluster::spec::{
-    api_server::state_machine::generated_name_is_unique,
     cluster::*,
     cluster_state_machine::Step,
     controller::types::{ControllerActionInput, ControllerStep},
@@ -106,14 +105,12 @@ pub proof fn lemma_always_stateful_set_in_etcd_satisfies_unchangeable(spec: Temp
                         assert(owner_refs.get_Some_0()[0] != RabbitmqClusterView::unmarshal(s_prime.resources()[key]).get_Ok_0().controller_owner_ref());
                     }
                 } else if s.resources()[key] != s_prime.resources()[key] {
-                    generated_name_is_unique(s.kubernetes_api_state);
                     assert(s.resources()[key].metadata.uid == s_prime.resources()[key].metadata.uid);
                     assert(RabbitmqClusterView::unmarshal(s.resources()[key]).get_Ok_0().controller_owner_ref() == RabbitmqClusterView::unmarshal(s_prime.resources()[key]).get_Ok_0().controller_owner_ref());
                     assert(RabbitmqClusterView::unmarshal(s_prime.resources()[key]).get_Ok_0()
                         .transition_validation(RabbitmqClusterView::unmarshal(s.resources()[key]).get_Ok_0()));
                 }
                 assert(certain_fields_of_stateful_set_stay_unchanged(s_prime.resources()[sts_key], RabbitmqClusterView::unmarshal(s_prime.resources()[key]).get_Ok_0()));
-                assert(inv(s_prime));
             } else {
                 let step = choose |step| RMQCluster::next_step(s, s_prime, step);
                 match step {
@@ -122,7 +119,6 @@ pub proof fn lemma_always_stateful_set_in_etcd_satisfies_unchangeable(spec: Temp
                         if resource_create_request_msg(sts_key)(req) {} else {}
                         if resource_update_request_msg(sts_key)(req) {} else {}
                         if resource_create_request_msg_with_empty_name(sts_key.kind, sts_key.namespace)(req) {} else {}
-                        generated_name_is_unique(s.kubernetes_api_state);
                     },
                     _ => {}
                 }
@@ -315,7 +311,6 @@ proof fn lemma_always_stateful_set_in_create_request_msg_satisfies_unchangeable(
                     assert(s.controller_state == s_prime.controller_state);
                     assert(s.in_flight().contains(msg));
                     if s.resources().contains_key(key) {
-                        generated_name_is_unique(s.kubernetes_api_state);
                         assert(RabbitmqClusterView::unmarshal(s_prime.resources()[key]).get_Ok_0()
                         .transition_validation(RabbitmqClusterView::unmarshal(s.resources()[key]).get_Ok_0()));
                     } else {

--- a/src/controller_examples/rabbitmq_controller/proof/liveness/proof.rs
+++ b/src/controller_examples/rabbitmq_controller/proof/liveness/proof.rs
@@ -390,6 +390,7 @@ proof fn always_tla_forall_apply_for_sub_resource(spec: TempPred<RMQCluster>, su
         spec.entails(always(tla_forall(|res: SubResource| lift_state(helper_invariants::object_in_etcd_satisfies_unchangeable(res, rabbitmq))))),
         spec.entails(always(tla_forall(|res: SubResource| lift_state(helper_invariants::resource_object_only_has_owner_reference_pointing_to_current_cr(res, rabbitmq))))),
         spec.entails(always(tla_forall(|res: SubResource| lift_state(helper_invariants::object_in_etcd_satisfies_unchangeable(res, rabbitmq))))),
+        spec.entails(always(tla_forall(|res: SubResource| lift_state(helper_invariants::no_create_resource_request_msg_with_empty_name_in_flight(res, rabbitmq))))),
     ensures
         spec.entails(always(lift_state(helper_invariants::every_resource_update_request_implies_at_after_update_resource_step(sub_resource, rabbitmq)))),
         spec.entails(always(lift_state(helper_invariants::every_resource_create_request_implies_at_after_create_resource_step(sub_resource, rabbitmq)))),
@@ -399,6 +400,7 @@ proof fn always_tla_forall_apply_for_sub_resource(spec: TempPred<RMQCluster>, su
         spec.entails(always(lift_state(helper_invariants::object_in_etcd_satisfies_unchangeable(sub_resource, rabbitmq)))),
         spec.entails(always(lift_state(helper_invariants::resource_object_only_has_owner_reference_pointing_to_current_cr(sub_resource, rabbitmq)))),
         spec.entails(always(lift_state(helper_invariants::object_in_etcd_satisfies_unchangeable(sub_resource, rabbitmq)))),
+        spec.entails(always(lift_state(helper_invariants::no_create_resource_request_msg_with_empty_name_in_flight(sub_resource, rabbitmq)))),
 {
     always_tla_forall_apply(spec, |res: SubResource| lift_state(helper_invariants::every_resource_update_request_implies_at_after_update_resource_step(res, rabbitmq)), sub_resource);
     always_tla_forall_apply(spec, |res: SubResource| lift_state(helper_invariants::every_resource_create_request_implies_at_after_create_resource_step(res, rabbitmq)), sub_resource);
@@ -408,6 +410,7 @@ proof fn always_tla_forall_apply_for_sub_resource(spec: TempPred<RMQCluster>, su
     always_tla_forall_apply(spec, |res: SubResource| lift_state(helper_invariants::object_in_etcd_satisfies_unchangeable(res, rabbitmq)), sub_resource);
     always_tla_forall_apply(spec, |res: SubResource| lift_state(helper_invariants::resource_object_only_has_owner_reference_pointing_to_current_cr(res, rabbitmq)), sub_resource);
     always_tla_forall_apply(spec, |res: SubResource| lift_state(helper_invariants::object_in_etcd_satisfies_unchangeable(res, rabbitmq)), sub_resource);
+    always_tla_forall_apply(spec, |res: SubResource| lift_state(helper_invariants::no_create_resource_request_msg_with_empty_name_in_flight(res, rabbitmq)), sub_resource);
 }
 
 }

--- a/src/controller_examples/rabbitmq_controller/proof/liveness/resource_match.rs
+++ b/src/controller_examples/rabbitmq_controller/proof/liveness/resource_match.rs
@@ -6,7 +6,6 @@ use crate::kubernetes_api_objects::spec::{
     api_method::*, common::*, dynamic::*, owner_reference::*, prelude::*, resource::*,
 };
 use crate::kubernetes_cluster::spec::{
-    api_server::state_machine::generated_name_is_unique,
     builtin_controllers::types::BuiltinControllerChoice,
     cluster::*,
     cluster_state_machine::Step,
@@ -865,7 +864,6 @@ proof fn lemma_resource_state_matches_at_after_update_resource_step(
                 assert(!resource_delete_request_msg(resource_key)(input.get_Some_0()));
                 assert(!resource_update_status_request_msg(resource_key)(input.get_Some_0()));
                 if resource_update_request_msg(resource_key)(input.get_Some_0()) {} else {}
-                generated_name_is_unique(s.kubernetes_api_state);
             },
             _ => {},
         }
@@ -945,7 +943,6 @@ proof fn lemma_from_after_get_resource_step_to_after_update_resource_step(
                 assert(!resource_update_status_request_msg(get_request(sub_resource, rabbitmq).key)(req));
                 assert(!resource_delete_request_msg(get_request(sub_resource, rabbitmq).key)(req));
                 if resource_update_request_msg(get_request(sub_resource, rabbitmq).key)(req) {} else {}
-                generated_name_is_unique(s.kubernetes_api_state);
             },
             _ => {},
         }
@@ -999,7 +996,6 @@ pub proof fn lemma_resource_object_is_stable(
                 assert(!resource_delete_request_msg(get_request(sub_resource, rabbitmq).key)(req));
                 assert(!resource_update_status_request_msg(get_request(sub_resource, rabbitmq).key)(req));
                 if resource_update_request_msg(get_request(sub_resource, rabbitmq).key)(req) {} else {}
-                generated_name_is_unique(s.kubernetes_api_state);
             },
             _ => {},
         }

--- a/src/controller_examples/rabbitmq_controller/proof/liveness/resource_match.rs
+++ b/src/controller_examples/rabbitmq_controller/proof/liveness/resource_match.rs
@@ -6,6 +6,7 @@ use crate::kubernetes_api_objects::spec::{
     api_method::*, common::*, dynamic::*, owner_reference::*, prelude::*, resource::*,
 };
 use crate::kubernetes_cluster::spec::{
+    api_server::state_machine::generated_name_is_unique,
     builtin_controllers::types::BuiltinControllerChoice,
     cluster::*,
     cluster_state_machine::Step,
@@ -54,6 +55,7 @@ pub proof fn lemma_from_after_get_resource_step_to_resource_matches(
         spec.entails(always(lift_state(helper_invariants::resource_object_only_has_owner_reference_pointing_to_current_cr(sub_resource, rabbitmq)))),
         spec.entails(always(lift_state(helper_invariants::object_in_etcd_satisfies_unchangeable(sub_resource, rabbitmq)))),
         spec.entails(always(lift_state(helper_invariants::resource_object_has_no_finalizers_or_timestamp_and_only_has_controller_owner_ref(sub_resource, rabbitmq)))),
+        spec.entails(always(lift_state(helper_invariants::no_create_resource_request_msg_with_empty_name_in_flight(sub_resource, rabbitmq)))),
     ensures
         spec.entails(lift_state(pending_req_in_flight_at_after_get_resource_step(sub_resource, rabbitmq))
             .leads_to(lift_state(sub_resource_state_matches(sub_resource, rabbitmq)))),
@@ -96,6 +98,7 @@ pub proof fn lemma_from_after_get_resource_step_and_key_not_exists_to_resource_m
         spec.entails(always(lift_state(RMQCluster::each_object_in_reconcile_has_consistent_key_and_valid_metadata()))),
         spec.entails(always(lift_state(helper_invariants::the_object_in_reconcile_satisfies_state_validation(rabbitmq.object_ref())))),
         spec.entails(always(lift_state(helper_invariants::every_resource_create_request_implies_at_after_create_resource_step(sub_resource, rabbitmq)))),
+        spec.entails(always(lift_state(helper_invariants::no_create_resource_request_msg_with_empty_name_in_flight(sub_resource, rabbitmq)))),
         spec.entails(always(lift_state(helper_invariants::cm_rv_is_the_same_as_etcd_server_cm_if_cm_updated(rabbitmq)))),
     ensures
         spec.entails(lift_state(|s: RMQCluster| {
@@ -427,6 +430,7 @@ proof fn lemma_from_key_not_exists_to_receives_not_found_resp_at_after_get_resou
         spec.entails(always(lift_state(RMQCluster::busy_disabled()))),
         spec.entails(always(lift_state(RMQCluster::every_in_flight_msg_has_unique_id()))),
         spec.entails(always(lift_state(helper_invariants::every_resource_create_request_implies_at_after_create_resource_step(sub_resource, rabbitmq)))),
+        spec.entails(always(lift_state(helper_invariants::no_create_resource_request_msg_with_empty_name_in_flight(sub_resource, rabbitmq)))),
     ensures
         spec.entails(
             lift_state(
@@ -442,12 +446,13 @@ proof fn lemma_from_key_not_exists_to_receives_not_found_resp_at_after_get_resou
             ))
         ),
 {
+    let resource_key = get_request(sub_resource, rabbitmq).key;
     let pre = |s: RMQCluster| {
-        &&& !s.resources().contains_key(get_request(sub_resource, rabbitmq).key)
+        &&& !s.resources().contains_key(resource_key)
         &&& req_msg_is_the_in_flight_pending_req_at_after_get_resource_step(sub_resource, rabbitmq, req_msg)(s)
     };
     let post = |s: RMQCluster| {
-        &&& !s.resources().contains_key(get_request(sub_resource, rabbitmq).key)
+        &&& !s.resources().contains_key(resource_key)
         &&& at_after_get_resource_step_and_exists_not_found_resp_in_flight(sub_resource, rabbitmq)(s)
     };
     let input = Some(req_msg);
@@ -457,6 +462,7 @@ proof fn lemma_from_key_not_exists_to_receives_not_found_resp_at_after_get_resou
         &&& RMQCluster::busy_disabled()(s)
         &&& RMQCluster::every_in_flight_msg_has_unique_id()(s)
         &&& helper_invariants::every_resource_create_request_implies_at_after_create_resource_step(sub_resource, rabbitmq)(s)
+        &&& helper_invariants::no_create_resource_request_msg_with_empty_name_in_flight(sub_resource, rabbitmq)(s)
     };
     combine_spec_entails_always_n!(
         spec, lift_action(stronger_next),
@@ -464,14 +470,16 @@ proof fn lemma_from_key_not_exists_to_receives_not_found_resp_at_after_get_resou
         lift_state(RMQCluster::crash_disabled()),
         lift_state(RMQCluster::busy_disabled()),
         lift_state(RMQCluster::every_in_flight_msg_has_unique_id()),
-        lift_state(helper_invariants::every_resource_create_request_implies_at_after_create_resource_step(sub_resource, rabbitmq))
+        lift_state(helper_invariants::every_resource_create_request_implies_at_after_create_resource_step(sub_resource, rabbitmq)),
+        lift_state(helper_invariants::no_create_resource_request_msg_with_empty_name_in_flight(sub_resource, rabbitmq))
     );
 
     assert forall |s, s_prime| pre(s) && #[trigger] stronger_next(s, s_prime) implies pre(s_prime) || post(s_prime) by {
         let step = choose |step| RMQCluster::next_step(s, s_prime, step);
         match step {
             Step::ApiServerStep(input) => {
-                assert(!resource_create_request_msg(get_request(sub_resource, rabbitmq).key)(input.get_Some_0()));
+                assert(!resource_create_request_msg(resource_key)(input.get_Some_0()));
+                assert(!resource_create_request_msg_with_empty_name(resource_key.kind, resource_key.namespace)(input.get_Some_0()));
                 if input.get_Some_0() == req_msg {
                     let resp_msg = RMQCluster::handle_get_request_msg(req_msg, s.kubernetes_api_state).1;
                     assert({
@@ -514,6 +522,7 @@ proof fn lemma_from_after_get_resource_step_to_after_create_resource_step(
         spec.entails(always(lift_state(RMQCluster::each_object_in_reconcile_has_consistent_key_and_valid_metadata()))),
         spec.entails(always(lift_state(RMQCluster::every_in_flight_msg_has_unique_id()))),
         spec.entails(always(lift_state(helper_invariants::every_resource_create_request_implies_at_after_create_resource_step(sub_resource, rabbitmq)))),
+        spec.entails(always(lift_state(helper_invariants::no_create_resource_request_msg_with_empty_name_in_flight(sub_resource, rabbitmq)))),
         spec.entails(always(lift_state(helper_invariants::cm_rv_is_the_same_as_etcd_server_cm_if_cm_updated(rabbitmq)))),
     ensures
         spec.entails(
@@ -528,14 +537,15 @@ proof fn lemma_from_after_get_resource_step_to_after_create_resource_step(
             }))
         ),
 {
+    let resource_key = get_request(sub_resource, rabbitmq).key;
     let pre = |s: RMQCluster| {
-        &&& !s.resources().contains_key(get_request(sub_resource, rabbitmq).key)
+        &&& !s.resources().contains_key(resource_key)
         &&& resp_msg_is_the_in_flight_resp_at_after_get_resource_step(sub_resource, rabbitmq, resp_msg)(s)
         &&& resp_msg.content.get_get_response().res.is_Err()
         &&& resp_msg.content.get_get_response().res.get_Err_0().is_ObjectNotFound()
     };
     let post = |s: RMQCluster| {
-        &&& !s.resources().contains_key(get_request(sub_resource, rabbitmq).key)
+        &&& !s.resources().contains_key(resource_key)
         &&& pending_req_in_flight_at_after_create_resource_step(sub_resource, rabbitmq)(s)
     };
     let key = rabbitmq.object_ref();
@@ -550,6 +560,7 @@ proof fn lemma_from_after_get_resource_step_to_after_create_resource_step(
         &&& consistent_key(s)
         &&& RMQCluster::every_in_flight_msg_has_unique_id()(s)
         &&& helper_invariants::every_resource_create_request_implies_at_after_create_resource_step(sub_resource, rabbitmq)(s)
+        &&& helper_invariants::no_create_resource_request_msg_with_empty_name_in_flight(sub_resource, rabbitmq)(s)
         &&& helper_invariants::cm_rv_is_the_same_as_etcd_server_cm_if_cm_updated(rabbitmq)(s)
     };
     always_weaken_temp(spec, lift_state(RMQCluster::each_object_in_reconcile_has_consistent_key_and_valid_metadata()), lift_state(consistent_key));
@@ -561,6 +572,7 @@ proof fn lemma_from_after_get_resource_step_to_after_create_resource_step(
         lift_state(consistent_key),
         lift_state(RMQCluster::every_in_flight_msg_has_unique_id()),
         lift_state(helper_invariants::every_resource_create_request_implies_at_after_create_resource_step(sub_resource, rabbitmq)),
+        lift_state(helper_invariants::no_create_resource_request_msg_with_empty_name_in_flight(sub_resource, rabbitmq)),
         lift_state(helper_invariants::cm_rv_is_the_same_as_etcd_server_cm_if_cm_updated(rabbitmq))
     );
 
@@ -568,7 +580,8 @@ proof fn lemma_from_after_get_resource_step_to_after_create_resource_step(
         let step = choose |step| RMQCluster::next_step(s, s_prime, step);
         match step {
             Step::ApiServerStep(input) => {
-                assert(!resource_create_request_msg(get_request(sub_resource, rabbitmq).key)(input.get_Some_0()));
+                assert(!resource_create_request_msg(resource_key)(input.get_Some_0()));
+                assert(!resource_create_request_msg_with_empty_name(resource_key.kind, resource_key.namespace)(input.get_Some_0()));
             },
             _ => {}
         }
@@ -592,6 +605,7 @@ proof fn lemma_resource_state_matches_at_after_create_resource_step(
         spec.entails(always(lift_state(helper_invariants::the_object_in_reconcile_satisfies_state_validation(rabbitmq.object_ref())))),
         spec.entails(always(lift_state(helper_invariants::cm_rv_is_the_same_as_etcd_server_cm_if_cm_updated(rabbitmq)))),
         spec.entails(always(lift_state(helper_invariants::every_resource_create_request_implies_at_after_create_resource_step(sub_resource, rabbitmq)))),
+        spec.entails(always(lift_state(helper_invariants::no_create_resource_request_msg_with_empty_name_in_flight(sub_resource, rabbitmq)))),
     ensures
         spec.entails(
             lift_state(
@@ -605,8 +619,9 @@ proof fn lemma_resource_state_matches_at_after_create_resource_step(
             )
         ),
 {
+    let resource_key = get_request(sub_resource, rabbitmq).key;
     let pre = |s: RMQCluster| {
-        &&& !s.resources().contains_key(get_request(sub_resource, rabbitmq).key)
+        &&& !s.resources().contains_key(resource_key)
         &&& req_msg_is_the_in_flight_pending_req_at_after_create_resource_step(sub_resource, rabbitmq, req_msg)(s)
     };
     let input = Some(req_msg);
@@ -619,6 +634,7 @@ proof fn lemma_resource_state_matches_at_after_create_resource_step(
         &&& helper_invariants::the_object_in_reconcile_satisfies_state_validation(rabbitmq.object_ref())(s)
         &&& helper_invariants::cm_rv_is_the_same_as_etcd_server_cm_if_cm_updated(rabbitmq)(s)
         &&& helper_invariants::every_resource_create_request_implies_at_after_create_resource_step(sub_resource, rabbitmq)(s)
+        &&& helper_invariants::no_create_resource_request_msg_with_empty_name_in_flight(sub_resource, rabbitmq)(s)
     };
     combine_spec_entails_always_n!(
         spec, lift_action(stronger_next),
@@ -629,7 +645,8 @@ proof fn lemma_resource_state_matches_at_after_create_resource_step(
         lift_state(RMQCluster::each_object_in_etcd_is_well_formed()),
         lift_state(helper_invariants::the_object_in_reconcile_satisfies_state_validation(rabbitmq.object_ref())),
         lift_state(helper_invariants::cm_rv_is_the_same_as_etcd_server_cm_if_cm_updated(rabbitmq)),
-        lift_state(helper_invariants::every_resource_create_request_implies_at_after_create_resource_step(sub_resource, rabbitmq))
+        lift_state(helper_invariants::every_resource_create_request_implies_at_after_create_resource_step(sub_resource, rabbitmq)),
+        lift_state(helper_invariants::no_create_resource_request_msg_with_empty_name_in_flight(sub_resource, rabbitmq))
     );
 
     let post = |s: RMQCluster| {
@@ -659,7 +676,8 @@ proof fn lemma_resource_state_matches_at_after_create_resource_step(
         let step = choose |step| RMQCluster::next_step(s, s_prime, step);
         match step {
             Step::ApiServerStep(input) => {
-                if resource_create_request_msg(get_request(sub_resource, rabbitmq).key)(input.get_Some_0()) {} else {}
+                if resource_create_request_msg(resource_key)(input.get_Some_0()) {} else {}
+                if resource_create_request_msg_with_empty_name(resource_key.kind, resource_key.namespace)(input.get_Some_0()) {} else {}
             },
             _ => {},
         }
@@ -847,6 +865,7 @@ proof fn lemma_resource_state_matches_at_after_update_resource_step(
                 assert(!resource_delete_request_msg(resource_key)(input.get_Some_0()));
                 assert(!resource_update_status_request_msg(resource_key)(input.get_Some_0()));
                 if resource_update_request_msg(resource_key)(input.get_Some_0()) {} else {}
+                generated_name_is_unique(s.kubernetes_api_state);
             },
             _ => {},
         }
@@ -926,6 +945,7 @@ proof fn lemma_from_after_get_resource_step_to_after_update_resource_step(
                 assert(!resource_update_status_request_msg(get_request(sub_resource, rabbitmq).key)(req));
                 assert(!resource_delete_request_msg(get_request(sub_resource, rabbitmq).key)(req));
                 if resource_update_request_msg(get_request(sub_resource, rabbitmq).key)(req) {} else {}
+                generated_name_is_unique(s.kubernetes_api_state);
             },
             _ => {},
         }
@@ -979,6 +999,7 @@ pub proof fn lemma_resource_object_is_stable(
                 assert(!resource_delete_request_msg(get_request(sub_resource, rabbitmq).key)(req));
                 assert(!resource_update_status_request_msg(get_request(sub_resource, rabbitmq).key)(req));
                 if resource_update_request_msg(get_request(sub_resource, rabbitmq).key)(req) {} else {}
+                generated_name_is_unique(s.kubernetes_api_state);
             },
             _ => {},
         }

--- a/src/controller_examples/rabbitmq_controller/proof/liveness/spec.rs
+++ b/src/controller_examples/rabbitmq_controller/proof/liveness/spec.rs
@@ -220,6 +220,7 @@ pub open spec fn derived_invariants_since_beginning(rabbitmq: RabbitmqClusterVie
     .and(always(tla_forall(|res: SubResource| lift_state(RMQCluster::object_in_ok_get_resp_is_same_as_etcd_with_same_rv(get_request(res, rabbitmq).key)))))
     .and(always(lift_state(helper_invariants::stateful_set_in_etcd_satisfies_unchangeable(rabbitmq))))
     .and(always(tla_forall(|sub_resource: SubResource| lift_state(helper_invariants::object_in_etcd_satisfies_unchangeable(sub_resource, rabbitmq)))))
+    .and(always(tla_forall(|sub_resource: SubResource| lift_state(helper_invariants::no_create_resource_request_msg_with_empty_name_in_flight(sub_resource, rabbitmq)))))
 }
 
 pub proof fn derived_invariants_since_beginning_is_stable(rabbitmq: RabbitmqClusterView)
@@ -231,6 +232,7 @@ pub proof fn derived_invariants_since_beginning_is_stable(rabbitmq: RabbitmqClus
     let a_to_p_4 = |res: SubResource| lift_state(helper_invariants::response_at_after_get_resource_step_is_resource_get_response(res, rabbitmq));
     let a_to_p_5 = |res: SubResource| lift_state(RMQCluster::object_in_ok_get_resp_is_same_as_etcd_with_same_rv(get_request(res, rabbitmq).key));
     let a_to_p_6 = |sub_resource: SubResource| lift_state(helper_invariants::object_in_etcd_satisfies_unchangeable(sub_resource, rabbitmq));
+    let a_to_p_7 = |sub_resource: SubResource| lift_state(helper_invariants::no_create_resource_request_msg_with_empty_name_in_flight(sub_resource, rabbitmq));
     stable_and_always_n!(
         lift_state(RMQCluster::every_in_flight_msg_has_unique_id()),
         lift_state(RMQCluster::every_in_flight_req_msg_has_different_id_from_pending_req_msg_of(rabbitmq.object_ref())),
@@ -252,7 +254,8 @@ pub proof fn derived_invariants_since_beginning_is_stable(rabbitmq: RabbitmqClus
         tla_forall(a_to_p_4),
         tla_forall(a_to_p_5),
         lift_state(helper_invariants::stateful_set_in_etcd_satisfies_unchangeable(rabbitmq)),
-        tla_forall(a_to_p_6)
+        tla_forall(a_to_p_6),
+        tla_forall(a_to_p_7)
     );
 }
 
@@ -446,6 +449,13 @@ pub proof fn sm_spec_entails_all_invariants(rabbitmq: RabbitmqClusterView)
         }
         spec_entails_always_tla_forall(spec, a_to_p_6);
     });
+    let a_to_p_7 = |sub_resource: SubResource| lift_state(helper_invariants::no_create_resource_request_msg_with_empty_name_in_flight(sub_resource, rabbitmq));
+    assert_by(spec.entails(always(tla_forall(a_to_p_7))), {
+        assert forall |sub_resource: SubResource| spec.entails(always(#[trigger] a_to_p_7(sub_resource))) by {
+            helper_invariants::lemma_always_no_create_resource_request_msg_with_empty_name_in_flight(spec, sub_resource, rabbitmq);
+        }
+        spec_entails_always_tla_forall(spec, a_to_p_7);
+    });
 
     entails_always_and_n!(
         spec,
@@ -469,7 +479,8 @@ pub proof fn sm_spec_entails_all_invariants(rabbitmq: RabbitmqClusterView)
         tla_forall(a_to_p_4),
         tla_forall(a_to_p_5),
         lift_state(helper_invariants::stateful_set_in_etcd_satisfies_unchangeable(rabbitmq)),
-        tla_forall(a_to_p_6)
+        tla_forall(a_to_p_6),
+        tla_forall(a_to_p_7)
     );
 }
 

--- a/src/controller_examples/rabbitmq_controller/proof/liveness/stateful_set_match.rs
+++ b/src/controller_examples/rabbitmq_controller/proof/liveness/stateful_set_match.rs
@@ -6,6 +6,7 @@ use crate::kubernetes_api_objects::spec::{
     api_method::*, common::*, dynamic::*, owner_reference::*, prelude::*, resource::*,
 };
 use crate::kubernetes_cluster::spec::{
+    api_server::state_machine::generated_name_is_unique,
     builtin_controllers::types::BuiltinControllerChoice,
     cluster::*,
     cluster_state_machine::Step,
@@ -46,6 +47,7 @@ pub proof fn lemma_from_after_get_stateful_set_step_to_stateful_set_matches(
         spec.entails(always(lift_state(helper_invariants::every_resource_update_request_implies_at_after_update_resource_step(SubResource::StatefulSet, rabbitmq)))),
         spec.entails(always(lift_state(helper_invariants::stateful_set_not_exists_or_matches_or_no_more_status_update(rabbitmq)))),
         spec.entails(always(lift_state(helper_invariants::no_delete_resource_request_msg_in_flight(SubResource::StatefulSet, rabbitmq)))),
+        spec.entails(always(lift_state(helper_invariants::no_create_resource_request_msg_with_empty_name_in_flight(SubResource::StatefulSet, rabbitmq)))),
         spec.entails(always(lift_state(helper_invariants::cm_rv_is_the_same_as_etcd_server_cm_if_cm_updated(rabbitmq)))),
         spec.entails(always(lift_state(helper_invariants::resource_object_only_has_owner_reference_pointing_to_current_cr(SubResource::StatefulSet, rabbitmq)))),
         spec.entails(always(lift_state(helper_invariants::resource_object_has_no_finalizers_or_timestamp_and_only_has_controller_owner_ref(SubResource::StatefulSet, rabbitmq)))),
@@ -259,6 +261,7 @@ proof fn lemma_from_key_exists_to_receives_ok_resp_at_after_get_stateful_set_ste
                 assert(!resource_delete_request_msg(resource_key)(req));
                 assert(!resource_update_request_msg(resource_key)(req));
                 assert(!resource_update_status_request_msg(resource_key)(req));
+                generated_name_is_unique(s.kubernetes_api_state);
                 if req == req_msg {
                     let resp_msg = RMQCluster::handle_get_request_msg(req_msg, s.kubernetes_api_state).1;
                     assert({
@@ -375,6 +378,7 @@ proof fn lemma_from_after_get_stateful_set_step_to_after_update_stateful_set_ste
                 assert(!resource_delete_request_msg(resource_key)(req));
                 assert(!resource_update_request_msg(resource_key)(req));
                 assert(!resource_update_status_request_msg(resource_key)(req));
+                generated_name_is_unique(s.kubernetes_api_state);
             },
             _ => {}
         }
@@ -472,6 +476,7 @@ proof fn lemma_stateful_set_state_matches_at_after_update_stateful_set_step(spec
                 assert(!resource_delete_request_msg(resource_key)(req));
                 assert(!resource_update_status_request_msg(resource_key)(req));
                 if resource_update_request_msg(resource_key)(req) {} else {}
+                generated_name_is_unique(s.kubernetes_api_state);
             },
             _ => {}
         }
@@ -520,6 +525,7 @@ pub proof fn lemma_stateful_set_is_stable(spec: TempPred<RMQCluster>, rabbitmq: 
                 let req = input.get_Some_0();
                 assert(!resource_delete_request_msg(resource_key)(req));
                 if resource_update_request_msg(resource_key)(req) {} else {}
+                generated_name_is_unique(s.kubernetes_api_state);
             },
             _ => {}
         }

--- a/src/controller_examples/rabbitmq_controller/proof/liveness/stateful_set_match.rs
+++ b/src/controller_examples/rabbitmq_controller/proof/liveness/stateful_set_match.rs
@@ -6,7 +6,6 @@ use crate::kubernetes_api_objects::spec::{
     api_method::*, common::*, dynamic::*, owner_reference::*, prelude::*, resource::*,
 };
 use crate::kubernetes_cluster::spec::{
-    api_server::state_machine::generated_name_is_unique,
     builtin_controllers::types::BuiltinControllerChoice,
     cluster::*,
     cluster_state_machine::Step,
@@ -261,7 +260,6 @@ proof fn lemma_from_key_exists_to_receives_ok_resp_at_after_get_stateful_set_ste
                 assert(!resource_delete_request_msg(resource_key)(req));
                 assert(!resource_update_request_msg(resource_key)(req));
                 assert(!resource_update_status_request_msg(resource_key)(req));
-                generated_name_is_unique(s.kubernetes_api_state);
                 if req == req_msg {
                     let resp_msg = RMQCluster::handle_get_request_msg(req_msg, s.kubernetes_api_state).1;
                     assert({
@@ -378,7 +376,6 @@ proof fn lemma_from_after_get_stateful_set_step_to_after_update_stateful_set_ste
                 assert(!resource_delete_request_msg(resource_key)(req));
                 assert(!resource_update_request_msg(resource_key)(req));
                 assert(!resource_update_status_request_msg(resource_key)(req));
-                generated_name_is_unique(s.kubernetes_api_state);
             },
             _ => {}
         }
@@ -476,7 +473,6 @@ proof fn lemma_stateful_set_state_matches_at_after_update_stateful_set_step(spec
                 assert(!resource_delete_request_msg(resource_key)(req));
                 assert(!resource_update_status_request_msg(resource_key)(req));
                 if resource_update_request_msg(resource_key)(req) {} else {}
-                generated_name_is_unique(s.kubernetes_api_state);
             },
             _ => {}
         }
@@ -525,7 +521,6 @@ pub proof fn lemma_stateful_set_is_stable(spec: TempPred<RMQCluster>, rabbitmq: 
                 let req = input.get_Some_0();
                 assert(!resource_delete_request_msg(resource_key)(req));
                 if resource_update_request_msg(resource_key)(req) {} else {}
-                generated_name_is_unique(s.kubernetes_api_state);
             },
             _ => {}
         }

--- a/src/controller_examples/rabbitmq_controller/proof/safety/proof.rs
+++ b/src/controller_examples/rabbitmq_controller/proof/safety/proof.rs
@@ -6,7 +6,6 @@ use crate::kubernetes_api_objects::spec::{
     api_method::*, common::*, dynamic::*, resource::*, stateful_set::*,
 };
 use crate::kubernetes_cluster::spec::{
-    api_server::state_machine::generated_name_is_unique,
     cluster::*,
     cluster_state_machine::Step,
     controller::types::{ControllerActionInput, ControllerStep},
@@ -66,7 +65,6 @@ proof fn lemma_stateful_set_never_scaled_down_for_rabbitmq(spec: TempPred<RMQClu
             if s.resources()[sts_key].spec != s_prime.resources()[sts_key].spec {
                 let step = choose |step| RMQCluster::next_step(s, s_prime, step);
                 let input = step.get_ApiServerStep_0().get_Some_0();
-                generated_name_is_unique(s.kubernetes_api_state);
                 if input.content.is_delete_request() {
                     assert(StatefulSetView::unmarshal(s.resources()[sts_key]).get_Ok_0().spec == StatefulSetView::unmarshal(s_prime.resources()[sts_key]).get_Ok_0().spec);
                 } else {
@@ -229,7 +227,6 @@ proof fn lemma_always_replicas_of_etcd_stateful_set_satisfies_order(spec: TempPr
     assert forall |s, s_prime| inv(s) && #[trigger] next(s, s_prime) implies inv(s_prime) by {
         let key = rabbitmq.object_ref();
         let sts_key = make_stateful_set_key(rabbitmq);
-        generated_name_is_unique(s.kubernetes_api_state);
         if s_prime.resources().contains_key(sts_key) {
             if s.resources().contains_key(sts_key) && s.resources()[sts_key] == s_prime.resources()[sts_key] {
                 if s_prime.resources().contains_key(key) {
@@ -341,7 +338,6 @@ proof fn replicas_of_stateful_set_create_request_msg_satisfies_order_induction(
         Step::ApiServerStep(input) => {
             assert(s.controller_state == s_prime.controller_state);
             assert(s.in_flight().contains(msg));
-            generated_name_is_unique(s.kubernetes_api_state);
             if s_prime.resources().contains_key(key) {
                 if s.resources().contains_key(key) {
                     assert(replicas_of_rabbitmq(s.resources()[key]) <= replicas_of_rabbitmq(s_prime.resources()[key]));
@@ -394,7 +390,6 @@ proof fn replicas_of_stateful_set_update_request_msg_satisfies_order_induction(
         Step::ApiServerStep(input) => {
             assert(s.in_flight().contains(msg));
             assert(s.controller_state == s_prime.controller_state);
-            generated_name_is_unique(s.kubernetes_api_state);
             if s_prime.resources().contains_key(key) {
                 if s.resources().contains_key(key) {
                     assert(replicas_of_rabbitmq(s.resources()[key]) <= replicas_of_rabbitmq(s_prime.resources()[key]));

--- a/src/controller_examples/rabbitmq_controller/proof/safety/proof.rs
+++ b/src/controller_examples/rabbitmq_controller/proof/safety/proof.rs
@@ -6,6 +6,7 @@ use crate::kubernetes_api_objects::spec::{
     api_method::*, common::*, dynamic::*, resource::*, stateful_set::*,
 };
 use crate::kubernetes_cluster::spec::{
+    api_server::state_machine::generated_name_is_unique,
     cluster::*,
     cluster_state_machine::Step,
     controller::types::{ControllerActionInput, ControllerStep},
@@ -65,6 +66,7 @@ proof fn lemma_stateful_set_never_scaled_down_for_rabbitmq(spec: TempPred<RMQClu
             if s.resources()[sts_key].spec != s_prime.resources()[sts_key].spec {
                 let step = choose |step| RMQCluster::next_step(s, s_prime, step);
                 let input = step.get_ApiServerStep_0().get_Some_0();
+                generated_name_is_unique(s.kubernetes_api_state);
                 if input.content.is_delete_request() {
                     assert(StatefulSetView::unmarshal(s.resources()[sts_key]).get_Ok_0().spec == StatefulSetView::unmarshal(s_prime.resources()[sts_key]).get_Ok_0().spec);
                 } else {
@@ -210,20 +212,24 @@ proof fn lemma_always_replicas_of_etcd_stateful_set_satisfies_order(spec: TempPr
         &&& RMQCluster::each_object_in_etcd_is_well_formed()(s_prime)
         &&& every_owner_ref_of_every_object_in_etcd_has_different_uid_from_uid_counter(SubResource::StatefulSet, rabbitmq)(s)
         &&& replicas_of_stateful_set_create_or_update_request_msg_satisfies_order(rabbitmq)(s)
+        &&& no_create_resource_request_msg_with_empty_name_in_flight(SubResource::StatefulSet, rabbitmq)(s)
     };
     RMQCluster::lemma_always_each_object_in_etcd_is_well_formed(spec);
     always_to_always_later(spec, lift_state(RMQCluster::each_object_in_etcd_is_well_formed()));
     lemma_always_every_owner_ref_of_every_object_in_etcd_has_different_uid_from_uid_counter(spec, SubResource::StatefulSet, rabbitmq);
     lemma_always_replicas_of_stateful_set_create_or_update_request_msg_satisfies_order(spec, rabbitmq);
+    lemma_always_no_create_resource_request_msg_with_empty_name_in_flight(spec, SubResource::StatefulSet, rabbitmq);
     combine_spec_entails_always_n!(
         spec, lift_action(next), lift_action(RMQCluster::next()), lift_state(RMQCluster::each_object_in_etcd_is_well_formed()),
         later(lift_state(RMQCluster::each_object_in_etcd_is_well_formed())),
         lift_state(every_owner_ref_of_every_object_in_etcd_has_different_uid_from_uid_counter(SubResource::StatefulSet, rabbitmq)),
-        lift_state(replicas_of_stateful_set_create_or_update_request_msg_satisfies_order(rabbitmq))
+        lift_state(replicas_of_stateful_set_create_or_update_request_msg_satisfies_order(rabbitmq)),
+        lift_state(no_create_resource_request_msg_with_empty_name_in_flight(SubResource::StatefulSet, rabbitmq))
     );
     assert forall |s, s_prime| inv(s) && #[trigger] next(s, s_prime) implies inv(s_prime) by {
         let key = rabbitmq.object_ref();
         let sts_key = make_stateful_set_key(rabbitmq);
+        generated_name_is_unique(s.kubernetes_api_state);
         if s_prime.resources().contains_key(sts_key) {
             if s.resources().contains_key(sts_key) && s.resources()[sts_key] == s_prime.resources()[sts_key] {
                 if s_prime.resources().contains_key(key) {
@@ -237,6 +243,15 @@ proof fn lemma_always_replicas_of_etcd_stateful_set_satisfies_order(spec: TempPr
                         assert(RabbitmqClusterView::unmarshal(s.resources()[key]).get_Ok_0().controller_owner_ref() == RabbitmqClusterView::unmarshal(s_prime.resources()[key]).get_Ok_0().controller_owner_ref());
                         assert(replicas_of_rabbitmq(s.resources()[key]) <= replicas_of_rabbitmq(s_prime.resources()[key]));
                     }
+                }
+            } else {
+                let step = choose |step| RMQCluster::next_step(s, s_prime, step);
+                match step {
+                    Step::ApiServerStep(input) => {
+                        let req = input.get_Some_0();
+                        assert(!resource_create_request_msg_with_empty_name(sts_key.kind, sts_key.namespace)(req));
+                    },
+                    _ => {},
                 }
             }
         }
@@ -326,6 +341,7 @@ proof fn replicas_of_stateful_set_create_request_msg_satisfies_order_induction(
         Step::ApiServerStep(input) => {
             assert(s.controller_state == s_prime.controller_state);
             assert(s.in_flight().contains(msg));
+            generated_name_is_unique(s.kubernetes_api_state);
             if s_prime.resources().contains_key(key) {
                 if s.resources().contains_key(key) {
                     assert(replicas_of_rabbitmq(s.resources()[key]) <= replicas_of_rabbitmq(s_prime.resources()[key]));
@@ -365,6 +381,7 @@ proof fn replicas_of_stateful_set_update_request_msg_satisfies_order_induction(
         RMQCluster::each_object_in_reconcile_has_consistent_key_and_valid_metadata()(s),
         RMQCluster::transition_rule_applies_to_etcd_and_scheduled_and_triggering_cr(rabbitmq)(s),
         object_in_every_resource_create_or_update_request_msg_only_has_valid_owner_references(SubResource::StatefulSet, rabbitmq)(s),
+        // no_create_resource_request_msg_with_empty_name_in_flight(SubResource::StatefulSet, rabbitmq)(s),
         replicas_of_stateful_set_create_or_update_request_msg_satisfies_order(rabbitmq)(s),
         s_prime.in_flight().contains(msg),
         resource_update_request_msg(make_stateful_set_key(rabbitmq))(msg),
@@ -377,6 +394,7 @@ proof fn replicas_of_stateful_set_update_request_msg_satisfies_order_induction(
         Step::ApiServerStep(input) => {
             assert(s.in_flight().contains(msg));
             assert(s.controller_state == s_prime.controller_state);
+            generated_name_is_unique(s.kubernetes_api_state);
             if s_prime.resources().contains_key(key) {
                 if s.resources().contains_key(key) {
                     assert(replicas_of_rabbitmq(s.resources()[key]) <= replicas_of_rabbitmq(s_prime.resources()[key]));

--- a/src/controller_examples/zookeeper_controller/proof/helper_invariants/owner_ref.rs
+++ b/src/controller_examples/zookeeper_controller/proof/helper_invariants/owner_ref.rs
@@ -7,7 +7,6 @@ use crate::kubernetes_api_objects::spec::{
     stateful_set::*,
 };
 use crate::kubernetes_cluster::spec::{
-    api_server::state_machine::generated_name_is_unique,
     builtin_controllers::types::BuiltinControllerChoice,
     cluster::*,
     cluster_state_machine::Step,

--- a/src/controller_examples/zookeeper_controller/proof/helper_invariants/owner_ref.rs
+++ b/src/controller_examples/zookeeper_controller/proof/helper_invariants/owner_ref.rs
@@ -7,6 +7,7 @@ use crate::kubernetes_api_objects::spec::{
     stateful_set::*,
 };
 use crate::kubernetes_cluster::spec::{
+    api_server::state_machine::generated_name_is_unique,
     builtin_controllers::types::BuiltinControllerChoice,
     cluster::*,
     cluster_state_machine::Step,
@@ -131,14 +132,26 @@ pub proof fn lemma_always_every_owner_ref_of_every_object_in_etcd_has_different_
     let next = |s, s_prime| {
         &&& ZKCluster::next()(s, s_prime)
         &&& object_in_every_resource_create_or_update_request_msg_only_has_valid_owner_references(sub_resource, zookeeper)(s)
+        &&& no_create_resource_request_msg_with_empty_name_in_flight(sub_resource, zookeeper)(s)
     };
     lemma_always_object_in_every_resource_create_or_update_request_msg_only_has_valid_owner_references(spec, sub_resource, zookeeper);
-    combine_spec_entails_always_n!(spec, lift_action(next), lift_action(ZKCluster::next()), lift_state(object_in_every_resource_create_or_update_request_msg_only_has_valid_owner_references(sub_resource, zookeeper)));
+    lemma_always_no_create_resource_request_msg_with_empty_name_in_flight(spec, sub_resource, zookeeper);
+    combine_spec_entails_always_n!(spec, lift_action(next), lift_action(ZKCluster::next()),
+        lift_state(object_in_every_resource_create_or_update_request_msg_only_has_valid_owner_references(sub_resource, zookeeper)),
+        lift_state(no_create_resource_request_msg_with_empty_name_in_flight(sub_resource, zookeeper))
+    );
     let resource_key = get_request(sub_resource, zookeeper).key;
     assert forall |s, s_prime| inv(s) && #[trigger] next(s, s_prime) implies inv(s_prime) by {
         if s_prime.resources().contains_key(resource_key) {
             assert(s.kubernetes_api_state.uid_counter <= s_prime.kubernetes_api_state.uid_counter);
-            if !s.resources().contains_key(resource_key) || s.resources()[resource_key].metadata.owner_references != s_prime.resources()[resource_key].metadata.owner_references {} else {}
+            let step = choose |step| ZKCluster::next_step(s, s_prime, step);
+            match step {
+                Step::ApiServerStep(input) => {
+                    assert(!resource_create_request_msg_with_empty_name(resource_key.kind, resource_key.namespace)(input.get_Some_0()));
+                    if !s.resources().contains_key(resource_key) || s.resources()[resource_key].metadata.owner_references != s_prime.resources()[resource_key].metadata.owner_references {} else {}
+                },
+                _ => {}
+            }
         }
     }
     init_invariant(spec, ZKCluster::init(), next, inv);

--- a/src/controller_examples/zookeeper_controller/proof/helper_invariants/predicate.rs
+++ b/src/controller_examples/zookeeper_controller/proof/helper_invariants/predicate.rs
@@ -229,12 +229,8 @@ pub open spec fn resource_object_only_has_owner_reference_pointing_to_current_cr
 }
 
 pub open spec fn no_create_resource_request_msg_with_empty_name_in_flight(sub_resource: SubResource, zookeeper: ZookeeperClusterView) -> StatePred<ZKCluster> {
-    |s: ZKCluster| {
-        forall |msg: ZKMessage| !{
-            &&& s.in_flight().contains(msg)
-            &&& #[trigger] resource_create_request_msg_with_empty_name(get_request(sub_resource, zookeeper).key.kind, get_request(sub_resource, zookeeper).key.namespace)(msg)
-        }
-    }
+    let resource_key = get_request(sub_resource, zookeeper).key;
+    ZKCluster::no_create_msg_that_uses_generate_name(resource_key.kind, resource_key.namespace)
 }
 
 pub open spec fn no_delete_resource_request_msg_in_flight(sub_resource: SubResource, zookeeper: ZookeeperClusterView) -> StatePred<ZKCluster> {

--- a/src/controller_examples/zookeeper_controller/proof/helper_invariants/predicate.rs
+++ b/src/controller_examples/zookeeper_controller/proof/helper_invariants/predicate.rs
@@ -228,6 +228,15 @@ pub open spec fn resource_object_only_has_owner_reference_pointing_to_current_cr
     }
 }
 
+pub open spec fn no_create_resource_request_msg_with_empty_name_in_flight(sub_resource: SubResource, zookeeper: ZookeeperClusterView) -> StatePred<ZKCluster> {
+    |s: ZKCluster| {
+        forall |msg: ZKMessage| !{
+            &&& s.in_flight().contains(msg)
+            &&& #[trigger] resource_create_request_msg_with_empty_name(get_request(sub_resource, zookeeper).key.kind, get_request(sub_resource, zookeeper).key.namespace)(msg)
+        }
+    }
+}
+
 pub open spec fn no_delete_resource_request_msg_in_flight(sub_resource: SubResource, zookeeper: ZookeeperClusterView) -> StatePred<ZKCluster> {
     |s: ZKCluster| {
         forall |msg: ZKMessage| !{

--- a/src/controller_examples/zookeeper_controller/proof/helper_invariants/proof.rs
+++ b/src/controller_examples/zookeeper_controller/proof/helper_invariants/proof.rs
@@ -6,7 +6,6 @@ use crate::kubernetes_api_objects::spec::{
     api_method::*, common::*, owner_reference::*, prelude::*, resource::*,
 };
 use crate::kubernetes_cluster::spec::{
-    api_server::state_machine::generated_name_is_unique,
     cluster::*,
     cluster_state_machine::Step,
     controller::types::{ControllerActionInput, ControllerStep},
@@ -171,7 +170,6 @@ pub proof fn lemma_eventually_always_cm_rv_is_the_same_as_etcd_server_cm_if_cm_u
                     let req = input.get_Some_0();
                     assert(!resource_delete_request_msg(cm_key)(req));
                     assert(!resource_update_status_request_msg(cm_key)(req));
-                    generated_name_is_unique(s.kubernetes_api_state);
                     if resource_update_request_msg(cm_key)(req) {} else {}
                 },
                 _ => {},
@@ -1599,7 +1597,6 @@ pub proof fn lemma_always_cm_rv_stays_unchanged(spec: TempPred<ZKCluster>, zooke
                 let req = input.get_Some_0();
                 assert(!resource_delete_request_msg(cm_key)(req));
                 assert(!resource_update_status_request_msg(cm_key)(req));
-                generated_name_is_unique(s.kubernetes_api_state);
                 if resource_update_request_msg(cm_key)(req) {} else {}
             },
             _ => {},

--- a/src/controller_examples/zookeeper_controller/proof/helper_invariants/proof.rs
+++ b/src/controller_examples/zookeeper_controller/proof/helper_invariants/proof.rs
@@ -1252,6 +1252,33 @@ pub proof fn lemma_resource_create_or_update_request_msg_implies_key_in_reconcil
     }
 }
 
+// We can probably hide a lof of spec functions to make this lemma faster
+#[verifier(spinoff_prover)]
+pub proof fn lemma_always_no_create_resource_request_msg_with_empty_name_in_flight(spec: TempPred<ZKCluster>, sub_resource: SubResource, zookeeper: ZookeeperClusterView)
+    requires
+        spec.entails(lift_state(ZKCluster::init())),
+        spec.entails(always(lift_action(ZKCluster::next()))),
+    ensures spec.entails(always(lift_state(no_create_resource_request_msg_with_empty_name_in_flight(sub_resource, zookeeper)))),
+{
+    let key = zookeeper.object_ref();
+    let resource_key = get_request(sub_resource, zookeeper).key;
+    let inv = no_create_resource_request_msg_with_empty_name_in_flight(sub_resource, zookeeper);
+
+    assert forall |s: ZKCluster| #[trigger] ZKCluster::init()(s) implies inv(s) by {}
+
+    assert forall |s: ZKCluster, s_prime: ZKCluster| #[trigger] ZKCluster::next()(s, s_prime) && inv(s) implies inv(s_prime) by {
+        assert forall |msg: ZKMessage|
+            !(s_prime.in_flight().contains(msg) && #[trigger] resource_create_request_msg_with_empty_name(resource_key.kind, resource_key.namespace)(msg))
+        by {
+            if !s.in_flight().contains(msg) && s_prime.in_flight().contains(msg) {
+                assert(!resource_create_request_msg_with_empty_name(resource_key.kind, resource_key.namespace)(msg));
+            }
+        }
+    }
+    init_invariant(spec, ZKCluster::init(), ZKCluster::next(), inv);
+}
+
+
 pub proof fn lemma_eventually_always_no_delete_resource_request_msg_in_flight_forall(
     spec: TempPred<ZKCluster>, zookeeper: ZookeeperClusterView
 )

--- a/src/controller_examples/zookeeper_controller/proof/helper_invariants/proof.rs
+++ b/src/controller_examples/zookeeper_controller/proof/helper_invariants/proof.rs
@@ -1253,7 +1253,6 @@ pub proof fn lemma_resource_create_or_update_request_msg_implies_key_in_reconcil
 }
 
 // We can probably hide a lof of spec functions to make this lemma faster
-#[verifier(spinoff_prover)]
 pub proof fn lemma_always_no_create_resource_request_msg_with_empty_name_in_flight(spec: TempPred<ZKCluster>, sub_resource: SubResource, zookeeper: ZookeeperClusterView)
     requires
         spec.entails(lift_state(ZKCluster::init())),

--- a/src/controller_examples/zookeeper_controller/proof/helper_invariants/unchangeable.rs
+++ b/src/controller_examples/zookeeper_controller/proof/helper_invariants/unchangeable.rs
@@ -6,7 +6,6 @@ use crate::kubernetes_api_objects::spec::{
     api_method::*, common::*, dynamic::*, owner_reference::*, prelude::*, resource::*,
 };
 use crate::kubernetes_cluster::spec::{
-    api_server::state_machine::generated_name_is_unique,
     cluster::*,
     cluster_state_machine::Step,
     controller::types::{ControllerActionInput, ControllerStep},

--- a/src/controller_examples/zookeeper_controller/proof/helper_invariants/unchangeable.rs
+++ b/src/controller_examples/zookeeper_controller/proof/helper_invariants/unchangeable.rs
@@ -6,6 +6,7 @@ use crate::kubernetes_api_objects::spec::{
     api_method::*, common::*, dynamic::*, owner_reference::*, prelude::*, resource::*,
 };
 use crate::kubernetes_cluster::spec::{
+    api_server::state_machine::generated_name_is_unique,
     cluster::*,
     cluster_state_machine::Step,
     controller::types::{ControllerActionInput, ControllerStep},
@@ -128,6 +129,7 @@ pub proof fn lemma_always_object_in_etcd_satisfies_unchangeable(spec: TempPred<Z
         &&& object_in_every_create_request_msg_satisfies_unchangeable(sub_resource, zookeeper)(s)
         &&& response_at_after_get_resource_step_is_resource_get_response(sub_resource, zookeeper)(s)
         &&& the_object_in_reconcile_satisfies_state_validation(zookeeper.object_ref())(s)
+        &&& no_create_resource_request_msg_with_empty_name_in_flight(sub_resource, zookeeper)(s)
     };
     ZKCluster::lemma_always_each_object_in_reconcile_has_consistent_key_and_valid_metadata(spec);
     ZKCluster::lemma_always_each_object_in_etcd_is_well_formed(spec);
@@ -137,6 +139,7 @@ pub proof fn lemma_always_object_in_etcd_satisfies_unchangeable(spec: TempPred<Z
     lemma_always_object_in_every_create_request_msg_satisfies_unchangeable(spec, sub_resource, zookeeper);
     lemma_always_response_at_after_get_resource_step_is_resource_get_response(spec, sub_resource, zookeeper);
     lemma_always_the_object_in_reconcile_satisfies_state_validation(spec, zookeeper.object_ref());
+    lemma_always_no_create_resource_request_msg_with_empty_name_in_flight(spec, sub_resource, zookeeper);
     combine_spec_entails_always_n!(
         spec, lift_action(next), lift_action(ZKCluster::next()),
         lift_state(ZKCluster::each_object_in_reconcile_has_consistent_key_and_valid_metadata()),
@@ -146,7 +149,8 @@ pub proof fn lemma_always_object_in_etcd_satisfies_unchangeable(spec: TempPred<Z
         lift_state(object_in_resource_update_request_msg_has_smaller_rv_than_etcd(sub_resource, zookeeper)),
         lift_state(object_in_every_create_request_msg_satisfies_unchangeable(sub_resource, zookeeper)),
         lift_state(response_at_after_get_resource_step_is_resource_get_response(sub_resource, zookeeper)),
-        lift_state(the_object_in_reconcile_satisfies_state_validation(zookeeper.object_ref()))
+        lift_state(the_object_in_reconcile_satisfies_state_validation(zookeeper.object_ref())),
+        lift_state(no_create_resource_request_msg_with_empty_name_in_flight(sub_resource, zookeeper))
     );
     assert forall |s: ZKCluster, s_prime: ZKCluster| inv(s) && #[trigger] next(s, s_prime) implies inv(s_prime) by {
         object_in_etcd_satisfies_unchangeable_induction(sub_resource, zookeeper, s, s_prime);
@@ -166,6 +170,7 @@ pub proof fn object_in_etcd_satisfies_unchangeable_induction(sub_resource: SubRe
         ZKCluster::each_object_in_etcd_is_well_formed()(s_prime),
         object_in_resource_update_request_msg_has_smaller_rv_than_etcd(sub_resource, zookeeper)(s),
         object_in_etcd_satisfies_unchangeable(sub_resource, zookeeper)(s),
+        no_create_resource_request_msg_with_empty_name_in_flight(sub_resource, zookeeper)(s),
     ensures object_in_etcd_satisfies_unchangeable(sub_resource, zookeeper)(s_prime),
 {
     let resource_key = get_request(sub_resource, zookeeper).key;
@@ -187,6 +192,7 @@ pub proof fn object_in_etcd_satisfies_unchangeable_induction(sub_resource: SubRe
                 let req = input.get_Some_0();
                 if resource_create_request_msg(resource_key)(req) {} else {}
                 if resource_update_request_msg(resource_key)(req) {} else {}
+                if resource_create_request_msg_with_empty_name(resource_key.kind, resource_key.namespace)(req) {} else {}
             },
             _ => {}
         }

--- a/src/controller_examples/zookeeper_controller/proof/helper_invariants/validation.rs
+++ b/src/controller_examples/zookeeper_controller/proof/helper_invariants/validation.rs
@@ -7,6 +7,7 @@ use crate::kubernetes_api_objects::spec::{
     stateful_set::*,
 };
 use crate::kubernetes_cluster::spec::{
+    api_server::state_machine::generated_name_is_unique,
     cluster::*,
     cluster_state_machine::Step,
     controller::types::{ControllerActionInput, ControllerStep},
@@ -101,6 +102,7 @@ pub proof fn lemma_always_stateful_set_in_etcd_satisfies_unchangeable(spec: Temp
                         assert(owner_refs.get_Some_0()[0] != ZookeeperClusterView::unmarshal(s_prime.resources()[key]).get_Ok_0().controller_owner_ref());
                     }
                 } else if s.resources()[key] != s_prime.resources()[key] {
+                    generated_name_is_unique(s.kubernetes_api_state);
                     assert(s.resources()[key].metadata.uid == s_prime.resources()[key].metadata.uid);
                     assert(ZookeeperClusterView::unmarshal(s.resources()[key]).get_Ok_0().controller_owner_ref() == ZookeeperClusterView::unmarshal(s_prime.resources()[key]).get_Ok_0().controller_owner_ref());
                     assert(ZookeeperClusterView::unmarshal(s_prime.resources()[key]).get_Ok_0()
@@ -114,6 +116,7 @@ pub proof fn lemma_always_stateful_set_in_etcd_satisfies_unchangeable(spec: Temp
                         let req = input.get_Some_0();
                         if resource_create_request_msg(sts_key)(req) {} else {}
                         if resource_update_request_msg(sts_key)(req) {} else {}
+                        generated_name_is_unique(s.kubernetes_api_state);
                     },
                     _ => {}
                 }
@@ -305,6 +308,7 @@ proof fn lemma_always_stateful_set_in_create_request_msg_satisfies_unchangeable(
                     assert(s.controller_state == s_prime.controller_state);
                     assert(s.in_flight().contains(msg));
                     if s.resources().contains_key(key) {
+                        generated_name_is_unique(s.kubernetes_api_state);
                         assert(ZookeeperClusterView::unmarshal(s_prime.resources()[key]).get_Ok_0()
                         .transition_validation(ZookeeperClusterView::unmarshal(s.resources()[key]).get_Ok_0()));
                     } else {

--- a/src/controller_examples/zookeeper_controller/proof/helper_invariants/validation.rs
+++ b/src/controller_examples/zookeeper_controller/proof/helper_invariants/validation.rs
@@ -7,7 +7,6 @@ use crate::kubernetes_api_objects::spec::{
     stateful_set::*,
 };
 use crate::kubernetes_cluster::spec::{
-    api_server::state_machine::generated_name_is_unique,
     cluster::*,
     cluster_state_machine::Step,
     controller::types::{ControllerActionInput, ControllerStep},
@@ -74,6 +73,7 @@ pub proof fn lemma_always_stateful_set_in_etcd_satisfies_unchangeable(spec: Temp
         &&& stateful_set_in_create_request_msg_satisfies_unchangeable(zookeeper)(s)
         &&& stateful_set_update_request_msg_does_not_change_owner_reference(zookeeper)(s)
         &&& object_in_resource_update_request_msg_has_smaller_rv_than_etcd(SubResource::StatefulSet, zookeeper)(s)
+        &&& no_create_resource_request_msg_with_empty_name_in_flight(SubResource::StatefulSet, zookeeper)(s)
     };
     ZKCluster::lemma_always_each_object_in_etcd_is_well_formed(spec);
     always_to_always_later(spec, lift_state(ZKCluster::each_object_in_etcd_is_well_formed()));
@@ -81,13 +81,15 @@ pub proof fn lemma_always_stateful_set_in_etcd_satisfies_unchangeable(spec: Temp
     lemma_always_stateful_set_in_create_request_msg_satisfies_unchangeable(spec, zookeeper);
     lemma_always_stateful_set_update_request_msg_does_not_change_owner_reference(spec, zookeeper);
     lemma_always_object_in_resource_update_request_msg_has_smaller_rv_than_etcd(spec, sts_res, zookeeper);
+    lemma_always_no_create_resource_request_msg_with_empty_name_in_flight(spec, sts_res, zookeeper);
     combine_spec_entails_always_n!(
         spec, lift_action(next), lift_action(ZKCluster::next()), lift_state(ZKCluster::each_object_in_etcd_is_well_formed()),
         later(lift_state(ZKCluster::each_object_in_etcd_is_well_formed())),
         lift_state(every_owner_ref_of_every_object_in_etcd_has_different_uid_from_uid_counter(sts_res, zookeeper)),
         lift_state(stateful_set_in_create_request_msg_satisfies_unchangeable(zookeeper)),
         lift_state(stateful_set_update_request_msg_does_not_change_owner_reference(zookeeper)),
-        lift_state(object_in_resource_update_request_msg_has_smaller_rv_than_etcd(SubResource::StatefulSet, zookeeper))
+        lift_state(object_in_resource_update_request_msg_has_smaller_rv_than_etcd(SubResource::StatefulSet, zookeeper)),
+        lift_state(no_create_resource_request_msg_with_empty_name_in_flight(SubResource::StatefulSet, zookeeper))
     );
     assert forall |s, s_prime| inv(s) && #[trigger] next(s, s_prime) implies inv(s_prime) by {
         let key = zookeeper.object_ref();
@@ -102,7 +104,6 @@ pub proof fn lemma_always_stateful_set_in_etcd_satisfies_unchangeable(spec: Temp
                         assert(owner_refs.get_Some_0()[0] != ZookeeperClusterView::unmarshal(s_prime.resources()[key]).get_Ok_0().controller_owner_ref());
                     }
                 } else if s.resources()[key] != s_prime.resources()[key] {
-                    generated_name_is_unique(s.kubernetes_api_state);
                     assert(s.resources()[key].metadata.uid == s_prime.resources()[key].metadata.uid);
                     assert(ZookeeperClusterView::unmarshal(s.resources()[key]).get_Ok_0().controller_owner_ref() == ZookeeperClusterView::unmarshal(s_prime.resources()[key]).get_Ok_0().controller_owner_ref());
                     assert(ZookeeperClusterView::unmarshal(s_prime.resources()[key]).get_Ok_0()
@@ -116,7 +117,7 @@ pub proof fn lemma_always_stateful_set_in_etcd_satisfies_unchangeable(spec: Temp
                         let req = input.get_Some_0();
                         if resource_create_request_msg(sts_key)(req) {} else {}
                         if resource_update_request_msg(sts_key)(req) {} else {}
-                        generated_name_is_unique(s.kubernetes_api_state);
+                        if resource_create_request_msg_with_empty_name(sts_key.kind, sts_key.namespace)(req) {} else {}
                     },
                     _ => {}
                 }
@@ -308,7 +309,6 @@ proof fn lemma_always_stateful_set_in_create_request_msg_satisfies_unchangeable(
                     assert(s.controller_state == s_prime.controller_state);
                     assert(s.in_flight().contains(msg));
                     if s.resources().contains_key(key) {
-                        generated_name_is_unique(s.kubernetes_api_state);
                         assert(ZookeeperClusterView::unmarshal(s_prime.resources()[key]).get_Ok_0()
                         .transition_validation(ZookeeperClusterView::unmarshal(s.resources()[key]).get_Ok_0()));
                     } else {

--- a/src/controller_examples/zookeeper_controller/proof/liveness/proof.rs
+++ b/src/controller_examples/zookeeper_controller/proof/liveness/proof.rs
@@ -380,6 +380,7 @@ proof fn always_tla_forall_apply_for_sub_resource(spec: TempPred<ZKCluster>, sub
         spec.entails(always(tla_forall(|res: SubResource| lift_state(helper_invariants::resource_object_has_no_finalizers_or_timestamp_and_only_has_controller_owner_ref(res, zookeeper))))),
         spec.entails(always(tla_forall(|res: SubResource| lift_state(helper_invariants::object_in_etcd_satisfies_unchangeable(res, zookeeper))))),
         spec.entails(always(tla_forall(|res: SubResource| lift_state(helper_invariants::resource_object_only_has_owner_reference_pointing_to_current_cr(res, zookeeper))))),
+        spec.entails(always(tla_forall(|res: SubResource| lift_state(helper_invariants::no_create_resource_request_msg_with_empty_name_in_flight(res, zookeeper))))),
     ensures
         spec.entails(always(lift_state(helper_invariants::every_resource_update_request_implies_at_after_update_resource_step(sub_resource, zookeeper)))),
         spec.entails(always(lift_state(helper_invariants::every_resource_create_request_implies_at_after_create_resource_step(sub_resource, zookeeper)))),
@@ -388,6 +389,7 @@ proof fn always_tla_forall_apply_for_sub_resource(spec: TempPred<ZKCluster>, sub
         spec.entails(always(lift_state(helper_invariants::resource_object_has_no_finalizers_or_timestamp_and_only_has_controller_owner_ref(sub_resource, zookeeper)))),
         spec.entails(always(lift_state(helper_invariants::object_in_etcd_satisfies_unchangeable(sub_resource, zookeeper)))),
         spec.entails(always(lift_state(helper_invariants::resource_object_only_has_owner_reference_pointing_to_current_cr(sub_resource, zookeeper)))),
+        spec.entails(always(lift_state(helper_invariants::no_create_resource_request_msg_with_empty_name_in_flight(sub_resource, zookeeper)))),
 {
     always_tla_forall_apply(spec, |res: SubResource| lift_state(helper_invariants::every_resource_update_request_implies_at_after_update_resource_step(res, zookeeper)), sub_resource);
     always_tla_forall_apply(spec, |res: SubResource| lift_state(helper_invariants::every_resource_create_request_implies_at_after_create_resource_step(res, zookeeper)), sub_resource);
@@ -396,6 +398,7 @@ proof fn always_tla_forall_apply_for_sub_resource(spec: TempPred<ZKCluster>, sub
     always_tla_forall_apply(spec, |res: SubResource| lift_state(helper_invariants::resource_object_has_no_finalizers_or_timestamp_and_only_has_controller_owner_ref(res, zookeeper)), sub_resource);
     always_tla_forall_apply(spec, |res: SubResource| lift_state(helper_invariants::object_in_etcd_satisfies_unchangeable(res, zookeeper)), sub_resource);
     always_tla_forall_apply(spec, |res: SubResource| lift_state(helper_invariants::resource_object_only_has_owner_reference_pointing_to_current_cr(res, zookeeper)), sub_resource);
+    always_tla_forall_apply(spec, |res: SubResource| lift_state(helper_invariants::no_create_resource_request_msg_with_empty_name_in_flight(res, zookeeper)), sub_resource);
 }
 
 }

--- a/src/controller_examples/zookeeper_controller/proof/liveness/resource_match.rs
+++ b/src/controller_examples/zookeeper_controller/proof/liveness/resource_match.rs
@@ -6,7 +6,6 @@ use crate::kubernetes_api_objects::spec::{
     api_method::*, common::*, dynamic::*, owner_reference::*, prelude::*, resource::*,
 };
 use crate::kubernetes_cluster::spec::{
-    api_server::state_machine::generated_name_is_unique,
     builtin_controllers::types::BuiltinControllerChoice,
     cluster::*,
     cluster_state_machine::Step,
@@ -865,7 +864,6 @@ proof fn lemma_resource_state_matches_at_after_update_resource_step(spec: TempPr
                 assert(!resource_delete_request_msg(resource_key)(input.get_Some_0()));
                 assert(!resource_update_status_request_msg(resource_key)(input.get_Some_0()));
                 if resource_update_request_msg(resource_key)(input.get_Some_0()) {} else {}
-                generated_name_is_unique(s.kubernetes_api_state);
             },
             _ => {},
         }
@@ -940,7 +938,6 @@ proof fn lemma_from_after_get_resource_step_to_after_update_resource_step(spec: 
                 assert(!resource_update_status_request_msg(resource_key)(req));
                 assert(!resource_delete_request_msg(resource_key)(req));
                 if resource_update_request_msg(resource_key)(req) {} else {}
-                generated_name_is_unique(s.kubernetes_api_state);
             },
             _ => {},
         }
@@ -992,7 +989,6 @@ pub proof fn lemma_resource_object_is_stable(spec: TempPred<ZKCluster>, sub_reso
                 assert(!resource_delete_request_msg(resource_key)(req));
                 assert(!resource_update_status_request_msg(resource_key)(req));
                 if resource_update_request_msg(resource_key)(req) {} else {}
-                generated_name_is_unique(s.kubernetes_api_state);
             },
             _ => {},
         }

--- a/src/controller_examples/zookeeper_controller/proof/liveness/spec.rs
+++ b/src/controller_examples/zookeeper_controller/proof/liveness/spec.rs
@@ -230,6 +230,7 @@ pub open spec fn derived_invariants_since_beginning(zookeeper: ZookeeperClusterV
     .and(always(tla_forall(|res: SubResource| lift_state(ZKCluster::object_in_ok_get_resp_is_same_as_etcd_with_same_rv(get_request(res, zookeeper).key)))))
     .and(always(lift_state(helper_invariants::stateful_set_in_etcd_satisfies_unchangeable(zookeeper))))
     .and(always(tla_forall(|sub_resource: SubResource| lift_state(helper_invariants::object_in_etcd_satisfies_unchangeable(sub_resource, zookeeper)))))
+    .and(always(tla_forall(|sub_resource: SubResource| lift_state(helper_invariants::no_create_resource_request_msg_with_empty_name_in_flight(sub_resource, zookeeper)))))
 }
 
 pub proof fn derived_invariants_since_beginning_is_stable(zookeeper: ZookeeperClusterView)
@@ -241,6 +242,7 @@ pub proof fn derived_invariants_since_beginning_is_stable(zookeeper: ZookeeperCl
     let a_to_p_4 = |res: SubResource| lift_state(helper_invariants::response_at_after_get_resource_step_is_resource_get_response(res, zookeeper));
     let a_to_p_5 = |res: SubResource| lift_state(ZKCluster::object_in_ok_get_resp_is_same_as_etcd_with_same_rv(get_request(res, zookeeper).key));
     let a_to_p_6 = |sub_resource: SubResource| lift_state(helper_invariants::object_in_etcd_satisfies_unchangeable(sub_resource, zookeeper));
+    let a_to_p_7 = |sub_resource: SubResource| lift_state(helper_invariants::no_create_resource_request_msg_with_empty_name_in_flight(sub_resource, zookeeper));
     stable_and_always_n!(
         lift_state(ZKCluster::every_in_flight_msg_has_unique_id()),
         lift_state(ZKCluster::object_in_ok_get_response_has_smaller_rv_than_etcd()),
@@ -268,7 +270,8 @@ pub proof fn derived_invariants_since_beginning_is_stable(zookeeper: ZookeeperCl
         tla_forall(a_to_p_4),
         tla_forall(a_to_p_5),
         lift_state(helper_invariants::stateful_set_in_etcd_satisfies_unchangeable(zookeeper)),
-        tla_forall(a_to_p_6)
+        tla_forall(a_to_p_6),
+        tla_forall(a_to_p_7)
     );
 }
 
@@ -535,6 +538,13 @@ pub proof fn sm_spec_entails_all_invariants(zookeeper: ZookeeperClusterView)
         }
         spec_entails_always_tla_forall(spec, a_to_p_6);
     });
+    let a_to_p_7 = |sub_resource: SubResource| lift_state(helper_invariants::no_create_resource_request_msg_with_empty_name_in_flight(sub_resource, zookeeper));
+    assert_by(spec.entails(always(tla_forall(a_to_p_7))), {
+        assert forall |sub_resource: SubResource| spec.entails(always(#[trigger] a_to_p_7(sub_resource))) by {
+            helper_invariants::lemma_always_no_create_resource_request_msg_with_empty_name_in_flight(spec, sub_resource, zookeeper);
+        }
+        spec_entails_always_tla_forall(spec, a_to_p_7);
+    });
 
     entails_always_and_n!(
         spec,
@@ -564,7 +574,8 @@ pub proof fn sm_spec_entails_all_invariants(zookeeper: ZookeeperClusterView)
         tla_forall(a_to_p_4),
         tla_forall(a_to_p_5),
         lift_state(helper_invariants::stateful_set_in_etcd_satisfies_unchangeable(zookeeper)),
-        tla_forall(a_to_p_6)
+        tla_forall(a_to_p_6),
+        tla_forall(a_to_p_7)
     );
 }
 

--- a/src/controller_examples/zookeeper_controller/proof/liveness/stateful_set_match.rs
+++ b/src/controller_examples/zookeeper_controller/proof/liveness/stateful_set_match.rs
@@ -6,6 +6,7 @@ use crate::kubernetes_api_objects::spec::{
     api_method::*, common::*, dynamic::*, owner_reference::*, prelude::*, resource::*,
 };
 use crate::kubernetes_cluster::spec::{
+    api_server::state_machine::generated_name_is_unique,
     builtin_controllers::types::BuiltinControllerChoice,
     cluster::*,
     cluster_state_machine::Step,
@@ -41,6 +42,7 @@ pub proof fn lemma_from_after_get_stateful_set_step_to_stateful_set_matches(
         spec.entails(always(lift_state(helper_invariants::every_resource_update_request_implies_at_after_update_resource_step(SubResource::StatefulSet, zookeeper)))),
         spec.entails(always(lift_state(helper_invariants::stateful_set_not_exists_or_matches_or_no_more_status_update(zookeeper)))),
         spec.entails(always(lift_state(helper_invariants::no_delete_resource_request_msg_in_flight(SubResource::StatefulSet, zookeeper)))),
+        spec.entails(always(lift_state(helper_invariants::no_create_resource_request_msg_with_empty_name_in_flight(SubResource::StatefulSet, zookeeper)))),
         spec.entails(always(lift_state(helper_invariants::cm_rv_is_the_same_as_etcd_server_cm_if_cm_updated(zookeeper)))),
         spec.entails(always(lift_state(helper_invariants::resource_object_only_has_owner_reference_pointing_to_current_cr(SubResource::StatefulSet, zookeeper)))),
         spec.entails(always(lift_state(helper_invariants::object_in_etcd_satisfies_unchangeable(SubResource::StatefulSet, zookeeper)))),
@@ -256,6 +258,7 @@ proof fn lemma_from_key_exists_to_receives_ok_resp_at_after_get_stateful_set_ste
                 assert(!resource_delete_request_msg(resource_key)(req));
                 assert(!resource_update_request_msg(resource_key)(req));
                 assert(!resource_update_status_request_msg(resource_key)(req));
+                generated_name_is_unique(s.kubernetes_api_state);
                 if input.get_Some_0() == req_msg {
                     let resp_msg = ZKCluster::handle_get_request_msg(req_msg, s.kubernetes_api_state).1;
                     assert({
@@ -374,6 +377,7 @@ proof fn lemma_from_after_get_stateful_set_step_to_after_update_stateful_set_ste
                 assert(!resource_delete_request_msg(resource_key)(req));
                 assert(!resource_update_request_msg(resource_key)(req));
                 assert(!resource_update_status_request_msg(resource_key)(req));
+                generated_name_is_unique(s.kubernetes_api_state);
             },
             _ => {}
         }
@@ -471,6 +475,7 @@ proof fn lemma_stateful_set_state_matches_at_after_update_stateful_set_step(spec
                 assert(!resource_delete_request_msg(resource_key)(req));
                 assert(!resource_update_status_request_msg(resource_key)(req));
                 if resource_update_request_msg(resource_key)(req) {} else {}
+                generated_name_is_unique(s.kubernetes_api_state);
             },
             _ => {}
         }
@@ -520,6 +525,7 @@ pub proof fn lemma_stateful_set_is_stable(
                 let req = input.get_Some_0();
                 assert(!resource_delete_request_msg(resource_key)(req));
                 if resource_update_request_msg(resource_key)(req) {} else {}
+                generated_name_is_unique(s.kubernetes_api_state);
             },
             _ => {}
         }

--- a/src/controller_examples/zookeeper_controller/proof/liveness/stateful_set_match.rs
+++ b/src/controller_examples/zookeeper_controller/proof/liveness/stateful_set_match.rs
@@ -6,7 +6,6 @@ use crate::kubernetes_api_objects::spec::{
     api_method::*, common::*, dynamic::*, owner_reference::*, prelude::*, resource::*,
 };
 use crate::kubernetes_cluster::spec::{
-    api_server::state_machine::generated_name_is_unique,
     builtin_controllers::types::BuiltinControllerChoice,
     cluster::*,
     cluster_state_machine::Step,
@@ -258,7 +257,6 @@ proof fn lemma_from_key_exists_to_receives_ok_resp_at_after_get_stateful_set_ste
                 assert(!resource_delete_request_msg(resource_key)(req));
                 assert(!resource_update_request_msg(resource_key)(req));
                 assert(!resource_update_status_request_msg(resource_key)(req));
-                generated_name_is_unique(s.kubernetes_api_state);
                 if input.get_Some_0() == req_msg {
                     let resp_msg = ZKCluster::handle_get_request_msg(req_msg, s.kubernetes_api_state).1;
                     assert({
@@ -377,7 +375,6 @@ proof fn lemma_from_after_get_stateful_set_step_to_after_update_stateful_set_ste
                 assert(!resource_delete_request_msg(resource_key)(req));
                 assert(!resource_update_request_msg(resource_key)(req));
                 assert(!resource_update_status_request_msg(resource_key)(req));
-                generated_name_is_unique(s.kubernetes_api_state);
             },
             _ => {}
         }
@@ -475,7 +472,6 @@ proof fn lemma_stateful_set_state_matches_at_after_update_stateful_set_step(spec
                 assert(!resource_delete_request_msg(resource_key)(req));
                 assert(!resource_update_status_request_msg(resource_key)(req));
                 if resource_update_request_msg(resource_key)(req) {} else {}
-                generated_name_is_unique(s.kubernetes_api_state);
             },
             _ => {}
         }
@@ -525,7 +521,6 @@ pub proof fn lemma_stateful_set_is_stable(
                 let req = input.get_Some_0();
                 assert(!resource_delete_request_msg(resource_key)(req));
                 if resource_update_request_msg(resource_key)(req) {} else {}
-                generated_name_is_unique(s.kubernetes_api_state);
             },
             _ => {}
         }

--- a/src/controller_examples/zookeeper_controller/proof/liveness/zookeeper_api.rs
+++ b/src/controller_examples/zookeeper_controller/proof/liveness/zookeeper_api.rs
@@ -6,7 +6,6 @@ use crate::kubernetes_api_objects::spec::{
     api_method::*, common::*, dynamic::*, owner_reference::*, prelude::*, resource::*,
 };
 use crate::kubernetes_cluster::spec::{
-    api_server::state_machine::generated_name_is_unique,
     builtin_controllers::types::BuiltinControllerChoice,
     cluster::*,
     cluster_state_machine::Step,
@@ -881,7 +880,6 @@ proof fn lemma_from_pending_req_to_receives_ok_resp_at_after_exists_zk_node_step
             Step::ApiServerStep(input) => {
                 assert(!resource_delete_request_msg(resource_key)(input.get_Some_0()));
                 assert(!resource_update_request_msg(resource_key)(input.get_Some_0()));
-                generated_name_is_unique(s.kubernetes_api_state);
             },
             _ => {}
         }
@@ -974,7 +972,6 @@ proof fn lemma_from_after_exists_zk_node_step_to_after_update_zk_node_step(spec:
             Step::ApiServerStep(input) => {
                 assert(!resource_delete_request_msg(sts_key)(input.get_Some_0()));
                 assert(!resource_update_request_msg(sts_key)(input.get_Some_0()));
-                generated_name_is_unique(s.kubernetes_api_state);
             },
             _ => {}
         }
@@ -1060,7 +1057,6 @@ proof fn lemma_from_pending_req_to_receives_ok_resp_at_after_update_zk_node_step
             Step::ApiServerStep(input) => {
                 assert(!resource_delete_request_msg(sts_key)(input.get_Some_0()));
                 assert(!resource_update_request_msg(sts_key)(input.get_Some_0()));
-                generated_name_is_unique(s.kubernetes_api_state);
             },
             _ => {}
         }
@@ -1215,7 +1211,6 @@ proof fn lemma_from_pending_req_to_receives_not_found_resp_at_after_exists_zk_no
             Step::ApiServerStep(input) => {
                 assert(!resource_delete_request_msg(sts_key)(input.get_Some_0()));
                 assert(!resource_update_request_msg(sts_key)(input.get_Some_0()));
-                generated_name_is_unique(s.kubernetes_api_state);
             },
             _ => {}
         }
@@ -1308,7 +1303,6 @@ proof fn lemma_from_after_exists_zk_node_step_to_after_create_zk_parent_node_ste
                 let sts_key = get_request(SubResource::StatefulSet, zookeeper).key;
                 assert(!resource_delete_request_msg(sts_key)(input.get_Some_0()));
                 assert(!resource_update_request_msg(sts_key)(input.get_Some_0()));
-                generated_name_is_unique(s.kubernetes_api_state);
             },
             _ => {}
         }
@@ -1404,7 +1398,6 @@ proof fn lemma_from_pending_req_to_receives_ok_or_already_exists_resp_at_after_c
                 let sts_key = get_request(SubResource::StatefulSet, zookeeper).key;
                 assert(!resource_delete_request_msg(sts_key)(input.get_Some_0()));
                 assert(!resource_update_request_msg(sts_key)(input.get_Some_0()));
-                generated_name_is_unique(s.kubernetes_api_state);
             }
             _ => {}
         }
@@ -1501,7 +1494,6 @@ proof fn lemma_from_after_create_zk_parent_node_step_to_after_create_zk_node_ste
             Step::ApiServerStep(input) => {
                 assert(!resource_delete_request_msg(sts_key)(input.get_Some_0()));
                 assert(!resource_update_request_msg(sts_key)(input.get_Some_0()));
-                generated_name_is_unique(s.kubernetes_api_state);
             },
             _ => {}
         }
@@ -1587,7 +1579,6 @@ proof fn lemma_from_pending_req_to_receives_ok_resp_at_after_create_zk_node_step
             Step::ApiServerStep(input) => {
                 assert(!resource_delete_request_msg(sts_key)(input.get_Some_0()));
                 assert(!resource_update_request_msg(sts_key)(input.get_Some_0()));
-                generated_name_is_unique(s.kubernetes_api_state);
             },
             _ => {}
         }

--- a/src/executable_model/api_server.rs
+++ b/src/executable_model/api_server.rs
@@ -162,13 +162,13 @@ pub fn handle_get_request(req: &KubeGetRequest, s: &ApiServerState) -> (ret: Kub
 fn create_request_admission_check(req: &KubeCreateRequest, s: &ApiServerState) -> (ret: Option<APIError>)
     ensures ret == model::create_request_admission_check::<K::V>(req@, s@),
 {
-    if req.obj.metadata().name().is_none() {
+    if req.obj.metadata().name().is_none() && req.obj.metadata().generate_name().is_none() {
         Some(APIError::Invalid)
     } else if req.obj.metadata().namespace().is_some() && !req.namespace.eq(&req.obj.metadata().namespace().unwrap()) {
         Some(APIError::BadRequest)
     } else if !Self::unmarshallable_object(&req.obj) {
         Some(APIError::BadRequest)
-    } else if s.resources.contains_key(&KubeObjectRef {
+    } else if req.obj.metadata().name().is_some() && s.resources.contains_key(&KubeObjectRef {
         kind: req.obj.kind(),
         name: req.obj.metadata().name().unwrap(),
         namespace: req.namespace.clone(),
@@ -192,11 +192,22 @@ fn created_object_validity_check(created_obj: &DynamicObject) -> (ret: Option<AP
     }
 }
 
+// Here we just convert the counter to a String which certainly isn't
+// how the actual API server generates the name, but we are OK about
+// it here as we won't check the returned name in the test
+#[verifier(external_body)]
+fn generate_name(counter: i64) -> (ret: String)
+    ensures ret@ == model::generate_name(counter as int)
+{
+    counter.to_string()
+}
+
 pub fn handle_create_request(req: &KubeCreateRequest, s: &mut ApiServerState) -> (ret: KubeCreateResponse)
     requires
         // No integer overflow
         old(s).resource_version_counter < i64::MAX,
         old(s).uid_counter < i64::MAX,
+        old(s).generate_name_counter < i64::MAX,
     ensures (s@, ret@) == model::handle_create_request::<K::V>(req@, old(s)@)
 {
     // TODO: use if-let?
@@ -205,6 +216,9 @@ pub fn handle_create_request(req: &KubeCreateRequest, s: &mut ApiServerState) ->
         KubeCreateResponse{res: Err(request_check_error.unwrap())}
     } else {
         let mut created_obj = req.obj.clone();
+        if req.obj.metadata().name().is_none() {
+            created_obj.set_name(Self::generate_name(s.generate_name_counter));
+        }
         created_obj.set_namespace(req.namespace.clone());
         created_obj.set_resource_version(s.resource_version_counter);
         created_obj.set_uid(s.uid_counter);
@@ -218,6 +232,9 @@ pub fn handle_create_request(req: &KubeCreateRequest, s: &mut ApiServerState) ->
             s.stable_resources.remove(&created_obj.object_ref());
             s.uid_counter = s.uid_counter + 1;
             s.resource_version_counter = s.resource_version_counter + 1;
+            if req.obj.metadata().name().is_none() {
+                s.generate_name_counter = s.generate_name_counter + 1;
+            }
             KubeCreateResponse{res: Ok(created_obj)}
         }
     }

--- a/src/executable_model/api_server_state.rs
+++ b/src/executable_model/api_server_state.rs
@@ -16,7 +16,6 @@ pub struct ApiServerState {
     pub resources: ObjectMap,
     pub uid_counter: i64,
     pub resource_version_counter: i64,
-    pub generate_name_counter: i64,
     pub stable_resources: ObjectRefSet,
 }
 
@@ -26,7 +25,6 @@ impl ApiServerState {
             resources: ObjectMap::new(),
             uid_counter: 0,
             resource_version_counter: 0,
-            generate_name_counter: 0,
             stable_resources: ObjectRefSet::new(),
         }
     }
@@ -39,7 +37,6 @@ impl View for ApiServerState {
             resources: self.resources@,
             uid_counter: self.uid_counter as int,
             resource_version_counter: self.resource_version_counter as int,
-            generate_name_counter: self.generate_name_counter as int,
             stable_resources: self.stable_resources@,
         }
     }

--- a/src/executable_model/api_server_state.rs
+++ b/src/executable_model/api_server_state.rs
@@ -16,6 +16,7 @@ pub struct ApiServerState {
     pub resources: ObjectMap,
     pub uid_counter: i64,
     pub resource_version_counter: i64,
+    pub generate_name_counter: i64,
     pub stable_resources: ObjectRefSet,
 }
 
@@ -25,6 +26,7 @@ impl ApiServerState {
             resources: ObjectMap::new(),
             uid_counter: 0,
             resource_version_counter: 0,
+            generate_name_counter: 0,
             stable_resources: ObjectRefSet::new(),
         }
     }
@@ -37,6 +39,7 @@ impl View for ApiServerState {
             resources: self.resources@,
             uid_counter: self.uid_counter as int,
             resource_version_counter: self.resource_version_counter as int,
+            generate_name_counter: self.generate_name_counter as int,
             stable_resources: self.stable_resources@,
         }
     }

--- a/src/kubernetes_api_objects/exec/object_meta.rs
+++ b/src/kubernetes_api_objects/exec/object_meta.rs
@@ -60,6 +60,15 @@ impl ObjectMeta {
     }
 
     #[verifier(external_body)]
+    pub fn generate_name(&self) -> (generate_name: Option<String>)
+        ensures
+            self@.generate_name.is_Some() == generate_name.is_Some(),
+            generate_name.is_Some() ==> generate_name.get_Some_0()@ == self@.generate_name.get_Some_0(),
+    {
+        self.inner.generate_name.clone()
+    }
+
+    #[verifier(external_body)]
     pub fn labels(&self) -> (labels: Option<StringMap>)
         ensures
             self@.labels.is_Some() == labels.is_Some(),

--- a/src/kubernetes_api_objects/spec/common.rs
+++ b/src/kubernetes_api_objects/spec/common.rs
@@ -12,6 +12,11 @@ pub type Uid = int;
 // make ResourceVersion an int, instead of String, so that it is easy to compare in spec/proof
 pub type ResourceVersion = int;
 
+// GenerateNameCounter is used to specify how the API server generates a random and unique name
+// according to the generate name field
+// make GenerateNameCounter an int, instead of String, so that it is easy to compare in spec/proof
+pub type GenerateNameCounter = int;
+
 #[is_variant]
 #[derive(PartialEq, Eq, PartialOrd, Ord, Debug)]
 pub enum Kind {

--- a/src/kubernetes_cluster/proof/builtin_controllers.rs
+++ b/src/kubernetes_cluster/proof/builtin_controllers.rs
@@ -51,9 +51,10 @@ pub open spec fn no_create_msg_that_uses_generate_name(
     kind: Kind, namespace: StringView
 ) -> StatePred<Self> {
     |s: Self| {
-        forall |msg: MsgType<E>|
-            #[trigger] resource_create_request_msg_with_empty_name(kind, namespace)(msg)
-            ==> !s.in_flight().contains(msg)
+        forall |msg: MsgType<E>| !{
+            &&& s.in_flight().contains(msg)
+            &&& #[trigger] resource_create_request_msg_with_empty_name(kind, namespace)(msg)
+        }
     }
 }
 

--- a/src/kubernetes_cluster/proof/builtin_controllers.rs
+++ b/src/kubernetes_cluster/proof/builtin_controllers.rs
@@ -4,7 +4,6 @@
 use crate::external_api::spec::*;
 use crate::kubernetes_api_objects::spec::prelude::*;
 use crate::kubernetes_cluster::spec::{
-    api_server::state_machine::generated_name_is_unique,
     builtin_controllers::types::BuiltinControllerChoice,
     cluster::*,
     cluster_state_machine::Step,
@@ -216,7 +215,6 @@ pub proof fn lemma_eventually_objects_owner_references_satisfies(
     or_leads_to_combine_and_equality!(spec, true_pred(), lift_state(Self::objects_owner_references_violates(key, eventual_owner_ref)), lift_state(post); lift_state(post));
 
     assert forall |s, s_prime| post(s) && #[trigger] stronger_next(s, s_prime) implies post(s_prime) by {
-        generated_name_is_unique(s.kubernetes_api_state);
         let step = choose |step| Self::next_step(s, s_prime, step);
         match step {
             Step::ApiServerStep(input) => {

--- a/src/kubernetes_cluster/proof/daemon_set_controller.rs
+++ b/src/kubernetes_cluster/proof/daemon_set_controller.rs
@@ -90,6 +90,7 @@ pub proof fn lemma_true_leads_to_always_daemon_set_not_exist_or_updated_or_no_mo
         spec.entails(tla_forall(|i| Self::builtin_controllers_next().weak_fairness(i))),
         spec.entails(always(lift_state(Self::every_in_flight_create_req_msg_for_this_ds_matches(key, make_fn)))),
         spec.entails(always(lift_state(Self::every_in_flight_update_req_msg_for_this_ds_matches(key, make_fn)))),
+        spec.entails(always(lift_state(Self::no_create_msg_that_uses_generate_name(key.kind, key.namespace)))),
         spec.entails(always(lift_state(Self::each_object_in_etcd_is_well_formed()))),
     ensures spec.entails(true_pred().leads_to(always(lift_state(Self::daemon_set_not_exist_or_updated_or_no_more_status_from_bc(key, make_fn))))),
 {
@@ -100,6 +101,7 @@ pub proof fn lemma_true_leads_to_always_daemon_set_not_exist_or_updated_or_no_mo
         &&& Self::next()(s, s_prime)
         &&& Self::every_in_flight_create_req_msg_for_this_ds_matches(key, make_fn)(s)
         &&& Self::every_in_flight_update_req_msg_for_this_ds_matches(key, make_fn)(s)
+        &&& Self::no_create_msg_that_uses_generate_name(key.kind, key.namespace)(s)
         &&& Self::each_object_in_etcd_is_well_formed()(s)
     };
     combine_spec_entails_always_n!(
@@ -107,6 +109,7 @@ pub proof fn lemma_true_leads_to_always_daemon_set_not_exist_or_updated_or_no_mo
         lift_action(Self::next()),
         lift_state(Self::every_in_flight_create_req_msg_for_this_ds_matches(key, make_fn)),
         lift_state(Self::every_in_flight_update_req_msg_for_this_ds_matches(key, make_fn)),
+        lift_state(Self::no_create_msg_that_uses_generate_name(key.kind, key.namespace)),
         lift_state(Self::each_object_in_etcd_is_well_formed())
     );
 
@@ -120,6 +123,7 @@ pub proof fn lemma_true_leads_to_always_daemon_set_not_exist_or_updated_or_no_mo
                 match req.content.get_APIRequest_0() {
                     APIRequest::CreateRequest(_) => {
                         if resource_create_request_msg(key)(req) {}
+                        if resource_create_request_msg_with_empty_name(key.kind, key.namespace)(req) {}
                     }
                     APIRequest::UpdateRequest(_) => {
                         if resource_update_request_msg(key)(req) {}
@@ -142,6 +146,7 @@ proof fn lemma_true_leads_to_daemon_set_not_exist_or_updated_or_no_more_pending_
         spec.entails(tla_forall(|i| Self::builtin_controllers_next().weak_fairness(i))),
         spec.entails(always(lift_state(Self::every_in_flight_create_req_msg_for_this_ds_matches(key, make_fn)))),
         spec.entails(always(lift_state(Self::every_in_flight_update_req_msg_for_this_ds_matches(key, make_fn)))),
+        spec.entails(always(lift_state(Self::no_create_msg_that_uses_generate_name(key.kind, key.namespace)))),
         spec.entails(always(lift_state(Self::each_object_in_etcd_is_well_formed()))),
     ensures spec.entails(true_pred().leads_to(lift_state(Self::daemon_set_not_exist_or_updated_or_no_more_status_from_bc(key, make_fn)))),
 {
@@ -196,6 +201,7 @@ proof fn lemma_pending_update_status_req_num_is_n_leads_to_daemon_set_not_exist_
         spec.entails(tla_forall(|i| Self::kubernetes_api_next().weak_fairness(i))),
         spec.entails(always(lift_state(Self::every_in_flight_create_req_msg_for_this_ds_matches(key, make_fn)))),
         spec.entails(always(lift_state(Self::every_in_flight_update_req_msg_for_this_ds_matches(key, make_fn)))),
+        spec.entails(always(lift_state(Self::no_create_msg_that_uses_generate_name(key.kind, key.namespace)))),
         spec.entails(always(lift_state(Self::each_object_in_etcd_is_well_formed()))),
     ensures
         spec.entails(
@@ -297,6 +303,7 @@ proof fn daemon_set_not_exist_or_updated_or_pending_update_status_requests_num_d
         spec.entails(tla_forall(|i| Self::kubernetes_api_next().weak_fairness(i))),
         spec.entails(always(lift_state(Self::every_in_flight_create_req_msg_for_this_ds_matches(key, make_fn)))),
         spec.entails(always(lift_state(Self::every_in_flight_update_req_msg_for_this_ds_matches(key, make_fn)))),
+        spec.entails(always(lift_state(Self::no_create_msg_that_uses_generate_name(key.kind, key.namespace)))),
         spec.entails(always(lift_state(Self::each_object_in_etcd_is_well_formed()))),
     ensures
         spec.entails(
@@ -350,6 +357,7 @@ proof fn daemon_set_not_exist_or_updated_or_pending_update_status_requests_num_d
         &&& Self::next()(s, s_prime)
         &&& Self::every_in_flight_create_req_msg_for_this_ds_matches(key, make_fn)(s)
         &&& Self::every_in_flight_update_req_msg_for_this_ds_matches(key, make_fn)(s)
+        &&& Self::no_create_msg_that_uses_generate_name(key.kind, key.namespace)(s)
         &&& Self::each_object_in_etcd_is_well_formed()(s)
     };
     combine_spec_entails_always_n!(
@@ -357,6 +365,7 @@ proof fn daemon_set_not_exist_or_updated_or_pending_update_status_requests_num_d
         lift_action(Self::next()),
         lift_state(Self::every_in_flight_create_req_msg_for_this_ds_matches(key, make_fn)),
         lift_state(Self::every_in_flight_update_req_msg_for_this_ds_matches(key, make_fn)),
+        lift_state(Self::no_create_msg_that_uses_generate_name(key.kind, key.namespace)),
         lift_state(Self::each_object_in_etcd_is_well_formed())
     );
 
@@ -374,6 +383,7 @@ proof fn daemon_set_not_exist_or_updated_or_pending_update_status_requests_num_d
                     DaemonSetView::marshal_status_preserves_integrity();
                     if resource_create_request_msg(key)(input.get_Some_0()) {} else {}
                     if resource_update_request_msg(key)(input.get_Some_0()) {} else {}
+                    if resource_create_request_msg_with_empty_name(key.kind, key.namespace)(input.get_Some_0()) {}
                     assert(pending_req_multiset =~= pending_req_multiset_prime);
                 }
             },

--- a/src/kubernetes_cluster/proof/message.rs
+++ b/src/kubernetes_cluster/proof/message.rs
@@ -715,8 +715,8 @@ pub open spec fn key_of_object_in_matched_ok_create_resp_message_is_same_as_key_
             && s.ongoing_reconciles().contains_key(key)
             && s.ongoing_reconciles()[key].pending_req_msg.is_Some()
             && #[trigger] Message::resp_msg_matches_req_msg(msg, s.ongoing_reconciles()[key].pending_req_msg.get_Some_0())
-            ==> (create_req.obj.metadata.name.is_Some()
-                && Self::is_ok_create_response_msg_and_matches_key(create_req.key())(msg))
+            && create_req.obj.metadata.name.is_Some()
+            ==> Self::is_ok_create_response_msg_and_matches_key(create_req.key())(msg)
     }
 }
 
@@ -746,11 +746,13 @@ pub proof fn lemma_always_key_of_object_in_matched_ok_create_resp_message_is_sam
         lift_state(Self::every_in_flight_msg_has_unique_id())
     );
     assert forall |s, s_prime| inv(s) && #[trigger] next(s, s_prime) implies inv(s_prime) by {
+        let create_req = s_prime.ongoing_reconciles()[key].pending_req_msg.get_Some_0().content.get_create_request();
         assert forall |msg| #[trigger] s_prime.in_flight().contains(msg) && Self::is_ok_create_response_msg()(msg) && s_prime.ongoing_reconciles().contains_key(key)
-        && s_prime.ongoing_reconciles()[key].pending_req_msg.is_Some() && Message::resp_msg_matches_req_msg(msg, s_prime.ongoing_reconciles()[key].pending_req_msg.get_Some_0()) implies s_prime.ongoing_reconciles()[key].pending_req_msg.get_Some_0().content.get_create_request().obj.metadata.name.is_Some() &&
+        && s_prime.ongoing_reconciles()[key].pending_req_msg.is_Some() && Message::resp_msg_matches_req_msg(msg, s_prime.ongoing_reconciles()[key].pending_req_msg.get_Some_0())
+        && create_req.obj.metadata.name.is_Some()
+        implies s_prime.ongoing_reconciles()[key].pending_req_msg.get_Some_0().content.get_create_request().obj.metadata.name.is_Some() &&
         Self::is_ok_create_response_msg_and_matches_key(s_prime.ongoing_reconciles()[key].pending_req_msg.get_Some_0().content.get_create_request().key())(msg) by {
             assert(s_prime.ongoing_reconciles()[key].pending_req_msg.get_Some_0().content.is_create_request());
-            let create_req = s_prime.ongoing_reconciles()[key].pending_req_msg.get_Some_0().content.get_create_request();
             let req_key = create_req.key();
             let step = choose |step| Self::next_step(s, s_prime, step);
             match step {
@@ -761,7 +763,8 @@ pub proof fn lemma_always_key_of_object_in_matched_ok_create_resp_message_is_sam
                         assert(false);
                     } else {
                         assert(s.ongoing_reconciles()[key].pending_req_msg == s_prime.ongoing_reconciles()[key].pending_req_msg);
-                        assert(create_req.obj.metadata.name.is_Some());
+                        // assert(create_req.obj.metadata.name.is_Some());
+
                         assert(Self::is_ok_create_response_msg_and_matches_key(create_req.key())(msg));
                     }
                 },

--- a/src/kubernetes_cluster/proof/stateful_set_controller.rs
+++ b/src/kubernetes_cluster/proof/stateful_set_controller.rs
@@ -136,6 +136,7 @@ pub proof fn lemma_true_leads_to_always_stateful_set_not_exist_or_updated_or_no_
         spec.entails(tla_forall(|i| Self::builtin_controllers_next().weak_fairness(i))),
         spec.entails(always(lift_state(Self::every_in_flight_create_req_msg_for_this_sts_matches(key, cm_key, make_fn)))),
         spec.entails(always(lift_state(Self::every_in_flight_update_req_msg_for_this_sts_matches(key, cm_key, make_fn)))),
+        spec.entails(always(lift_state(Self::no_create_msg_that_uses_generate_name(key.kind, key.namespace)))),
         spec.entails(always(lift_state(Self::each_object_in_etcd_is_well_formed()))),
         spec.entails(always(lift_action(Self::obj_rv_stays_unchanged(cm_key)))),
     ensures spec.entails(true_pred().leads_to(always(lift_state(Self::stateful_set_not_exist_or_updated_or_no_more_status_from_bc(key, cm_key, make_fn))))),
@@ -147,6 +148,7 @@ pub proof fn lemma_true_leads_to_always_stateful_set_not_exist_or_updated_or_no_
         &&& Self::next()(s, s_prime)
         &&& Self::every_in_flight_create_req_msg_for_this_sts_matches(key, cm_key, make_fn)(s)
         &&& Self::every_in_flight_update_req_msg_for_this_sts_matches(key, cm_key, make_fn)(s)
+        &&& Self::no_create_msg_that_uses_generate_name(key.kind, key.namespace)(s)
         &&& Self::each_object_in_etcd_is_well_formed()(s)
         &&& Self::obj_rv_stays_unchanged(cm_key)(s, s_prime)
     };
@@ -155,6 +157,7 @@ pub proof fn lemma_true_leads_to_always_stateful_set_not_exist_or_updated_or_no_
         lift_action(Self::next()),
         lift_state(Self::every_in_flight_create_req_msg_for_this_sts_matches(key, cm_key, make_fn)),
         lift_state(Self::every_in_flight_update_req_msg_for_this_sts_matches(key, cm_key, make_fn)),
+        lift_state(Self::no_create_msg_that_uses_generate_name(key.kind, key.namespace)),
         lift_state(Self::each_object_in_etcd_is_well_formed()),
         lift_action(Self::obj_rv_stays_unchanged(cm_key))
     );
@@ -169,6 +172,7 @@ pub proof fn lemma_true_leads_to_always_stateful_set_not_exist_or_updated_or_no_
                 match req.content.get_APIRequest_0() {
                     APIRequest::CreateRequest(_) => {
                         if resource_create_request_msg(key)(req) {}
+                        if resource_create_request_msg_with_empty_name(key.kind, key.namespace)(req) {}
                     }
                     APIRequest::UpdateRequest(_) => {
                         if resource_update_request_msg(key)(req) {}
@@ -191,6 +195,7 @@ proof fn lemma_true_leads_to_stateful_set_not_exist_or_updated_or_no_more_pendin
         spec.entails(tla_forall(|i| Self::builtin_controllers_next().weak_fairness(i))),
         spec.entails(always(lift_state(Self::every_in_flight_create_req_msg_for_this_sts_matches(key, cm_key, make_fn)))),
         spec.entails(always(lift_state(Self::every_in_flight_update_req_msg_for_this_sts_matches(key, cm_key, make_fn)))),
+        spec.entails(always(lift_state(Self::no_create_msg_that_uses_generate_name(key.kind, key.namespace)))),
         spec.entails(always(lift_state(Self::each_object_in_etcd_is_well_formed()))),
         spec.entails(always(lift_action(Self::obj_rv_stays_unchanged(cm_key)))),
     ensures spec.entails(true_pred().leads_to(lift_state(Self::stateful_set_not_exist_or_updated_or_no_more_status_from_bc(key, cm_key, make_fn)))),
@@ -248,6 +253,7 @@ proof fn lemma_pending_update_status_req_num_is_n_leads_to_stateful_set_not_exis
         spec.entails(tla_forall(|i| Self::kubernetes_api_next().weak_fairness(i))),
         spec.entails(always(lift_state(Self::every_in_flight_create_req_msg_for_this_sts_matches(key, cm_key, make_fn)))),
         spec.entails(always(lift_state(Self::every_in_flight_update_req_msg_for_this_sts_matches(key, cm_key, make_fn)))),
+        spec.entails(always(lift_state(Self::no_create_msg_that_uses_generate_name(key.kind, key.namespace)))),
         spec.entails(always(lift_state(Self::each_object_in_etcd_is_well_formed()))),
         spec.entails(always(lift_action(Self::obj_rv_stays_unchanged(cm_key)))),
     ensures
@@ -356,6 +362,7 @@ proof fn stateful_set_not_exist_or_updated_or_pending_update_status_requests_num
         spec.entails(tla_forall(|i| Self::kubernetes_api_next().weak_fairness(i))),
         spec.entails(always(lift_state(Self::every_in_flight_create_req_msg_for_this_sts_matches(key, cm_key, make_fn)))),
         spec.entails(always(lift_state(Self::every_in_flight_update_req_msg_for_this_sts_matches(key, cm_key, make_fn)))),
+        spec.entails(always(lift_state(Self::no_create_msg_that_uses_generate_name(key.kind, key.namespace)))),
         spec.entails(always(lift_state(Self::each_object_in_etcd_is_well_formed()))),
         spec.entails(always(lift_action(Self::obj_rv_stays_unchanged(cm_key)))),
     ensures
@@ -416,6 +423,7 @@ proof fn stateful_set_not_exist_or_updated_or_pending_update_status_requests_num
         &&& Self::next()(s, s_prime)
         &&& Self::every_in_flight_create_req_msg_for_this_sts_matches(key, cm_key, make_fn)(s)
         &&& Self::every_in_flight_update_req_msg_for_this_sts_matches(key, cm_key, make_fn)(s)
+        &&& Self::no_create_msg_that_uses_generate_name(key.kind, key.namespace)(s)
         &&& Self::each_object_in_etcd_is_well_formed()(s)
         &&& Self::obj_rv_stays_unchanged(cm_key)(s, s_prime)
     };
@@ -424,6 +432,7 @@ proof fn stateful_set_not_exist_or_updated_or_pending_update_status_requests_num
         lift_action(Self::next()),
         lift_state(Self::every_in_flight_create_req_msg_for_this_sts_matches(key, cm_key, make_fn)),
         lift_state(Self::every_in_flight_update_req_msg_for_this_sts_matches(key, cm_key, make_fn)),
+        lift_state(Self::no_create_msg_that_uses_generate_name(key.kind, key.namespace)),
         lift_state(Self::each_object_in_etcd_is_well_formed()),
         lift_action(Self::obj_rv_stays_unchanged(cm_key))
     );
@@ -441,6 +450,7 @@ proof fn stateful_set_not_exist_or_updated_or_pending_update_status_requests_num
                     StatefulSetView::marshal_spec_preserves_integrity();
                     StatefulSetView::marshal_status_preserves_integrity();
                     if resource_create_request_msg(key)(input.get_Some_0()) {} else {}
+                    if resource_create_request_msg_with_empty_name(key.kind, key.namespace)(input.get_Some_0()) {} else {}
                     if resource_update_request_msg(key)(input.get_Some_0()) {} else {}
                     assert(pending_req_multiset =~= pending_req_multiset_prime);
                 }

--- a/src/kubernetes_cluster/spec/api_server/state_machine.rs
+++ b/src/kubernetes_cluster/spec/api_server/state_machine.rs
@@ -175,8 +175,8 @@ pub open spec fn create_request_admission_check<K: CustomResourceView>(req: Crea
     } else if !unmarshallable_object::<K>(req.obj) {
         // Creation fails because the provided object is not well formed
         Some(APIError::BadRequest) // TODO: should the error be BadRequest?
-    } else if s.resources.contains_key(req.obj.set_namespace(req.namespace).object_ref()) {
-        // Creation fails because the object already exists
+    } else if req.obj.metadata.name.is_Some() && s.resources.contains_key(req.obj.set_namespace(req.namespace).object_ref()) {
+        // Creation fails because the object has a name and it already exists
         Some(APIError::ObjectAlreadyExists)
     } else {
         None

--- a/src/kubernetes_cluster/spec/api_server/types.rs
+++ b/src/kubernetes_cluster/spec/api_server/types.rs
@@ -16,7 +16,6 @@ pub struct ApiServerState {
     pub resources: StoredState,
     pub uid_counter: Uid,
     pub resource_version_counter: ResourceVersion,
-    pub generate_name_counter: GenerateNameCounter,
     pub stable_resources: Set<ObjectRef>,
 }
 

--- a/src/kubernetes_cluster/spec/api_server/types.rs
+++ b/src/kubernetes_cluster/spec/api_server/types.rs
@@ -16,6 +16,7 @@ pub struct ApiServerState {
     pub resources: StoredState,
     pub uid_counter: Uid,
     pub resource_version_counter: ResourceVersion,
+    pub generate_name_counter: GenerateNameCounter,
     pub stable_resources: Set<ObjectRef>,
 }
 

--- a/src/kubernetes_cluster/spec/message.rs
+++ b/src/kubernetes_cluster/spec/message.rs
@@ -493,6 +493,17 @@ pub open spec fn resource_create_request_msg<I, O>(key: ObjectRef) -> spec_fn(Me
         && msg.content.get_create_request().obj.kind == key.kind
 }
 
+// This is mainly used for reasoning about create requests with generate name
+pub open spec fn resource_create_request_msg_with_empty_name<I, O>(kind: Kind, namespace: StringView) -> spec_fn(Message<I, O>) -> bool {
+    |msg: Message<I, O>|
+        msg.dst.is_ApiServer()
+        && msg.content.is_create_request()
+        && msg.content.get_create_request().namespace == namespace
+        && msg.content.get_create_request().obj.metadata.name.is_None()
+        && msg.content.get_create_request().obj.metadata.generate_name.is_Some()
+        && msg.content.get_create_request().obj.kind == kind
+}
+
 pub open spec fn resource_update_status_request_msg<I, O>(key: ObjectRef) -> spec_fn(Message<I, O>) -> bool {
     |msg: Message<I, O>|
         msg.dst.is_ApiServer()


### PR DESCRIPTION
This PR revises the API server model to allow resource creation requests that carry a `generate_name` rather than a `name`. For such requests, the API server will generate a unique name for the object and create the object with the generated name. Before the revision, such requests are rejected by our model. We do not specify the details on how the API server guarantees the uniqueness of the generated name, but rather use a trusted proof function saying that the generated name is different from any existing names. Note that this trusted proof is better written as a "spec ensures" once that gets supported by Verus.

We make this revision mainly to enable verifying Kubernetes core controllers such as the ReplicaSet controller that often creates pods with `generate_name`.

This revision breaks many proofs of the custom controllers we have built, but it is straightforward to fix these broken proofs. In most cases, we only need to say that there does not exist any create request that might create the "same" object.