### PR TITLE
Use the most recent version of Verus in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,59 +36,51 @@ jobs:
         run: |
           echo "home_dir=$HOME" >> $GITHUB_ENV
           echo "home_dir=$HOME"
-      - name: Cache Verus
-        id: cache-verus
+      - name: Cache toolchains and dependencies
+        id: cache-toolchain
         uses: actions/cache@v4
         with:
           path: |
             ${{ env.home_dir }}/verus
             ${{ env.home_dir }}/.cargo
             ${{ env.home_dir }}/.rustup
-          key: verus-${{ runner.os }}-${{ steps.verus-sha.outputs.sha }}-${{ hashFiles('rust-toolchain.toml') }}
+            src/deps_hack/target/debug
+            src/deps_hack/.cargo-home
+          key: toolchain-${{ runner.os }}-${{ steps.verus-sha.outputs.sha }}-${{ hashFiles('rust-toolchain.toml') }}-${{ hashFiles('src/deps_hack/Cargo.lock') }}
       - name: Install Rust if cache is missing
-        if: steps.cache-verus.outputs.cache-hit != 'true'
+        if: steps.cache-toolchain.outputs.cache-hit != 'true'
         run: |
           curl --proto '=https' --tlsv1.2 --retry 10 --retry-connrefused -fsSL "https://sh.rustup.rs" | sh -s -- --default-toolchain none -y
           . "$HOME/.cargo/env"
           rustup toolchain install
       - name: Build Verus if cache is missing
-        if: steps.cache-verus.outputs.cache-hit != 'true'
+        if: steps.cache-toolchain.outputs.cache-hit != 'true'
         run: |
           cd verus-src/source
           ./tools/get-z3.sh
           source ../tools/activate
           vargo build --release
           mv target-verus/release $HOME/verus
-      - name: Cache deps_hack
-        id: cache-deps-hack
-        uses: actions/cache@v4
-        with:
-          path: src/deps_hack/target/debug
-          key: deps-hack-${{ runner.os }}-${{ hashFiles('src/deps_hack/Cargo.lock') }}-${{ hashFiles('rust-toolchain.toml') }}
       - name: Build deps_hack if cache is missing
-        if: steps.cache-deps-hack.outputs.cache-hit != 'true'
+        if: steps.cache-toolchain.outputs.cache-hit != 'true'
         run: |
           . "$HOME/.cargo/env"
-          cd src/deps_hack
-          cargo build
+          CARGO_HOME=$GITHUB_WORKSPACE/src/deps_hack/.cargo-home cargo build --manifest-path src/deps_hack/Cargo.toml
   vreplicaset-verification:
     needs: setup-toolchain
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
-      - name: Restore Verus cache
+      - name: Restore toolchains and dependencies cache
         uses: actions/cache@v4
         with:
           path: |
             ${{ env.home_dir }}/verus
             ${{ env.home_dir }}/.cargo
             ${{ env.home_dir }}/.rustup
-          key: verus-${{ runner.os }}-${{ needs.setup-toolchain.outputs.verus-sha }}-${{ hashFiles('rust-toolchain.toml') }}
-      - name: Restore deps_hack cache
-        uses: actions/cache@v4
-        with:
-          path: src/deps_hack/target/debug
-          key: deps-hack-${{ runner.os }}-${{ hashFiles('src/deps_hack/Cargo.lock') }}-${{ hashFiles('rust-toolchain.toml') }}
+            src/deps_hack/target/debug
+            src/deps_hack/.cargo-home
+          key: toolchain-${{ runner.os }}-${{ needs.setup-toolchain.outputs.verus-sha }}-${{ hashFiles('rust-toolchain.toml') }}-${{ hashFiles('src/deps_hack/Cargo.lock') }}
       - name: Verify vreplicaset controller
         run: |
           . "$HOME/.cargo/env"
@@ -99,19 +91,16 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
-      - name: Restore Verus cache
+      - name: Restore toolchains and dependencies cache
         uses: actions/cache@v4
         with:
           path: |
             ${{ env.home_dir }}/verus
             ${{ env.home_dir }}/.cargo
             ${{ env.home_dir }}/.rustup
-          key: verus-${{ runner.os }}-${{ needs.setup-toolchain.outputs.verus-sha }}-${{ hashFiles('rust-toolchain.toml') }}
-      - name: Restore deps_hack cache
-        uses: actions/cache@v4
-        with:
-          path: src/deps_hack/target/debug
-          key: deps-hack-${{ runner.os }}-${{ hashFiles('src/deps_hack/Cargo.lock') }}-${{ hashFiles('rust-toolchain.toml') }}
+            src/deps_hack/target/debug
+            src/deps_hack/.cargo-home
+          key: toolchain-${{ runner.os }}-${{ needs.setup-toolchain.outputs.verus-sha }}-${{ hashFiles('rust-toolchain.toml') }}-${{ hashFiles('src/deps_hack/Cargo.lock') }}
       - name: Verify vdeployment controller
         run: |
           . "$HOME/.cargo/env"
@@ -122,19 +111,16 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
-      - name: Restore Verus cache
+      - name: Restore toolchains and dependencies cache
         uses: actions/cache@v4
         with:
           path: |
             ${{ env.home_dir }}/verus
             ${{ env.home_dir }}/.cargo
             ${{ env.home_dir }}/.rustup
-          key: verus-${{ runner.os }}-${{ needs.setup-toolchain.outputs.verus-sha }}-${{ hashFiles('rust-toolchain.toml') }}
-      - name: Restore deps_hack cache
-        uses: actions/cache@v4
-        with:
-          path: src/deps_hack/target/debug
-          key: deps-hack-${{ runner.os }}-${{ hashFiles('src/deps_hack/Cargo.lock') }}-${{ hashFiles('rust-toolchain.toml') }}
+            src/deps_hack/target/debug
+            src/deps_hack/.cargo-home
+          key: toolchain-${{ runner.os }}-${{ needs.setup-toolchain.outputs.verus-sha }}-${{ hashFiles('rust-toolchain.toml') }}-${{ hashFiles('src/deps_hack/Cargo.lock') }}
       - name: Verify vstatefulset controller
         run: |
           . "$HOME/.cargo/env"
@@ -145,19 +131,16 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
-      - name: Restore Verus cache
+      - name: Restore toolchains and dependencies cache
         uses: actions/cache@v4
         with:
           path: |
             ${{ env.home_dir }}/verus
             ${{ env.home_dir }}/.cargo
             ${{ env.home_dir }}/.rustup
-          key: verus-${{ runner.os }}-${{ needs.setup-toolchain.outputs.verus-sha }}-${{ hashFiles('rust-toolchain.toml') }}
-      - name: Restore deps_hack cache
-        uses: actions/cache@v4
-        with:
-          path: src/deps_hack/target/debug
-          key: deps-hack-${{ runner.os }}-${{ hashFiles('src/deps_hack/Cargo.lock') }}-${{ hashFiles('rust-toolchain.toml') }}
+            src/deps_hack/target/debug
+            src/deps_hack/.cargo-home
+          key: toolchain-${{ runner.os }}-${{ needs.setup-toolchain.outputs.verus-sha }}-${{ hashFiles('rust-toolchain.toml') }}-${{ hashFiles('src/deps_hack/Cargo.lock') }}
       - name: Verify the ESR composition
         run: |
           . "$HOME/.cargo/env"
@@ -168,19 +151,16 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
-      - name: Restore Verus cache
+      - name: Restore toolchains and dependencies cache
         uses: actions/cache@v4
         with:
           path: |
             ${{ env.home_dir }}/verus
             ${{ env.home_dir }}/.cargo
             ${{ env.home_dir }}/.rustup
-          key: verus-${{ runner.os }}-${{ needs.setup-toolchain.outputs.verus-sha }}-${{ hashFiles('rust-toolchain.toml') }}
-      - name: Restore deps_hack cache
-        uses: actions/cache@v4
-        with:
-          path: src/deps_hack/target/debug
-          key: deps-hack-${{ runner.os }}-${{ hashFiles('src/deps_hack/Cargo.lock') }}-${{ hashFiles('rust-toolchain.toml') }}
+            src/deps_hack/target/debug
+            src/deps_hack/.cargo-home
+          key: toolchain-${{ runner.os }}-${{ needs.setup-toolchain.outputs.verus-sha }}-${{ hashFiles('rust-toolchain.toml') }}-${{ hashFiles('src/deps_hack/Cargo.lock') }}
       - name: Verify the Anvil framework
         run: |
           . "$HOME/.cargo/env"
@@ -192,19 +172,16 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
-      - name: Restore Verus cache
+      - name: Restore toolchains and dependencies cache
         uses: actions/cache@v4
         with:
           path: |
             ${{ env.home_dir }}/verus
             ${{ env.home_dir }}/.cargo
             ${{ env.home_dir }}/.rustup
-          key: verus-${{ runner.os }}-${{ needs.setup-toolchain.outputs.verus-sha }}-${{ hashFiles('rust-toolchain.toml') }}
-      - name: Restore deps_hack cache
-        uses: actions/cache@v4
-        with:
-          path: src/deps_hack/target/debug
-          key: deps-hack-${{ runner.os }}-${{ hashFiles('src/deps_hack/Cargo.lock') }}-${{ hashFiles('rust-toolchain.toml') }}
+            src/deps_hack/target/debug
+            src/deps_hack/.cargo-home
+          key: toolchain-${{ runner.os }}-${{ needs.setup-toolchain.outputs.verus-sha }}-${{ hashFiles('rust-toolchain.toml') }}-${{ hashFiles('src/deps_hack/Cargo.lock') }}
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
@@ -251,19 +228,16 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
-      - name: Restore Verus cache
+      - name: Restore toolchains and dependencies cache
         uses: actions/cache@v4
         with:
           path: |
             ${{ env.home_dir }}/verus
             ${{ env.home_dir }}/.cargo
             ${{ env.home_dir }}/.rustup
-          key: verus-${{ runner.os }}-${{ needs.setup-toolchain.outputs.verus-sha }}-${{ hashFiles('rust-toolchain.toml') }}
-      - name: Restore deps_hack cache
-        uses: actions/cache@v4
-        with:
-          path: src/deps_hack/target/debug
-          key: deps-hack-${{ runner.os }}-${{ hashFiles('src/deps_hack/Cargo.lock') }}-${{ hashFiles('rust-toolchain.toml') }}
+            src/deps_hack/target/debug
+            src/deps_hack/.cargo-home
+          key: toolchain-${{ runner.os }}-${{ needs.setup-toolchain.outputs.verus-sha }}-${{ hashFiles('rust-toolchain.toml') }}-${{ hashFiles('src/deps_hack/Cargo.lock') }}
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
@@ -282,19 +256,16 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
-      - name: Restore Verus cache
+      - name: Restore toolchains and dependencies cache
         uses: actions/cache@v4
         with:
           path: |
             ${{ env.home_dir }}/verus
             ${{ env.home_dir }}/.cargo
             ${{ env.home_dir }}/.rustup
-          key: verus-${{ runner.os }}-${{ needs.setup-toolchain.outputs.verus-sha }}-${{ hashFiles('rust-toolchain.toml') }}
-      - name: Restore deps_hack cache
-        uses: actions/cache@v4
-        with:
-          path: src/deps_hack/target/debug
-          key: deps-hack-${{ runner.os }}-${{ hashFiles('src/deps_hack/Cargo.lock') }}-${{ hashFiles('rust-toolchain.toml') }}
+            src/deps_hack/target/debug
+            src/deps_hack/.cargo-home
+          key: toolchain-${{ runner.os }}-${{ needs.setup-toolchain.outputs.verus-sha }}-${{ hashFiles('rust-toolchain.toml') }}-${{ hashFiles('src/deps_hack/Cargo.lock') }}
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
@@ -313,19 +284,16 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
-      - name: Restore Verus cache
+      - name: Restore toolchains and dependencies cache
         uses: actions/cache@v4
         with:
           path: |
             ${{ env.home_dir }}/verus
             ${{ env.home_dir }}/.cargo
             ${{ env.home_dir }}/.rustup
-          key: verus-${{ runner.os }}-${{ needs.setup-toolchain.outputs.verus-sha }}-${{ hashFiles('rust-toolchain.toml') }}
-      - name: Restore deps_hack cache
-        uses: actions/cache@v4
-        with:
-          path: src/deps_hack/target/debug
-          key: deps-hack-${{ runner.os }}-${{ hashFiles('src/deps_hack/Cargo.lock') }}-${{ hashFiles('rust-toolchain.toml') }}
+            src/deps_hack/target/debug
+            src/deps_hack/.cargo-home
+          key: toolchain-${{ runner.os }}-${{ needs.setup-toolchain.outputs.verus-sha }}-${{ hashFiles('rust-toolchain.toml') }}-${{ hashFiles('src/deps_hack/Cargo.lock') }}
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
@@ -344,19 +312,16 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
-      - name: Restore Verus cache
+      - name: Restore toolchains and dependencies cache
         uses: actions/cache@v4
         with:
           path: |
             ${{ env.home_dir }}/verus
             ${{ env.home_dir }}/.cargo
             ${{ env.home_dir }}/.rustup
-          key: verus-${{ runner.os }}-${{ needs.setup-toolchain.outputs.verus-sha }}-${{ hashFiles('rust-toolchain.toml') }}
-      - name: Restore deps_hack cache
-        uses: actions/cache@v4
-        with:
-          path: src/deps_hack/target/debug
-          key: deps-hack-${{ runner.os }}-${{ hashFiles('src/deps_hack/Cargo.lock') }}-${{ hashFiles('rust-toolchain.toml') }}
+            src/deps_hack/target/debug
+            src/deps_hack/.cargo-home
+          key: toolchain-${{ runner.os }}-${{ needs.setup-toolchain.outputs.verus-sha }}-${{ hashFiles('rust-toolchain.toml') }}-${{ hashFiles('src/deps_hack/Cargo.lock') }}
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
@@ -375,19 +340,16 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
-      - name: Restore Verus cache
+      - name: Restore toolchains and dependencies cache
         uses: actions/cache@v4
         with:
           path: |
             ${{ env.home_dir }}/verus
             ${{ env.home_dir }}/.cargo
             ${{ env.home_dir }}/.rustup
-          key: verus-${{ runner.os }}-${{ needs.setup-toolchain.outputs.verus-sha }}-${{ hashFiles('rust-toolchain.toml') }}
-      - name: Restore deps_hack cache
-        uses: actions/cache@v4
-        with:
-          path: src/deps_hack/target/debug
-          key: deps-hack-${{ runner.os }}-${{ hashFiles('src/deps_hack/Cargo.lock') }}-${{ hashFiles('rust-toolchain.toml') }}
+            src/deps_hack/target/debug
+            src/deps_hack/.cargo-home
+          key: toolchain-${{ runner.os }}-${{ needs.setup-toolchain.outputs.verus-sha }}-${{ hashFiles('rust-toolchain.toml') }}-${{ hashFiles('src/deps_hack/Cargo.lock') }}
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
@@ -405,19 +367,16 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
-      - name: Restore Verus cache
+      - name: Restore toolchains and dependencies cache
         uses: actions/cache@v4
         with:
           path: |
             ${{ env.home_dir }}/verus
             ${{ env.home_dir }}/.cargo
             ${{ env.home_dir }}/.rustup
-          key: verus-${{ runner.os }}-${{ needs.setup-toolchain.outputs.verus-sha }}-${{ hashFiles('rust-toolchain.toml') }}
-      - name: Restore deps_hack cache
-        uses: actions/cache@v4
-        with:
-          path: src/deps_hack/target/debug
-          key: deps-hack-${{ runner.os }}-${{ hashFiles('src/deps_hack/Cargo.lock') }}-${{ hashFiles('rust-toolchain.toml') }}
+            src/deps_hack/target/debug
+            src/deps_hack/.cargo-home
+          key: toolchain-${{ runner.os }}-${{ needs.setup-toolchain.outputs.verus-sha }}-${{ hashFiles('rust-toolchain.toml') }}-${{ hashFiles('src/deps_hack/Cargo.lock') }}
       - name: Verify the TLA demo
         run: |
           . "$HOME/.cargo/env"
@@ -429,19 +388,16 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
-      - name: Restore Verus cache
+      - name: Restore toolchains and dependencies cache
         uses: actions/cache@v4
         with:
           path: |
             ${{ env.home_dir }}/verus
             ${{ env.home_dir }}/.cargo
             ${{ env.home_dir }}/.rustup
-          key: verus-${{ runner.os }}-${{ needs.setup-toolchain.outputs.verus-sha }}-${{ hashFiles('rust-toolchain.toml') }}
-      - name: Restore deps_hack cache
-        uses: actions/cache@v4
-        with:
-          path: src/deps_hack/target/debug
-          key: deps-hack-${{ runner.os }}-${{ hashFiles('src/deps_hack/Cargo.lock') }}-${{ hashFiles('rust-toolchain.toml') }}
+            src/deps_hack/target/debug
+            src/deps_hack/.cargo-home
+          key: toolchain-${{ runner.os }}-${{ needs.setup-toolchain.outputs.verus-sha }}-${{ hashFiles('rust-toolchain.toml') }}-${{ hashFiles('src/deps_hack/Cargo.lock') }}
       - name: Verify rabbitmq controller
         run: |
           . "$HOME/.cargo/env"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,7 +58,7 @@ jobs:
           ./tools/get-z3.sh
           source ../tools/activate
           vargo build --release
-          mv z3 target-verus/release/z3
+          ls -la target-verus/release
           mv target-verus/release $HOME/verus
       - name: Debug verus install
         run: ls -la $HOME/verus/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,6 @@ on:
   merge_group:
   workflow_dispatch:
 env:
-  verus_release: 0.2025.11.30.840fa61
   kind_version: 0.23.0
   go_version: "^1.20"
   home_dir: /home/runner
@@ -20,8 +19,18 @@ env:
 jobs:
   setup-toolchain:
     runs-on: ubuntu-24.04
+    outputs:
+      verus-sha: ${{ steps.verus-sha.outputs.sha }}
     steps:
       - uses: actions/checkout@v4
+      - name: Checkout Verus
+        uses: actions/checkout@v4
+        with:
+          repository: verus-lang/verus
+          path: verus-src
+      - name: Get Verus commit SHA
+        id: verus-sha
+        run: echo "sha=$(git -C verus-src rev-parse HEAD)" >> $GITHUB_OUTPUT
       - name: Get HOME env variable
         id: get-home
         run: |
@@ -35,20 +44,23 @@ jobs:
             ${{ env.home_dir }}/verus
             ${{ env.home_dir }}/.cargo
             ${{ env.home_dir }}/.rustup
-          key: verus-${{ runner.os }}-${{ env.verus_release }}-${{ hashFiles('rust-toolchain.toml') }}
-      - name: Download Rust if cache is missing
+          key: verus-${{ runner.os }}-${{ steps.verus-sha.outputs.sha }}-${{ hashFiles('rust-toolchain.toml') }}
+      - name: Install Rust if cache is missing
         if: steps.cache-verus.outputs.cache-hit != 'true'
         run: |
           curl --proto '=https' --tlsv1.2 --retry 10 --retry-connrefused -fsSL "https://sh.rustup.rs" | sh -s -- --default-toolchain none -y
           . "$HOME/.cargo/env"
           rustup toolchain install
-      - name: Download Verus if cache is missing
+      - name: Build Verus if cache is missing
         if: steps.cache-verus.outputs.cache-hit != 'true'
         run: |
-          wget -q https://github.com/verus-lang/verus/releases/download/release%2F${{ env.verus_release }}/verus-${{ env.verus_release }}-x86-linux.zip
-          unzip verus-${{ env.verus_release }}-x86-linux.zip
-          rm verus-${{ env.verus_release }}-x86-linux.zip
-          mv verus-x86-linux $HOME/verus
+          cd verus-src/source
+          ./tools/get-z3.sh
+          source ../tools/activate
+          vargo build --release
+          mkdir -p $HOME/verus
+          cp target-verus/release/verus $HOME/verus/verus
+          cp z3 $HOME/verus/z3
   vreplicaset-verification:
     needs: setup-toolchain
     runs-on: ubuntu-24.04
@@ -61,7 +73,7 @@ jobs:
             ${{ env.home_dir }}/verus
             ${{ env.home_dir }}/.cargo
             ${{ env.home_dir }}/.rustup
-          key: verus-${{ runner.os }}-${{ env.verus_release }}-${{ hashFiles('rust-toolchain.toml') }}
+          key: verus-${{ runner.os }}-${{ needs.setup-toolchain.outputs.verus-sha }}-${{ hashFiles('rust-toolchain.toml') }}
       - name: Verify vreplicaset controller
         run: |
           . "$HOME/.cargo/env"
@@ -79,7 +91,7 @@ jobs:
             ${{ env.home_dir }}/verus
             ${{ env.home_dir }}/.cargo
             ${{ env.home_dir }}/.rustup
-          key: verus-${{ runner.os }}-${{ env.verus_release }}-${{ hashFiles('rust-toolchain.toml') }}
+          key: verus-${{ runner.os }}-${{ needs.setup-toolchain.outputs.verus-sha }}-${{ hashFiles('rust-toolchain.toml') }}
       - name: Verify vdeployment controller
         run: |
           . "$HOME/.cargo/env"
@@ -97,7 +109,7 @@ jobs:
             ${{ env.home_dir }}/verus
             ${{ env.home_dir }}/.cargo
             ${{ env.home_dir }}/.rustup
-          key: verus-${{ runner.os }}-${{ env.verus_release }}-${{ hashFiles('rust-toolchain.toml') }}
+          key: verus-${{ runner.os }}-${{ needs.setup-toolchain.outputs.verus-sha }}-${{ hashFiles('rust-toolchain.toml') }}
       - name: Verify vstatefulset controller
         run: |
           . "$HOME/.cargo/env"
@@ -115,7 +127,7 @@ jobs:
             ${{ env.home_dir }}/verus
             ${{ env.home_dir }}/.cargo
             ${{ env.home_dir }}/.rustup
-          key: verus-${{ runner.os }}-${{ env.verus_release }}-${{ hashFiles('rust-toolchain.toml') }}
+          key: verus-${{ runner.os }}-${{ needs.setup-toolchain.outputs.verus-sha }}-${{ hashFiles('rust-toolchain.toml') }}
       - name: Verify the ESR composition
         run: |
           . "$HOME/.cargo/env"
@@ -133,7 +145,7 @@ jobs:
             ${{ env.home_dir }}/verus
             ${{ env.home_dir }}/.cargo
             ${{ env.home_dir }}/.rustup
-          key: verus-${{ runner.os }}-${{ env.verus_release }}-${{ hashFiles('rust-toolchain.toml') }}
+          key: verus-${{ runner.os }}-${{ needs.setup-toolchain.outputs.verus-sha }}-${{ hashFiles('rust-toolchain.toml') }}
       - name: Verify the Anvil framework
         run: |
           . "$HOME/.cargo/env"
@@ -152,7 +164,7 @@ jobs:
             ${{ env.home_dir }}/verus
             ${{ env.home_dir }}/.cargo
             ${{ env.home_dir }}/.rustup
-          key: verus-${{ runner.os }}-${{ env.verus_release }}-${{ hashFiles('rust-toolchain.toml') }}
+          key: verus-${{ runner.os }}-${{ needs.setup-toolchain.outputs.verus-sha }}-${{ hashFiles('rust-toolchain.toml') }}
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
@@ -179,7 +191,7 @@ jobs:
   #           ${{ env.home_dir }}/verus
   #           ${{ env.home_dir }}/.cargo
   #           ${{ env.home_dir }}/.rustup
-  #         key: verus-${{ runner.os }}-${{ env.verus_release }}-${{ hashFiles('rust-toolchain.toml') }}
+  #         key: verus-${{ runner.os }}-${{ needs.setup-toolchain.outputs.verus-sha }}-${{ hashFiles('rust-toolchain.toml') }}
   #     - name: Setup Go
   #       uses: actions/setup-go@v5
   #       with:
@@ -206,7 +218,7 @@ jobs:
             ${{ env.home_dir }}/verus
             ${{ env.home_dir }}/.cargo
             ${{ env.home_dir }}/.rustup
-          key: verus-${{ runner.os }}-${{ env.verus_release }}-${{ hashFiles('rust-toolchain.toml') }}
+          key: verus-${{ runner.os }}-${{ needs.setup-toolchain.outputs.verus-sha }}-${{ hashFiles('rust-toolchain.toml') }}
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
@@ -232,7 +244,7 @@ jobs:
             ${{ env.home_dir }}/verus
             ${{ env.home_dir }}/.cargo
             ${{ env.home_dir }}/.rustup
-          key: verus-${{ runner.os }}-${{ env.verus_release }}-${{ hashFiles('rust-toolchain.toml') }}
+          key: verus-${{ runner.os }}-${{ needs.setup-toolchain.outputs.verus-sha }}-${{ hashFiles('rust-toolchain.toml') }}
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
@@ -258,7 +270,7 @@ jobs:
             ${{ env.home_dir }}/verus
             ${{ env.home_dir }}/.cargo
             ${{ env.home_dir }}/.rustup
-          key: verus-${{ runner.os }}-${{ env.verus_release }}-${{ hashFiles('rust-toolchain.toml') }}
+          key: verus-${{ runner.os }}-${{ needs.setup-toolchain.outputs.verus-sha }}-${{ hashFiles('rust-toolchain.toml') }}
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
@@ -284,7 +296,7 @@ jobs:
             ${{ env.home_dir }}/verus
             ${{ env.home_dir }}/.cargo
             ${{ env.home_dir }}/.rustup
-          key: verus-${{ runner.os }}-${{ env.verus_release }}-${{ hashFiles('rust-toolchain.toml') }}
+          key: verus-${{ runner.os }}-${{ needs.setup-toolchain.outputs.verus-sha }}-${{ hashFiles('rust-toolchain.toml') }}
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
@@ -310,7 +322,7 @@ jobs:
             ${{ env.home_dir }}/verus
             ${{ env.home_dir }}/.cargo
             ${{ env.home_dir }}/.rustup
-          key: verus-${{ runner.os }}-${{ env.verus_release }}-${{ hashFiles('rust-toolchain.toml') }}
+          key: verus-${{ runner.os }}-${{ needs.setup-toolchain.outputs.verus-sha }}-${{ hashFiles('rust-toolchain.toml') }}
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
@@ -335,7 +347,7 @@ jobs:
             ${{ env.home_dir }}/verus
             ${{ env.home_dir }}/.cargo
             ${{ env.home_dir }}/.rustup
-          key: verus-${{ runner.os }}-${{ env.verus_release }}-${{ hashFiles('rust-toolchain.toml') }}
+          key: verus-${{ runner.os }}-${{ needs.setup-toolchain.outputs.verus-sha }}-${{ hashFiles('rust-toolchain.toml') }}
       - name: Verify the TLA demo
         run: |
           . "$HOME/.cargo/env"
@@ -354,7 +366,7 @@ jobs:
             ${{ env.home_dir }}/verus
             ${{ env.home_dir }}/.cargo
             ${{ env.home_dir }}/.rustup
-          key: verus-${{ runner.os }}-${{ env.verus_release }}-${{ hashFiles('rust-toolchain.toml') }}
+          key: verus-${{ runner.os }}-${{ needs.setup-toolchain.outputs.verus-sha }}-${{ hashFiles('rust-toolchain.toml') }}
       - name: Verify rabbitmq controller
         run: |
           . "$HOME/.cargo/env"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,9 +58,8 @@ jobs:
           ./tools/get-z3.sh
           source ../tools/activate
           vargo build --release
-          mkdir -p $HOME/verus
-          cp target-verus/release/verus $HOME/verus/verus
-          cp z3 $HOME/verus/z3
+          mv z3 target-verus/release/z3
+          mv target-verus/release $HOME/verus
   vreplicaset-verification:
     needs: setup-toolchain
     runs-on: ubuntu-24.04

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,6 +60,8 @@ jobs:
           vargo build --release
           mv z3 target-verus/release/z3
           mv target-verus/release $HOME/verus
+      - name: Debug verus install
+        run: ls -la $HOME/verus/
   vreplicaset-verification:
     needs: setup-toolchain
     runs-on: ubuntu-24.04
@@ -73,6 +75,12 @@ jobs:
             ${{ env.home_dir }}/.cargo
             ${{ env.home_dir }}/.rustup
           key: verus-${{ runner.os }}-${{ needs.setup-toolchain.outputs.verus-sha }}-${{ hashFiles('rust-toolchain.toml') }}
+      - name: Debug verus install
+        run: |
+          ls -la $HOME/verus/
+          export PATH="$PATH:$HOME/verus"
+          which verus
+          verus --version || true
       - name: Verify vreplicaset controller
         run: |
           . "$HOME/.cargo/env"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,10 +58,7 @@ jobs:
           ./tools/get-z3.sh
           source ../tools/activate
           vargo build --release
-          ls -la target-verus/release
           mv target-verus/release $HOME/verus
-      - name: Debug verus install
-        run: ls -la $HOME/verus/
   vreplicaset-verification:
     needs: setup-toolchain
     runs-on: ubuntu-24.04
@@ -75,12 +72,6 @@ jobs:
             ${{ env.home_dir }}/.cargo
             ${{ env.home_dir }}/.rustup
           key: verus-${{ runner.os }}-${{ needs.setup-toolchain.outputs.verus-sha }}-${{ hashFiles('rust-toolchain.toml') }}
-      - name: Debug verus install
-        run: |
-          ls -la $HOME/verus/
-          export PATH="$PATH:$HOME/verus"
-          which verus
-          verus --version || true
       - name: Verify vreplicaset controller
         run: |
           . "$HOME/.cargo/env"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,6 +59,18 @@ jobs:
           source ../tools/activate
           vargo build --release
           mv target-verus/release $HOME/verus
+      - name: Cache deps_hack
+        id: cache-deps-hack
+        uses: actions/cache@v4
+        with:
+          path: src/deps_hack/target/debug
+          key: deps-hack-${{ runner.os }}-${{ hashFiles('src/deps_hack/Cargo.lock') }}-${{ hashFiles('rust-toolchain.toml') }}
+      - name: Build deps_hack if cache is missing
+        if: steps.cache-deps-hack.outputs.cache-hit != 'true'
+        run: |
+          . "$HOME/.cargo/env"
+          cd src/deps_hack
+          cargo build
   vreplicaset-verification:
     needs: setup-toolchain
     runs-on: ubuntu-24.04
@@ -72,6 +84,11 @@ jobs:
             ${{ env.home_dir }}/.cargo
             ${{ env.home_dir }}/.rustup
           key: verus-${{ runner.os }}-${{ needs.setup-toolchain.outputs.verus-sha }}-${{ hashFiles('rust-toolchain.toml') }}
+      - name: Restore deps_hack cache
+        uses: actions/cache@v4
+        with:
+          path: src/deps_hack/target/debug
+          key: deps-hack-${{ runner.os }}-${{ hashFiles('src/deps_hack/Cargo.lock') }}-${{ hashFiles('rust-toolchain.toml') }}
       - name: Verify vreplicaset controller
         run: |
           . "$HOME/.cargo/env"
@@ -90,6 +107,11 @@ jobs:
             ${{ env.home_dir }}/.cargo
             ${{ env.home_dir }}/.rustup
           key: verus-${{ runner.os }}-${{ needs.setup-toolchain.outputs.verus-sha }}-${{ hashFiles('rust-toolchain.toml') }}
+      - name: Restore deps_hack cache
+        uses: actions/cache@v4
+        with:
+          path: src/deps_hack/target/debug
+          key: deps-hack-${{ runner.os }}-${{ hashFiles('src/deps_hack/Cargo.lock') }}-${{ hashFiles('rust-toolchain.toml') }}
       - name: Verify vdeployment controller
         run: |
           . "$HOME/.cargo/env"
@@ -108,6 +130,11 @@ jobs:
             ${{ env.home_dir }}/.cargo
             ${{ env.home_dir }}/.rustup
           key: verus-${{ runner.os }}-${{ needs.setup-toolchain.outputs.verus-sha }}-${{ hashFiles('rust-toolchain.toml') }}
+      - name: Restore deps_hack cache
+        uses: actions/cache@v4
+        with:
+          path: src/deps_hack/target/debug
+          key: deps-hack-${{ runner.os }}-${{ hashFiles('src/deps_hack/Cargo.lock') }}-${{ hashFiles('rust-toolchain.toml') }}
       - name: Verify vstatefulset controller
         run: |
           . "$HOME/.cargo/env"
@@ -126,6 +153,11 @@ jobs:
             ${{ env.home_dir }}/.cargo
             ${{ env.home_dir }}/.rustup
           key: verus-${{ runner.os }}-${{ needs.setup-toolchain.outputs.verus-sha }}-${{ hashFiles('rust-toolchain.toml') }}
+      - name: Restore deps_hack cache
+        uses: actions/cache@v4
+        with:
+          path: src/deps_hack/target/debug
+          key: deps-hack-${{ runner.os }}-${{ hashFiles('src/deps_hack/Cargo.lock') }}-${{ hashFiles('rust-toolchain.toml') }}
       - name: Verify the ESR composition
         run: |
           . "$HOME/.cargo/env"
@@ -144,6 +176,11 @@ jobs:
             ${{ env.home_dir }}/.cargo
             ${{ env.home_dir }}/.rustup
           key: verus-${{ runner.os }}-${{ needs.setup-toolchain.outputs.verus-sha }}-${{ hashFiles('rust-toolchain.toml') }}
+      - name: Restore deps_hack cache
+        uses: actions/cache@v4
+        with:
+          path: src/deps_hack/target/debug
+          key: deps-hack-${{ runner.os }}-${{ hashFiles('src/deps_hack/Cargo.lock') }}-${{ hashFiles('rust-toolchain.toml') }}
       - name: Verify the Anvil framework
         run: |
           . "$HOME/.cargo/env"
@@ -163,6 +200,11 @@ jobs:
             ${{ env.home_dir }}/.cargo
             ${{ env.home_dir }}/.rustup
           key: verus-${{ runner.os }}-${{ needs.setup-toolchain.outputs.verus-sha }}-${{ hashFiles('rust-toolchain.toml') }}
+      - name: Restore deps_hack cache
+        uses: actions/cache@v4
+        with:
+          path: src/deps_hack/target/debug
+          key: deps-hack-${{ runner.os }}-${{ hashFiles('src/deps_hack/Cargo.lock') }}-${{ hashFiles('rust-toolchain.toml') }}
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
@@ -217,6 +259,11 @@ jobs:
             ${{ env.home_dir }}/.cargo
             ${{ env.home_dir }}/.rustup
           key: verus-${{ runner.os }}-${{ needs.setup-toolchain.outputs.verus-sha }}-${{ hashFiles('rust-toolchain.toml') }}
+      - name: Restore deps_hack cache
+        uses: actions/cache@v4
+        with:
+          path: src/deps_hack/target/debug
+          key: deps-hack-${{ runner.os }}-${{ hashFiles('src/deps_hack/Cargo.lock') }}-${{ hashFiles('rust-toolchain.toml') }}
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
@@ -243,6 +290,11 @@ jobs:
             ${{ env.home_dir }}/.cargo
             ${{ env.home_dir }}/.rustup
           key: verus-${{ runner.os }}-${{ needs.setup-toolchain.outputs.verus-sha }}-${{ hashFiles('rust-toolchain.toml') }}
+      - name: Restore deps_hack cache
+        uses: actions/cache@v4
+        with:
+          path: src/deps_hack/target/debug
+          key: deps-hack-${{ runner.os }}-${{ hashFiles('src/deps_hack/Cargo.lock') }}-${{ hashFiles('rust-toolchain.toml') }}
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
@@ -269,6 +321,11 @@ jobs:
             ${{ env.home_dir }}/.cargo
             ${{ env.home_dir }}/.rustup
           key: verus-${{ runner.os }}-${{ needs.setup-toolchain.outputs.verus-sha }}-${{ hashFiles('rust-toolchain.toml') }}
+      - name: Restore deps_hack cache
+        uses: actions/cache@v4
+        with:
+          path: src/deps_hack/target/debug
+          key: deps-hack-${{ runner.os }}-${{ hashFiles('src/deps_hack/Cargo.lock') }}-${{ hashFiles('rust-toolchain.toml') }}
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
@@ -295,6 +352,11 @@ jobs:
             ${{ env.home_dir }}/.cargo
             ${{ env.home_dir }}/.rustup
           key: verus-${{ runner.os }}-${{ needs.setup-toolchain.outputs.verus-sha }}-${{ hashFiles('rust-toolchain.toml') }}
+      - name: Restore deps_hack cache
+        uses: actions/cache@v4
+        with:
+          path: src/deps_hack/target/debug
+          key: deps-hack-${{ runner.os }}-${{ hashFiles('src/deps_hack/Cargo.lock') }}-${{ hashFiles('rust-toolchain.toml') }}
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
@@ -321,6 +383,11 @@ jobs:
             ${{ env.home_dir }}/.cargo
             ${{ env.home_dir }}/.rustup
           key: verus-${{ runner.os }}-${{ needs.setup-toolchain.outputs.verus-sha }}-${{ hashFiles('rust-toolchain.toml') }}
+      - name: Restore deps_hack cache
+        uses: actions/cache@v4
+        with:
+          path: src/deps_hack/target/debug
+          key: deps-hack-${{ runner.os }}-${{ hashFiles('src/deps_hack/Cargo.lock') }}-${{ hashFiles('rust-toolchain.toml') }}
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
@@ -346,6 +413,11 @@ jobs:
             ${{ env.home_dir }}/.cargo
             ${{ env.home_dir }}/.rustup
           key: verus-${{ runner.os }}-${{ needs.setup-toolchain.outputs.verus-sha }}-${{ hashFiles('rust-toolchain.toml') }}
+      - name: Restore deps_hack cache
+        uses: actions/cache@v4
+        with:
+          path: src/deps_hack/target/debug
+          key: deps-hack-${{ runner.os }}-${{ hashFiles('src/deps_hack/Cargo.lock') }}-${{ hashFiles('rust-toolchain.toml') }}
       - name: Verify the TLA demo
         run: |
           . "$HOME/.cargo/env"
@@ -365,6 +437,11 @@ jobs:
             ${{ env.home_dir }}/.cargo
             ${{ env.home_dir }}/.rustup
           key: verus-${{ runner.os }}-${{ needs.setup-toolchain.outputs.verus-sha }}-${{ hashFiles('rust-toolchain.toml') }}
+      - name: Restore deps_hack cache
+        uses: actions/cache@v4
+        with:
+          path: src/deps_hack/target/debug
+          key: deps-hack-${{ runner.os }}-${{ hashFiles('src/deps_hack/Cargo.lock') }}-${{ hashFiles('rust-toolchain.toml') }}
       - name: Verify rabbitmq controller
         run: |
           . "$HOME/.cargo/env"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 # this should be synchronized with the Verus version, since we need to combine
 # k8s compiled with rustc and our own code compiled with rust-verify.sh
 [toolchain]
-channel = "1.91.0"
+channel = "1.94.0"

--- a/src/controllers/rabbitmq_controller/proof/helper_invariants/proof.rs
+++ b/src/controllers/rabbitmq_controller/proof/helper_invariants/proof.rs
@@ -366,14 +366,17 @@ proof fn object_in_response_at_after_create_resource_step_is_same_as_etcd_helper
                             }
                         },
                         _ => {
+                            assert(s.in_flight().contains(msg));
                             assert(resp_msg_matches_req_msg(msg, s.ongoing_reconciles(controller_id)[key].pending_req_msg->0));
                             assert(s.resources()[resource_key] == s_prime.resources()[resource_key]);
+                            assert(resource_create_response_msg(resource_key, s_prime)(msg));
                         }
                     }
                 },
                 _ => {
                     assert(s.in_flight().contains(msg));
                     assert(s.ongoing_reconciles(controller_id)[key] == s_prime.ongoing_reconciles(controller_id)[key]);
+                    assert(resource_create_response_msg(resource_key, s_prime)(msg));
                 }
             }
         }

--- a/src/controllers/vdeployment_controller/exec/reconciler.rs
+++ b/src/controllers/vdeployment_controller/exec/reconciler.rs
@@ -599,7 +599,23 @@ ensures
             assert(spec_filter(vrs@) ==> old_vrs_list.deep_view() == pre_filtered_vrs_list.push(vrs@));
         }
     }
-    assert(old_vrs_list.deep_view() == model_reconciler::filter_old_and_new_vrs(vd@, vrs_list.deep_view()).1);
+    assert(old_vrs_list.deep_view() == model_reconciler::filter_old_and_new_vrs(vd@, vrs_list.deep_view()).1) by {
+        assert(vrs_list.deep_view().take(vrs_list.len() as int) == vrs_list.deep_view());
+        let model_reusable_vrs = model_reconciler::filter_old_and_new_vrs(vd@, vrs_list.deep_view()).0;
+        let exec_filter = |vrs: VReplicaSetView| {
+            &&& (reusable_vrs.is_none() || vrs.metadata.uid != reusable_vrs.deep_view().unwrap().metadata.uid)
+            &&& (vrs.spec.replicas.is_none() || vrs.spec.replicas.unwrap() > 0)
+        };
+        let model_filter = |vrs: VReplicaSetView| {
+            &&& (model_reusable_vrs is None || vrs.metadata.uid != model_reusable_vrs->0.metadata.uid)
+            &&& (vrs.spec.replicas is None || vrs.spec.replicas.unwrap() > 0)
+        };
+        assert forall |vrs: VReplicaSetView| #[trigger] vrs_list.deep_view().contains(vrs)
+            implies exec_filter(vrs) == model_filter(vrs) by {
+            assert(reusable_vrs.deep_view() == model_reusable_vrs);
+        };
+        same_filter_implies_same_result(vrs_list.deep_view(), exec_filter, model_filter);
+    };
     return (reusable_vrs, old_vrs_list);
 }
 

--- a/src/controllers/vdeployment_controller/exec/reconciler.rs
+++ b/src/controllers/vdeployment_controller/exec/reconciler.rs
@@ -601,20 +601,6 @@ ensures
     }
     assert(old_vrs_list.deep_view() == model_reconciler::filter_old_and_new_vrs(vd@, vrs_list.deep_view()).1) by {
         assert(vrs_list.deep_view().take(vrs_list.len() as int) == vrs_list.deep_view());
-        let model_reusable_vrs = model_reconciler::filter_old_and_new_vrs(vd@, vrs_list.deep_view()).0;
-        let exec_filter = |vrs: VReplicaSetView| {
-            &&& (reusable_vrs.is_none() || vrs.metadata.uid != reusable_vrs.deep_view().unwrap().metadata.uid)
-            &&& (vrs.spec.replicas.is_none() || vrs.spec.replicas.unwrap() > 0)
-        };
-        let model_filter = |vrs: VReplicaSetView| {
-            &&& (model_reusable_vrs is None || vrs.metadata.uid != model_reusable_vrs->0.metadata.uid)
-            &&& (vrs.spec.replicas is None || vrs.spec.replicas.unwrap() > 0)
-        };
-        assert forall |vrs: VReplicaSetView| #[trigger] vrs_list.deep_view().contains(vrs)
-            implies exec_filter(vrs) == model_filter(vrs) by {
-            assert(reusable_vrs.deep_view() == model_reusable_vrs);
-        };
-        same_filter_implies_same_result(vrs_list.deep_view(), exec_filter, model_filter);
     };
     return (reusable_vrs, old_vrs_list);
 }

--- a/src/controllers/vdeployment_controller/proof/helper_lemmas.rs
+++ b/src/controllers/vdeployment_controller/proof/helper_lemmas.rs
@@ -317,7 +317,7 @@ ensures
         &&& valid_owned_obj_key(vd, s)(k)
         &&& filter_new_vrs_keys(vd.spec.template, s)(k)
         &&& etcd_vrs.metadata.uid is Some
-        &&& vd.spec.replicas.unwrap_or(1) > 0 ==> etcd_vrs.spec.replicas.unwrap_or(1) > 0
+        &&& get_replicas(vd.spec.replicas) > 0 ==> get_replicas(etcd_vrs.spec.replicas) > 0
         &&& !exists |k: ObjectRef| {
             &&& s.resources().contains_key(k)
             &&& valid_owned_obj_key(vd, s)(k)
@@ -340,7 +340,7 @@ ensures
     if current_state_matches_with_new_vrs_key(vd, new_vrs_key)(s) {
         let new_vrs = VReplicaSetView::unmarshal(s.resources()[new_vrs_key])->Ok_0;
         let nv_uid = new_vrs.metadata.uid->0;
-        assert(etcd_state_is(vd, controller_id, Some((nv_uid, new_vrs_key, new_vrs.spec.replicas.unwrap_or(1))), 0)(s)) by {
+        assert(etcd_state_is(vd, controller_id, Some((nv_uid, new_vrs_key, get_replicas(new_vrs.spec.replicas))), 0)(s)) by {
             let filtered_old_vrs_keys = filter_obj_keys_managed_by_vd(vd, s).filter(filter_old_vrs_keys(Some(nv_uid), s));
             if exists |k: ObjectRef| filtered_old_vrs_keys.contains(k) {
                 let k = choose |k: ObjectRef| filtered_old_vrs_keys.contains(k);
@@ -353,17 +353,15 @@ ensures
                 }
             }
         }
-        assert(exists |nv_uid_replicas: (Uid, int)| vd.spec.replicas.unwrap_or(1) > 0 ==> nv_uid_replicas.1 > 0 &&
-            #[trigger] etcd_state_is(vd, controller_id, Some((nv_uid_replicas.0, new_vrs_key, nv_uid_replicas.1)), 0)(s)) by {
-            assert((|nv_uid_replicas: (Uid, int)| vd.spec.replicas.unwrap_or(1) > 0 ==> nv_uid_replicas.1 > 0
-                && etcd_state_is(vd, controller_id, Some((nv_uid_replicas.0, new_vrs_key, nv_uid_replicas.1)), 0)(s))((nv_uid, new_vrs.spec.replicas.unwrap_or(1))));
-        }
+        assert((|nv_uid_replicas: (Uid, int)| get_replicas(vd.spec.replicas) > 0 ==> nv_uid_replicas.1 > 0
+            && etcd_state_is(vd, controller_id, Some((nv_uid_replicas.0, new_vrs_key, nv_uid_replicas.1)), 0)(s))((nv_uid, get_replicas(new_vrs.spec.replicas))));
+        assert(instantiated_etcd_state_is_with_zero_old_vrs_and_nv_key(vd, controller_id, new_vrs_key)(s));
     }
     // <==
     if instantiated_etcd_state_is_with_zero_old_vrs_and_nv_key(vd, controller_id, new_vrs_key)(s) {
         let vrs_with_nv_key = VReplicaSetView::unmarshal(s.resources()[new_vrs_key])->Ok_0;
         let nv_uid_replicas = choose |nv_uid_replicas: (Uid, int)| {
-            &&&vd.spec.replicas.unwrap_or(1) > 0 ==> nv_uid_replicas.1 > 0
+            &&& get_replicas(vd.spec.replicas) > 0 ==> nv_uid_replicas.1 > 0
             &&& #[trigger] etcd_state_is(vd, controller_id, Some((nv_uid_replicas.0, new_vrs_key, nv_uid_replicas.1)), 0)(s)
         };
         assert forall |k: ObjectRef| #[trigger] s.resources().contains_key(k) implies !({

--- a/src/controllers/vdeployment_controller/proof/liveness/api_actions.rs
+++ b/src/controllers/vdeployment_controller/proof/liveness/api_actions.rs
@@ -292,7 +292,7 @@ ensures
             &&& #[trigger] managed_vrs_list.contains(vrs)
             &&& vrs.object_ref() == new_vrs.object_ref()
             &&& vrs.status is Some
-            &&& vrs.status->0.replicas == vrs.spec.replicas.unwrap_or(1)
+            &&& vrs.status->0.replicas == get_replicas(vrs.spec.replicas)
         }) by {
             VReplicaSetView::marshal_preserves_integrity();
             assert(filter_obj_keys_managed_by_vd(vd, s).contains(new_vrs.object_ref()));
@@ -325,7 +325,7 @@ ensures
     res.0 == handle_create_request_msg(cluster.installed_types, req_msg, s.api_server).1,
     resp_msg_matches_req_msg(res.0, req_msg),
     resp_msg_is_ok_create_new_vrs_resp(vd, controller_id, res.0, res.1)(s_prime),
-    etcd_state_is(vd, controller_id, Some(((res.1).0, (res.1).1, if vd.spec.replicas.unwrap_or(1) > 0 {1} else {0})), n)(s_prime),
+    etcd_state_is(vd, controller_id, Some(((res.1).0, (res.1).1, if get_replicas(vd.spec.replicas) > 0 {1} else {0})), n)(s_prime),
     filter_obj_keys_managed_by_vd(vd, s_prime).filter(filter_old_vrs_keys(Some((res.1).0), s_prime))
         == filter_obj_keys_managed_by_vd(vd, s).filter(filter_old_vrs_keys(None, s)),
     // created obj has different key and uid from all old_vrs in local_state
@@ -640,7 +640,7 @@ ensures
         lemma_esr_equiv_to_instantiated_etcd_state_is_with_nv_key(vd, cluster, controller_id, new_vrs_key, s);
     }
     let nv_uid_replicas = choose |nv_uid_replicas: (Uid, int)| {
-        &&&vd.spec.replicas.unwrap_or(1) > 0 ==> nv_uid_replicas.1 > 0
+        &&&get_replicas(vd.spec.replicas) > 0 ==> nv_uid_replicas.1 > 0
         &&& #[trigger] etcd_state_is(vd, controller_id, Some((nv_uid_replicas.0, new_vrs_key, nv_uid_replicas.1)), 0)(s)
     };
     lemma_api_request_other_than_pending_req_msg_maintains_etcd_state(

--- a/src/controllers/vdeployment_controller/proof/liveness/composition.rs
+++ b/src/controllers/vdeployment_controller/proof/liveness/composition.rs
@@ -43,13 +43,13 @@ pub open spec fn current_state_match_vd_applied_to_vrs_set(vrs_set: Set<VReplica
             .filter(|vrs: VReplicaSetView| valid_owned_vrs(vrs, vd))
         &&& exists |vrs: VReplicaSetView| {
             &&& #[trigger] vrs_set.contains(vrs)
-            &&& vrs.spec.replicas.unwrap_or(1) == vd.spec.replicas.unwrap_or(1) // vd.spec.replicas can be Some(0)
+            &&& get_replicas(vrs.spec.replicas) == get_replicas(vd.spec.replicas) // vd.spec.replicas can be Some(0)
             &&& match_template_without_hash(vd.spec.template)(vrs)
             // no old vrs, including the 2nd new vrs (if any)
             &&& !exists |old_vrs: VReplicaSetView| {
                 &&& #[trigger] vrs_set.contains(old_vrs)
                 &&& old_vrs != vrs
-                &&& old_vrs.spec.replicas.unwrap_or(1) > 0 // != Some(0)
+                &&& get_replicas(old_vrs.spec.replicas) > 0 // != Some(0)
             }
         }
         &&& vrs_set.finite() && vrs_set.len() > 0
@@ -390,7 +390,7 @@ ensures
         &&& valid_owned_obj_key(vd, s)(k)
         &&& filter_new_vrs_keys(vd.spec.template, s)(k)
         &&& etcd_vrs.metadata.uid is Some
-        &&& etcd_vrs.spec.replicas.unwrap_or(1) == vd.spec.replicas.unwrap_or(1)
+        &&& get_replicas(etcd_vrs.spec.replicas) == get_replicas(vd.spec.replicas)
     };
     let new_obj = s.resources()[k];
     let new_vrs = VReplicaSetView::unmarshal(s.resources()[k])->Ok_0;
@@ -399,16 +399,16 @@ ensures
         assert(s.resources().values().filter(|obj: DynamicObjectView| obj.kind == VReplicaSetView::kind()).contains(new_obj));
     }
     assert(match_template_without_hash(vd.spec.template)(new_vrs));
-    assert(new_vrs.spec.replicas.unwrap_or(1) == vd.spec.replicas.unwrap_or(1));
+    assert(get_replicas(new_vrs.spec.replicas) == get_replicas(vd.spec.replicas));
     if exists |old_vrs: VReplicaSetView| {
         &&& #[trigger] vrs_set.contains(old_vrs)
         &&& old_vrs != new_vrs
-        &&& old_vrs.spec.replicas.unwrap_or(1) > 0
+        &&& get_replicas(old_vrs.spec.replicas) > 0
     } {
         let old_vrs = choose |old_vrs: VReplicaSetView| {
             &&& #[trigger] vrs_set.contains(old_vrs)
             &&& old_vrs != new_vrs
-            &&& old_vrs.spec.replicas.unwrap_or(1) > 0
+            &&& get_replicas(old_vrs.spec.replicas) > 0
         };
         let old_k = old_vrs.object_ref();
         assert(s.resources().contains_key(old_k));
@@ -429,7 +429,7 @@ ensures
     VReplicaSetView::marshal_preserves_integrity();
     let new_vrs = choose |vrs: VReplicaSetView| {
         &&& #[trigger] vrs_set.contains(vrs)
-        &&& vrs.spec.replicas.unwrap_or(1) == vd.spec.replicas.unwrap_or(1)
+        &&& get_replicas(vrs.spec.replicas) == get_replicas(vd.spec.replicas)
         &&& match_template_without_hash(vd.spec.template)(vrs)
     };
     assert(s.resources().values().filter(valid_owned_pods(vd, s)) == vrs_liveness::matching_pods(new_vrs, s.resources())) by {
@@ -447,7 +447,7 @@ ensures
                         let havoc_obj = s.resources()[havoc_vrs.object_ref()];
                         assert(s.resources().values().filter(|obj: DynamicObjectView| obj.kind == VReplicaSetView::kind()).contains(havoc_obj));
                     }
-                    assert(havoc_vrs.spec.replicas.unwrap_or(1) > 0) by {
+                    assert(get_replicas(havoc_vrs.spec.replicas) > 0) by {
                         assert(vrs_liveness::matching_pods(havoc_vrs, s.resources()).len() > 0) by {
                             assert(vrs_liveness::matching_pods(havoc_vrs, s.resources()).contains(obj));
                             // Cluster::etcd_is_finite() |= s.resources().values().is_finite()

--- a/src/controllers/vdeployment_controller/proof/liveness/resource_match.rs
+++ b/src/controllers/vdeployment_controller/proof/liveness/resource_match.rs
@@ -113,7 +113,7 @@ ensures
     assert forall |msg: Message| #![trigger list_resp_msg(msg)]
         spec.entails(list_resp_msg(msg).leads_to(tla_exists(after_ensure_vrs))) by {
         // (\A |msg|) list_resp_msg(msg) == \E |replicas: Options<int>, n: nat| after_ensure_vrs((nv_uid, nv_key, n))
-        // here replicas.is_Some == if new vrs exists, replicas->0 == new_vrs.spec.replicas.unwrap_or(int1!())
+        // here replicas.is_Some == if new vrs exists, replicas->0 == get_replicas(new_vrs.spec.replicas)
         // 1 is the default value if not set
         assert(spec.entails(list_resp_msg(msg).leads_to(tla_exists(|i: (Option<(Uid, ObjectRef, int, bool)>, nat)| after_list_with_etcd_state(msg, i.0, i.1))))) by {
             assert forall |ex: Execution<ClusterState>| #[trigger] list_resp_msg(msg).satisfied_by(ex) && inv.satisfied_by(ex) implies
@@ -124,13 +124,13 @@ ensures
                 let (new_vrs, old_vrs_list) = filter_old_and_new_vrs(vd, managed_vrs_list);
                 let nv_uid_key_replicas_sm = if new_vrs is Some {
                     let vrs = new_vrs->0;
-                    Some((vrs.metadata.uid->0, vrs.object_ref(), vrs.spec.replicas.unwrap_or(int1!()), mismatch_replicas(vd, vrs)))
+                    Some((vrs.metadata.uid->0, vrs.object_ref(), get_replicas(vrs.spec.replicas), mismatch_replicas(vd, vrs)))
                 } else {
                     None
                 };
                 let nv_uid_key_replicas = if new_vrs is Some {
                     let vrs = new_vrs->0;
-                    Some((vrs.metadata.uid->0, vrs.object_ref(), vrs.spec.replicas.unwrap_or(int1!())))
+                    Some((vrs.metadata.uid->0, vrs.object_ref(), get_replicas(vrs.spec.replicas)))
                 } else {
                     None
                 };

--- a/src/controllers/vdeployment_controller/proof/liveness/rolling_update/composition.rs
+++ b/src/controllers/vdeployment_controller/proof/liveness/rolling_update/composition.rs
@@ -31,8 +31,8 @@ pub open spec fn conjuncted_current_state_matches_vrs(vrs_set: Set<VReplicaSetVi
 // Compute the absolute difference between desired replicas and new VRS replicas
 // This is the ranking function for iterative_esr
 pub open spec fn replicas_diff(vd: VDeploymentView, new_vrs: VReplicaSetView) -> nat {
-    let desired = vd.spec.replicas.unwrap_or(1);
-    let current = new_vrs.spec.replicas.unwrap_or(1);
+    let desired = get_replicas(vd.spec.replicas);
+    let current = get_replicas(new_vrs.spec.replicas);
     if desired >= current {
         (desired - current) as nat
     } else {
@@ -52,10 +52,10 @@ pub open spec fn desired_state_is_vrs_with_replicas_diff_and_key(vd: VDeployment
     |s: ClusterState| {
         // don't touch vrs if there is no need to patch replicas
         let vrs_with_replicas = vrs.with_spec(vrs.spec.with_replicas(
-            if vd.spec.replicas.unwrap_or(1) > vrs.spec.replicas.unwrap_or(1) {
-                vd.spec.replicas.unwrap_or(1) - diff
+            if get_replicas(vd.spec.replicas) > get_replicas(vrs.spec.replicas) {
+                get_replicas(vd.spec.replicas) - diff
             } else {
-                vd.spec.replicas.unwrap_or(1) + diff
+                get_replicas(vd.spec.replicas) + diff
             }
         ));
         &&& vrs_liveness::desired_state_is(vrs_with_replicas)(s)
@@ -67,10 +67,10 @@ pub open spec fn desired_state_is_vrs_with_replicas_diff_and_key(vd: VDeployment
 pub open spec fn current_state_matches_vrs_with_replicas_diff_and_key(vd: VDeploymentView, vrs: VReplicaSetView, vrs_key: ObjectRef, diff: nat) -> StatePred<ClusterState> {
     |s: ClusterState| {
         let vrs_with_replicas = vrs.with_spec(vrs.spec.with_replicas(
-            if vd.spec.replicas.unwrap_or(1) > vrs.spec.replicas.unwrap_or(1) {
-                vd.spec.replicas.unwrap_or(1) - diff
+            if get_replicas(vd.spec.replicas) > get_replicas(vrs.spec.replicas) {
+                get_replicas(vd.spec.replicas) - diff
             } else {
-                vd.spec.replicas.unwrap_or(1) + diff
+                get_replicas(vd.spec.replicas) + diff
             }
         ));
         &&& vrs_liveness::current_state_matches(vrs_with_replicas)(s)
@@ -91,7 +91,7 @@ pub open spec fn old_vrs_set_is_owned_by_vd(vrs_set: Set<VReplicaSetView>, vd: V
             .filter(|vrs: VReplicaSetView| is_old_vrs_of(vrs, vd, new_vrs_key))
             .map(|vrs: VReplicaSetView| vrs_with_no_rv_status(vrs))
         &&& vrs_set.finite()
-        &&& forall |vrs| #[trigger] vrs_set.contains(vrs) ==> vrs.spec.replicas.unwrap_or(1) == 0
+        &&& forall |vrs| #[trigger] vrs_set.contains(vrs) ==> get_replicas(vrs.spec.replicas) == 0
     }
 }
 
@@ -304,13 +304,13 @@ ensures
             // assert(next_local_state.old_vrs_index == 0);
             // let etcd_obj = s_prime.resources()[new_vrs_key];
             // let etcd_vrs = VReplicaSetView::unmarshal(etcd_obj)->Ok_0;
-            // if next_local_state.new_vrs is Some && etcd_vrs.spec.replicas.unwrap_or(1) > 0 {
+            // if next_local_state.new_vrs is Some && get_replicas(etcd_vrs.spec.replicas) > 0 {
             //     assert(next_local_state.new_vrs->0.object_ref() == new_vrs_key);
             //     assert(next_local_state.new_vrs->0.metadata.uid->0 == etcd_vrs.metadata.uid->0);
             // }
             // assert(next_local_state.new_vrs is Some && next_local_state.new_vrs->0.object_ref() != new_vrs_key ==> {
-            //     &&& vd.spec.replicas.unwrap_or(1) == 0 // optional, can be implied from above
-            //     &&& next_local_state.new_vrs->0.spec.replicas.unwrap_or(1) == 0
+            //     &&& get_replicas(vd.spec.replicas) == 0 // optional, can be implied from above
+            //     &&& next_local_state.new_vrs->get_replicas(0.spec.replicas) == 0
             // });
             // assert(at_vd_step_with_vd(vd, controller_id, at_step_or![Init, AfterListVRS, AfterScaleNewVRS, AfterEnsureNewVRS, Done, Error])(s_prime));
             // if at_vd_step_with_vd(vd, controller_id, at_step![AfterScaleNewVRS])(s_prime) {
@@ -795,7 +795,7 @@ pub proof fn current_state_match_vd_implies_exists_old_vrs_set(
             .lemma_map_finite(|vrs: VReplicaSetView| vrs_with_no_rv_status(vrs));
     }
     // |= conjuncted_desired_state_is_vrs(vrs_set)(s)
-    assert forall |vrs| #[trigger] vrs_set.contains(vrs) implies vrs_liveness::desired_state_is(vrs)(s) && vrs.spec.replicas.unwrap_or(1) == 0 by {
+    assert forall |vrs| #[trigger] vrs_set.contains(vrs) implies vrs_liveness::desired_state_is(vrs)(s) && get_replicas(vrs.spec.replicas) == 0 by {
         VReplicaSetView::marshal_preserves_integrity();
         let etcd_obj = choose |obj: DynamicObjectView| #[trigger] s.resources().values().contains(obj) && obj.object_ref() == vrs.object_ref();
         let etcd_vrs = VReplicaSetView::unmarshal(etcd_obj)->Ok_0;
@@ -827,9 +827,9 @@ pub proof fn current_state_match_vd_implies_exists_old_vrs_set(
             assert(etcd_obj.metadata.owner_references->0.filter(controller_owner_filter()).contains(vd.controller_owner_ref()));
         }
         assert(vrs_liveness::desired_state_is(etcd_vrs)(s));
-        if vrs.spec.replicas.unwrap_or(1) > 0 {
+        if get_replicas(vrs.spec.replicas) > 0 {
             let etcd_new_vrs = VReplicaSetView::unmarshal(s.resources()[new_vrs_key])->Ok_0;
-            assert(vrs_with_rv_status.spec.replicas.unwrap_or(1) > 0);
+            assert(get_replicas(vrs_with_rv_status.spec.replicas) > 0);
             assert(valid_owned_obj_key(vd, s)(vrs.object_ref()));
             assert(filter_old_vrs_keys(Some(etcd_new_vrs.metadata.uid->0), s)(vrs.object_ref()));
             assert(false);
@@ -863,7 +863,7 @@ pub proof fn conjuncted_current_state_matches_old_vrs_0_implies_composed(
 {
     VReplicaSetView::marshal_preserves_integrity();
     // new_vrs replicas might be updated during reconciliation
-    let new_vrs = new_vrs.with_spec(new_vrs.spec.with_replicas(vd.spec.replicas.unwrap_or(1)));
+    let new_vrs = new_vrs.with_spec(new_vrs.spec.with_replicas(get_replicas(vd.spec.replicas)));
     assert(s.resources().values().filter(valid_owned_pods(vd, s)) == vrs_liveness::matching_pods(new_vrs, s.resources())) by {
         assert forall |obj: DynamicObjectView| #[trigger] s.resources().values().contains(obj)
             implies valid_owned_pods(vd, s)(obj) == vrs_liveness::owned_selector_match_is(new_vrs, obj) by {
@@ -894,7 +894,7 @@ pub proof fn conjuncted_current_state_matches_old_vrs_0_implies_composed(
                         && vrs_with_no_rv_status(vrs) == vrs_with_no_rv_status(havoc_vrs) && vrs != new_vrs);
                     let havoc_vrs_in_set = choose |vrs: VReplicaSetView| #[trigger] vrs_set.contains(vrs)
                         && vrs_with_no_rv_status(vrs) == vrs_with_no_rv_status(havoc_vrs) && vrs != new_vrs;
-                    assert(havoc_vrs_in_set.spec.replicas.unwrap_or(1) > 0) by {
+                    assert(get_replicas(havoc_vrs_in_set.spec.replicas) > 0) by {
                         assert(vrs_liveness::matching_pods(havoc_vrs_in_set, s.resources()).len() > 0) by {
                             assert(vrs_liveness::matching_pods(havoc_vrs_in_set, s.resources()).contains(obj));
                             // Cluster::etcd_is_finite() |= s.resources().values().is_finite()
@@ -1333,10 +1333,10 @@ pub proof fn rolling_update_leads_to_composed_current_state_matches_vd(
                         false_leads_to_anything(spec, always(new_vrs_post_with_diff(n)));
                     } else {
                         let vrs_with_replicas = new_vrs.with_spec(new_vrs.spec.with_replicas(
-                            if vd.spec.replicas.unwrap_or(1) > new_vrs.spec.replicas.unwrap_or(1) {
-                                vd.spec.replicas.unwrap_or(1) - n
+                            if get_replicas(vd.spec.replicas) > get_replicas(new_vrs.spec.replicas) {
+                                get_replicas(vd.spec.replicas) - n
                             } else {
-                                vd.spec.replicas.unwrap_or(1) + n
+                                get_replicas(vd.spec.replicas) + n
                             }
                         ));
                         use_tla_forall(spec,

--- a/src/controllers/vdeployment_controller/proof/liveness/rolling_update/helper_lemmas.rs
+++ b/src/controllers/vdeployment_controller/proof/liveness/rolling_update/helper_lemmas.rs
@@ -31,9 +31,9 @@ requires
     s.ongoing_reconciles(controller_id).contains_key(vd.object_ref()),
     cluster_invariants_since_reconciliation(cluster, vd, controller_id)(s),
 ensures
-    vd.spec.replicas.unwrap_or(1) > 0 ==> nv_uid_key_replicas_status.2 > 0,
+    get_replicas(vd.spec.replicas) > 0 ==> nv_uid_key_replicas_status.2 > 0,
     // nv_uid_key_replicas.1 (controller's choice) can be different from new_vrs_key when both vd and new_vrs have 0 replicas
-    nv_uid_key_replicas_status.1 != new_vrs_key ==> nv_uid_key_replicas_status.2 == 0 && vd.spec.replicas.unwrap_or(1) == 0,
+    nv_uid_key_replicas_status.1 != new_vrs_key ==> nv_uid_key_replicas_status.2 == 0 && get_replicas(vd.spec.replicas) == 0,
     ru_new_vrs_and_no_old_vrs_from_resp_objs(vd, controller_id, msg, nv_uid_key_replicas_status, new_vrs_key)(s),
 {
     lemma_esr_equiv_to_instantiated_etcd_state_is_with_nv_key(
@@ -124,7 +124,7 @@ ensures
             assert(filter_obj_keys_managed_by_vd(vd, s).filter(filter_old_vrs_keys(new_vrs_uid, s)).len() == 0);
         }
     } else {
-        if new_vrs.spec.replicas.unwrap_or(1) > 0 {
+        if get_replicas(new_vrs.spec.replicas) > 0 {
             assert(new_vrs.metadata.uid->0 != uid_of_vrs_with_nv_key);
             assert(managed_vrs_list.contains(new_vrs)); // trigger
             assert(managed_vrs_list.filter(|vrs: VReplicaSetView| {
@@ -137,7 +137,7 @@ ensures
             assert(filter_obj_keys_managed_by_vd(vd, s).filter(filter_old_vrs_keys(Some(uid_of_vrs_with_nv_key), s)).contains(new_vrs.object_ref()));
             assert(false);
         }
-        if vrs_with_nv_key.spec.replicas.unwrap_or(1) > 0 {
+        if get_replicas(vrs_with_nv_key.spec.replicas) > 0 {
             // vrs with nv_uid_key can pass the nonempty_vrs_filter, it's impossible for new_vrs to be selected here
             assert(new_vrs.metadata.uid->0 != uid_of_vrs_with_nv_key);
             assert(valid_owned_obj_key(vd, s)(new_vrs.object_ref()));
@@ -162,11 +162,11 @@ ensures
             let havoc_vrs = old_vrs_list[0];
             assert(old_vrs_list.contains(havoc_vrs));
             seq_filter_contains_implies_seq_contains(managed_vrs_list, old_vrs_filter, havoc_vrs);
-            assert(havoc_vrs.spec.replicas.unwrap_or(1) > 0);
+            assert(get_replicas(havoc_vrs.spec.replicas) > 0);
             if havoc_vrs.object_ref() == new_vrs_key {
-                assert(vrs_with_nv_key.spec.replicas.unwrap_or(1) > 0);
+                assert(get_replicas(vrs_with_nv_key.spec.replicas) > 0);
                 let vrs_with_nv_key = choose |vrs| #[trigger] managed_vrs_list.contains(vrs) && vrs.object_ref() == new_vrs_key;
-                assert(vrs_with_nv_key.spec.replicas.unwrap_or(1) > 0);
+                assert(get_replicas(vrs_with_nv_key.spec.replicas) > 0);
                 assert(managed_vrs_list.filter(match_template_without_hash(vd.spec.template)).contains(vrs_with_nv_key));
                 assert(managed_vrs_list.filter(match_template_without_hash(vd.spec.template)).filter(nonempty_vrs_filter).contains(vrs_with_nv_key));
                 assert(false);
@@ -181,7 +181,7 @@ ensures
     } else {
         None
     };
-    return (new_vrs_uid->0, new_vrs.object_ref(), new_vrs.spec.replicas.unwrap_or(1), status_replicas);
+    return (new_vrs_uid->0, new_vrs.object_ref(), get_replicas(new_vrs.spec.replicas), status_replicas);
 }
 
 }

--- a/src/controllers/vdeployment_controller/proof/liveness/rolling_update/predicate.rs
+++ b/src/controllers/vdeployment_controller/proof/liveness/rolling_update/predicate.rs
@@ -86,7 +86,7 @@ pub open spec fn ru_resp_msg_is_ok_list_resp_containing_matched_vrs(
         &&& #[trigger] managed_vrs_list.contains(vrs)
         &&& vrs.object_ref() == new_vrs_key
         &&& vrs.status is Some
-        &&& vrs.status->0.replicas == vrs.spec.replicas.unwrap_or(1)
+        &&& vrs.status->0.replicas == get_replicas(vrs.spec.replicas)
     }
 }
 
@@ -117,14 +117,14 @@ pub open spec fn ru_new_vrs_and_no_old_vrs_from_resp_objs(
             }
             &&& old_vrs_list.len() == 0
             // reasoning on nondeterminism in new vrs choice
-            &&& etcd_vrs.spec.replicas.unwrap_or(1) > 0 ==> {
+            &&& get_replicas(etcd_vrs.spec.replicas) > 0 ==> {
                 &&& new_vrs->0.object_ref() == new_vrs_key
                 &&& new_vrs->0.metadata.uid->0 == etcd_vrs.metadata.uid->0
-                &&& new_vrs->0.spec.replicas.unwrap_or(1) > 0
+                &&& get_replicas(new_vrs->0.spec.replicas) > 0
             }
             &&& new_vrs->0.object_ref() != new_vrs_key ==> {
-                &&& new_vrs->0.spec.replicas.unwrap_or(1) == 0
-                &&& vd.spec.replicas.unwrap_or(1) == 0
+                &&& get_replicas(new_vrs->0.spec.replicas) == 0
+                &&& get_replicas(vd.spec.replicas) == 0
             }
         }
     }
@@ -202,7 +202,7 @@ pub open spec fn ru_req_msg_is_scale_new_vrs_by_one_req(
         // owned by vd
         &&& req_vrs.metadata.owner_references is Some
         &&& req_vrs.metadata.owner_references->0.filter(controller_owner_filter()) == seq![vd.controller_owner_ref()]
-        &&& vd.spec.replicas.unwrap_or(1) > 0 ==> req_vrs.spec.replicas.unwrap_or(1) > 0
+        &&& get_replicas(vd.spec.replicas) > 0 ==> get_replicas(req_vrs.spec.replicas) > 0
         &&& key == req_vrs.object_ref()
         // required by rank_never_increases
         // before the request is applied, it's < or >

--- a/src/controllers/vdeployment_controller/proof/liveness/rolling_update/resource_match.rs
+++ b/src/controllers/vdeployment_controller/proof/liveness/rolling_update/resource_match.rs
@@ -317,12 +317,12 @@ ensures
                     VDeploymentReconcileState::marshal_preserves_integrity();
                     VReplicaSetView::marshal_preserves_integrity();
                     let etcd_vrs = VReplicaSetView::unmarshal(s.resources()[new_vrs.object_ref()])->Ok_0;
-                    if etcd_vrs.spec.replicas.unwrap_or(1) == vd.spec.replicas.unwrap_or(1) {
+                    if get_replicas(etcd_vrs.spec.replicas) == get_replicas(vd.spec.replicas) {
                         assert(false); // diff > 0
                     }
-                    if etcd_vrs.spec.replicas.unwrap_or(1) == 0 {
-                        assert(vd.spec.replicas.unwrap_or(1) >= 0);
-                        if vd.spec.replicas.unwrap_or(1) != 0 {
+                    if get_replicas(etcd_vrs.spec.replicas) == 0 {
+                        assert(get_replicas(vd.spec.replicas) >= 0);
+                        if get_replicas(vd.spec.replicas) != 0 {
                             assert(false); // diff > 0
                         } else {
                             assert(false); // vd > 0 ==> vrs > 0
@@ -442,8 +442,8 @@ requires
     ru_resp_msg_is_pending_list_resp_in_flight_and_match_req(vd, controller_id, resp_msg, new_vrs_key)(s),
     inductive_current_state_matches(vd, controller_id, new_vrs_key)(s),
     // from diff != 0
-    VReplicaSetView::unmarshal(s.resources()[new_vrs_key])->Ok_0.spec.replicas.unwrap_or(1) > 0,
-    VReplicaSetView::unmarshal(s.resources()[new_vrs_key])->Ok_0.spec.replicas.unwrap_or(1) != vd.spec.replicas.unwrap_or(1)
+    get_replicas(VReplicaSetView::unmarshal(s.resources()[new_vrs_key])->Ok_0.spec.replicas) > 0,
+    get_replicas(VReplicaSetView::unmarshal(s.resources()[new_vrs_key])->Ok_0.spec.replicas) != get_replicas(vd.spec.replicas)
 ensures
     at_vd_step_with_vd(vd, controller_id, at_step![AfterScaleNewVRS])(s_prime),
     local_state_at_after_scale_vrs(vd, controller_id, new_vrs_key)(s_prime),
@@ -524,7 +524,7 @@ ensures
         }
     }
     if new_vrs.object_ref() != new_vrs_key {
-        assert(etcd_new_vrs.spec.replicas.unwrap_or(1) > 0);
+        assert(get_replicas(etcd_new_vrs.spec.replicas) > 0);
         // vrs with nv_uid_key can pass the nonempty_vrs_filter, it's impossible for new_vrs to be selected here
         assert(new_vrs.metadata.uid->0 != etcd_new_vrs.metadata.uid->0);
         assert(valid_owned_obj_key(vd, s)(new_vrs.object_ref()));
@@ -541,18 +541,18 @@ ensures
         assert(!managed_vrs_list.filter(match_template_without_hash(vd.spec.template)).filter(nonempty_vrs_filter).contains(new_vrs));
         assert(false);
     }
-    assert(new_vrs.status is Some && new_vrs.status->0.replicas == new_vrs.spec.replicas.unwrap_or(1)) by {
+    assert(new_vrs.status is Some && new_vrs.status->0.replicas == get_replicas(new_vrs.spec.replicas)) by {
         assert(exists |vrs| {
             &&& #[trigger] managed_vrs_list.contains(vrs)
             &&& vrs.object_ref() == new_vrs_key
             &&& vrs.status is Some
-            &&& vrs.status->0.replicas == vrs.spec.replicas.unwrap_or(1)
+            &&& vrs.status->0.replicas == get_replicas(vrs.spec.replicas)
         });
         let pretend_to_be_non_new_vrs = choose |vrs| {
             &&& #[trigger] managed_vrs_list.contains(vrs)
             &&& vrs.object_ref() == new_vrs_key
             &&& vrs.status is Some
-            &&& vrs.status->0.replicas == vrs.spec.replicas.unwrap_or(1)
+            &&& vrs.status->0.replicas == get_replicas(vrs.spec.replicas)
         };
         if pretend_to_be_non_new_vrs != new_vrs {
             VReplicaSetView::marshal_preserves_integrity();
@@ -587,7 +587,7 @@ requires
     resp_msg_is_pending_list_resp_in_flight_and_match_req(vd, controller_id, resp_msg)(s),
     ru_new_vrs_and_no_old_vrs_from_resp_objs(vd, controller_id, resp_msg, nv_uid_key_replicas_status, new_vrs_key)(s),
 ensures
-    if (nv_uid_key_replicas_status.2 == 0 || (nv_uid_key_replicas_status.3 is Some && nv_uid_key_replicas_status.3->0 == nv_uid_key_replicas_status.2)) && nv_uid_key_replicas_status.2 != vd.spec.replicas.unwrap_or(int1!()) { // mismatch_replicas
+    if (nv_uid_key_replicas_status.2 == 0 || (nv_uid_key_replicas_status.3 is Some && nv_uid_key_replicas_status.3->0 == nv_uid_key_replicas_status.2)) && nv_uid_key_replicas_status.2 != get_replicas(vd.spec.replicas) { // mismatch_replicas
         &&& at_vd_step_with_vd(vd, controller_id, at_step![AfterScaleNewVRS])(s_prime)
         &&& local_state_at_after_scale_vrs(vd, controller_id, new_vrs_key)(s_prime)
         &&& ru_pending_scale_new_vrs_by_one_req_in_flight(vd, controller_id)(s_prime)
@@ -601,12 +601,12 @@ ensures
         let local_state_prime = VDeploymentReconcileState::unmarshal(s_prime.ongoing_reconciles(controller_id)[vd.object_ref()].local_state).unwrap();
         let etcd_vrs = VReplicaSetView::unmarshal(s.resources()[new_vrs_key])->Ok_0;
         &&& local_state_prime.new_vrs is Some
-        &&& etcd_vrs.spec.replicas.unwrap_or(1) > 0 ==> {
+        &&& get_replicas(etcd_vrs.spec.replicas) > 0 ==> {
             &&& local_state_prime.new_vrs->0.object_ref() == new_vrs_key
             &&& local_state_prime.new_vrs->0.metadata.uid->0 == etcd_vrs.metadata.uid->0
         }
         &&& local_state_prime.new_vrs->0.object_ref() != new_vrs_key ==> {
-            &&& local_state_prime.new_vrs->0.spec.replicas.unwrap_or(1) == 0
+            &&& get_replicas(local_state_prime.new_vrs->0.spec.replicas) == 0
         }
     }),
 {

--- a/src/controllers/vdeployment_controller/proof/liveness/terminate.rs
+++ b/src/controllers/vdeployment_controller/proof/liveness/terminate.rs
@@ -26,7 +26,7 @@ pub open spec fn scale_down_old_vrs_rank_n(n: nat) -> spec_fn(ReconcileLocalStat
 
 pub open spec fn new_vrs_some_and_replicas(n: nat) -> spec_fn(VDeploymentReconcileState) -> bool {
     // vrs.spec.replicas.is_None => 1 replica
-    |vds: VDeploymentReconcileState| vds.new_vrs is Some && vds.new_vrs.unwrap().spec.replicas.unwrap_or(1) == n
+    |vds: VDeploymentReconcileState| vds.new_vrs is Some && get_replicas(vds.new_vrs.unwrap().spec.replicas) == n
 }
 
 pub proof fn reconcile_eventually_terminates(

--- a/src/controllers/vdeployment_controller/proof/predicate.rs
+++ b/src/controllers/vdeployment_controller/proof/predicate.rs
@@ -278,7 +278,7 @@ pub open spec fn resp_msg_is_ok_create_resp_containing_new_vrs(
     // strengthen valid_owned_vrs, as only one controller owner is allowed
     &&& vrs.metadata.owner_references is Some
     &&& vrs.metadata.owner_references->0.filter(controller_owner_filter()) == seq![vd.controller_owner_ref()]
-    &&& vrs.spec.replicas.unwrap_or(1) == created_replicas(vd.spec.replicas)
+    &&& get_replicas(vrs.spec.replicas) == created_replicas(vd.spec.replicas)
     // this combined with all above ==> valid_owned_vrs
     &&& vrs.metadata.deletion_timestamp is None
     &&& s.resources().contains_key(key)
@@ -329,7 +329,7 @@ pub open spec fn req_msg_is_scale_old_vrs_req(
         // of course, replica isn't updated locally
         &&& req_vrs.metadata.without_resource_version() == local_vrs.metadata.without_resource_version()
         // this is important, then we know etcd_vrs can pass old_vrs_filter from the coherence predicate
-        &&& pre_update ==> etcd_vrs.spec.replicas.unwrap_or(1) > 0
+        &&& pre_update ==> get_replicas(etcd_vrs.spec.replicas) > 0
         // derive from no_duplicates(), coherence isn't affected
         &&& forall |i: int| #![trigger state.old_vrs_list[i]] 0 <= i < state.old_vrs_index ==>
             state.old_vrs_list[i].object_ref() != key
@@ -379,7 +379,7 @@ pub open spec fn req_msg_is_scale_new_vrs_req(
         &&& req_vrs.metadata.owner_references is Some
         &&& req_vrs.metadata.owner_references->0.filter(controller_owner_filter()) == seq![vd.controller_owner_ref()]
         // scaled down vrs should not pass old vrs filter in s_prime
-        &&& req_vrs.spec.replicas.unwrap_or(1) == nv_uid_key_replicas.2
+        &&& get_replicas(req_vrs.spec.replicas) == nv_uid_key_replicas.2
         &&& key == state.new_vrs->0.object_ref()
         &&& key == req_vrs.object_ref()
     }
@@ -496,7 +496,7 @@ pub open spec fn etcd_state_is(vd: VDeploymentView, controller_id: int, nv_uid_k
                 &&& filter_new_vrs_keys(vd.spec.template, s)(key)
                 &&& etcd_vrs.metadata.uid is Some
                 &&& etcd_vrs.metadata.uid->0 == uid
-                &&& etcd_vrs.spec.replicas.unwrap_or(1) == replicas
+                &&& get_replicas(etcd_vrs.spec.replicas) == replicas
             },
             None => {
                 &&& !exists |k: ObjectRef| {
@@ -514,7 +514,7 @@ pub open spec fn instantiated_etcd_state_is_with_zero_old_vrs_and_nv_key(vd: VDe
 -> StatePred<ClusterState> {
     |s: ClusterState| exists |nv_uid_replicas: (Uid, int)| {
         // holds after state is stable
-        &&& vd.spec.replicas.unwrap_or(1) > 0 ==> nv_uid_replicas.1 > 0
+        &&& get_replicas(vd.spec.replicas) > 0 ==> nv_uid_replicas.1 > 0
         &&& #[trigger] etcd_state_is(vd, controller_id, Some((nv_uid_replicas.0, new_vrs_key, nv_uid_replicas.1)), 0)(s)
     }
 }
@@ -770,13 +770,13 @@ pub open spec fn inductive_current_state_matches(vd: VDeploymentView, controller
             // if vd has 0 replicas, local new vrs can have 0 replicas or not
             // if the new_vrs in etcd has > 0 replicas, it will be chosen at after list step
             &&& local_state.reconcile_step == AfterScaleNewVRS || local_state.reconcile_step == AfterEnsureNewVRS ==> {
-                &&& local_state.new_vrs is Some && etcd_vrs.spec.replicas.unwrap_or(1) > 0 ==> {
+                &&& local_state.new_vrs is Some && get_replicas(etcd_vrs.spec.replicas) > 0 ==> {
                     &&& local_state.new_vrs->0.object_ref() == new_vrs_key
                     &&& local_state.new_vrs->0.metadata.uid->0 == etcd_vrs.metadata.uid->0
                 }
                 &&& local_state.new_vrs is Some && local_state.new_vrs->0.object_ref() != new_vrs_key ==> {
-                    &&& vd.spec.replicas.unwrap_or(1) == 0 // optional, can be implied from above
-                    &&& local_state.new_vrs->0.spec.replicas.unwrap_or(1) == 0
+                    &&& get_replicas(vd.spec.replicas) == 0 // optional, can be implied from above
+                    &&& get_replicas(local_state.new_vrs->0.spec.replicas) == 0
                 }
                 &&& local_state.old_vrs_index == 0
             }

--- a/src/controllers/vdeployment_controller/proof/predicate.rs
+++ b/src/controllers/vdeployment_controller/proof/predicate.rs
@@ -524,6 +524,9 @@ pub open spec fn instantiated_etcd_state_is_with_zero_old_vrs_and_nv_key(vd: VDe
 //    --> verus/source/target-verus/release/vstd/std_specs/option.rs:194:9
 //     |
 // 194 |         Some(t) => t,
+// and
+// error: variable shadowing not yet supported
+ // --> vstd/std_specs/option.rs:167:10
 pub open spec fn get_replicas(i: Option<int>) -> int {
     i.unwrap_or(int1!())
 }

--- a/src/deps_hack/Cargo.lock
+++ b/src/deps_hack/Cargo.lock
@@ -34,7 +34,7 @@ version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91429305e9f0a25f6205c5b8e0d2db09e0708a7a6df0f42212bb56c32c8ac97a"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "getrandom",
  "once_cell",
  "version_check",
@@ -153,7 +153,7 @@ checksum = "2089b7e3f35b9dd2d0ed921ead4f6d318c27680d4a5bd167b3ee120edb105837"
 dependencies = [
  "addr2line",
  "cc",
- "cfg-if 1.0.0",
+ "cfg-if",
  "libc",
  "miniz_oxide",
  "object",
@@ -233,7 +233,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfd1e3f8955a5d7de9fab72fc8373fade9fb8a703968cb200ae3dc6cf08e185a"
 dependencies = [
  "borsh-derive",
- "bytes 1.5.0",
+ "bytes",
  "cfg_aliases",
 ]
 
@@ -286,12 +286,6 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "0.5.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e4cec68f03f32e44924783795810fa50a7035d8c8ebe78580ad7e6c703fba38"
-
-[[package]]
-name = "bytes"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2bd12c1caf447e69cd4528f47f94d203fd2582878ecb9e9465484c4148a8223"
@@ -305,12 +299,6 @@ dependencies = [
  "find-msvc-tools",
  "shlex",
 ]
-
-[[package]]
-name = "cfg-if"
-version = "0.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
 
 [[package]]
 name = "cfg-if"
@@ -455,7 +443,6 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "warp",
- "zookeeper",
 ]
 
 [[package]]
@@ -497,7 +484,7 @@ version = "0.8.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
 ]
 
 [[package]]
@@ -578,22 +565,6 @@ checksum = "e13624c2627564efccf4934284bdd98cbaa14e79b0b5a141218e507b3a823456"
 dependencies = [
  "percent-encoding",
 ]
-
-[[package]]
-name = "fuchsia-zircon"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e9763c69ebaae630ba35f74888db465e49e259ba1bc0eda7d06f4a067615d82"
-dependencies = [
- "bitflags 1.3.2",
- "fuchsia-zircon-sys",
-]
-
-[[package]]
-name = "fuchsia-zircon-sys"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7"
 
 [[package]]
 name = "funty"
@@ -706,7 +677,7 @@ version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fe9006bed769170c11f845cf00c7c1e9092aeb3f268e007c3e760ac68008070f"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "libc",
  "wasi",
 ]
@@ -723,7 +694,7 @@ version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81fe527a889e1532da5c525686d96d4c2e74cdd345badf8dfef9f6b39dd5f5e8"
 dependencies = [
- "bytes 1.5.0",
+ "bytes",
  "fnv",
  "futures-core",
  "futures-sink",
@@ -768,7 +739,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06683b93020a07e3dbcf5f8c0f6d40080d725bea7936fc01ad345c01b97dc270"
 dependencies = [
  "base64 0.21.5",
- "bytes 1.5.0",
+ "bytes",
  "headers-core",
  "http 0.2.12",
  "httpdate",
@@ -806,7 +777,7 @@ version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "601cbb57e577e2f5ef5be8e7b83f0f63994f25aa94d673e54a92d5c516d101f1"
 dependencies = [
- "bytes 1.5.0",
+ "bytes",
  "fnv",
  "itoa",
 ]
@@ -817,7 +788,7 @@ version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "21b9ddb458710bc376481b842f5da65cdf31522de232c1ca8146abce2a358258"
 dependencies = [
- "bytes 1.5.0",
+ "bytes",
  "fnv",
  "itoa",
 ]
@@ -828,7 +799,7 @@ version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ceab25649e9960c0311ea418d17bee82c0dcec1bd053b5f9a66e265a693bed2"
 dependencies = [
- "bytes 1.5.0",
+ "bytes",
  "http 0.2.12",
  "pin-project-lite",
 ]
@@ -839,7 +810,7 @@ version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1cac85db508abc24a2e48553ba12a996e87244a0395ce011e62b37158745d643"
 dependencies = [
- "bytes 1.5.0",
+ "bytes",
  "http 1.1.0",
 ]
 
@@ -849,7 +820,7 @@ version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0475f8b2ac86659c21b64320d5d653f9efe42acd2a4e560073ec61a155a34f1d"
 dependencies = [
- "bytes 1.5.0",
+ "bytes",
  "futures-core",
  "http 1.1.0",
  "http-body 1.0.0",
@@ -874,7 +845,7 @@ version = "0.14.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "41dfc780fdec9373c01bae43289ea34c972e40ee3c9f6b3c8801a35f35586ce7"
 dependencies = [
- "bytes 1.5.0",
+ "bytes",
  "futures-channel",
  "futures-core",
  "futures-util",
@@ -898,7 +869,7 @@ version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fe575dd17d0862a9a33781c8c4696a55c320909004a67a00fb286ba8b1bc496d"
 dependencies = [
- "bytes 1.5.0",
+ "bytes",
  "futures-channel",
  "futures-util",
  "http 1.1.0",
@@ -968,7 +939,7 @@ version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b875924a60b96e5d7b9ae7b066540b1dd1cbd90d1828f54c92e02a283351c56"
 dependencies = [
- "bytes 1.5.0",
+ "bytes",
  "futures-channel",
  "futures-util",
  "http 1.1.0",
@@ -1037,16 +1008,7 @@ version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
 dependencies = [
- "cfg-if 1.0.0",
-]
-
-[[package]]
-name = "iovec"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2b3ea6ff95e175473f8ffe6a7eb7c00d054240321b84c57051175fe3c1e075e"
-dependencies = [
- "libc",
+ "cfg-if",
 ]
 
 [[package]]
@@ -1106,16 +1068,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "kernel32-sys"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
-dependencies = [
- "winapi 0.2.8",
- "winapi-build",
-]
-
-[[package]]
 name = "kube"
 version = "0.91.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1135,7 +1087,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47164ad6c47398ee4bdf90509c7b44026229721cb1377eb4623a1ec2a00a85e9"
 dependencies = [
  "base64 0.22.1",
- "bytes 1.5.0",
+ "bytes",
  "chrono",
  "either",
  "futures",
@@ -1246,12 +1198,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
-name = "lazycell"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
-
-[[package]]
 name = "libc"
 version = "0.2.179"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1333,25 +1279,6 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "0.6.23"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4afd66f5b91bf2a3bc13fad0e21caedac168ca4c707504e75585648ae80e4cc4"
-dependencies = [
- "cfg-if 0.1.10",
- "fuchsia-zircon",
- "fuchsia-zircon-sys",
- "iovec",
- "kernel32-sys",
- "libc",
- "log",
- "miow",
- "net2",
- "slab",
- "winapi 0.2.8",
-]
-
-[[package]]
-name = "mio"
 version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f3d0b296e374a4e6f3c7b0a1f5a51d748a0d34c85e7dc48fc3fa9a87657fe09"
@@ -1362,36 +1289,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "mio-extras"
-version = "2.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52403fe290012ce777c4626790c8951324a2b9e3316b3143779c72b029742f19"
-dependencies = [
- "lazycell",
- "log",
- "mio 0.6.23",
- "slab",
-]
-
-[[package]]
-name = "miow"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebd808424166322d4a38da87083bfddd3ac4c131334ed55856112eb06d46944d"
-dependencies = [
- "kernel32-sys",
- "net2",
- "winapi 0.2.8",
- "ws2_32-sys",
-]
-
-[[package]]
 name = "multer"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "01acbdc23469fd8fe07ab135923371d5f5a422fbf9c522158677c8eb15bc51c2"
 dependencies = [
- "bytes 1.5.0",
+ "bytes",
  "encoding_rs",
  "futures-util",
  "http 0.2.12",
@@ -1401,17 +1304,6 @@ dependencies = [
  "mime",
  "spin",
  "version_check",
-]
-
-[[package]]
-name = "net2"
-version = "0.2.39"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b13b648036a2339d06de780866fbdfda0dde886de7b3af2ddeba8b14f4ee34ac"
-dependencies = [
- "cfg-if 0.1.10",
- "libc",
- "winapi 0.3.9",
 ]
 
 [[package]]
@@ -1474,7 +1366,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08838db121398ad17ab8531ce9de97b244589089e290a384c900cb9ff7434328"
 dependencies = [
  "bitflags 2.4.1",
- "cfg-if 1.0.0",
+ "cfg-if",
  "foreign-types",
  "libc",
  "once_cell",
@@ -1542,7 +1434,7 @@ version = "0.9.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c42a9226546d68acdd9c0a280d17ce19bfe27a46bf68784e4066115788d008e"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "libc",
  "redox_syscall",
  "smallvec",
@@ -1826,7 +1718,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
 dependencies = [
  "cc",
- "cfg-if 1.0.0",
+ "cfg-if",
  "getrandom",
  "libc",
  "untrusted",
@@ -1841,7 +1733,7 @@ checksum = "2297bf9c81a3f0dc96bc9521370b88f054168c29826a75e89c55ff196e7ed6a1"
 dependencies = [
  "bitvec",
  "bytecheck",
- "bytes 1.5.0",
+ "bytes",
  "hashbrown 0.12.3",
  "ptr_meta",
  "rend",
@@ -1870,7 +1762,7 @@ checksum = "61f703d19852dbf87cbc513643fa81428361eb6940f1ac14fd58155d295a3eb0"
 dependencies = [
  "arrayvec",
  "borsh",
- "bytes 1.5.0",
+ "bytes",
  "num-traits",
  "rand",
  "rkyv",
@@ -2167,7 +2059,7 @@ version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "cpufeatures",
  "digest",
 ]
@@ -2178,7 +2070,7 @@ version = "0.10.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "793db75ad2bcafc3ffa7c68b215fee268f537982cd901d132f89c6343f3a3dc8"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "cpufeatures",
  "digest",
 ]
@@ -2227,12 +2119,6 @@ name = "smallvec"
 version = "1.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
-
-[[package]]
-name = "snowflake"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27207bb65232eda1f588cf46db2fee75c0808d557f6b3cf19a75f5d6d7c94df1"
 
 [[package]]
 name = "socket2"
@@ -2296,7 +2182,7 @@ version = "3.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "01ce4141aa927a6d1bd34a041795abd0db1cccba5d5f24b009f694bdf3a1f3fa"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "fastrand",
  "redox_syscall",
  "rustix",
@@ -2349,7 +2235,7 @@ version = "1.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3fdd6f064ccff2d6567adcb3873ca630700f00b5ad3f060c25b5dcfd9a4ce152"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "once_cell",
 ]
 
@@ -2375,9 +2261,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68722da18b0fc4a05fdc1120b302b82051265792a1e1b399086e9b204b10ad3d"
 dependencies = [
  "backtrace",
- "bytes 1.5.0",
+ "bytes",
  "libc",
- "mio 0.8.10",
+ "mio",
  "num_cpus",
  "parking_lot",
  "pin-project-lite",
@@ -2438,7 +2324,7 @@ version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5419f34732d9eb6ee4c3578b7989078579b7f039cbbb9ca2c4da015749371e15"
 dependencies = [
- "bytes 1.5.0",
+ "bytes",
  "futures-core",
  "futures-sink",
  "pin-project-lite",
@@ -2502,7 +2388,7 @@ checksum = "1e9cd434a998747dd2c4276bc96ee2e0c7a2eadf3cae88e52be55a05fa9053f5"
 dependencies = [
  "base64 0.21.5",
  "bitflags 2.4.1",
- "bytes 1.5.0",
+ "bytes",
  "http 1.1.0",
  "http-body 1.0.0",
  "http-body-util",
@@ -2596,7 +2482,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ef1a641ea34f399a848dea702823bbecfb4c486f911735368f1f137cb8257e1"
 dependencies = [
  "byteorder",
- "bytes 1.5.0",
+ "bytes",
  "data-encoding",
  "http 1.1.0",
  "httparse",
@@ -2734,7 +2620,7 @@ version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4378d202ff965b011c64817db11d5829506d3404edeadb61f190d111da3f231c"
 dependencies = [
- "bytes 1.5.0",
+ "bytes",
  "futures-channel",
  "futures-util",
  "headers",
@@ -2771,7 +2657,7 @@ version = "0.2.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6532f9a5c1ece3798cb1c2cfdba640b9b3ba884f5db45973a6f442510a87d38e"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "once_cell",
  "rustversion",
  "wasm-bindgen-macro",
@@ -2809,40 +2695,6 @@ checksum = "75a326b8c223ee17883a4251907455a2431acc2791c98c26279376490c378c16"
 dependencies = [
  "unicode-ident",
 ]
-
-[[package]]
-name = "winapi"
-version = "0.2.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "167dc9d6949a9b857f3451275e911c3f44255842c1f7a76f33c55103a909087a"
-
-[[package]]
-name = "winapi"
-version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
-dependencies = [
- "winapi-i686-pc-windows-gnu",
- "winapi-x86_64-pc-windows-gnu",
-]
-
-[[package]]
-name = "winapi-build"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d315eee3b34aca4797b2da6b13ed88266e6d612562a0c46390af8299fc699bc"
-
-[[package]]
-name = "winapi-i686-pc-windows-gnu"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
-
-[[package]]
-name = "winapi-x86_64-pc-windows-gnu"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-core"
@@ -3023,16 +2875,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a90e88e4667264a994d34e6d1ab2d26d398dcdca8b7f52bec8668957517fc7d8"
 
 [[package]]
-name = "ws2_32-sys"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d59cefebd0c892fa2dd6de581e937301d8552cb44489cdff035c6187cb63fa5e"
-dependencies = [
- "winapi 0.2.8",
- "winapi-build",
-]
-
-[[package]]
 name = "wyz"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3066,29 +2908,3 @@ name = "zeroize"
 version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "525b4ec142c6b68a2d10f01f7bbf6755599ca3f81ea53b8431b7dd348f5fdb2d"
-
-[[package]]
-name = "zookeeper"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2312b424380193701a7341cec0551b80d2e3afd827ea0d3440af67899156ce10"
-dependencies = [
- "byteorder",
- "bytes 0.5.6",
- "lazy_static",
- "log",
- "mio 0.6.23",
- "mio-extras",
- "snowflake",
- "zookeeper_derive",
-]
-
-[[package]]
-name = "zookeeper_derive"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42307291e3c8b2e4082e5647572da863f0470511d0ecb1618a4cd0a361549723"
-dependencies = [
- "quote",
- "syn 1.0.109",
-]

--- a/src/deps_hack/Cargo.toml
+++ b/src/deps_hack/Cargo.toml
@@ -31,7 +31,7 @@ anyhow = "1.0.71"
 futures = "0.3.17"
 base64 = "0.13.0"
 rand = "0.8"
-zookeeper = "0.8"
+# zookeeper = "0.8"
 chrono = "0.4.19"
 proptest = "1.4.0"
 warp = { version = "0.3", features = ["tls"] }

--- a/src/deps_hack/src/lib.rs
+++ b/src/deps_hack/src/lib.rs
@@ -18,7 +18,12 @@ pub use tokio;
 pub use tracing;
 pub use tracing_subscriber;
 pub use warp;
-pub use zookeeper;
+/*
+Note: zookeeper 0.8.0 is not actively maintained, we don't want it to break verita once Rust drops the support for its syntax:
+warning: the following packages contain code that will be rejected by a future version of Rust: zookeeper v0.8.0
+for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/never-type-fallback.html>
+*/
+// pub use zookeeper;
 pub use kube_quantity;
 
 #[derive(Debug, thiserror::Error)]


### PR DESCRIPTION
This PR updates CI to use the most recent version of Verus, fixes failed proof caused by the update and removed zookeeper because it's not actively maintained and will not be supported by newer version of Rust soon.

After this update, proofs on VStatefulSet controller are much slower. This performance regression is left to future PR to fix.