### PR TITLE
update Rust toolchain to 1.96

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 # this should be synchronized with the Verus version, since we need to combine
 # k8s compiled with rustc and our own code compiled with rust-verify.sh
 [toolchain]
-channel = "1.95.0"
+channel = "1.96.0"


### PR DESCRIPTION
This PR updates toolchain version in Anvil following https://github.com/verus-lang/verus/pull/2528