### PR TITLE
Add rlimit and spinoff_prover attribute

### DIFF
--- a/src/controllers/vstatefulset_controller/proof/guarantee.rs
+++ b/src/controllers/vstatefulset_controller/proof/guarantee.rs
@@ -88,6 +88,8 @@ pub proof fn lemma_guarantee_from_reconcile_state(
     }
 }
 
+#[verifier(rlimit(50))]
+#[verifier(spinoff_prover)]
 pub proof fn guarantee_condition_holds(spec: TempPred<ClusterState>, cluster: Cluster, controller_id: int)
     requires
         spec.entails(lift_state(cluster.init())),

--- a/src/controllers/vstatefulset_controller/proof/helper_invariants.rs
+++ b/src/controllers/vstatefulset_controller/proof/helper_invariants.rs
@@ -1197,6 +1197,8 @@ ensures
     init_invariant(spec, cluster.init(), stronger_next, inv);
 }
 
+#[verifier(spinoff_prover)]
+#[verifier(rlimit(50))]
 pub proof fn lemma_always_there_is_no_request_msg_to_external_from_controller(
     spec: TempPred<ClusterState>, cluster: Cluster, controller_id: int,
 )


### PR DESCRIPTION
I ran [verita](https://github.com/parno/verita) on main and some proofs require more resources to finish. This PR adds attributes for them.