### PR TITLE
Update vstd to 0.0.0-2026-07-12-0122 and pin Verus release in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,9 @@ on:
 env:
   kind_version: 0.23.0
   go_version: "^1.20"
+  # should match the vstd version in Cargo.toml
+  # https://github.com/verus-lang/verus/releases
+  VERUS_TAG: "0.2026.07.12.0b42f4c"
 
 jobs:
   setup-toolchain:
@@ -14,13 +17,12 @@ jobs:
     outputs:
       verus-tag: ${{ steps.verus-tag.outputs.tag }}
     steps:
-      - name: Discover the latest Verus release
+      - name: Pin the Verus release matching vstd in Cargo.toml
         id: verus-tag
         run: |
-          TAG=$(curl -fsSL https://api.github.com/repos/verus-lang/verus/releases/latest \
-                | jq -r .tag_name | sed 's|^release/||')
+          TAG="$VERUS_TAG"
           echo "tag=$TAG" >> "$GITHUB_OUTPUT"
-          echo "Latest Verus release: $TAG"
+          echo "Pinned Verus release: $TAG"
       - uses: actions/checkout@v7
       - name: Cache toolchains
         id: cache-toolchain

--- a/.github/workflows/controller-build.yml
+++ b/.github/workflows/controller-build.yml
@@ -3,19 +3,21 @@ on:
   workflow_dispatch:
 env:
   IMAGE_NAME: ${{ github.repository }}
+  # should match the vstd version in Cargo.toml
+  # https://github.com/verus-lang/verus/releases
+  VERUS_TAG: "0.2026.07.12.0b42f4c"
 jobs:
   setup-toolchain:
     runs-on: ubuntu-24.04
     outputs:
       verus-tag: ${{ steps.verus-tag.outputs.tag }}
     steps:
-      - name: Discover the latest Verus release
+      - name: Pin the Verus release matching vstd in Cargo.toml
         id: verus-tag
         run: |
-          TAG=$(curl -fsSL https://api.github.com/repos/verus-lang/verus/releases/latest \
-                | jq -r .tag_name | sed 's|^release/||')
+          TAG="$VERUS_TAG"
           echo "tag=$TAG" >> "$GITHUB_OUTPUT"
-          echo "Latest Verus release: $TAG"
+          echo "Pinned Verus release: $TAG"
       - uses: actions/checkout@v7
       - name: Cache toolchains
         id: cache-toolchain

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2647,9 +2647,9 @@ checksum = "cab9266bfb5cf45a080f425c560b0e0be2bf81194f0e80258990c49c1829d8b9"
 
 [[package]]
 name = "verus_builtin_macros"
-version = "0.0.0-2026-06-14-0213"
+version = "0.0.0-2026-07-12-0122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "472dd2037f1194cf402c982d3423b058173e34a5ec0aab3c0bef78801ebd5e34"
+checksum = "3fb60e3a141ababe618fbdb759f14aa8544f6346a98a44c1e3a7dbe20b1f2892"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2695,16 +2695,16 @@ dependencies = [
 [[package]]
 name = "verus_temporal_logic"
 version = "0.1.0"
-source = "git+https://github.com/anvil-verifier/verus-tla?rev=91dcde63d45c4980e9d4555b7e9f6861cfb95705#91dcde63d45c4980e9d4555b7e9f6861cfb95705"
+source = "git+https://github.com/anvil-verifier/verus-tla?rev=d0d0b4acfd849f90a3f58bab016c8e8f90de5d9d#d0d0b4acfd849f90a3f58bab016c8e8f90de5d9d"
 dependencies = [
  "vstd",
 ]
 
 [[package]]
 name = "vstd"
-version = "0.0.0-2026-06-14-0213"
+version = "0.0.0-2026-07-12-0122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9c9b87576c9126305f9a91fdd72b0eb246e88e094f6a55e46c67ae2c83568c9"
+checksum = "dd0a0d328e1d6382af99a65f71677cf4b9200ec24e09fcafa7b1a3af8c8f5111"
 dependencies = [
  "verus_builtin",
  "verus_builtin_macros",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2695,7 +2695,7 @@ dependencies = [
 [[package]]
 name = "verus_temporal_logic"
 version = "0.1.0"
-source = "git+https://github.com/anvil-verifier/verus-tla?rev=d0d0b4acfd849f90a3f58bab016c8e8f90de5d9d#d0d0b4acfd849f90a3f58bab016c8e8f90de5d9d"
+source = "git+https://github.com/anvil-verifier/verus-tla?rev=8bb157b50b6200296d4b04d1302644d269e29443#8bb157b50b6200296d4b04d1302644d269e29443"
 dependencies = [
  "vstd",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ ws = ["kube/ws"]
 
 [dependencies]
 vstd = "=0.0.0-2026-07-12-0122"
-verus_temporal_logic = { git = "https://github.com/anvil-verifier/verus-tla", rev = "d0d0b4acfd849f90a3f58bab016c8e8f90de5d9d" }
+verus_temporal_logic = { git = "https://github.com/anvil-verifier/verus-tla", rev = "8bb157b50b6200296d4b04d1302644d269e29443" }
 
 kube = { version = "0.91.0", default-features = false, features = ["admission"] }
 kube-client = { version = "0.91.0", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,8 +12,8 @@ runtime = ["kube/runtime"]
 ws = ["kube/ws"]
 
 [dependencies]
-vstd = "=0.0.0-2026-06-14-0213"
-verus_temporal_logic = { git = "https://github.com/anvil-verifier/verus-tla", rev = "91dcde63d45c4980e9d4555b7e9f6861cfb95705" }
+vstd = "=0.0.0-2026-07-12-0122"
+verus_temporal_logic = { git = "https://github.com/anvil-verifier/verus-tla", rev = "d0d0b4acfd849f90a3f58bab016c8e8f90de5d9d" }
 
 kube = { version = "0.91.0", default-features = false, features = ["admission"] }
 kube-client = { version = "0.91.0", default-features = false }

--- a/build.md
+++ b/build.md
@@ -43,10 +43,11 @@ go_version:   "^1.20"
 ```
 
 `Cargo.toml` pins `vstd = "=…"` to a specific crates.io snapshot. CI
-fetches the latest Verus release from
-[verus-lang/verus](https://github.com/verus-lang/verus/releases/latest)
-at runtime. When you bump `vstd`, also rebuild your local Verus binary
-to a compatible release (typically the closest dated GitHub release).
+downloads the matching Verus release (the `VERUS_TAG` env in
+`.github/workflows/ci.yml`) from
+[verus-lang/verus](https://github.com/verus-lang/verus/releases).
+When you bump `vstd`, also bump `VERUS_TAG` and update your local Verus
+binary to the compatible release (the closest dated GitHub release).
 
 ## Build and verify
 

--- a/e2e/Cargo.lock
+++ b/e2e/Cargo.lock
@@ -2725,7 +2725,7 @@ dependencies = [
 [[package]]
 name = "verus_temporal_logic"
 version = "0.1.0"
-source = "git+https://github.com/anvil-verifier/verus-tla?rev=d0d0b4acfd849f90a3f58bab016c8e8f90de5d9d#d0d0b4acfd849f90a3f58bab016c8e8f90de5d9d"
+source = "git+https://github.com/anvil-verifier/verus-tla?rev=8bb157b50b6200296d4b04d1302644d269e29443#8bb157b50b6200296d4b04d1302644d269e29443"
 dependencies = [
  "vstd",
 ]

--- a/e2e/Cargo.lock
+++ b/e2e/Cargo.lock
@@ -2658,6 +2658,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "tungstenite 0.20.1",
+ "verus_temporal_logic",
  "vstd",
  "warp",
 ]
@@ -2676,9 +2677,9 @@ checksum = "cab9266bfb5cf45a080f425c560b0e0be2bf81194f0e80258990c49c1829d8b9"
 
 [[package]]
 name = "verus_builtin_macros"
-version = "0.0.0-2026-06-14-0213"
+version = "0.0.0-2026-07-12-0122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "472dd2037f1194cf402c982d3423b058173e34a5ec0aab3c0bef78801ebd5e34"
+checksum = "3fb60e3a141ababe618fbdb759f14aa8544f6346a98a44c1e3a7dbe20b1f2892"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2722,10 +2723,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "verus_temporal_logic"
+version = "0.1.0"
+source = "git+https://github.com/anvil-verifier/verus-tla?rev=d0d0b4acfd849f90a3f58bab016c8e8f90de5d9d#d0d0b4acfd849f90a3f58bab016c8e8f90de5d9d"
+dependencies = [
+ "vstd",
+]
+
+[[package]]
 name = "vstd"
-version = "0.0.0-2026-06-14-0213"
+version = "0.0.0-2026-07-12-0122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9c9b87576c9126305f9a91fdd72b0eb246e88e094f6a55e46c67ae2c83568c9"
+checksum = "dd0a0d328e1d6382af99a65f71677cf4b9200ec24e09fcafa7b1a3af8c8f5111"
 dependencies = [
  "verus_builtin",
  "verus_builtin_macros",


### PR DESCRIPTION
## Summary
- Bump `vstd` to `0.0.0-2026-07-12-0122` (latest published snapshot) and `verus_temporal_logic` to the verus-tla main commit (anvil-verifier/verus-tla#8) that uses the same vstd.
- Pin CI to Verus release `0.2026.07.12.0b42f4c` (the durable weekly release matching this vstd) via a `VERUS_TAG` env var in `ci.yml` and `controller-build.yml`, instead of discovering the latest release at runtime. A newer Verus binary can be incompatible with the pinned vstd crate — e.g. the current latest release `0.2026.07.18.3a4d30b` fails to compile vstd `2026-07-12` with `unexpected verus diagnostic item verus::verus_builtin::opens_invariants_none` — so CI could break without any code change.
- Update `build.md` to document the pinned `VERUS_TAG`.

## Testing
- `cargo verus verify --lib` with Verus `0.2026.07.12.0b42f4c`: 911 verified, 0 errors (plus vstd 1972 and verus_temporal_logic 139, all 0 errors).
- `cargo verus build --release --bin vreplicaset_controller -- --no-verify` succeeds.