### PR TITLE
Weaken gc lemma preconditions

### DIFF
--- a/src/controllers/rabbitmq_controller/proof/helper_invariants/proof.rs
+++ b/src/controllers/rabbitmq_controller/proof/helper_invariants/proof.rs
@@ -1938,7 +1938,7 @@ proof fn lemma_eventually_always_resource_object_only_has_owner_reference_pointi
     assert forall |s: ClusterState|
         #[trigger] object_in_every_resource_update_request_only_has_owner_references_pointing_to_current_cr(controller_id, sub_resource, rabbitmq)(s)
         && no_get_then_requests_and_update_resource_status_requests_in_flight(sub_resource, rabbitmq)(s)
-        implies Cluster::every_update_msg_sets_owner_references_as(key, eventual_owner_ref)(s) by {
+        implies Cluster::every_valid_update_msg_sets_owner_references_as(cluster.installed_types, key, eventual_owner_ref)(s) by {
         assert forall |msg: Message| s.in_flight().contains(msg) && #[trigger] resource_update_request_msg(key)(msg)
             implies eventual_owner_ref(msg.content.get_update_request().obj.metadata.owner_references) by {
         }
@@ -1963,7 +1963,7 @@ proof fn lemma_eventually_always_resource_object_only_has_owner_reference_pointi
     always_weaken(spec,
         lift_state(object_in_every_resource_update_request_only_has_owner_references_pointing_to_current_cr(controller_id, sub_resource, rabbitmq))
             .and(lift_state(no_get_then_requests_and_update_resource_status_requests_in_flight(sub_resource, rabbitmq))),
-        lift_state(Cluster::every_update_msg_sets_owner_references_as(key, eventual_owner_ref))
+        lift_state(Cluster::every_valid_update_msg_sets_owner_references_as(cluster.installed_types, key, eventual_owner_ref))
     );
     always_weaken(spec, lift_state(every_resource_create_request_implies_at_after_create_resource_step(controller_id, sub_resource, rabbitmq)), lift_state(Cluster::every_create_msg_sets_owner_references_as(key, eventual_owner_ref)));
     always_weaken(spec, lift_state(resource_object_has_no_finalizers_or_timestamp_and_only_has_controller_owner_ref(sub_resource, rabbitmq)), lift_state(Cluster::object_has_no_finalizers(key)));

--- a/src/controllers/vstatefulset_controller/proof/helper_invariants.rs
+++ b/src/controllers/vstatefulset_controller/proof/helper_invariants.rs
@@ -544,7 +544,7 @@ ensures
     );
 }
 
-pub proof fn lemma_eventually_always_every_update_msg_sets_owner_references_as_for_all(
+pub proof fn lemma_eventually_always_every_valid_update_msg_sets_owner_references_as_for_all(
     spec: TempPred<ClusterState>, cluster: Cluster, controller_id: int, vsts: VStatefulSetView
 )
 requires
@@ -562,7 +562,8 @@ requires
     cluster.type_is_installed_in_cluster::<VStatefulSetView>(),
     cluster.controller_models.contains_pair(controller_id, vsts_controller_model()),
 ensures
-    spec.entails(true_pred().leads_to(always(lift_state(Cluster::every_update_msg_sets_owner_references_as_for_all(
+    spec.entails(true_pred().leads_to(always(lift_state(Cluster::every_valid_update_msg_sets_owner_references_as_for_all(
+        cluster.installed_types,
         is_vsts_pod_key(vsts),
         owner_reference_requirements(vsts)
     )))))
@@ -648,9 +649,9 @@ ensures
     );
     cluster.lemma_true_leads_to_always_every_in_flight_req_msg_satisfies(spec, requirements);
     assert forall |ex: Execution<ClusterState>| #[trigger] lift_state(Cluster::every_in_flight_req_msg_satisfies(requirements)).satisfied_by(ex)
-        implies lift_state(Cluster::every_update_msg_sets_owner_references_as_for_all(is_vsts_pod_key(vsts), owner_reference_requirements(vsts))).satisfied_by(ex) by {
+        implies lift_state(Cluster::every_valid_update_msg_sets_owner_references_as_for_all(cluster.installed_types, is_vsts_pod_key(vsts), owner_reference_requirements(vsts))).satisfied_by(ex) by {
         let s = ex.head();
-        assert forall |key: ObjectRef| #[trigger] is_vsts_pod_key(vsts)(key) implies Cluster::every_update_msg_sets_owner_references_as(key, owner_reference_requirements(vsts))(s) by {
+        assert forall |key: ObjectRef| #[trigger] is_vsts_pod_key(vsts)(key) implies Cluster::every_valid_update_msg_sets_owner_references_as(cluster.installed_types, key, owner_reference_requirements(vsts))(s) by {
             assert forall |msg: Message| s.in_flight().contains(msg) && #[trigger] resource_update_request_msg(key)(msg)
                 implies owner_reference_requirements(vsts)(msg.content.get_update_request().obj.metadata.owner_references) by {
                 assert(key_cond(key));
@@ -666,16 +667,16 @@ ensures
     };
     entails_preserved_by_always(
         lift_state(Cluster::every_in_flight_req_msg_satisfies(requirements)),
-        lift_state(Cluster::every_update_msg_sets_owner_references_as_for_all(is_vsts_pod_key(vsts), owner_reference_requirements(vsts)))
+        lift_state(Cluster::every_valid_update_msg_sets_owner_references_as_for_all(cluster.installed_types, is_vsts_pod_key(vsts), owner_reference_requirements(vsts)))
     );
     entails_implies_leads_to(spec,
         always(lift_state(Cluster::every_in_flight_req_msg_satisfies(requirements))),
-        always(lift_state(Cluster::every_update_msg_sets_owner_references_as_for_all(is_vsts_pod_key(vsts), owner_reference_requirements(vsts))))
+        always(lift_state(Cluster::every_valid_update_msg_sets_owner_references_as_for_all(cluster.installed_types, is_vsts_pod_key(vsts), owner_reference_requirements(vsts))))
     );
     leads_to_trans(spec,
         true_pred(),
         always(lift_state(Cluster::every_in_flight_req_msg_satisfies(requirements))),
-        always(lift_state(Cluster::every_update_msg_sets_owner_references_as_for_all(is_vsts_pod_key(vsts), owner_reference_requirements(vsts))))
+        always(lift_state(Cluster::every_valid_update_msg_sets_owner_references_as_for_all(cluster.installed_types, is_vsts_pod_key(vsts), owner_reference_requirements(vsts))))
     );
 }
 
@@ -692,8 +693,8 @@ requires
     spec.entails(always(lift_state(Cluster::every_create_msg_sets_owner_references_as_for_all(
         is_vsts_pod_key(vsts), owner_reference_requirements(vsts)
     )))),
-    spec.entails(always(lift_state(Cluster::every_update_msg_sets_owner_references_as_for_all(
-        is_vsts_pod_key(vsts), owner_reference_requirements(vsts)
+    spec.entails(always(lift_state(Cluster::every_valid_update_msg_sets_owner_references_as_for_all(
+        cluster.installed_types, is_vsts_pod_key(vsts), owner_reference_requirements(vsts)
     )))),
     spec.entails(always(lift_state(Cluster::every_create_msg_with_generate_name_matching_key_set_owner_references_as_for_all(
         is_vsts_pod_key(vsts), owner_reference_requirements(vsts)

--- a/src/controllers/vstatefulset_controller/proof/liveness/proof.rs
+++ b/src/controllers/vstatefulset_controller/proof/liveness/proof.rs
@@ -277,7 +277,7 @@ pub proof fn spec_of_previous_phases_entails_eventually_new_invariants(provided_
                 entails_trans(spec, provided_spec, always(lift_state(vsts_rely_conditions_pod_monkey())));
             }
             helper_invariants::lemma_eventually_always_every_create_msg_sets_owner_references_as_for_all(spec, cluster, controller_id, vsts);
-            helper_invariants::lemma_eventually_always_every_update_msg_sets_owner_references_as_for_all(spec, cluster, controller_id, vsts);
+            helper_invariants::lemma_eventually_always_every_valid_update_msg_sets_owner_references_as_for_all(spec, cluster, controller_id, vsts);
             helper_invariants::lemma_eventually_always_every_create_msg_with_generate_name_matching_key_set_owner_references_as_for_all(spec, cluster, controller_id, vsts);
             helper_invariants::lemma_eventually_buildin_controllers_do_not_delete_pods_owned_by_vsts(spec, cluster, controller_id, vsts);
             leads_to_always_combine_n!(
@@ -286,8 +286,8 @@ pub proof fn spec_of_previous_phases_entails_eventually_new_invariants(provided_
                 lift_state(Cluster::every_create_msg_sets_owner_references_as_for_all(
                     helper_invariants::is_vsts_pod_key(vsts), helper_invariants::owner_reference_requirements(vsts)
                 )),
-                lift_state(Cluster::every_update_msg_sets_owner_references_as_for_all(
-                    helper_invariants::is_vsts_pod_key(vsts), helper_invariants::owner_reference_requirements(vsts)
+                lift_state(Cluster::every_valid_update_msg_sets_owner_references_as_for_all(
+                    cluster.installed_types, helper_invariants::is_vsts_pod_key(vsts), helper_invariants::owner_reference_requirements(vsts)
                 )),
                 lift_state(Cluster::every_create_msg_with_generate_name_matching_key_set_owner_references_as_for_all(
                     helper_invariants::is_vsts_pod_key(vsts), helper_invariants::owner_reference_requirements(vsts)

--- a/src/controllers/vstatefulset_controller/proof/liveness/spec.rs
+++ b/src/controllers/vstatefulset_controller/proof/liveness/spec.rs
@@ -408,8 +408,8 @@ pub open spec fn invariants_since_phase_iv(vsts: VStatefulSetView, cluster: Clus
     always(lift_state(Cluster::every_create_msg_sets_owner_references_as_for_all(
         helper_invariants::is_vsts_pod_key(vsts), helper_invariants::owner_reference_requirements(vsts)
     )))
-    .and(always(lift_state(Cluster::every_update_msg_sets_owner_references_as_for_all(
-        helper_invariants::is_vsts_pod_key(vsts), helper_invariants::owner_reference_requirements(vsts)
+    .and(always(lift_state(Cluster::every_valid_update_msg_sets_owner_references_as_for_all(
+        cluster.installed_types, helper_invariants::is_vsts_pod_key(vsts), helper_invariants::owner_reference_requirements(vsts)
     ))))
     .and(always(lift_state(Cluster::every_create_msg_with_generate_name_matching_key_set_owner_references_as_for_all(
         helper_invariants::is_vsts_pod_key(vsts), helper_invariants::owner_reference_requirements(vsts)
@@ -424,8 +424,8 @@ pub proof fn invariants_since_phase_iv_is_stable(vsts: VStatefulSetView, cluster
         lift_state(Cluster::every_create_msg_sets_owner_references_as_for_all(
             helper_invariants::is_vsts_pod_key(vsts), helper_invariants::owner_reference_requirements(vsts)
         )),
-        lift_state(Cluster::every_update_msg_sets_owner_references_as_for_all(
-            helper_invariants::is_vsts_pod_key(vsts), helper_invariants::owner_reference_requirements(vsts)
+        lift_state(Cluster::every_valid_update_msg_sets_owner_references_as_for_all(
+            cluster.installed_types, helper_invariants::is_vsts_pod_key(vsts), helper_invariants::owner_reference_requirements(vsts)
         )),
         lift_state(Cluster::every_create_msg_with_generate_name_matching_key_set_owner_references_as_for_all(
             helper_invariants::is_vsts_pod_key(vsts), helper_invariants::owner_reference_requirements(vsts)

--- a/src/kubernetes_cluster/proof/garbage_collector.rs
+++ b/src/kubernetes_cluster/proof/garbage_collector.rs
@@ -145,6 +145,8 @@ pub open spec fn garbage_collector_deletion_enabled(key: ObjectRef) -> StatePred
 // and the second holds due to the weak fairness of kubernetes api.
 //
 // This lemma is enough for current proof, if later we introduce more complex case, we can try to strengthen it.
+#[verifier(spinoff_prover)]
+#[verifier(rlimit(100))]
 pub proof fn lemma_eventually_objects_owner_references_satisfies(
     self, spec: TempPred<ClusterState>, key: ObjectRef, eventual_owner_ref: spec_fn(Option<Seq<OwnerReferenceView>>) -> bool
 )
@@ -250,7 +252,6 @@ pub proof fn lemma_eventually_objects_owner_references_satisfies(
     );
 
     or_leads_to_combine_and_equality!(spec, true_pred(), lift_state(Self::objects_owner_references_violates(key, eventual_owner_ref)), lift_state(post); lift_state(post));
-
     assert forall |s, s_prime| post(s) && #[trigger] stronger_next(s, s_prime) implies post(s_prime) by {
         let step = choose |step| self.next_step(s, s_prime, step);
         match step {

--- a/src/kubernetes_cluster/proof/garbage_collector.rs
+++ b/src/kubernetes_cluster/proof/garbage_collector.rs
@@ -1,6 +1,6 @@
 use crate::kubernetes_api_objects::spec::prelude::*;
 use crate::kubernetes_cluster::spec::{
-    api_server::{types::*, state_machine::generated_name}, builtin_controllers::garbage_collector::run_garbage_collector,
+    api_server::{types::*, state_machine::*}, builtin_controllers::garbage_collector::run_garbage_collector,
     builtin_controllers::types::*, cluster::*, message::*,
 };
 use crate::temporal_logic::{defs::*, rules::*};
@@ -11,23 +11,24 @@ verus! {
 
 impl Cluster {
 
-// Everytime when we reason about update request message, we can only consider those valid ones (see validata_update_request).
-// However, listing all requirements makes spec looks cumbersome (consider using validate_create/update_request); we can only
-// list those that we need or that may appear according to the spec of system.
-//
-// For example, in some lemma we use msg.content.get_update_request().obj.kind == key.kind, so this requirement is added here.
-pub open spec fn every_update_msg_sets_owner_references_as(
-    key: ObjectRef, requirements: spec_fn(Option<Seq<OwnerReferenceView>>) -> bool
+pub open spec fn every_valid_update_msg_sets_owner_references_as(
+    installed_types: InstalledTypes, key: ObjectRef, requirements: spec_fn(Option<Seq<OwnerReferenceView>>) -> bool
 ) -> StatePred<ClusterState> {
     |s: ClusterState| {
         &&& forall |msg: Message|
             s.in_flight().contains(msg)
             && #[trigger] resource_update_request_msg(key)(msg)
+            // the request is valid
+            && update_request_admission_check(installed_types, msg.content.get_update_request(), s.api_server) is None
             ==> requirements(msg.content.get_update_request().obj.metadata.owner_references)
-        &&& forall |msg: Message|
-            s.in_flight().contains(msg)
-            && #[trigger] resource_get_then_update_request_msg(key)(msg)
-            ==> requirements(msg.content.get_get_then_update_request().obj.metadata.owner_references)
+        &&& forall |msg: Message| {
+            let req = msg.content.get_get_then_update_request();
+            &&& s.in_flight().contains(msg)
+            &&& #[trigger] resource_get_then_update_request_msg(key)(msg)
+            // the request is valid
+            &&& req.well_formed()
+            &&& (s.resources().contains_key(req.key()) ==> s.resources()[req.key()].metadata.owner_references_contains(req.owner_ref))
+        } ==> requirements(msg.content.get_get_then_update_request().obj.metadata.owner_references)
     }
 }
 
@@ -153,7 +154,7 @@ pub proof fn lemma_eventually_objects_owner_references_satisfies(
         spec.entails(tla_forall(|i| self.builtin_controllers_next().weak_fairness(i))),
         spec.entails(always(lift_state(Self::req_drop_disabled()))),
         spec.entails(always(lift_state(Self::every_create_msg_sets_owner_references_as(key, eventual_owner_ref)))),
-        spec.entails(always(lift_state(Self::every_update_msg_sets_owner_references_as(key, eventual_owner_ref)))),
+        spec.entails(always(lift_state(Self::every_valid_update_msg_sets_owner_references_as(self.installed_types, key, eventual_owner_ref)))),
         spec.entails(always(lift_state(Self::every_create_msg_with_generate_name_matching_key_set_owner_references_as(key, eventual_owner_ref)))),
         spec.entails(always(lift_state(Self::object_has_no_finalizers(key)))),
         // If the current owner_references does not satisfy the eventual requirement, the gc action is enabled.
@@ -181,7 +182,7 @@ pub proof fn lemma_eventually_objects_owner_references_satisfies(
     let stronger_next = |s, s_prime| {
         &&& self.next()(s, s_prime)
         &&& Self::every_create_msg_sets_owner_references_as(key, eventual_owner_ref)(s)
-        &&& Self::every_update_msg_sets_owner_references_as(key, eventual_owner_ref)(s)
+        &&& Self::every_valid_update_msg_sets_owner_references_as(self.installed_types, key, eventual_owner_ref)(s)
         &&& Self::every_create_msg_with_generate_name_matching_key_set_owner_references_as(key, eventual_owner_ref)(s)
         &&& Self::objects_owner_references_violates(key, eventual_owner_ref)(s) ==> Self::garbage_collector_deletion_enabled(key)(s)
         &&& Self::objects_owner_references_violates(key, eventual_owner_ref)(s_prime) ==> Self::garbage_collector_deletion_enabled(key)(s_prime)
@@ -191,7 +192,7 @@ pub proof fn lemma_eventually_objects_owner_references_satisfies(
         spec, lift_action(stronger_next),
         lift_action(self.next()),
         lift_state(Self::every_create_msg_sets_owner_references_as(key, eventual_owner_ref)),
-        lift_state(Self::every_update_msg_sets_owner_references_as(key, eventual_owner_ref)),
+        lift_state(Self::every_valid_update_msg_sets_owner_references_as(self.installed_types, key, eventual_owner_ref)),
         lift_state(Self::every_create_msg_with_generate_name_matching_key_set_owner_references_as(key, eventual_owner_ref)),
         lift_state(Self::objects_owner_references_violates(key, eventual_owner_ref)).implies(lift_state(Self::garbage_collector_deletion_enabled(key))),
         later(lift_state(Self::objects_owner_references_violates(key, eventual_owner_ref)).implies(lift_state(Self::garbage_collector_deletion_enabled(key))))
@@ -275,7 +276,7 @@ proof fn lemma_delete_msg_in_flight_leads_to_owner_references_satisfies(
         spec.entails(tla_forall(|i| self.api_server_next().weak_fairness(i))),
         spec.entails(always(lift_action(self.next()))),
         spec.entails(always(lift_state(Self::every_create_msg_sets_owner_references_as(key, eventual_owner_ref)))),
-        spec.entails(always(lift_state(Self::every_update_msg_sets_owner_references_as(key, eventual_owner_ref)))),
+        spec.entails(always(lift_state(Self::every_valid_update_msg_sets_owner_references_as(self.installed_types, key, eventual_owner_ref)))),
         spec.entails(always(lift_state(Self::object_has_no_finalizers(key)))),
         spec.entails(always(lift_state(Self::each_object_in_etcd_is_weakly_well_formed()))),
     ensures spec.entails(lift_state(Self::exists_effective_delete_request_msg_for_key(key)).leads_to(lift_state(Self::objects_owner_references_satisfies(key, eventual_owner_ref)))),
@@ -293,7 +294,7 @@ proof fn lemma_delete_msg_in_flight_leads_to_owner_references_satisfies(
                     &&& self.next()(s, s_prime)
                     &&& Self::req_drop_disabled()(s)
                     &&& Self::every_create_msg_sets_owner_references_as(key, eventual_owner_ref)(s)
-                    &&& Self::every_update_msg_sets_owner_references_as(key, eventual_owner_ref)(s)
+                    &&& Self::every_valid_update_msg_sets_owner_references_as(self.installed_types, key, eventual_owner_ref)(s)
                     &&& Self::object_has_no_finalizers(key)(s)
                     &&& Self::each_object_in_etcd_is_weakly_well_formed()(s)
                 };
@@ -302,7 +303,7 @@ proof fn lemma_delete_msg_in_flight_leads_to_owner_references_satisfies(
                     lift_action(self.next()),
                     lift_state(Self::req_drop_disabled()),
                     lift_state(Self::every_create_msg_sets_owner_references_as(key, eventual_owner_ref)),
-                    lift_state(Self::every_update_msg_sets_owner_references_as(key, eventual_owner_ref)),
+                    lift_state(Self::every_valid_update_msg_sets_owner_references_as(self.installed_types, key, eventual_owner_ref)),
                     lift_state(Self::object_has_no_finalizers(key)),
                     lift_state(Self::each_object_in_etcd_is_weakly_well_formed())
                 );
@@ -333,11 +334,11 @@ proof fn lemma_delete_msg_in_flight_leads_to_owner_references_satisfies(
 
 // Universally quantified versions of spec fns for reasoning about all keys satisfying cond.
 
-pub open spec fn every_update_msg_sets_owner_references_as_for_all(
-    cond: spec_fn(ObjectRef) -> bool, requirements: spec_fn(Option<Seq<OwnerReferenceView>>) -> bool
+pub open spec fn every_valid_update_msg_sets_owner_references_as_for_all(
+    installed_types: InstalledTypes, cond: spec_fn(ObjectRef) -> bool, requirements: spec_fn(Option<Seq<OwnerReferenceView>>) -> bool
 ) -> StatePred<ClusterState> {
     |s: ClusterState| {
-        forall |key: ObjectRef| #[trigger] cond(key) ==> Self::every_update_msg_sets_owner_references_as(key, requirements)(s)
+        forall |key: ObjectRef| #[trigger] cond(key) ==> Self::every_valid_update_msg_sets_owner_references_as(installed_types, key, requirements)(s)
     }
 }
 
@@ -400,7 +401,7 @@ pub proof fn lemma_eventually_objects_owner_references_satisfies_for_all(
         spec.entails(tla_forall(|i| self.builtin_controllers_next().weak_fairness(i))),
         spec.entails(always(lift_state(Self::req_drop_disabled()))),
         spec.entails(always(lift_state(Self::every_create_msg_sets_owner_references_as_for_all(cond, eventual_owner_ref)))),
-        spec.entails(always(lift_state(Self::every_update_msg_sets_owner_references_as_for_all(cond, eventual_owner_ref)))),
+        spec.entails(always(lift_state(Self::every_valid_update_msg_sets_owner_references_as_for_all(self.installed_types, cond, eventual_owner_ref)))),
         spec.entails(always(lift_state(Self::every_create_msg_with_generate_name_matching_key_set_owner_references_as_for_all(cond, eventual_owner_ref)))),
         spec.entails(always(lift_state(Self::object_has_no_finalizers_for_all(cond)))),
         // If any key satisfying cond violates the requirement, gc deletion is enabled for that key.
@@ -414,7 +415,7 @@ pub proof fn lemma_eventually_objects_owner_references_satisfies_for_all(
     let stronger_next = |s: ClusterState, s_prime: ClusterState| {
         &&& self.next()(s, s_prime)
         &&& Self::every_create_msg_sets_owner_references_as_for_all(cond, eventual_owner_ref)(s)
-        &&& Self::every_update_msg_sets_owner_references_as_for_all(cond, eventual_owner_ref)(s)
+        &&& Self::every_valid_update_msg_sets_owner_references_as_for_all(self.installed_types, cond, eventual_owner_ref)(s)
         &&& Self::every_create_msg_with_generate_name_matching_key_set_owner_references_as_for_all(cond, eventual_owner_ref)(s)
         &&& Self::gc_is_enabled_for_all_keys_violating_owner_ref_requirements(cond, eventual_owner_ref)(s)
         &&& Self::gc_is_enabled_for_all_keys_violating_owner_ref_requirements(cond, eventual_owner_ref)(s_prime)
@@ -428,7 +429,7 @@ pub proof fn lemma_eventually_objects_owner_references_satisfies_for_all(
         spec, lift_action(stronger_next),
         lift_action(self.next()),
         lift_state(Self::every_create_msg_sets_owner_references_as_for_all(cond, eventual_owner_ref)),
-        lift_state(Self::every_update_msg_sets_owner_references_as_for_all(cond, eventual_owner_ref)),
+        lift_state(Self::every_valid_update_msg_sets_owner_references_as_for_all(self.installed_types, cond, eventual_owner_ref)),
         lift_state(Self::every_create_msg_with_generate_name_matching_key_set_owner_references_as_for_all(cond, eventual_owner_ref)),
         lift_state(Self::gc_is_enabled_for_all_keys_violating_owner_ref_requirements(cond, eventual_owner_ref)),
         later(lift_state(Self::gc_is_enabled_for_all_keys_violating_owner_ref_requirements(cond, eventual_owner_ref))),
@@ -458,12 +459,12 @@ pub proof fn lemma_eventually_objects_owner_references_satisfies_for_all(
                         always(lift_state(Self::every_create_msg_sets_owner_references_as(k, eventual_owner_ref)))
                     );
                     entails_preserved_by_always(
-                        lift_state(Self::every_update_msg_sets_owner_references_as_for_all(cond, eventual_owner_ref)),
-                        lift_state(Self::every_update_msg_sets_owner_references_as(k, eventual_owner_ref))
+                        lift_state(Self::every_valid_update_msg_sets_owner_references_as_for_all(self.installed_types, cond, eventual_owner_ref)),
+                        lift_state(Self::every_valid_update_msg_sets_owner_references_as(self.installed_types, k, eventual_owner_ref))
                     );
                     entails_trans(spec,
-                        always(lift_state(Self::every_update_msg_sets_owner_references_as_for_all(cond, eventual_owner_ref))),
-                        always(lift_state(Self::every_update_msg_sets_owner_references_as(k, eventual_owner_ref)))
+                        always(lift_state(Self::every_valid_update_msg_sets_owner_references_as_for_all(self.installed_types, cond, eventual_owner_ref))),
+                        always(lift_state(Self::every_valid_update_msg_sets_owner_references_as(self.installed_types, k, eventual_owner_ref)))
                     );
                     entails_preserved_by_always(
                         lift_state(Self::every_create_msg_with_generate_name_matching_key_set_owner_references_as_for_all(cond, eventual_owner_ref)),


### PR DESCRIPTION
This PR weakens the preconditions of `lemma_eventually_objects_owner_references_satisfies` and `lemma_eventually_objects_owner_references_satisfies_for_all` by adding a validity check of update requests.

Previously we require all update requests to satisfy the owner reference requirements. The old comment in #529 mentioned the problem but didn't implement the validity check (it's likely to be left out during migration):

```rust
// Everytime when we reason about update request message, we can only consider those valid ones (see validate_update_request).
// However, listing all requirements makes spec looks cumbersome (consider using validate_create/update_request); we can only
// list those that we need or that may appear according to the spec of system.
```
