### PR TITLE
add rlib to ignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,12 +8,11 @@ src/.verus-log/
 e2e/target/
 /target
 /Cargo.lock
-src/liblib.rlib
 verifiable-controllers.code-workspace
 src/.verus-solver-log/
 src/*.d
-src/*.rlib
 src/*.o
+**/*.rlib
 tools/*.json
 vreplicaset_controller.*.txt
 vstatefulset_controller.*.txt


### PR DESCRIPTION
This PR adds rlib to ignore in all locations to avoid including the side effect of `verus --crate-type=lib`