### PR TITLE
Add a toy example for controller interaction

### DIFF
--- a/.github/workflows/controller-build.yml
+++ b/.github/workflows/controller-build.yml
@@ -80,3 +80,41 @@ jobs:
         run: |
           docker push ghcr.io/${{ env.IMAGE_NAME }}/vreplicaset-controller:latest
           docker push ghcr.io/${{ env.IMAGE_NAME }}/vreplicaset-controller:${{ github.sha }}
+  build-producer-controller:
+    runs-on: ubuntu-20.04
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+      - name: Log into registry ghcr.io
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u "${{ github.actor }}" --password-stdin
+      - name: Build producer controller image
+        run: |
+          cp docker/controller/Dockerfile .
+          docker build -t ghcr.io/${{ env.IMAGE_NAME }}/producer-controller:latest --build-arg APP=producer .
+          docker tag ghcr.io/${{ env.IMAGE_NAME }}/producer-controller:latest ghcr.io/${{ env.IMAGE_NAME }}/producer-controller:${{ github.sha }}
+      - name: Push producer controller image
+        run: |
+          docker push ghcr.io/${{ env.IMAGE_NAME }}/producer-controller:latest
+          docker push ghcr.io/${{ env.IMAGE_NAME }}/producer-controller:${{ github.sha }}
+  build-consumer-controller:
+    runs-on: ubuntu-20.04
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+      - name: Log into registry ghcr.io
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u "${{ github.actor }}" --password-stdin
+      - name: Build consumer controller image
+        run: |
+          cp docker/controller/Dockerfile .
+          docker build -t ghcr.io/${{ env.IMAGE_NAME }}/consumer-controller:latest --build-arg APP=consumer .
+          docker tag ghcr.io/${{ env.IMAGE_NAME }}/consumer-controller:latest ghcr.io/${{ env.IMAGE_NAME }}/consumer-controller:${{ github.sha }}
+      - name: Push consumer controller image
+        run: |
+          docker push ghcr.io/${{ env.IMAGE_NAME }}/consumer-controller:latest
+          docker push ghcr.io/${{ env.IMAGE_NAME }}/consumer-controller:${{ github.sha }}

--- a/deploy.sh
+++ b/deploy.sh
@@ -15,8 +15,8 @@ app=$1
 registry=$2
 
 if [ "$app" != "zookeeper" ] && [ "$app" != "rabbitmq" ] && [ "$app" != "fluent" ]\
-   [ "$app" != "vreplicaset" ] && [ "$app" != "v_stateful_set" ]; then
-    echo -e "${RED}The first argument has to be one of: zookeeper, rabbitmq, fluent, vreplicaset, v_stateful_set.${NC}"
+   [ "$app" != "vreplicaset" ] && [ "$app" != "producer" ]; then
+    echo -e "${RED}The first argument has to be one of: zookeeper, rabbitmq, fluent, vreplicaset, producer.${NC}"
     exit 1    
 fi
 
@@ -25,21 +25,15 @@ if [ "$registry" != "remote" ] && [ "$registry" != "local" ]; then
     exit 2
 fi
 
-if [ "$app" == "v_stateful_set" ]; then
-    app_ns="vstatefulset"
-else
-    app_ns=$app
-fi
-
 ## use imperative management for CRDs since metadata for PodTemplateSpec is too long.
 if cd deploy/$1 && kubectl create -f crd.yaml && kubectl apply -f rbac.yaml && kubectl apply -f deploy_$registry.yaml; then
     echo ""
-    echo -e "${GREEN}The $app controller is deployed in your Kubernetes cluster in namespace \"$app_ns\"."
-    echo -e "Run \"kubectl get pod -n $app_ns\" to check the controller pod."
-    echo -e "Run \"kubectl apply -f deploy/$app/$app.yaml\" to deploy the cluster custom resource(s).${NC}"
+    echo -e "${GREEN}The $app controller is deployed in your Kubernetes cluster in namespace \"$app\".${NC}"
+    echo -e "${GREEN}Run \"kubectl get pod -n $app\" to check the controller pod.${NC}"
+    echo -e "${GREEN}Run \"kubectl apply -f deploy/$app/$app.yaml\" to deploy the cluster custom resource(s).${NC}"
 else
     echo ""
-    echo -e "${RED}Cannot deploy the controller."
+    echo -e "${RED}Cannot deploy the controller.${NC}"
     echo -e "${YELLOW}Please ensure kubectl can connect to a Kubernetes cluster.${NC}"
     exit 3
 fi

--- a/deploy.sh
+++ b/deploy.sh
@@ -11,19 +11,8 @@ GREEN='\033[1;32m'
 RED='\033[0;31m'
 NC='\033[0m'
 
-app=$1
-registry=$2
-
-if [ "$app" != "zookeeper" ] && [ "$app" != "rabbitmq" ] && [ "$app" != "fluent" ]\
-   [ "$app" != "vreplicaset" ] && [ "$app" != "producer" ]; then
-    echo -e "${RED}The first argument has to be one of: zookeeper, rabbitmq, fluent, vreplicaset, producer.${NC}"
-    exit 1    
-fi
-
-if [ "$registry" != "remote" ] && [ "$registry" != "local" ]; then
-    echo -e "${RED}The second argument has to be one of: remote, local.${NC}"
-    exit 2
-fi
+app=$1 # should be the controller's name
+registry=$2 # should be either remote or local
 
 ## use imperative management for CRDs since metadata for PodTemplateSpec is too long.
 if cd deploy/$1 && kubectl create -f crd.yaml && kubectl apply -f rbac.yaml && kubectl apply -f deploy_$registry.yaml; then

--- a/deploy/consumer/consumer.yaml
+++ b/deploy/consumer/consumer.yaml
@@ -1,0 +1,6 @@
+apiVersion: anvil.dev/v1
+kind: Consumer
+metadata:
+  name: consumer
+spec:
+  message: consumer-message

--- a/deploy/consumer/consumer.yaml
+++ b/deploy/consumer/consumer.yaml
@@ -1,6 +1,6 @@
 apiVersion: anvil.dev/v1
 kind: Consumer
 metadata:
-  name: consumer
+  name: app
 spec:
-  message: consumer-message
+  message: world

--- a/deploy/consumer/crd.yaml
+++ b/deploy/consumer/crd.yaml
@@ -1,0 +1,34 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: consumers.anvil.dev
+spec:
+  group: anvil.dev
+  names:
+    categories: []
+    kind: Consumer
+    plural: consumers
+    shortNames: []
+    singular: consumer
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns: []
+    name: v1
+    schema:
+      openAPIV3Schema:
+        description: Auto-generated derived type for ConsumerSpec via `CustomResource`
+        properties:
+          spec:
+            properties:
+              message:
+                type: string
+            required:
+            - message
+            type: object
+        required:
+        - spec
+        title: Consumer
+        type: object
+    served: true
+    storage: true
+    subresources: {}

--- a/deploy/consumer/deploy_local.yaml
+++ b/deploy/consumer/deploy_local.yaml
@@ -1,0 +1,22 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: consumer-controller
+  namespace: consumer
+  labels:
+    app.kubernetes.io/name: consumer-controller
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: consumer-controller
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: consumer-controller
+    spec:
+      containers:
+        - image: local/consumer-controller:v0.1.0
+          imagePullPolicy: IfNotPresent
+          name: controller
+      serviceAccountName: consumer-controller

--- a/deploy/consumer/deploy_remote.yaml
+++ b/deploy/consumer/deploy_remote.yaml
@@ -1,0 +1,21 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: consumer-controller
+  namespace: consumer
+  labels:
+    app.kubernetes.io/name: consumer-controller
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: consumer-controller
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: consumer-controller
+    spec:
+      containers:
+        - image: ghcr.io/vmware-research/verifiable-controllers/consumer-controller:latest
+          name: controller
+      serviceAccountName: consumer-controller

--- a/deploy/consumer/rbac.yaml
+++ b/deploy/consumer/rbac.yaml
@@ -1,0 +1,47 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    app.kubernetes.io/name: consumer
+  name: consumer
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: consumer-controller
+  namespace: consumer
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/name: consumer-controller
+  name: consumer-controller-role
+rules:
+  - apiGroups:
+      - anvil.dev
+    resources:
+      - "*"
+    verbs:
+      - "*"
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+    verbs:
+      - "*"
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/name: consumer-controller
+  name: consumer-controller-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: consumer-controller-role
+subjects:
+  - kind: ServiceAccount
+    name: consumer-controller
+    namespace: consumer

--- a/deploy/producer/crd.yaml
+++ b/deploy/producer/crd.yaml
@@ -1,0 +1,34 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: producers.anvil.dev
+spec:
+  group: anvil.dev
+  names:
+    categories: []
+    kind: Producer
+    plural: producers
+    shortNames: []
+    singular: producer
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns: []
+    name: v1
+    schema:
+      openAPIV3Schema:
+        description: Auto-generated derived type for ProducerSpec via `CustomResource`
+        properties:
+          spec:
+            properties:
+              message:
+                type: string
+            required:
+            - message
+            type: object
+        required:
+        - spec
+        title: Producer
+        type: object
+    served: true
+    storage: true
+    subresources: {}

--- a/deploy/producer/deploy_local.yaml
+++ b/deploy/producer/deploy_local.yaml
@@ -1,0 +1,22 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: producer-controller
+  namespace: producer
+  labels:
+    app.kubernetes.io/name: producer-controller
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: producer-controller
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: producer-controller
+    spec:
+      containers:
+        - image: local/producer-controller:v0.1.0
+          imagePullPolicy: IfNotPresent
+          name: controller
+      serviceAccountName: producer-controller

--- a/deploy/producer/deploy_remote.yaml
+++ b/deploy/producer/deploy_remote.yaml
@@ -1,0 +1,21 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: producer-controller
+  namespace: producer
+  labels:
+    app.kubernetes.io/name: producer-controller
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: producer-controller
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: producer-controller
+    spec:
+      containers:
+        - image: ghcr.io/vmware-research/verifiable-controllers/producer-controller:latest
+          name: controller
+      serviceAccountName: producer-controller

--- a/deploy/producer/producer.yaml
+++ b/deploy/producer/producer.yaml
@@ -1,0 +1,6 @@
+apiVersion: anvil.dev/v1
+kind: Producer
+metadata:
+  name: producer
+spec:
+  message: producer-message

--- a/deploy/producer/producer.yaml
+++ b/deploy/producer/producer.yaml
@@ -1,6 +1,6 @@
 apiVersion: anvil.dev/v1
 kind: Producer
 metadata:
-  name: producer
+  name: app
 spec:
-  message: producer-message
+  message: hello

--- a/deploy/producer/rbac.yaml
+++ b/deploy/producer/rbac.yaml
@@ -1,0 +1,47 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    app.kubernetes.io/name: producer
+  name: producer
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: producer-controller
+  namespace: producer
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/name: producer-controller
+  name: producer-controller-role
+rules:
+  - apiGroups:
+      - anvil.dev
+    resources:
+      - "*"
+    verbs:
+      - "*"
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+    verbs:
+      - "*"
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/name: producer-controller
+  name: producer-controller-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: producer-controller-role
+subjects:
+  - kind: ServiceAccount
+    name: producer-controller
+    namespace: producer

--- a/src/consumer_controller.rs
+++ b/src/consumer_controller.rs
@@ -1,0 +1,46 @@
+// Copyright 2022 VMware, Inc.
+// SPDX-License-Identifier: MIT
+#![allow(unused_imports)]
+
+#[path = "controller_examples/composition_example/consumer_controller/mod.rs"]
+pub mod consumer_controller;
+pub mod external_api;
+pub mod kubernetes_api_objects;
+pub mod kubernetes_cluster;
+#[path = "controller_examples/composition_example/producer_controller/mod.rs"]
+pub mod producer_controller;
+pub mod reconciler;
+pub mod shim_layer;
+pub mod state_machine;
+pub mod temporal_logic;
+pub mod vstd_ext;
+
+use crate::consumer_controller::exec::reconciler::ConsumerReconciler;
+use deps_hack::anyhow::Result;
+use deps_hack::kube::CustomResourceExt;
+use deps_hack::serde_yaml;
+use deps_hack::tokio;
+use deps_hack::tracing::{error, info};
+use deps_hack::tracing_subscriber;
+use shim_layer::controller_runtime::run_controller;
+use std::env;
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    tracing_subscriber::fmt::init();
+    let args: Vec<String> = env::args().collect();
+    let cmd = args[1].clone();
+
+    if cmd == String::from("export") {
+        println!("{}", serde_yaml::to_string(&deps_hack::Consumer::crd())?);
+    } else if cmd == String::from("run") {
+        info!("running consumer-controller");
+        run_controller::<deps_hack::Consumer, ConsumerReconciler>(false).await?;
+    } else if cmd == String::from("crash") {
+        info!("running consumer-controller in crash-testing mode");
+        run_controller::<deps_hack::Consumer, ConsumerReconciler>(true).await?;
+    } else {
+        error!("wrong command; please use \"export\", \"run\" or \"crash\"");
+    }
+    Ok(())
+}

--- a/src/controller_examples/composition_example/consumer_controller/exec/mod.rs
+++ b/src/controller_examples/composition_example/consumer_controller/exec/mod.rs
@@ -1,5 +1,3 @@
 // Copyright 2022 VMware, Inc.
 // SPDX-License-Identifier: MIT
-pub mod exec;
-pub mod model;
-pub mod trusted;
+pub mod reconciler;

--- a/src/controller_examples/composition_example/consumer_controller/exec/reconciler.rs
+++ b/src/controller_examples/composition_example/consumer_controller/exec/reconciler.rs
@@ -1,0 +1,234 @@
+// Copyright 2022 VMware, Inc.
+// SPDX-License-Identifier: MIT
+use crate::consumer_controller::model::reconciler as model_reconciler;
+use crate::consumer_controller::trusted::exec_types::*;
+use crate::consumer_controller::trusted::spec_types;
+use crate::consumer_controller::trusted::step::*;
+use crate::external_api::exec::*;
+use crate::kubernetes_api_objects::exec::resource::ResourceWrapper;
+use crate::kubernetes_api_objects::exec::{
+    container::*, label_selector::*, pod_template_spec::*, prelude::*, resource_requirements::*,
+    volume::*,
+};
+use crate::kubernetes_api_objects::spec::prelude::DynamicObjectView;
+use crate::kubernetes_api_objects::spec::prelude::PodView;
+use crate::kubernetes_api_objects::spec::resource::ResourceView;
+use crate::producer_controller::trusted::exec_types::*;
+use crate::reconciler::exec::{io::*, reconciler::*, resource_builder::*};
+use crate::vstd_ext::{string_map::StringMap, string_view::*};
+use vstd::prelude::*;
+use vstd::seq_lib::*;
+use vstd::string::*;
+
+verus! {
+
+pub struct ConsumerReconciler {}
+
+impl Reconciler for ConsumerReconciler {
+    type R = Consumer;
+    type T = ConsumerReconcileState;
+    type ExternalAPIType = EmptyAPIShimLayer;
+
+    open spec fn well_formed(consumer: &Consumer) -> bool { consumer@.well_formed() }
+
+    fn reconcile_init_state() -> ConsumerReconcileState {
+        reconcile_init_state()
+    }
+
+    fn reconcile_core(consumer: &Consumer, resp_o: Option<Response<EmptyType>>, state: ConsumerReconcileState) -> (ConsumerReconcileState, Option<Request<EmptyType>>) {
+        reconcile_core(consumer, resp_o, state)
+    }
+
+    fn reconcile_done(state: &ConsumerReconcileState) -> bool {
+        reconcile_done(state)
+    }
+
+    fn reconcile_error(state: &ConsumerReconcileState) -> bool {
+        reconcile_error(state)
+    }
+}
+
+impl Default for ConsumerReconciler {
+    fn default() -> ConsumerReconciler { ConsumerReconciler{} }
+}
+
+#[verifier(external_body)]
+pub fn reconcile_init_state() -> (state: ConsumerReconcileState)
+    ensures state@ == model_reconciler::reconcile_init_state(),
+{
+    ConsumerReconcileState {
+        reconcile_step: ConsumerReconcileStep::Init,
+    }
+}
+
+#[verifier(external_body)]
+pub fn reconcile_done(state: &ConsumerReconcileState) -> (res: bool)
+    ensures res == model_reconciler::reconcile_done(state@),
+{
+    match state.reconcile_step {
+        ConsumerReconcileStep::Done => true,
+        _ => false,
+    }
+}
+
+#[verifier(external_body)]
+pub fn reconcile_error(state: &ConsumerReconcileState) -> (res: bool)
+    ensures res == model_reconciler::reconcile_error(state@),
+{
+    match state.reconcile_step {
+        ConsumerReconcileStep::Error => true,
+        _ => false,
+    }
+}
+
+#[verifier(external_body)]
+pub fn reconcile_core(consumer: &Consumer, resp_o: Option<Response<EmptyType>>, state: ConsumerReconcileState) -> (res: (ConsumerReconcileState, Option<Request<EmptyType>>))
+    requires consumer@.well_formed(),
+    ensures (res.0@, opt_request_to_view(&res.1)) == model_reconciler::reconcile_core(consumer@, opt_response_to_view(&resp_o), state@),
+{
+    let namespace = consumer.metadata().namespace().unwrap();
+    match &state.reconcile_step {
+        ConsumerReconcileStep::Init => {
+            let req = KubeAPIRequest::GetRequest(KubeGetRequest {
+                api_resource: Producer::api_resource(),
+                name: consumer.metadata().name().unwrap(),
+                namespace: consumer.metadata().namespace().unwrap(),
+            });
+            let state_prime = ConsumerReconcileState {
+                reconcile_step: ConsumerReconcileStep::AfterGetProducer,
+                ..state
+            };
+            return (state_prime, Some(Request::KRequest(req)));
+        },
+        ConsumerReconcileStep::AfterGetProducer => {
+            if resp_o.is_some() && resp_o.as_ref().unwrap().is_k_response()
+            && resp_o.as_ref().unwrap().as_k_response_ref().is_get_response() {
+                let get_producer_resp = resp_o.unwrap().into_k_response().into_get_response().res;
+                if get_producer_resp.is_ok() {
+                    let req = KubeAPIRequest::GetRequest(KubeGetRequest {
+                        api_resource: Pod::api_resource(),
+                        name: consumer.metadata().name().unwrap(),
+                        namespace: consumer.metadata().namespace().unwrap(),
+                    });
+                    let state_prime = ConsumerReconcileState {
+                        reconcile_step: ConsumerReconcileStep::AfterGetPod,
+                        ..state
+                    };
+                    return (state_prime, Some(Request::KRequest(req)));
+                } else if get_producer_resp.unwrap_err().is_object_not_found() {
+                    let producer = make_producer(consumer);
+                    let req = KubeAPIRequest::CreateRequest(KubeCreateRequest {
+                        api_resource: Producer::api_resource(),
+                        namespace: namespace,
+                        obj: producer.marshal(),
+                    });
+                    let state_prime = ConsumerReconcileState {
+                        reconcile_step: ConsumerReconcileStep::AfterCreateProducer,
+                        ..state
+                    };
+                    return (state_prime, Some(Request::KRequest(req)));
+                } else {
+                    return (error_state(state), None);
+                }
+            }
+            return (error_state(state), None);
+        },
+        // ConsumerReconcileStep::AfterCreateProducer => {
+
+        // },
+        // ConsumerReconcileStep::AfterGetPod => {
+
+        // },
+        // ConsumerReconcileStep::AfterUpdatePod => {
+
+        // },
+        _ => {
+            return (state, None);
+        }
+    }
+}
+
+pub fn error_state(state: ConsumerReconcileState) -> (state_prime: ConsumerReconcileState)
+    // ensures state_prime@ == model_reconciler::error_state(state@),
+{
+    ConsumerReconcileState {
+        reconcile_step: ConsumerReconcileStep::Error,
+        ..state
+    }
+}
+
+#[verifier(external_body)]
+pub fn make_owner_references(consumer: &Consumer) -> (owner_references: Vec<OwnerReference>)
+    requires consumer@.well_formed(),
+    ensures owner_references@.map_values(|or: OwnerReference| or@) ==  model_reconciler::make_owner_references(consumer@),
+{
+    let mut owner_references = Vec::new();
+    owner_references.push(consumer.controller_owner_ref());
+    proof {
+        assert_seqs_equal!(
+            owner_references@.map_values(|owner_ref: OwnerReference| owner_ref@),
+            model_reconciler::make_owner_references(consumer@)
+        );
+    }
+    owner_references
+}
+
+#[verifier(external_body)]
+fn make_pod(consumer: &Consumer) -> (pod: Pod)
+    requires consumer@.well_formed(),
+    ensures pod@ == model_reconciler::make_pod(consumer@),
+{
+    let mut pod = Pod::default();
+    pod.set_metadata({
+        let mut metadata = ObjectMeta::default();
+        metadata.set_name(consumer.metadata().name().unwrap());
+        metadata.set_owner_references(make_owner_references(consumer));
+        metadata
+    });
+    pod.set_spec({
+        let mut pod_spec = PodSpec::default();
+        pod_spec.set_containers({
+            let mut containers = Vec::new();
+            containers.push({
+                let mut container = Container::default();
+                container.set_name("nginx".to_string());
+                container.set_image("nginx:1.14.2".to_string());
+                container.set_ports({
+                    let mut ports = Vec::new();
+                    ports.push({
+                        let mut container_port = ContainerPort::default();
+                        container_port.set_container_port(80);
+                        container_port
+                    });
+                    ports
+                });
+                container
+            });
+            containers
+        });
+        pod_spec
+    });
+    pod
+}
+
+#[verifier(external_body)]
+fn make_producer(consumer: &Consumer) -> (producer: Producer)
+    // requires consumer@.well_formed(),
+    // ensures pod@ == model_reconciler::make_pod(consumer@),
+{
+    let mut producer = Producer::default();
+    producer.set_metadata({
+        let mut metadata = ObjectMeta::default();
+        metadata.set_name(consumer.metadata().name().unwrap());
+        metadata.set_owner_references(make_owner_references(consumer));
+        metadata
+    });
+    producer.set_spec({
+        let mut producer_spec = ProducerSpec::default();
+        producer_spec.set_message("hello".to_string());
+        producer_spec
+    });
+    producer
+}
+
+}

--- a/src/controller_examples/composition_example/consumer_controller/mod.rs
+++ b/src/controller_examples/composition_example/consumer_controller/mod.rs
@@ -1,0 +1,4 @@
+// Copyright 2022 VMware, Inc.
+// SPDX-License-Identifier: MIT
+pub mod exec;
+pub mod trusted;

--- a/src/controller_examples/composition_example/consumer_controller/model/mod.rs
+++ b/src/controller_examples/composition_example/consumer_controller/model/mod.rs
@@ -1,5 +1,3 @@
 // Copyright 2022 VMware, Inc.
 // SPDX-License-Identifier: MIT
-pub mod exec;
-pub mod model;
-pub mod trusted;
+pub mod reconciler;

--- a/src/controller_examples/composition_example/consumer_controller/model/reconciler.rs
+++ b/src/controller_examples/composition_example/consumer_controller/model/reconciler.rs
@@ -1,0 +1,104 @@
+// Copyright 2022 VMware, Inc.
+// SPDX-License-Identifier: MIT
+#![allow(unused_imports)]
+use crate::consumer_controller::trusted::{spec_types::*, step::*};
+use crate::external_api::spec::*;
+use crate::kubernetes_api_objects::spec::{container::*, prelude::*};
+use crate::reconciler::spec::{io::*, reconciler::*};
+use vstd::{prelude::*, string::*};
+
+verus! {
+
+impl Reconciler<ConsumerView, EmptyAPI> for ConsumerReconciler {
+    type T = ConsumerReconcileState;
+
+    open spec fn reconcile_init_state() -> ConsumerReconcileState {
+        reconcile_init_state()
+    }
+
+    open spec fn reconcile_core(fb: ConsumerView, resp_o: Option<ResponseView<EmptyTypeView>>, state: ConsumerReconcileState)
+    -> (ConsumerReconcileState, Option<RequestView<EmptyTypeView>>) {
+        reconcile_core(fb, resp_o, state)
+    }
+
+    open spec fn reconcile_done(state: ConsumerReconcileState) -> bool {
+        reconcile_done(state)
+    }
+
+    open spec fn reconcile_error(state: ConsumerReconcileState) -> bool {
+        reconcile_error(state)
+    }
+
+    open spec fn expect_from_user(obj: DynamicObjectView) -> bool { false /* expect nothing */ }
+}
+
+pub open spec fn reconcile_init_state() -> ConsumerReconcileState {
+    ConsumerReconcileState {
+        reconcile_step: ConsumerReconcileStepView::Init,
+    }
+}
+
+pub open spec fn reconcile_done(state: ConsumerReconcileState) -> bool {
+    match state.reconcile_step {
+        ConsumerReconcileStepView::Done => true,
+        _ => false,
+    }
+}
+
+pub open spec fn reconcile_error(state: ConsumerReconcileState) -> bool {
+    match state.reconcile_step {
+        ConsumerReconcileStepView::Error => true,
+        _ => false,
+    }
+}
+
+pub open spec fn reconcile_core(
+    consumer: ConsumerView, resp_o: Option<ResponseView<EmptyTypeView>>, state: ConsumerReconcileState
+) -> (ConsumerReconcileState, Option<RequestView<EmptyTypeView>>) {
+    let namespace = consumer.metadata.namespace.unwrap();
+    match &state.reconcile_step {
+        ConsumerReconcileStepView::Init => {
+            let pod = make_pod(consumer);
+            let req = APIRequest::CreateRequest(CreateRequest {
+                namespace: namespace,
+                obj: pod.marshal(),
+            });
+            let state_prime = ConsumerReconcileState {
+                reconcile_step: ConsumerReconcileStepView::Done,
+                ..state
+            };
+            (state_prime, Some(RequestView::KRequest(req)))
+        },
+        _ => {
+            (state, None)
+        }
+    }
+}
+
+pub open spec fn make_pod(consumer: ConsumerView) -> (pod: PodView) {
+    let pod = PodView {
+        metadata: ObjectMetaView {
+            name: Some(consumer.metadata.name.unwrap()),
+            owner_references: Some(make_owner_references(consumer)),
+            ..ObjectMetaView::default()
+        },
+        spec: Some(PodSpecView {
+            containers: seq![ContainerView {
+                name: "nginx"@,
+                image: Some("nginx:1.14.2"@),
+                ports: Some(seq![ContainerPortView {
+                    container_port: 80,
+                    ..ContainerPortView::default()
+                }]),
+                ..ContainerView::default()
+            }],
+            ..PodSpecView::default()
+        }),
+        ..PodView::default()
+    };
+    pod
+}
+
+pub open spec fn make_owner_references(consumer: ConsumerView) -> Seq<OwnerReferenceView> { seq![consumer.controller_owner_ref()] }
+
+}

--- a/src/controller_examples/composition_example/consumer_controller/trusted/exec_types.rs
+++ b/src/controller_examples/composition_example/consumer_controller/trusted/exec_types.rs
@@ -1,0 +1,120 @@
+// Copyright 2022 VMware, Inc.
+// SPDX-License-Identifier: MIT
+use crate::consumer_controller::trusted::{spec_types, step::*};
+use crate::kubernetes_api_objects::error::ParseDynamicObjectError;
+use crate::kubernetes_api_objects::exec::{
+    api_resource::*, label_selector::*, pod_template_spec::*, prelude::*,
+};
+use crate::kubernetes_api_objects::spec::resource::*;
+use crate::vstd_ext::{string_map::*, string_view::*};
+use deps_hack::kube::Resource;
+use vstd::prelude::*;
+
+verus! {
+
+/// ConsumerReconcileState describes the local state with which the reconcile functions makes decisions.
+pub struct ConsumerReconcileState {
+    pub reconcile_step: ConsumerReconcileStep,
+}
+
+impl View for ConsumerReconcileState {
+    type V = spec_types::ConsumerReconcileState;
+
+    open spec fn view(&self) -> spec_types::ConsumerReconcileState {
+        spec_types::ConsumerReconcileState {
+            reconcile_step: self.reconcile_step@,
+        }
+    }
+}
+
+#[verifier(external_body)]
+pub struct Consumer {
+    inner: deps_hack::Consumer
+}
+
+impl View for Consumer {
+    type V = spec_types::ConsumerView;
+
+    spec fn view(&self) -> spec_types::ConsumerView;
+}
+
+impl Consumer {
+    #[verifier(external_body)]
+    pub fn metadata(&self) -> (metadata: ObjectMeta)
+        ensures metadata@ == self@.metadata,
+    {
+        ObjectMeta::from_kube(self.inner.metadata.clone())
+    }
+
+    #[verifier(external_body)]
+    pub fn spec(&self) -> (spec: ConsumerSpec)
+        ensures spec@ == self@.spec,
+    {
+        ConsumerSpec { inner: self.inner.spec.clone() }
+    }
+
+    #[verifier(external_body)]
+    pub fn api_resource() -> (res: ApiResource)
+        ensures res@.kind == spec_types::ConsumerView::kind(),
+    {
+        ApiResource::from_kube(deps_hack::kube::api::ApiResource::erase::<deps_hack::Consumer>(&()))
+    }
+
+    #[verifier(external_body)]
+    pub fn controller_owner_ref(&self) -> (owner_reference: OwnerReference)
+        ensures owner_reference@ == self@.controller_owner_ref(),
+    {
+        // We can safely unwrap here because the trait method implementation always returns a Some(...)
+        OwnerReference::from_kube(self.inner.controller_owner_ref(&()).unwrap())
+    }
+
+    // NOTE: This function assumes serde_json::to_string won't fail!
+    #[verifier(external_body)]
+    pub fn marshal(self) -> (obj: DynamicObject)
+        ensures obj@ == self@.marshal(),
+    {
+        // TODO: this might be unnecessarily slow
+        DynamicObject::from_kube(deps_hack::k8s_openapi::serde_json::from_str(&deps_hack::k8s_openapi::serde_json::to_string(&self.inner).unwrap()).unwrap())
+    }
+
+    #[verifier(external_body)]
+    pub fn unmarshal(obj: DynamicObject) -> (res: Result<Consumer, ParseDynamicObjectError>)
+        ensures
+            res.is_Ok() == spec_types::ConsumerView::unmarshal(obj@).is_Ok(),
+            res.is_Ok() ==> res.get_Ok_0()@ == spec_types::ConsumerView::unmarshal(obj@).get_Ok_0(),
+    {
+        let parse_result = obj.into_kube().try_parse::<deps_hack::Consumer>();
+        if parse_result.is_ok() {
+            let res = Consumer { inner: parse_result.unwrap() };
+            Ok(res)
+        } else {
+            Err(ParseDynamicObjectError::ExecError)
+        }
+    }
+}
+
+#[verifier(external)]
+impl ResourceWrapper<deps_hack::Consumer> for Consumer {
+    fn from_kube(inner: deps_hack::Consumer) -> Consumer { Consumer { inner: inner } }
+
+    fn into_kube(self) -> deps_hack::Consumer { self.inner }
+}
+
+#[verifier(external_body)]
+pub struct ConsumerSpec {
+    inner: deps_hack::ConsumerSpec,
+}
+
+impl ConsumerSpec {
+    pub spec fn view(&self) -> spec_types::ConsumerSpecView;
+
+    #[verifier(external_body)]
+    pub fn message(&self) -> (message: String)
+        ensures
+            message@ == self@.message,
+    {
+        self.inner.message.clone()
+    }
+}
+
+}

--- a/src/controller_examples/composition_example/consumer_controller/trusted/mod.rs
+++ b/src/controller_examples/composition_example/consumer_controller/trusted/mod.rs
@@ -1,5 +1,5 @@
 // Copyright 2022 VMware, Inc.
 // SPDX-License-Identifier: MIT
-pub mod exec;
-pub mod model;
-pub mod trusted;
+pub mod exec_types;
+pub mod spec_types;
+pub mod step;

--- a/src/controller_examples/composition_example/consumer_controller/trusted/spec_types.rs
+++ b/src/controller_examples/composition_example/consumer_controller/trusted/spec_types.rs
@@ -1,0 +1,149 @@
+// Copyright 2022 VMware, Inc.
+// SPDX-License-Identifier: MIT
+use crate::consumer_controller::trusted::step::*;
+use crate::external_api::spec::{EmptyAPI, EmptyTypeView};
+use crate::kubernetes_api_objects::error::*;
+use crate::kubernetes_api_objects::spec::{api_resource::*, prelude::*};
+use crate::kubernetes_cluster::spec::{cluster::*, cluster_state_machine::*, message::*};
+use crate::vstd_ext::string_view::*;
+use vstd::prelude::*;
+
+verus! {
+
+pub type VRSStep = Step<VRSMessage>;
+
+pub type VRSCluster = Cluster<ConsumerView, EmptyAPI, ConsumerReconciler>;
+
+pub type VRSMessage = Message<EmptyTypeView, EmptyTypeView>;
+
+pub struct ConsumerReconciler {}
+
+pub struct ConsumerReconcileState {
+    pub reconcile_step: ConsumerReconcileStepView,
+}
+
+pub struct ConsumerView {
+    pub metadata: ObjectMetaView,
+    pub spec: ConsumerSpecView,
+    pub status: Option<ConsumerStatusView>,
+}
+
+pub type ConsumerStatusView = EmptyStatusView;
+
+impl ConsumerView {
+    pub open spec fn well_formed(self) -> bool {
+        &&& self.metadata.name.is_Some()
+        &&& self.metadata.namespace.is_Some()
+        &&& self.metadata.uid.is_Some()
+    }
+
+    pub open spec fn controller_owner_ref(self) -> OwnerReferenceView {
+        OwnerReferenceView {
+            block_owner_deletion: Some(true),
+            controller: Some(true),
+            kind: Self::kind(),
+            name: self.metadata.name.get_Some_0(),
+            uid: self.metadata.uid.get_Some_0(),
+        }
+    }
+}
+
+impl ResourceView for ConsumerView {
+    type Spec = ConsumerSpecView;
+    type Status = Option<ConsumerStatusView>;
+
+    open spec fn default() -> ConsumerView {
+        ConsumerView {
+            metadata: ObjectMetaView::default(),
+            spec: arbitrary(), // TODO: specify the default value for spec
+            status: None,
+        }
+    }
+
+    open spec fn metadata(self) -> ObjectMetaView { self.metadata }
+
+    open spec fn kind() -> Kind { Kind::CustomResourceKind }
+
+    open spec fn object_ref(self) -> ObjectRef {
+        ObjectRef {
+            kind: Self::kind(),
+            name: self.metadata.name.get_Some_0(),
+            namespace: self.metadata.namespace.get_Some_0(),
+        }
+    }
+
+    proof fn object_ref_is_well_formed() {}
+
+    open spec fn spec(self) -> ConsumerSpecView { self.spec }
+
+    open spec fn status(self) -> Option<ConsumerStatusView> { self.status }
+
+    open spec fn marshal(self) -> DynamicObjectView {
+        DynamicObjectView {
+            kind: Self::kind(),
+            metadata: self.metadata,
+            spec: ConsumerView::marshal_spec(self.spec),
+            status: ConsumerView::marshal_status(self.status),
+        }
+    }
+
+    open spec fn unmarshal(obj: DynamicObjectView) -> Result<ConsumerView, ParseDynamicObjectError> {
+        if obj.kind != Self::kind() {
+            Err(ParseDynamicObjectError::UnmarshalError)
+        } else if !ConsumerView::unmarshal_spec(obj.spec).is_Ok() {
+            Err(ParseDynamicObjectError::UnmarshalError)
+        } else if !ConsumerView::unmarshal_status(obj.status).is_Ok() {
+            Err(ParseDynamicObjectError::UnmarshalError)
+        } else {
+            Ok(ConsumerView {
+                metadata: obj.metadata,
+                spec: ConsumerView::unmarshal_spec(obj.spec).get_Ok_0(),
+                status: ConsumerView::unmarshal_status(obj.status).get_Ok_0(),
+            })
+        }
+    }
+
+    proof fn marshal_preserves_integrity() {
+        ConsumerView::marshal_spec_preserves_integrity();
+        ConsumerView::marshal_status_preserves_integrity();
+    }
+
+    proof fn marshal_preserves_metadata() {}
+
+    proof fn marshal_preserves_kind() {}
+
+    closed spec fn marshal_spec(s: ConsumerSpecView) -> Value;
+
+    closed spec fn unmarshal_spec(v: Value) -> Result<ConsumerSpecView, ParseDynamicObjectError>;
+
+    closed spec fn marshal_status(s: Option<ConsumerStatusView>) -> Value;
+
+    closed spec fn unmarshal_status(v: Value) -> Result<Option<ConsumerStatusView>, ParseDynamicObjectError>;
+
+    #[verifier(external_body)]
+    proof fn marshal_spec_preserves_integrity() {}
+
+    #[verifier(external_body)]
+    proof fn marshal_status_preserves_integrity() {}
+
+    proof fn unmarshal_result_determined_by_unmarshal_spec_and_status() {}
+
+    open spec fn state_validation(self) -> bool {
+        true
+    }
+
+    open spec fn transition_validation(self, old_obj: ConsumerView) -> bool {
+        true
+    }
+
+}
+
+impl CustomResourceView for ConsumerView {
+    proof fn kind_is_custom_resource() {}
+}
+
+pub struct ConsumerSpecView {
+    pub message: StringView,
+}
+
+}

--- a/src/controller_examples/composition_example/consumer_controller/trusted/step.rs
+++ b/src/controller_examples/composition_example/consumer_controller/trusted/step.rs
@@ -1,0 +1,56 @@
+// Copyright 2022 VMware, Inc.
+// SPDX-License-Identifier: MIT
+#![allow(unused_imports)]
+use vstd::prelude::*;
+
+verus! {
+
+#[is_variant]
+pub enum ConsumerReconcileStep {
+    Init,
+    AfterGetProducer,
+    AfterCreateProducer,
+    AfterGetPod,
+    AfterUpdatePod,
+    Done,
+    Error,
+}
+
+impl std::marker::Copy for ConsumerReconcileStep {}
+
+impl std::clone::Clone for ConsumerReconcileStep {
+    #[verifier(external_body)]
+    fn clone(&self) -> (result: Self)
+        ensures result == self
+    { *self }
+}
+
+impl View for ConsumerReconcileStep {
+    type V = ConsumerReconcileStepView;
+
+    open spec fn view(&self) -> ConsumerReconcileStepView {
+        match self {
+            ConsumerReconcileStep::Init => ConsumerReconcileStepView::Init,
+            ConsumerReconcileStep::AfterGetProducer => ConsumerReconcileStepView::AfterGetProducer,
+            ConsumerReconcileStep::AfterCreateProducer => ConsumerReconcileStepView::AfterCreateProducer,
+            ConsumerReconcileStep::AfterGetPod => ConsumerReconcileStepView::AfterGetPod,
+            ConsumerReconcileStep::AfterUpdatePod => ConsumerReconcileStepView::AfterUpdatePod,
+            ConsumerReconcileStep::Done => ConsumerReconcileStepView::Done,
+            ConsumerReconcileStep::Error => ConsumerReconcileStepView::Error,
+        }
+    }
+}
+
+#[is_variant]
+pub enum ConsumerReconcileStepView {
+    Init,
+    AfterGetProducer,
+    AfterCreateProducer,
+    AfterGetPod,
+    AfterUpdatePod,
+    Done,
+    Error,
+}
+
+
+}

--- a/src/controller_examples/composition_example/producer_controller/exec/mod.rs
+++ b/src/controller_examples/composition_example/producer_controller/exec/mod.rs
@@ -1,0 +1,3 @@
+// Copyright 2022 VMware, Inc.
+// SPDX-License-Identifier: MIT
+pub mod reconciler;

--- a/src/controller_examples/composition_example/producer_controller/exec/reconciler.rs
+++ b/src/controller_examples/composition_example/producer_controller/exec/reconciler.rs
@@ -132,6 +132,11 @@ fn make_pod(producer: &Producer) -> (pod: Pod)
         let mut metadata = ObjectMeta::default();
         metadata.set_name(producer.metadata().name().unwrap());
         metadata.set_owner_references(make_owner_references(producer));
+        metadata.set_labels({
+            let mut labels = StringMap::empty();
+            labels.insert("producer_message".to_string(), producer.spec().message());
+            labels
+        });
         metadata
     });
     pod.set_spec({

--- a/src/controller_examples/composition_example/producer_controller/exec/reconciler.rs
+++ b/src/controller_examples/composition_example/producer_controller/exec/reconciler.rs
@@ -1,0 +1,163 @@
+// Copyright 2022 VMware, Inc.
+// SPDX-License-Identifier: MIT
+use crate::external_api::exec::*;
+use crate::kubernetes_api_objects::exec::resource::ResourceWrapper;
+use crate::kubernetes_api_objects::exec::{
+    container::*, label_selector::*, pod_template_spec::*, prelude::*, resource_requirements::*,
+    volume::*,
+};
+use crate::kubernetes_api_objects::spec::prelude::DynamicObjectView;
+use crate::kubernetes_api_objects::spec::prelude::PodView;
+use crate::kubernetes_api_objects::spec::resource::ResourceView;
+use crate::producer_controller::model::reconciler as model_reconciler;
+use crate::producer_controller::trusted::exec_types::*;
+use crate::producer_controller::trusted::spec_types;
+use crate::producer_controller::trusted::step::*;
+use crate::reconciler::exec::{io::*, reconciler::*, resource_builder::*};
+use crate::vstd_ext::{string_map::StringMap, string_view::*};
+use vstd::prelude::*;
+use vstd::seq_lib::*;
+use vstd::string::*;
+
+verus! {
+
+pub struct ProducerReconciler {}
+
+impl Reconciler for ProducerReconciler {
+    type R = Producer;
+    type T = ProducerReconcileState;
+    type ExternalAPIType = EmptyAPIShimLayer;
+
+    open spec fn well_formed(producer: &Producer) -> bool { producer@.well_formed() }
+
+    fn reconcile_init_state() -> ProducerReconcileState {
+        reconcile_init_state()
+    }
+
+    fn reconcile_core(producer: &Producer, resp_o: Option<Response<EmptyType>>, state: ProducerReconcileState) -> (ProducerReconcileState, Option<Request<EmptyType>>) {
+        reconcile_core(producer, resp_o, state)
+    }
+
+    fn reconcile_done(state: &ProducerReconcileState) -> bool {
+        reconcile_done(state)
+    }
+
+    fn reconcile_error(state: &ProducerReconcileState) -> bool {
+        reconcile_error(state)
+    }
+}
+
+impl Default for ProducerReconciler {
+    fn default() -> ProducerReconciler { ProducerReconciler{} }
+}
+
+#[verifier(external_body)]
+pub fn reconcile_init_state() -> (state: ProducerReconcileState)
+    ensures state@ == model_reconciler::reconcile_init_state(),
+{
+    ProducerReconcileState {
+        reconcile_step: ProducerReconcileStep::Init,
+    }
+}
+
+#[verifier(external_body)]
+pub fn reconcile_done(state: &ProducerReconcileState) -> (res: bool)
+    ensures res == model_reconciler::reconcile_done(state@),
+{
+    match state.reconcile_step {
+        ProducerReconcileStep::Done => true,
+        _ => false,
+    }
+}
+
+#[verifier(external_body)]
+pub fn reconcile_error(state: &ProducerReconcileState) -> (res: bool)
+    ensures res == model_reconciler::reconcile_error(state@),
+{
+    match state.reconcile_step {
+        ProducerReconcileStep::Error => true,
+        _ => false,
+    }
+}
+
+#[verifier(external_body)]
+pub fn reconcile_core(producer: &Producer, resp_o: Option<Response<EmptyType>>, state: ProducerReconcileState) -> (res: (ProducerReconcileState, Option<Request<EmptyType>>))
+    requires producer@.well_formed(),
+    ensures (res.0@, opt_request_to_view(&res.1)) == model_reconciler::reconcile_core(producer@, opt_response_to_view(&resp_o), state@),
+{
+    let namespace = producer.metadata().namespace().unwrap();
+    match &state.reconcile_step {
+        ProducerReconcileStep::Init => {
+            let pod = make_pod(producer);
+            let req = KubeAPIRequest::CreateRequest(KubeCreateRequest {
+                api_resource: Pod::api_resource(),
+                namespace: namespace,
+                obj: pod.marshal(),
+            });
+            let state_prime = ProducerReconcileState {
+                reconcile_step: ProducerReconcileStep::Done,
+                ..state
+            };
+            return (state_prime, Some(Request::KRequest(req)));
+        },
+        _ => {
+            return (state, None);
+        }
+    }
+}
+
+#[verifier(external_body)]
+pub fn make_owner_references(producer: &Producer) -> (owner_references: Vec<OwnerReference>)
+    requires producer@.well_formed(),
+    ensures owner_references@.map_values(|or: OwnerReference| or@) ==  model_reconciler::make_owner_references(producer@),
+{
+    let mut owner_references = Vec::new();
+    owner_references.push(producer.controller_owner_ref());
+    proof {
+        assert_seqs_equal!(
+            owner_references@.map_values(|owner_ref: OwnerReference| owner_ref@),
+            model_reconciler::make_owner_references(producer@)
+        );
+    }
+    owner_references
+}
+
+#[verifier(external_body)]
+fn make_pod(producer: &Producer) -> (pod: Pod)
+    requires producer@.well_formed(),
+    ensures pod@ == model_reconciler::make_pod(producer@),
+{
+    let mut pod = Pod::default();
+    pod.set_metadata({
+        let mut metadata = ObjectMeta::default();
+        metadata.set_name(producer.metadata().name().unwrap());
+        metadata.set_owner_references(make_owner_references(producer));
+        metadata
+    });
+    pod.set_spec({
+        let mut pod_spec = PodSpec::default();
+        pod_spec.set_containers({
+            let mut containers = Vec::new();
+            containers.push({
+                let mut container = Container::default();
+                container.set_name("nginx".to_string());
+                container.set_image("nginx:1.14.2".to_string());
+                container.set_ports({
+                    let mut ports = Vec::new();
+                    ports.push({
+                        let mut container_port = ContainerPort::default();
+                        container_port.set_container_port(80);
+                        container_port
+                    });
+                    ports
+                });
+                container
+            });
+            containers
+        });
+        pod_spec
+    });
+    pod
+}
+
+}

--- a/src/controller_examples/composition_example/producer_controller/exec/reconciler.rs
+++ b/src/controller_examples/composition_example/producer_controller/exec/reconciler.rs
@@ -47,9 +47,9 @@ impl Reconciler for ProducerReconciler {
     }
 }
 
-impl Default for ProducerReconciler {
-    fn default() -> ProducerReconciler { ProducerReconciler{} }
-}
+// impl Default for ProducerReconciler {
+//     pub fn default() -> ProducerReconciler { ProducerReconciler{} }
+// }
 
 #[verifier(external_body)]
 pub fn reconcile_init_state() -> (state: ProducerReconcileState)

--- a/src/controller_examples/composition_example/producer_controller/mod.rs
+++ b/src/controller_examples/composition_example/producer_controller/mod.rs
@@ -1,0 +1,5 @@
+// Copyright 2022 VMware, Inc.
+// SPDX-License-Identifier: MIT
+pub mod exec;
+pub mod model;
+pub mod trusted;

--- a/src/controller_examples/composition_example/producer_controller/model/mod.rs
+++ b/src/controller_examples/composition_example/producer_controller/model/mod.rs
@@ -1,0 +1,3 @@
+// Copyright 2022 VMware, Inc.
+// SPDX-License-Identifier: MIT
+pub mod reconciler;

--- a/src/controller_examples/composition_example/producer_controller/model/reconciler.rs
+++ b/src/controller_examples/composition_example/producer_controller/model/reconciler.rs
@@ -1,0 +1,104 @@
+// Copyright 2022 VMware, Inc.
+// SPDX-License-Identifier: MIT
+#![allow(unused_imports)]
+use crate::external_api::spec::*;
+use crate::kubernetes_api_objects::spec::{container::*, prelude::*};
+use crate::producer_controller::trusted::{spec_types::*, step::*};
+use crate::reconciler::spec::{io::*, reconciler::*};
+use vstd::{prelude::*, string::*};
+
+verus! {
+
+impl Reconciler<ProducerView, EmptyAPI> for ProducerReconciler {
+    type T = ProducerReconcileState;
+
+    open spec fn reconcile_init_state() -> ProducerReconcileState {
+        reconcile_init_state()
+    }
+
+    open spec fn reconcile_core(fb: ProducerView, resp_o: Option<ResponseView<EmptyTypeView>>, state: ProducerReconcileState)
+    -> (ProducerReconcileState, Option<RequestView<EmptyTypeView>>) {
+        reconcile_core(fb, resp_o, state)
+    }
+
+    open spec fn reconcile_done(state: ProducerReconcileState) -> bool {
+        reconcile_done(state)
+    }
+
+    open spec fn reconcile_error(state: ProducerReconcileState) -> bool {
+        reconcile_error(state)
+    }
+
+    open spec fn expect_from_user(obj: DynamicObjectView) -> bool { false /* expect nothing */ }
+}
+
+pub open spec fn reconcile_init_state() -> ProducerReconcileState {
+    ProducerReconcileState {
+        reconcile_step: ProducerReconcileStepView::Init,
+    }
+}
+
+pub open spec fn reconcile_done(state: ProducerReconcileState) -> bool {
+    match state.reconcile_step {
+        ProducerReconcileStepView::Done => true,
+        _ => false,
+    }
+}
+
+pub open spec fn reconcile_error(state: ProducerReconcileState) -> bool {
+    match state.reconcile_step {
+        ProducerReconcileStepView::Error => true,
+        _ => false,
+    }
+}
+
+pub open spec fn reconcile_core(
+    producer: ProducerView, resp_o: Option<ResponseView<EmptyTypeView>>, state: ProducerReconcileState
+) -> (ProducerReconcileState, Option<RequestView<EmptyTypeView>>) {
+    let namespace = producer.metadata.namespace.unwrap();
+    match &state.reconcile_step {
+        ProducerReconcileStepView::Init => {
+            let pod = make_pod(producer);
+            let req = APIRequest::CreateRequest(CreateRequest {
+                namespace: namespace,
+                obj: pod.marshal(),
+            });
+            let state_prime = ProducerReconcileState {
+                reconcile_step: ProducerReconcileStepView::Done,
+                ..state
+            };
+            (state_prime, Some(RequestView::KRequest(req)))
+        },
+        _ => {
+            (state, None)
+        }
+    }
+}
+
+pub open spec fn make_pod(producer: ProducerView) -> (pod: PodView) {
+    let pod = PodView {
+        metadata: ObjectMetaView {
+            name: Some(producer.metadata.name.unwrap()),
+            owner_references: Some(make_owner_references(producer)),
+            ..ObjectMetaView::default()
+        },
+        spec: Some(PodSpecView {
+            containers: seq![ContainerView {
+                name: "nginx"@,
+                image: Some("nginx:1.14.2"@),
+                ports: Some(seq![ContainerPortView {
+                    container_port: 80,
+                    ..ContainerPortView::default()
+                }]),
+                ..ContainerView::default()
+            }],
+            ..PodSpecView::default()
+        }),
+        ..PodView::default()
+    };
+    pod
+}
+
+pub open spec fn make_owner_references(producer: ProducerView) -> Seq<OwnerReferenceView> { seq![producer.controller_owner_ref()] }
+
+}

--- a/src/controller_examples/composition_example/producer_controller/trusted/exec_types.rs
+++ b/src/controller_examples/composition_example/producer_controller/trusted/exec_types.rs
@@ -40,6 +40,13 @@ impl View for Producer {
 
 impl Producer {
     #[verifier(external_body)]
+    pub fn default() -> (producer: Producer)
+        // ensures producer@ == ProducerView::default(),
+    {
+        Producer { inner: deps_hack::Producer::default() }
+    }
+
+    #[verifier(external_body)]
     pub fn metadata(&self) -> (metadata: ObjectMeta)
         ensures metadata@ == self@.metadata,
     {
@@ -47,10 +54,24 @@ impl Producer {
     }
 
     #[verifier(external_body)]
+    pub fn set_metadata(&mut self, metadata: ObjectMeta)
+        // ensures self@ == old(self)@.set_metadata(metadata@),
+    {
+        self.inner.metadata = metadata.into_kube();
+    }
+
+    #[verifier(external_body)]
     pub fn spec(&self) -> (spec: ProducerSpec)
         ensures spec@ == self@.spec,
     {
         ProducerSpec { inner: self.inner.spec.clone() }
+    }
+
+    #[verifier(external_body)]
+    pub fn set_spec(&mut self, spec: ProducerSpec)
+        // ensures self@ == old(self)@.set_spec(spec@),
+    {
+        self.inner.spec = spec.into_kube();
     }
 
     #[verifier(external_body)]
@@ -109,12 +130,29 @@ impl ProducerSpec {
     pub spec fn view(&self) -> spec_types::ProducerSpecView;
 
     #[verifier(external_body)]
+    pub fn default() -> (producer_spec: ProducerSpec)
+        // ensures producer_spec@ == ProducerSpecView::default(),
+    {
+        ProducerSpec { inner: deps_hack::ProducerSpec::default() }
+    }
+
+    #[verifier(external_body)]
     pub fn message(&self) -> (message: String)
         ensures
             message@ == self@.message,
     {
         self.inner.message.clone()
     }
+
+    #[verifier(external_body)]
+    pub fn set_message(&mut self, message: String)
+        // ensures self@ == old(self)@.set_message(message@),
+    {
+        self.inner.message = message
+    }
+
+    #[verifier(external)]
+    pub fn into_kube(self) -> deps_hack::ProducerSpec { self.inner }
 }
 
 }

--- a/src/controller_examples/composition_example/producer_controller/trusted/exec_types.rs
+++ b/src/controller_examples/composition_example/producer_controller/trusted/exec_types.rs
@@ -1,0 +1,120 @@
+// Copyright 2022 VMware, Inc.
+// SPDX-License-Identifier: MIT
+use crate::kubernetes_api_objects::error::ParseDynamicObjectError;
+use crate::kubernetes_api_objects::exec::{
+    api_resource::*, label_selector::*, pod_template_spec::*, prelude::*,
+};
+use crate::kubernetes_api_objects::spec::resource::*;
+use crate::producer_controller::trusted::{spec_types, step::*};
+use crate::vstd_ext::{string_map::*, string_view::*};
+use deps_hack::kube::Resource;
+use vstd::prelude::*;
+
+verus! {
+
+/// ProducerReconcileState describes the local state with which the reconcile functions makes decisions.
+pub struct ProducerReconcileState {
+    pub reconcile_step: ProducerReconcileStep,
+}
+
+impl View for ProducerReconcileState {
+    type V = spec_types::ProducerReconcileState;
+
+    open spec fn view(&self) -> spec_types::ProducerReconcileState {
+        spec_types::ProducerReconcileState {
+            reconcile_step: self.reconcile_step@,
+        }
+    }
+}
+
+#[verifier(external_body)]
+pub struct Producer {
+    inner: deps_hack::Producer
+}
+
+impl View for Producer {
+    type V = spec_types::ProducerView;
+
+    spec fn view(&self) -> spec_types::ProducerView;
+}
+
+impl Producer {
+    #[verifier(external_body)]
+    pub fn metadata(&self) -> (metadata: ObjectMeta)
+        ensures metadata@ == self@.metadata,
+    {
+        ObjectMeta::from_kube(self.inner.metadata.clone())
+    }
+
+    #[verifier(external_body)]
+    pub fn spec(&self) -> (spec: ProducerSpec)
+        ensures spec@ == self@.spec,
+    {
+        ProducerSpec { inner: self.inner.spec.clone() }
+    }
+
+    #[verifier(external_body)]
+    pub fn api_resource() -> (res: ApiResource)
+        ensures res@.kind == spec_types::ProducerView::kind(),
+    {
+        ApiResource::from_kube(deps_hack::kube::api::ApiResource::erase::<deps_hack::Producer>(&()))
+    }
+
+    #[verifier(external_body)]
+    pub fn controller_owner_ref(&self) -> (owner_reference: OwnerReference)
+        ensures owner_reference@ == self@.controller_owner_ref(),
+    {
+        // We can safely unwrap here because the trait method implementation always returns a Some(...)
+        OwnerReference::from_kube(self.inner.controller_owner_ref(&()).unwrap())
+    }
+
+    // NOTE: This function assumes serde_json::to_string won't fail!
+    #[verifier(external_body)]
+    pub fn marshal(self) -> (obj: DynamicObject)
+        ensures obj@ == self@.marshal(),
+    {
+        // TODO: this might be unnecessarily slow
+        DynamicObject::from_kube(deps_hack::k8s_openapi::serde_json::from_str(&deps_hack::k8s_openapi::serde_json::to_string(&self.inner).unwrap()).unwrap())
+    }
+
+    #[verifier(external_body)]
+    pub fn unmarshal(obj: DynamicObject) -> (res: Result<Producer, ParseDynamicObjectError>)
+        ensures
+            res.is_Ok() == spec_types::ProducerView::unmarshal(obj@).is_Ok(),
+            res.is_Ok() ==> res.get_Ok_0()@ == spec_types::ProducerView::unmarshal(obj@).get_Ok_0(),
+    {
+        let parse_result = obj.into_kube().try_parse::<deps_hack::Producer>();
+        if parse_result.is_ok() {
+            let res = Producer { inner: parse_result.unwrap() };
+            Ok(res)
+        } else {
+            Err(ParseDynamicObjectError::ExecError)
+        }
+    }
+}
+
+#[verifier(external)]
+impl ResourceWrapper<deps_hack::Producer> for Producer {
+    fn from_kube(inner: deps_hack::Producer) -> Producer { Producer { inner: inner } }
+
+    fn into_kube(self) -> deps_hack::Producer { self.inner }
+}
+
+#[verifier(external_body)]
+pub struct ProducerSpec {
+    inner: deps_hack::ProducerSpec,
+}
+
+impl ProducerSpec {
+    pub spec fn view(&self) -> spec_types::ProducerSpecView;
+
+    #[verifier(external_body)]
+    pub fn message(&self) -> (message: String)
+        ensures
+            message@ == self@.message,
+    {
+        self.inner.message.clone()
+    }
+}
+
+}

--- a/src/controller_examples/composition_example/producer_controller/trusted/mod.rs
+++ b/src/controller_examples/composition_example/producer_controller/trusted/mod.rs
@@ -1,0 +1,5 @@
+// Copyright 2022 VMware, Inc.
+// SPDX-License-Identifier: MIT
+pub mod exec_types;
+pub mod spec_types;
+pub mod step;

--- a/src/controller_examples/composition_example/producer_controller/trusted/spec_types.rs
+++ b/src/controller_examples/composition_example/producer_controller/trusted/spec_types.rs
@@ -1,0 +1,149 @@
+// Copyright 2022 VMware, Inc.
+// SPDX-License-Identifier: MIT
+use crate::external_api::spec::{EmptyAPI, EmptyTypeView};
+use crate::kubernetes_api_objects::error::*;
+use crate::kubernetes_api_objects::spec::{api_resource::*, prelude::*};
+use crate::kubernetes_cluster::spec::{cluster::*, cluster_state_machine::*, message::*};
+use crate::producer_controller::trusted::step::*;
+use crate::vstd_ext::string_view::*;
+use vstd::prelude::*;
+
+verus! {
+
+pub type VRSStep = Step<VRSMessage>;
+
+pub type VRSCluster = Cluster<ProducerView, EmptyAPI, ProducerReconciler>;
+
+pub type VRSMessage = Message<EmptyTypeView, EmptyTypeView>;
+
+pub struct ProducerReconciler {}
+
+pub struct ProducerReconcileState {
+    pub reconcile_step: ProducerReconcileStepView,
+}
+
+pub struct ProducerView {
+    pub metadata: ObjectMetaView,
+    pub spec: ProducerSpecView,
+    pub status: Option<ProducerStatusView>,
+}
+
+pub type ProducerStatusView = EmptyStatusView;
+
+impl ProducerView {
+    pub open spec fn well_formed(self) -> bool {
+        &&& self.metadata.name.is_Some()
+        &&& self.metadata.namespace.is_Some()
+        &&& self.metadata.uid.is_Some()
+    }
+
+    pub open spec fn controller_owner_ref(self) -> OwnerReferenceView {
+        OwnerReferenceView {
+            block_owner_deletion: Some(true),
+            controller: Some(true),
+            kind: Self::kind(),
+            name: self.metadata.name.get_Some_0(),
+            uid: self.metadata.uid.get_Some_0(),
+        }
+    }
+}
+
+impl ResourceView for ProducerView {
+    type Spec = ProducerSpecView;
+    type Status = Option<ProducerStatusView>;
+
+    open spec fn default() -> ProducerView {
+        ProducerView {
+            metadata: ObjectMetaView::default(),
+            spec: arbitrary(), // TODO: specify the default value for spec
+            status: None,
+        }
+    }
+
+    open spec fn metadata(self) -> ObjectMetaView { self.metadata }
+
+    open spec fn kind() -> Kind { Kind::CustomResourceKind }
+
+    open spec fn object_ref(self) -> ObjectRef {
+        ObjectRef {
+            kind: Self::kind(),
+            name: self.metadata.name.get_Some_0(),
+            namespace: self.metadata.namespace.get_Some_0(),
+        }
+    }
+
+    proof fn object_ref_is_well_formed() {}
+
+    open spec fn spec(self) -> ProducerSpecView { self.spec }
+
+    open spec fn status(self) -> Option<ProducerStatusView> { self.status }
+
+    open spec fn marshal(self) -> DynamicObjectView {
+        DynamicObjectView {
+            kind: Self::kind(),
+            metadata: self.metadata,
+            spec: ProducerView::marshal_spec(self.spec),
+            status: ProducerView::marshal_status(self.status),
+        }
+    }
+
+    open spec fn unmarshal(obj: DynamicObjectView) -> Result<ProducerView, ParseDynamicObjectError> {
+        if obj.kind != Self::kind() {
+            Err(ParseDynamicObjectError::UnmarshalError)
+        } else if !ProducerView::unmarshal_spec(obj.spec).is_Ok() {
+            Err(ParseDynamicObjectError::UnmarshalError)
+        } else if !ProducerView::unmarshal_status(obj.status).is_Ok() {
+            Err(ParseDynamicObjectError::UnmarshalError)
+        } else {
+            Ok(ProducerView {
+                metadata: obj.metadata,
+                spec: ProducerView::unmarshal_spec(obj.spec).get_Ok_0(),
+                status: ProducerView::unmarshal_status(obj.status).get_Ok_0(),
+            })
+        }
+    }
+
+    proof fn marshal_preserves_integrity() {
+        ProducerView::marshal_spec_preserves_integrity();
+        ProducerView::marshal_status_preserves_integrity();
+    }
+
+    proof fn marshal_preserves_metadata() {}
+
+    proof fn marshal_preserves_kind() {}
+
+    closed spec fn marshal_spec(s: ProducerSpecView) -> Value;
+
+    closed spec fn unmarshal_spec(v: Value) -> Result<ProducerSpecView, ParseDynamicObjectError>;
+
+    closed spec fn marshal_status(s: Option<ProducerStatusView>) -> Value;
+
+    closed spec fn unmarshal_status(v: Value) -> Result<Option<ProducerStatusView>, ParseDynamicObjectError>;
+
+    #[verifier(external_body)]
+    proof fn marshal_spec_preserves_integrity() {}
+
+    #[verifier(external_body)]
+    proof fn marshal_status_preserves_integrity() {}
+
+    proof fn unmarshal_result_determined_by_unmarshal_spec_and_status() {}
+
+    open spec fn state_validation(self) -> bool {
+        true
+    }
+
+    open spec fn transition_validation(self, old_obj: ProducerView) -> bool {
+        true
+    }
+
+}
+
+impl CustomResourceView for ProducerView {
+    proof fn kind_is_custom_resource() {}
+}
+
+pub struct ProducerSpecView {
+    pub message: StringView,
+}
+
+}

--- a/src/controller_examples/composition_example/producer_controller/trusted/step.rs
+++ b/src/controller_examples/composition_example/producer_controller/trusted/step.rs
@@ -1,0 +1,44 @@
+// Copyright 2022 VMware, Inc.
+// SPDX-License-Identifier: MIT
+#![allow(unused_imports)]
+use vstd::prelude::*;
+
+verus! {
+
+#[is_variant]
+pub enum ProducerReconcileStep {
+    Init,
+    Done,
+    Error,
+}
+
+impl std::marker::Copy for ProducerReconcileStep {}
+
+impl std::clone::Clone for ProducerReconcileStep {
+    #[verifier(external_body)]
+    fn clone(&self) -> (result: Self)
+        ensures result == self
+    { *self }
+}
+
+impl View for ProducerReconcileStep {
+    type V = ProducerReconcileStepView;
+
+    open spec fn view(&self) -> ProducerReconcileStepView {
+        match self {
+            ProducerReconcileStep::Init => ProducerReconcileStepView::Init,
+            ProducerReconcileStep::Done => ProducerReconcileStepView::Done,
+            ProducerReconcileStep::Error => ProducerReconcileStepView::Error,
+        }
+    }
+}
+
+#[is_variant]
+pub enum ProducerReconcileStepView {
+    Init,
+    Done,
+    Error,
+}
+
+
+}

--- a/src/controller_examples/v_replica_set_controller/model/reconciler.rs
+++ b/src/controller_examples/v_replica_set_controller/model/reconciler.rs
@@ -2,11 +2,9 @@
 // SPDX-License-Identifier: MIT
 #![allow(unused_imports)]
 use crate::external_api::spec::*;
-use crate::v_replica_set_controller::trusted::{
-    spec_types::*, step::*,
-};
 use crate::kubernetes_api_objects::spec::prelude::*;
 use crate::reconciler::spec::{io::*, reconciler::*};
+use crate::v_replica_set_controller::trusted::{spec_types::*, step::*};
 use vstd::{prelude::*, string::*};
 
 verus! {
@@ -34,11 +32,11 @@ impl Reconciler<VReplicaSetView, EmptyAPI> for VReplicaSetReconciler {
     open spec fn expect_from_user(obj: DynamicObjectView) -> bool { false /* expect nothing */ }
 }
 
-pub open spec fn reconcile_init_state() -> VReplicaSetReconcileState { 
-    VReplicaSetReconcileState { 
+pub open spec fn reconcile_init_state() -> VReplicaSetReconcileState {
+    VReplicaSetReconcileState {
         reconcile_step: VReplicaSetReconcileStepView::Init,
         filtered_pods: None,
-    } 
+    }
 }
 
 pub open spec fn reconcile_done(state: VReplicaSetReconcileState) -> bool {
@@ -254,4 +252,3 @@ pub open spec fn make_pod(v_replica_set: VReplicaSetView) -> (pod: PodView) {
 pub open spec fn make_owner_references(v_replica_set: VReplicaSetView) -> Seq<OwnerReferenceView> { seq![v_replica_set.controller_owner_ref()] }
 
 }
-    

--- a/src/deps_hack/src/lib.rs
+++ b/src/deps_hack/src/lib.rs
@@ -330,3 +330,19 @@ pub struct VStatefulSetStatus {
     #[serde(rename = "observedGeneration")]
     pub observed_generation: Option<i64>,
 }
+
+#[derive(
+    kube::CustomResource, Debug, Clone, serde::Deserialize, serde::Serialize, schemars::JsonSchema,
+)]
+#[kube(namespaced, group = "anvil.dev", version = "v1", kind = "Producer")]
+pub struct ProducerSpec {
+    pub message: String,
+}
+
+#[derive(
+    kube::CustomResource, Debug, Clone, serde::Deserialize, serde::Serialize, schemars::JsonSchema,
+)]
+#[kube(namespaced, group = "anvil.dev", version = "v1", kind = "Consumer")]
+pub struct ConsumerSpec {
+    pub message: String,
+}

--- a/src/deps_hack/src/lib.rs
+++ b/src/deps_hack/src/lib.rs
@@ -332,11 +332,26 @@ pub struct VStatefulSetStatus {
 }
 
 #[derive(
-    kube::CustomResource, Debug, Clone, serde::Deserialize, serde::Serialize, schemars::JsonSchema,
+    kube::CustomResource,
+    Debug,
+    Clone,
+    serde::Deserialize,
+    serde::Serialize,
+    schemars::JsonSchema,
+    Default,
 )]
 #[kube(namespaced, group = "anvil.dev", version = "v1", kind = "Producer")]
 pub struct ProducerSpec {
     pub message: String,
+}
+
+impl Default for Producer {
+    fn default() -> Producer {
+        Producer {
+            metadata: k8s_openapi::apimachinery::pkg::apis::meta::v1::ObjectMeta::default(),
+            spec: ProducerSpec::default(),
+        }
+    }
 }
 
 #[derive(

--- a/src/kubernetes_api_objects/spec/common.rs
+++ b/src/kubernetes_api_objects/spec/common.rs
@@ -17,6 +17,8 @@ pub type ResourceVersion = int;
 // make GenerateNameCounter an int, instead of String, so that it is easy to compare in spec/proof
 pub type GenerateNameCounter = int;
 
+// TODO: make CustomResourceKind take a string so that we
+// can differentiate between different custom resources
 #[is_variant]
 #[derive(PartialEq, Eq, PartialOrd, Ord, Debug)]
 pub enum Kind {

--- a/src/producer_controller.rs
+++ b/src/producer_controller.rs
@@ -1,0 +1,44 @@
+// Copyright 2022 VMware, Inc.
+// SPDX-License-Identifier: MIT
+#![allow(unused_imports)]
+
+pub mod external_api;
+pub mod kubernetes_api_objects;
+pub mod kubernetes_cluster;
+#[path = "controller_examples/composition_example/producer_controller/mod.rs"]
+pub mod producer_controller;
+pub mod reconciler;
+pub mod shim_layer;
+pub mod state_machine;
+pub mod temporal_logic;
+pub mod vstd_ext;
+
+use crate::producer_controller::exec::reconciler::ProducerReconciler;
+use deps_hack::anyhow::Result;
+use deps_hack::kube::CustomResourceExt;
+use deps_hack::serde_yaml;
+use deps_hack::tokio;
+use deps_hack::tracing::{error, info};
+use deps_hack::tracing_subscriber;
+use shim_layer::controller_runtime::run_controller;
+use std::env;
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    tracing_subscriber::fmt::init();
+    let args: Vec<String> = env::args().collect();
+    let cmd = args[1].clone();
+
+    if cmd == String::from("export") {
+        println!("{}", serde_yaml::to_string(&deps_hack::Producer::crd())?);
+    } else if cmd == String::from("run") {
+        info!("running producer-controller");
+        run_controller::<deps_hack::Producer, ProducerReconciler>(false).await?;
+    } else if cmd == String::from("crash") {
+        info!("running producer-controller in crash-testing mode");
+        run_controller::<deps_hack::Producer, ProducerReconciler>(true).await?;
+    } else {
+        error!("wrong command; please use \"export\", \"run\" or \"crash\"");
+    }
+    Ok(())
+}

--- a/src/shim_layer/controller_runtime.rs
+++ b/src/shim_layer/controller_runtime.rs
@@ -48,7 +48,7 @@ where
         + Sync
         + 'static,
     K::DynamicType: Default + Eq + Hash + Clone + Debug + Unpin,
-    ReconcilerType: Reconciler + Send + Sync + Default,
+    ReconcilerType: Reconciler + Send + Sync,
     ReconcilerType::R: ResourceWrapper<K> + Send,
     ReconcilerType::T: Send,
     <ReconcilerType::ExternalAPIType as ExternalAPIShimLayer>::Input: Send,


### PR DESCRIPTION
This PR adds two toy controllers: producer and consumer to illustrate how controllers work together. Their collaboration is simple: the consumer waits for the producer to create a pod and then the consumer adds a label to the pod.

The implementation is done but the model and proof are not.